### PR TITLE
[codex] Assemble LiteLLM provider context

### DIFF
--- a/.github/workflows/e2e-prod-tenant.yml
+++ b/.github/workflows/e2e-prod-tenant.yml
@@ -31,6 +31,7 @@ on:
       - 'Build and push klai-connector'
       - 'Build and push scribe-api'
       - 'Build and push caddy-hetzner'
+      - 'Deploy LiteLLM hooks'
       - 'Sync docker-compose.yml + config + smoke-test to core-01'
     types: [completed]
     branches: [main]

--- a/.github/workflows/litellm-hook-deploy.yml
+++ b/.github/workflows/litellm-hook-deploy.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           rsync -av deploy/litellm/ klai@${{ secrets.CORE01_HOST }}:/opt/klai/litellm/
           rsync -av --delete klai-libs/citations/klai_citations/ klai@${{ secrets.CORE01_HOST }}:/opt/klai/litellm/klai_citations/
+          rsync -av deploy/docker-compose.yml klai@${{ secrets.CORE01_HOST }}:/opt/klai/docker-compose.yml
 
       # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3 — use the canonical
       # compose-up wrapper (already used by caddy, klai-connector,
@@ -54,6 +55,11 @@ jobs:
       # + anti-hallucination); each required a manual
       # `docker compose up -d --force-recreate litellm` to land. See
       # pitfall `bind-mount-content-vs-python-module-cache`.
+      #
+      # Keep docker-compose.yml synced in this workflow too. New LiteLLM
+      # Python modules are bind-mounted explicitly, so a hook-only deploy must
+      # not recreate the container against a stale compose file that does not
+      # expose the new module at /app.
       - name: Recreate LiteLLM container
         run: ssh klai@${{ secrets.CORE01_HOST }} "/opt/klai/scripts/compose-up.sh --force-recreate litellm"
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -239,6 +239,7 @@ services:
     volumes:
       - ./litellm/config.yaml:/app/config.yaml:ro
       - ./litellm/klai_knowledge.py:/app/klai_knowledge.py:ro
+      - ./litellm/klai_context.py:/app/klai_context.py:ro
       - ./litellm/custom_router.py:/app/custom_router.py:ro
       # SPEC-CHAT-GUARDRAILS-001: vendored package copy of klai-libs/llm-safety
       # (kept byte-identical via deploy/litellm/tests/test_klai_llm_safety_drift.py).

--- a/deploy/litellm/klai_context.py
+++ b/deploy/litellm/klai_context.py
@@ -1,0 +1,264 @@
+"""Klai provider-context orchestration for Mistral-backed chat.
+
+LibreChat owns UI conversation state. Klai owns the provider-boundary contract:
+which messages are safe and useful to send to Mistral, which history is retained
+for retrieval/query rewriting, and which metadata explains those choices.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+
+STALE_ATTACHMENT_CONTEXT_PLACEHOLDER = (
+    "[Earlier uploaded document content omitted from model context. Use the "
+    "latest user question and retrieved knowledge-base context instead.]"
+)
+HISTORY_BUDGET_CONTEXT_PLACEHOLDER = (
+    "[Earlier conversation turns omitted from model context because they "
+    "exceeded Klai's provider context budget. Use the latest user question, "
+    "recent turns, and retrieved knowledge-base context instead.]"
+)
+STALE_LIBRECHAT_UPLOAD_PREFIX = "Attached document(s):"
+
+
+@dataclass(frozen=True)
+class MistralModelProfile:
+    """Budget profile for a Klai model alias backed by Mistral."""
+
+    alias: str
+    upstream_model: str
+    context_window_chars_estimate: int
+    history_budget_chars: int
+    output_reserve_chars: int
+
+
+@dataclass(frozen=True)
+class ContextAssemblyResult:
+    messages: object
+    meta: dict[str, Any]
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _default_profiles() -> dict[str, MistralModelProfile]:
+    shared_budget = os.getenv("KLAI_CONTEXT_HISTORY_BUDGET_CHARS")
+    primary_history_budget = _env_int("KLAI_CONTEXT_PRIMARY_HISTORY_BUDGET_CHARS", 24000)
+    fast_history_budget = _env_int("KLAI_CONTEXT_FAST_HISTORY_BUDGET_CHARS", 16000)
+    large_history_budget = _env_int("KLAI_CONTEXT_LARGE_HISTORY_BUDGET_CHARS", 48000)
+    if shared_budget is not None:
+        override = _env_int("KLAI_CONTEXT_HISTORY_BUDGET_CHARS", primary_history_budget)
+        primary_history_budget = override
+        fast_history_budget = override
+        large_history_budget = override
+
+    return {
+        "klai-primary": MistralModelProfile(
+            alias="klai-primary",
+            upstream_model="mistral-small-2603",
+            context_window_chars_estimate=768000,
+            history_budget_chars=primary_history_budget,
+            output_reserve_chars=24000,
+        ),
+        "klai-fast": MistralModelProfile(
+            alias="klai-fast",
+            upstream_model="mistral-small-2603",
+            context_window_chars_estimate=768000,
+            history_budget_chars=fast_history_budget,
+            output_reserve_chars=16000,
+        ),
+        "klai-large": MistralModelProfile(
+            alias="klai-large",
+            upstream_model="mistral-large-2512",
+            context_window_chars_estimate=768000,
+            history_budget_chars=large_history_budget,
+            output_reserve_chars=48000,
+        ),
+    }
+
+
+def _text_from_text_parts(content: object) -> str | None:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+
+    texts: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            return None
+        if part.get("type") != "text" or not isinstance(part.get("text"), str):
+            return None
+        texts.append(part["text"])
+    return "\n".join(texts)
+
+
+def _last_user_index(messages: list[object]) -> int | None:
+    return next(
+        (
+            index
+            for index in range(len(messages) - 1, -1, -1)
+            if isinstance(messages[index], dict) and messages[index].get("role") == "user"
+        ),
+        None,
+    )
+
+
+def _is_stale_upload_text(text: str) -> bool:
+    return text.lstrip().startswith(STALE_LIBRECHAT_UPLOAD_PREFIX)
+
+
+class KlaiContextOrchestrator:
+    """Build the Mistral/retrieval context view for one LiteLLM request.
+
+    In the current LiteLLM callback order this runs before ``custom_router`` on
+    the LibreChat path, so the model profile is based on the requested alias,
+    not the final routed alias. The profile metadata is still useful for direct
+    ``klai-fast``/``klai-large`` calls and for Phase 2 router integration.
+    """
+
+    def __init__(
+        self,
+        profiles: dict[str, MistralModelProfile] | None = None,
+        *,
+        default_profile: str = "klai-primary",
+    ) -> None:
+        self._profiles = profiles or _default_profiles()
+        self._default_profile = default_profile
+
+    def profile_for(self, requested_model: object) -> MistralModelProfile:
+        alias = requested_model if isinstance(requested_model, str) else ""
+        return self._profiles.get(alias) or self._profiles[self._default_profile]
+
+    def assemble(
+        self,
+        messages: object,
+        *,
+        requested_model: object = "klai-primary",
+        normalize_content: bool = True,
+        apply_history_budget: bool = True,
+    ) -> ContextAssemblyResult:
+        profile = self.profile_for(requested_model)
+        meta: dict[str, Any] = {
+            "version": "v1",
+            "orchestrator": "klai_context",
+            "provider": "mistral",
+            "requested_model": requested_model if isinstance(requested_model, str) else "",
+            "profile_selection_phase": "pre_router_litellm_callback",
+            "model_profile": profile.alias,
+            "upstream_model": profile.upstream_model,
+            "context_window_chars_estimate": profile.context_window_chars_estimate,
+            "history_budget_chars": profile.history_budget_chars,
+            "history_budget_applied": apply_history_budget,
+            "output_reserve_chars": profile.output_reserve_chars,
+            "normalized_text_part_messages": 0,
+            "normalized_user_text_part_messages": 0,
+            "stale_attachment_placeholders": 0,
+            "omitted_history_messages": 0,
+            "kept_history_chars": 0,
+            "unknown_message_shapes": 0,
+            "unknown_content_shapes": 0,
+            "reason_codes": [],
+        }
+        if not isinstance(messages, list):
+            meta["reason_codes"].append("messages_not_list")
+            return ContextAssemblyResult(messages=messages, meta=meta)
+
+        last_user_index = _last_user_index(messages)
+        if last_user_index is None:
+            meta["reason_codes"].append("no_user_message")
+            return ContextAssemblyResult(messages=messages, meta=meta)
+
+        normalized_messages: list[object] = []
+        for index, message in enumerate(messages):
+            if not isinstance(message, dict):
+                normalized_messages.append(message)
+                meta["unknown_message_shapes"] += 1
+                continue
+
+            role = message.get("role")
+            next_message = message
+            if normalize_content and role in ("user", "assistant"):
+                text_content = _text_from_text_parts(message.get("content"))
+                if text_content is None:
+                    meta["unknown_content_shapes"] += 1
+                elif text_content != message.get("content"):
+                    next_message = {**message, "content": text_content}
+                    meta["normalized_text_part_messages"] += 1
+                    if role == "user":
+                        meta["normalized_user_text_part_messages"] += 1
+
+                if (
+                    index != last_user_index
+                    and role == "user"
+                    and isinstance(next_message.get("content"), str)
+                    and _is_stale_upload_text(next_message["content"])
+                ):
+                    next_message = {
+                        **next_message,
+                        "content": STALE_ATTACHMENT_CONTEXT_PLACEHOLDER,
+                    }
+                    meta["stale_attachment_placeholders"] += 1
+
+            normalized_messages.append(next_message)
+
+        if not apply_history_budget:
+            return ContextAssemblyResult(messages=normalized_messages, meta=meta)
+
+        budget = max(profile.history_budget_chars, 0)
+        kept_chars = 0
+        omitted_history_indexes: set[int] = set()
+        history_indexes = [
+            index
+            for index in range(0, last_user_index)
+            if isinstance(normalized_messages[index], dict)
+            and normalized_messages[index].get("role") in ("user", "assistant")
+        ]
+        for index in reversed(history_indexes):
+            message = normalized_messages[index]
+            if not isinstance(message, dict) or message.get("role") not in ("user", "assistant"):
+                continue
+            content = message.get("content")
+            if not isinstance(content, str):
+                continue
+            if kept_chars + len(content) > budget:
+                omitted_history_indexes.update(
+                    history_index
+                    for history_index in history_indexes
+                    if history_index <= index
+                )
+                break
+            kept_chars += len(content)
+
+        meta["kept_history_chars"] = kept_chars
+        if not omitted_history_indexes:
+            return ContextAssemblyResult(messages=normalized_messages, meta=meta)
+
+        assembled: list[object] = []
+        placeholder_inserted = False
+        for index, message in enumerate(normalized_messages):
+            if index in omitted_history_indexes:
+                if not placeholder_inserted:
+                    assembled.append(
+                        {
+                            "role": "system",
+                            "content": HISTORY_BUDGET_CONTEXT_PLACEHOLDER,
+                        }
+                    )
+                    placeholder_inserted = True
+                continue
+            assembled.append(message)
+
+        meta["omitted_history_messages"] = len(omitted_history_indexes)
+        meta["reason_codes"].append("history_budget_exceeded")
+        return ContextAssemblyResult(messages=assembled, meta=meta)

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -53,6 +53,11 @@ from klai_chat_prompts import (
     META_CHAT_SYSTEM_PROMPT,
     no_citable_sources_message as _no_citable_sources_message,
 )
+from klai_context import (
+    HISTORY_BUDGET_CONTEXT_PLACEHOLDER as _HISTORY_BUDGET_CONTEXT_PLACEHOLDER,
+    KlaiContextOrchestrator,
+    STALE_ATTACHMENT_CONTEXT_PLACEHOLDER as _STALE_ATTACHMENT_CONTEXT_PLACEHOLDER,
+)
 from klai_citations import (
     compose_answer_with_trusted_sources,
     evidence_pack_items_as_chunks,
@@ -331,10 +336,7 @@ def _select_kb_render_strategy(original_stream: object) -> KbCitationRenderStrat
 
 KLAI_KB_CHAT_RENDER_MODE = _resolve_kb_render_mode(os.getenv("KLAI_KB_CHAT_RENDER_MODE"))
 _SENTINEL_URLS = {"undefined", "null", "none", "n/a", "na", "-", "#"}
-_STALE_ATTACHMENT_CONTEXT_PLACEHOLDER = (
-    "[Earlier uploaded document content omitted from model context. Use the "
-    "latest user question and retrieved knowledge-base context instead.]"
-)
+_KLAI_CONTEXT_ORCHESTRATOR = KlaiContextOrchestrator()
 
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-2 — anti-hallucination injection
 # fired when retrieval-api signals confidence_band ∈ {low, unknown}. Dutch
@@ -826,72 +828,6 @@ def _sanitize_assistant_history_messages(messages: object) -> object:
         else:
             sanitized.append({**message, "content": stripped_content})
     return sanitized
-
-
-def _text_from_text_parts(content: object) -> str | None:
-    """Return a provider-safe string for LibreChat text-part content."""
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return None
-
-    texts: list[str] = []
-    for part in content:
-        if not isinstance(part, dict):
-            return None
-        if part.get("type") != "text" or not isinstance(part.get("text"), str):
-            return None
-        texts.append(part["text"])
-    return "\n".join(texts)
-
-
-def _is_attached_document_text(text: str) -> bool:
-    return text.lstrip().startswith("Attached document(s):")
-
-
-def _normalize_user_text_part_messages(messages: object) -> tuple[object, int]:
-    """Normalize LibreChat text-part user messages before provider calls.
-
-    LibreChat represents uploaded document text as OpenAI-style text parts:
-    ``content=[{"type": "text", "text": "Attached document(s): ..."}]``.
-    Mistral's chat-completions API rejects that shape for this model and
-    expects a string. For the latest user turn we preserve the extracted text.
-    For earlier uploaded-document turns we keep only a marker; otherwise a
-    one-time prompt upload remains in every later request and can dominate or
-    overflow the model context after the same documents were moved into KB.
-    """
-    if not isinstance(messages, list):
-        return messages, 0
-
-    last_user_index = next(
-        (
-            index
-            for index in range(len(messages) - 1, -1, -1)
-            if isinstance(messages[index], dict) and messages[index].get("role") == "user"
-        ),
-        None,
-    )
-    if last_user_index is None:
-        return messages, 0
-
-    normalized = 0
-    sanitized: list[object] = []
-    for index, message in enumerate(messages):
-        if not isinstance(message, dict) or message.get("role") != "user":
-            sanitized.append(message)
-            continue
-
-        text_content = _text_from_text_parts(message.get("content"))
-        if text_content is None or text_content == message.get("content"):
-            sanitized.append(message)
-            continue
-
-        if index != last_user_index and _is_attached_document_text(text_content):
-            sanitized.append({**message, "content": _STALE_ATTACHMENT_CONTEXT_PLACEHOLDER})
-        else:
-            sanitized.append({**message, "content": text_content})
-        normalized += 1
-    return (sanitized, normalized) if normalized else (messages, 0)
 
 
 def _build_conversation_history(messages: list[dict]) -> list[dict]:
@@ -2767,10 +2703,15 @@ class KlaiKnowledgeHook(CustomLogger):
             return data
 
         messages = _sanitize_assistant_history_messages(data.get("messages", []))
-        messages, normalized_user_text_part_messages = _normalize_user_text_part_messages(
-            messages
+        context_result = _KLAI_CONTEXT_ORCHESTRATOR.assemble(
+            messages,
+            requested_model=data.get("model", "klai-primary"),
+            apply_history_budget=False,
         )
+        messages = context_result.messages
+        context_meta = context_result.meta
         data["messages"] = messages
+        data.setdefault("metadata", {})["_klai_context_meta"] = context_meta
         query = _last_user_message(messages)
         if not query or _is_trivial(query):
             return data
@@ -2791,12 +2732,47 @@ class KlaiKnowledgeHook(CustomLogger):
         librechat_user_id = data.get("user", "")
         if not librechat_user_id:
             return data
+
+        budget_context_result = _KLAI_CONTEXT_ORCHESTRATOR.assemble(
+            messages,
+            requested_model=data.get("model", "klai-primary"),
+            normalize_content=False,
+            apply_history_budget=True,
+        )
+        messages = budget_context_result.messages
+        budget_meta = budget_context_result.meta
+        context_meta = {
+            **context_meta,
+            "history_budget_applied": budget_meta["history_budget_applied"],
+            "omitted_history_messages": budget_meta["omitted_history_messages"],
+            "kept_history_chars": budget_meta["kept_history_chars"],
+            "reason_codes": [
+                *context_meta.get("reason_codes", []),
+                *budget_meta.get("reason_codes", []),
+            ],
+        }
+        data["messages"] = messages
+        data.setdefault("metadata", {})["_klai_context_meta"] = context_meta
+
+        normalized_user_text_part_messages = context_meta[
+            "normalized_user_text_part_messages"
+        ]
         if normalized_user_text_part_messages:
             logger.warning(
                 "librechat_user_text_part_messages_normalized org_id=%s user_id=%s normalized=%d",
                 org_id,
                 librechat_user_id,
                 normalized_user_text_part_messages,
+            )
+        if context_meta["omitted_history_messages"]:
+            logger.info(
+                "klai_provider_context_assembled org_id=%s user_id=%s "
+                "history_omitted=%d kept_history_chars=%d history_budget_chars=%d",
+                org_id,
+                librechat_user_id,
+                context_meta["omitted_history_messages"],
+                context_meta["kept_history_chars"],
+                context_meta["history_budget_chars"],
             )
 
         safety_metadata = data.setdefault("metadata", {})

--- a/deploy/litellm/tests/test_klai_context.py
+++ b/deploy/litellm/tests/test_klai_context.py
@@ -1,0 +1,159 @@
+import importlib
+import sys
+
+
+def _load_context(monkeypatch, extra_env=None):
+    env = {
+        "KLAI_CONTEXT_PRIMARY_HISTORY_BUDGET_CHARS": "1000",
+        "KLAI_CONTEXT_FAST_HISTORY_BUDGET_CHARS": "800",
+        "KLAI_CONTEXT_LARGE_HISTORY_BUDGET_CHARS": "2000",
+    }
+    if extra_env:
+        env.update(extra_env)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    sys.modules.pop("klai_context", None)
+    import klai_context
+
+    importlib.reload(klai_context)
+    return klai_context
+
+
+def test_orchestrator_exposes_mistral_model_profile_metadata(monkeypatch):
+    mod = _load_context(monkeypatch)
+    orchestrator = mod.KlaiContextOrchestrator()
+
+    result = orchestrator.assemble(
+        [{"role": "user", "content": "Hallo"}],
+        requested_model="klai-large",
+    )
+
+    meta = result.meta
+    assert meta["orchestrator"] == "klai_context"
+    assert meta["provider"] == "mistral"
+    assert meta["requested_model"] == "klai-large"
+    assert meta["profile_selection_phase"] == "pre_router_litellm_callback"
+    assert meta["model_profile"] == "klai-large"
+    assert meta["upstream_model"] == "mistral-large-2512"
+    assert meta["history_budget_chars"] == 2000
+    assert meta["output_reserve_chars"] == 48000
+
+
+def test_orchestrator_normalizes_text_parts_and_omits_stale_upload(monkeypatch):
+    mod = _load_context(monkeypatch)
+    orchestrator = mod.KlaiContextOrchestrator()
+
+    result = orchestrator.assemble(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Attached document(s):\nold body"}
+                ],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "Oud antwoord"}]},
+            {"role": "user", "content": [{"type": "text", "text": "Nieuwe vraag"}]},
+        ],
+        requested_model="klai-primary",
+    )
+
+    assert result.messages[-1]["content"] == "Nieuwe vraag"
+    assert result.messages[0]["content"] == mod.STALE_ATTACHMENT_CONTEXT_PLACEHOLDER
+    assert result.messages[1]["content"] == "Oud antwoord"
+    assert result.meta["normalized_text_part_messages"] == 3
+    assert result.meta["normalized_user_text_part_messages"] == 2
+    assert result.meta["stale_attachment_placeholders"] == 1
+
+
+def test_orchestrator_budget_omits_old_history_but_keeps_latest_user(monkeypatch):
+    mod = _load_context(monkeypatch, {"KLAI_CONTEXT_HISTORY_BUDGET_CHARS": "40"})
+    orchestrator = mod.KlaiContextOrchestrator()
+    latest = "Keep this exact latest user message"
+
+    result = orchestrator.assemble(
+        [
+            {"role": "user", "content": "old user " + ("x" * 80)},
+            {"role": "assistant", "content": "old assistant " + ("y" * 80)},
+            {"role": "user", "content": latest},
+        ],
+        requested_model="klai-primary",
+    )
+
+    rendered = "\n".join(
+        message.get("content", "")
+        for message in result.messages
+        if isinstance(message, dict) and isinstance(message.get("content"), str)
+    )
+    assert latest in rendered
+    assert "old user" not in rendered
+    assert "old assistant" not in rendered
+    assert mod.HISTORY_BUDGET_CONTEXT_PLACEHOLDER in rendered
+    assert result.meta["omitted_history_messages"] == 2
+    assert "history_budget_exceeded" in result.meta["reason_codes"]
+
+
+def test_orchestrator_omits_contiguous_older_history_after_budget_boundary(monkeypatch):
+    mod = _load_context(monkeypatch, {"KLAI_CONTEXT_HISTORY_BUDGET_CHARS": "40"})
+    orchestrator = mod.KlaiContextOrchestrator()
+
+    result = orchestrator.assemble(
+        [
+            {"role": "user", "content": "old-gap"},
+            {"role": "assistant", "content": "middle " + ("m" * 100)},
+            {"role": "user", "content": "recent-ok"},
+            {"role": "user", "content": "latest"},
+        ],
+        requested_model="klai-primary",
+    )
+
+    rendered = "\n".join(
+        message.get("content", "")
+        for message in result.messages
+        if isinstance(message, dict) and isinstance(message.get("content"), str)
+    )
+    assert "recent-ok" in rendered
+    assert "middle" not in rendered
+    assert "old-gap" not in rendered
+    assert result.meta["omitted_history_messages"] == 2
+
+
+def test_orchestrator_can_normalize_without_history_budget_before_scope(monkeypatch):
+    mod = _load_context(monkeypatch, {"KLAI_CONTEXT_HISTORY_BUDGET_CHARS": "1"})
+    orchestrator = mod.KlaiContextOrchestrator()
+
+    result = orchestrator.assemble(
+        [
+            {"role": "user", "content": "very old text"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": [{"type": "text", "text": "latest"}]},
+        ],
+        requested_model="klai-primary",
+        apply_history_budget=False,
+    )
+
+    rendered = "\n".join(
+        message.get("content", "")
+        for message in result.messages
+        if isinstance(message, dict) and isinstance(message.get("content"), str)
+    )
+    assert "very old text" in rendered
+    assert "old answer" in rendered
+    assert result.messages[-1]["content"] == "latest"
+    assert result.meta["history_budget_applied"] is False
+    assert result.meta["omitted_history_messages"] == 0
+
+
+def test_orchestrator_reports_unknown_shapes_without_silent_normalization(monkeypatch):
+    mod = _load_context(monkeypatch)
+    orchestrator = mod.KlaiContextOrchestrator()
+    message = {
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": "https://example.test/a.png"}}],
+    }
+
+    result = orchestrator.assemble([message], requested_model="klai-primary")
+
+    assert result.messages == [message]
+    assert result.meta["unknown_content_shapes"] == 1
+    assert result.meta["normalized_text_part_messages"] == 0

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -350,6 +350,8 @@ class TestKlaiKnowledgeHookLegacy:
     def test_normalizes_user_text_parts_and_omits_stale_attachments(self, monkeypatch):
         """LibreChat text-part uploads must be provider-safe on later turns."""
         mod = _load_hook(monkeypatch)
+        import klai_context
+
         uploaded_doc = "Attached document(s):\n```md\nprivacy document\n```"
         latest_question = "Wat staat er in de kennisbank over verwerkers?"
         messages = [
@@ -358,12 +360,12 @@ class TestKlaiKnowledgeHookLegacy:
             {"role": "user", "content": [{"type": "text", "text": latest_question}]},
         ]
 
-        sanitized, normalized = mod._normalize_user_text_part_messages(messages)
+        result = klai_context.KlaiContextOrchestrator().assemble(messages)
 
-        assert normalized == 2
-        assert sanitized[0]["content"] == mod._STALE_ATTACHMENT_CONTEXT_PLACEHOLDER
-        assert sanitized[1] is messages[1]
-        assert sanitized[2]["content"] == latest_question
+        assert result.meta["normalized_user_text_part_messages"] == 2
+        assert result.messages[0]["content"] == mod._STALE_ATTACHMENT_CONTEXT_PLACEHOLDER
+        assert result.messages[1] is messages[1]
+        assert result.messages[2]["content"] == latest_question
 
     @pytest.mark.asyncio
     async def test_retrieve_request_includes_auth_header(self, monkeypatch):
@@ -1597,6 +1599,161 @@ class TestKlaiKnowledgeHookKB010:
             if isinstance(message, dict)
         )
         assert "librechat_user_text_part_messages_normalized" in caplog.text
+
+
+class TestKlaiKnowledgeHookProviderContext:
+    @pytest.mark.asyncio
+    async def test_provider_context_normalizes_stale_librechat_upload_parts(
+        self, monkeypatch
+    ):
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+        latest = "What does the uploaded policy say about approvals?"
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Attached document(s): policy.pdf\n\nFull extracted text",
+                    }
+                ],
+            },
+            {"role": "assistant", "content": "I can help with that document."},
+            {"role": "user", "content": latest},
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        provider_messages = result["messages"]
+        assert provider_messages[-1] == {"role": "user", "content": latest}
+        assert all(
+            not isinstance(m.get("content"), list)
+            for m in provider_messages
+            if m.get("role") in ("user", "assistant")
+        )
+        provider_text = "\n".join(
+            m.get("content", "") for m in provider_messages if isinstance(m.get("content"), str)
+        )
+        assert "Attached document(s):" not in provider_text
+        assert mod._STALE_ATTACHMENT_CONTEXT_PLACEHOLDER in provider_text
+        meta = result["metadata"]["_klai_context_meta"]
+        assert meta["normalized_user_text_part_messages"] == 1
+        assert meta["stale_attachment_placeholders"] == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_context_keeps_latest_user_exact_under_budget(
+        self, monkeypatch
+    ):
+        mod = _load_hook(
+            monkeypatch,
+            {"KLAI_CONTEXT_HISTORY_BUDGET_CHARS": "40"},
+        )
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+        latest = "Please answer this exact latest question."
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "old user " + ("x" * 80)},
+            {"role": "assistant", "content": "old assistant " + ("y" * 80)},
+            {"role": "user", "content": latest},
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        provider_messages = result["messages"]
+        assert provider_messages[-1] == {"role": "user", "content": latest}
+        provider_text = "\n".join(
+            m.get("content", "") for m in provider_messages if isinstance(m.get("content"), str)
+        )
+        assert "old user" not in provider_text
+        assert "old assistant" not in provider_text
+        assert mod._HISTORY_BUDGET_CONTEXT_PLACEHOLDER in provider_text
+        meta = result["metadata"]["_klai_context_meta"]
+        assert meta["omitted_history_messages"] == 2
+        assert meta["history_budget_chars"] == 40
+
+    @pytest.mark.asyncio
+    async def test_provider_context_budget_waits_for_librechat_scope(
+        self, monkeypatch
+    ):
+        mod = _load_hook(
+            monkeypatch,
+            {"KLAI_CONTEXT_HISTORY_BUDGET_CHARS": "40"},
+        )
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {"role": "user", "content": "old user " + ("x" * 80)},
+            {"role": "assistant", "content": "old assistant " + ("y" * 80)},
+            {"role": "user", "content": "Latest question remains."},
+        ]}
+
+        result = await hook.async_pre_call_hook(
+            _make_user_api_key(org_id=None), cache, data, "completion"
+        )
+
+        provider_text = "\n".join(
+            m.get("content", "") for m in result["messages"] if isinstance(m.get("content"), str)
+        )
+        assert "old user" in provider_text
+        assert "old assistant" in provider_text
+        assert mod._HISTORY_BUDGET_CONTEXT_PLACEHOLDER not in provider_text
+        meta = result["metadata"]["_klai_context_meta"]
+        assert meta["history_budget_applied"] is False
+        assert meta["omitted_history_messages"] == 0
+
+    @pytest.mark.asyncio
+    async def test_provider_context_retrieval_history_uses_assembled_context(
+        self, monkeypatch
+    ):
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature_enabled=True)
+        data = {"user": "aabbcc112233445566778899", "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Attached document(s): stale.pdf\nbody"}
+                ],
+            },
+            {"role": "assistant", "content": "Earlier answer."},
+            {"role": "user", "content": "What did we decide after that?"},
+        ]}
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(_make_user_api_key(), cache, data, "completion")
+
+        body = mc.post.call_args.kwargs.get("json") or {}
+        history_text = "\n".join(
+            turn.get("content", "") for turn in body.get("conversation_history", [])
+        )
+        assert "Attached document(s):" not in history_text
+        assert mod._STALE_ATTACHMENT_CONTEXT_PLACEHOLDER in history_text
 
     @pytest.mark.asyncio
     async def test_gate_bypass_no_injection(self, monkeypatch):


### PR DESCRIPTION
## What changed

- Adds a LiteLLM provider-boundary context assembler for the LibreChat -> LiteLLM -> Mistral chatflow.
- Normalizes text-only LibreChat content-parts to string content.
- Replaces old `Attached document(s):` upload dumps with an explicit placeholder.
- Adds a configurable recent-history budget via `KLAI_CONTEXT_HISTORY_BUDGET_CHARS`.
- Stores assembler metadata in `data["metadata"]["_klai_context_meta"]`.
- Adds provider-context regression tests.
- Syncs the vendored LiteLLM chat prompt copy with the canonical prompt to satisfy the existing drift gate.

## Why

Old LibreChat upload turns could remain in the thread as content-parts containing raw `Attached document(s): ...` dumps. That polluted both retrieval conversation history and the provider context sent toward Mistral, even when KB retrieval itself worked.

## Validation

- `PYTHONPATH=../../klai-libs/citations uv run --with pytest --with pytest-asyncio --with httpx --with pydantic --with structlog pytest tests/test_klai_knowledge_hook.py -q -k 'provider_context'` -> 3 passed
- `PYTHONPATH=../../klai-libs/citations uv run --with pytest --with pytest-asyncio --with httpx --with pydantic --with structlog pytest tests/test_klai_knowledge_hook.py tests/test_low_confidence_injection.py tests/test_query_rewrite.py -q` -> 96 passed
- `git diff --check` -> passed
