### PR TITLE
fix(portal-ui): adversarial-review fixes — WCAG contrast, tab a11y, gaps layout

### DIFF
--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -788,8 +788,9 @@ decide the winner here: unlayered declarations rank after every explicit
 layer, so an unlayered `* { border-color }` would beat every Tailwind utility
 (which live in `@layer utilities`) regardless of class specificity. When this
 rule was unlayered, every colored border utility in the portal
-(`border-[var(--color-destructive)]`, `border-current`, `border-amber-300`,
-...) was silently overridden to the neutral grey — invisible because grey is
+(`border-[var(--color-destructive)]`, `border-current`,
+`border-[var(--color-warning)]`, ...) was silently overridden to the neutral
+grey — invisible because grey is
 close to `gray-200`. Keeping it in `@layer base` lets utilities win, which is
 Tailwind v4's intended preflight behaviour.
 

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -1561,6 +1561,7 @@
   "admin_join_requests_deny": "Deny",
   "admin_join_requests_column_name": "Name",
   "admin_join_requests_column_email": "Email",
+  "admin_join_requests_no_matches": "No matching join requests.",
   "select_workspace_heading": "Select workspace",
   "select_workspace_body": "Your account is linked to multiple workspaces. Select which one to open.",
   "select_workspace_continue": "Continue",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -1561,6 +1561,7 @@
   "admin_join_requests_deny": "Afwijzen",
   "admin_join_requests_column_name": "Naam",
   "admin_join_requests_column_email": "E-mailadres",
+  "admin_join_requests_no_matches": "Geen overeenkomende toegangsverzoeken.",
   "select_workspace_heading": "Werkruimte selecteren",
   "select_workspace_body": "Je account is gekoppeld aan meerdere werkruimtes. Selecteer welke je wilt openen.",
   "select_workspace_continue": "Doorgaan",

--- a/klai-portal/frontend/src/components/ui/__tests__/alert.test.tsx
+++ b/klai-portal/frontend/src/components/ui/__tests__/alert.test.tsx
@@ -16,7 +16,7 @@ describe('Alert', () => {
     const alert = container.querySelector('[role="alert"]')!
     expect(alert.className).toContain('bg-[var(--color-warning)]/5')
     expect(alert.className).toContain('border-[var(--color-warning)]/30')
-    expect(alert.className).toContain('text-[var(--color-warning)]')
+    expect(alert.className).toContain('text-[var(--color-warning-text)]')
   })
 
   it('renders the variant default icon (an svg) by default', () => {

--- a/klai-portal/frontend/src/components/ui/__tests__/tabs.test.tsx
+++ b/klai-portal/frontend/src/components/ui/__tests__/tabs.test.tsx
@@ -69,4 +69,27 @@ describe('Tabs', () => {
     )
     expect(container.querySelector('svg')).toBeTruthy()
   })
+
+  it('uses roving tabindex and activates on arrow keys', () => {
+    const onValueChange = vi.fn()
+    render(<Tabs tabs={baseTabs} value="details" onValueChange={onValueChange} />)
+    const active = screen.getByRole('tab', { name: 'Details' })
+    expect(active.getAttribute('tabindex')).toBe('0')
+    expect(screen.getByRole('tab', { name: 'Activity' }).getAttribute('tabindex')).toBe('-1')
+    fireEvent.keyDown(active, { key: 'ArrowRight' })
+    expect(onValueChange).toHaveBeenCalledWith('activity')
+    fireEvent.keyDown(active, { key: 'ArrowLeft' })
+    expect(onValueChange).toHaveBeenCalledWith('activity') // wraps to last (also 'activity')
+  })
+
+  it('exposes an accessible label on the count badge via countLabel', () => {
+    render(
+      <Tabs
+        tabs={[{ id: 'a', label: 'A', count: 3, countLabel: '3 unread' }]}
+        value="a"
+        onValueChange={() => {}}
+      />
+    )
+    expect(screen.getByLabelText('3 unread').textContent).toBe('3')
+  })
 })

--- a/klai-portal/frontend/src/components/ui/alert.tsx
+++ b/klai-portal/frontend/src/components/ui/alert.tsx
@@ -14,21 +14,21 @@ import { cn } from '@/lib/utils'
 // across wizard feedback and form warnings.
 //
 // Like Badge, the semantic variants derive from the SAME primary tokens as
-// the row-action tones (var(--color-success|warning|destructive|info)). The
-// surface is kept soft via a 5% tint background + 30% tint border, with the
-// solid token as icon/text color — same hue and meaning as the solid action
-// icons, just softer. Do not hand-roll status callouts with raw amber/red/
-// green Tailwind literals; use this component.
+// the row-action tones. The surface is kept soft via a 5% tint background +
+// 30% tint border; the icon/text use the darker `*-text` token variant
+// (var(--color-success-text) etc.) so labels clear WCAG AA on the light tint.
+// Do not hand-roll status callouts with raw amber/red/green Tailwind literals;
+// use this component.
 const alertVariants = cva('flex gap-2 rounded-lg border', {
   variants: {
     variant: {
-      info: 'border-[var(--color-info)]/30 bg-[var(--color-info)]/5 text-[var(--color-info)]',
+      info: 'border-[var(--color-info)]/30 bg-[var(--color-info)]/5 text-[var(--color-info-text)]',
       success:
-        'border-[var(--color-success)]/30 bg-[var(--color-success)]/5 text-[var(--color-success)]',
+        'border-[var(--color-success)]/30 bg-[var(--color-success)]/5 text-[var(--color-success-text)]',
       warning:
-        'border-[var(--color-warning)]/30 bg-[var(--color-warning)]/5 text-[var(--color-warning)]',
+        'border-[var(--color-warning)]/30 bg-[var(--color-warning)]/5 text-[var(--color-warning-text)]',
       destructive:
-        'border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 text-[var(--color-destructive)]',
+        'border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 text-[var(--color-destructive-text)]',
     },
     size: {
       sm: 'p-3 text-xs',

--- a/klai-portal/frontend/src/components/ui/badge.tsx
+++ b/klai-portal/frontend/src/components/ui/badge.tsx
@@ -6,10 +6,12 @@ import { cn } from '@/lib/utils'
 // - rounded-full (same as buttons)
 // - default/accent use neutral gray (polish-1 decides amber reintroduction)
 // - Semantic states derive from the SAME primary tokens as the row-action
-//   tones (var(--color-success|warning|destructive|info)), kept soft via a
-//   10% tint background — same hue and meaning as the solid action icons,
-//   just softer. This is the single source of the semantic badge palette;
-//   do not hand-roll status pills with ad-hoc /10 tints.
+//   tones, kept soft via a 10% tint background — same hue and meaning as the
+//   solid action icons, just softer. The TEXT uses the darker `*-text` token
+//   variant (var(--color-success-text) etc.) so small-size labels clear WCAG
+//   AA on the light tint; the solid token alone (~2.5:1) would fail.
+//   This is the single source of the semantic badge palette; do not hand-roll
+//   status pills with ad-hoc /10 tints.
 const badgeVariants = cva(
   'inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-xs font-medium transition-colors',
   {
@@ -24,13 +26,13 @@ const badgeVariants = cva(
         outline:
           'border-gray-200 text-gray-700',
         success:
-          'border-transparent bg-[var(--color-success)]/10 text-[var(--color-success)]',
+          'border-transparent bg-[var(--color-success)]/10 text-[var(--color-success-text)]',
         warning:
-          'border-transparent bg-[var(--color-warning)]/10 text-[var(--color-warning)]',
+          'border-transparent bg-[var(--color-warning)]/10 text-[var(--color-warning-text)]',
         destructive:
-          'border-transparent bg-[var(--color-destructive)]/10 text-[var(--color-destructive)]',
+          'border-transparent bg-[var(--color-destructive)]/10 text-[var(--color-destructive-text)]',
         info:
-          'border-transparent bg-[var(--color-info)]/10 text-[var(--color-info)]',
+          'border-transparent bg-[var(--color-info)]/10 text-[var(--color-info-text)]',
       },
     },
     defaultVariants: {

--- a/klai-portal/frontend/src/components/ui/tabs.tsx
+++ b/klai-portal/frontend/src/components/ui/tabs.tsx
@@ -19,6 +19,8 @@ export interface TabItem<T extends string = string> {
   count?: number
   /** Tone of the count badge. Defaults to `success`. */
   countTone?: TabCountTone
+  /** Accessible label for the count badge (e.g. "3 unread"). */
+  countLabel?: string
 }
 
 interface TabsProps<T extends string> extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
@@ -38,20 +40,57 @@ interface TabsProps<T extends string> extends Omit<React.HTMLAttributes<HTMLDivE
  * The active tab gets a near-black underline (`border-gray-900`) so the
  * active state is unmistakable against the gray-200 container divider. Icons
  * and counts are optional; text-only is the default, on-brand look.
+ *
+ * Implements the WAI-ARIA tablist keyboard pattern: roving tabindex (only the
+ * active tab is in the tab order) with Arrow/Home/End moving focus and
+ * activating the focused tab (selection follows focus).
  */
 function Tabs<T extends string>({ tabs, value, onValueChange, className, ...props }: TabsProps<T>) {
+  const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([])
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>, index: number) {
+    const last = tabs.length - 1
+    let next: number
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        next = index === last ? 0 : index + 1
+        break
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        next = index === 0 ? last : index - 1
+        break
+      case 'Home':
+        next = 0
+        break
+      case 'End':
+        next = last
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    onValueChange(tabs[next].id)
+    tabRefs.current[next]?.focus()
+  }
+
   return (
     <div role="tablist" className={cn('flex gap-6 border-b border-gray-200', className)} {...props}>
-      {tabs.map((tab) => {
+      {tabs.map((tab, index) => {
         const isActive = tab.id === value
         const Icon = tab.icon
         return (
           <button
             key={tab.id}
+            ref={(el) => {
+              tabRefs.current[index] = el
+            }}
             type="button"
             role="tab"
             aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
             onClick={() => onValueChange(tab.id)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
             className={cn(
               'flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 pb-2 text-sm font-medium transition-colors',
               isActive
@@ -63,6 +102,7 @@ function Tabs<T extends string>({ tabs, value, onValueChange, className, ...prop
             {tab.label}
             {typeof tab.count === 'number' && tab.count > 0 && (
               <span
+                aria-label={tab.countLabel}
                 className={cn(
                   'ml-0.5 inline-flex min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-medium leading-5 text-white',
                   tabCountToneClass[tab.countTone ?? 'success'],

--- a/klai-portal/frontend/src/routes/admin/join-requests.tsx
+++ b/klai-portal/frontend/src/routes/admin/join-requests.tsx
@@ -104,7 +104,7 @@ function AdminJoinRequestsPage() {
             </div>
           )}
           {controls.filteredCount === 0 ? (
-            <ListEmptyState title={m.admin_join_requests_empty()} />
+            <ListEmptyState title={m.admin_join_requests_no_matches()} />
           ) : (
             <DataTable>
               <DataTableHeader>

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -159,7 +159,13 @@ function AccountPage() {
 
   const tabs: TabItem<TabId>[] = [
     { id: 'settings', label: m.account_tab_settings(), icon: Settings },
-    { id: 'feedback', label: m.account_tab_feedback(), icon: MessageSquare, count: feedbackUnreadCount },
+    {
+      id: 'feedback',
+      label: m.account_tab_feedback(),
+      icon: MessageSquare,
+      count: feedbackUnreadCount,
+      countLabel: m.account_feedback_unread(),
+    },
     { id: 'advanced', label: m.account_tab_advanced(), icon: SlidersHorizontal },
   ]
 

--- a/klai-portal/frontend/src/routes/app/gaps/index.tsx
+++ b/klai-portal/frontend/src/routes/app/gaps/index.tsx
@@ -184,15 +184,15 @@ function GapsPage() {
       ) : gaps.length === 0 ? (
         <ListEmptyState title={m.gaps_empty_state()} />
       ) : (
-        <DataTable>
+        <DataTable className="table-fixed">
           <DataTableHeader>
             <DataTableRow>
               <DataTableHead>{m.gaps_column_query()}</DataTableHead>
-              <DataTableHead>{m.gaps_column_type()}</DataTableHead>
-              <DataTableHead>{m.gaps_column_nearest_kb()}</DataTableHead>
-              <DataTableHead align="right">{m.gaps_column_count()}</DataTableHead>
-              <DataTableHead align="right">{m.gaps_column_last()}</DataTableHead>
-              <DataTableHead align="right" />
+              <DataTableHead className="w-24">{m.gaps_column_type()}</DataTableHead>
+              <DataTableHead className="w-36">{m.gaps_column_nearest_kb()}</DataTableHead>
+              <DataTableHead align="right" className="w-20">{m.gaps_column_count()}</DataTableHead>
+              <DataTableHead align="right" className="w-28">{m.gaps_column_last()}</DataTableHead>
+              <DataTableHead align="right" className="w-12" />
             </DataTableRow>
           </DataTableHeader>
           <DataTableBody>
@@ -200,7 +200,9 @@ function GapsPage() {
               const rowKey = `${gap.query_text}-${gap.gap_type}`
               return (
                 <DataTableRow key={rowKey}>
-                  <DataTableCell>{gap.query_text}</DataTableCell>
+                  <DataTableCell className="truncate" title={gap.query_text}>
+                    {gap.query_text}
+                  </DataTableCell>
                   <DataTableCell>
                     <Badge variant={gap.gap_type === 'hard' ? 'destructive' : 'warning'}>
                       {gap.gap_type === 'hard' ? m.gaps_type_hard() : m.gaps_type_soft()}


### PR DESCRIPTION
Follow-up to #779 addressing an external LLM review.

- **WCAG AA**: Badge + Alert semantic text → darker `*-text` token variants (solid token on the /10–/5 tint was ~2.5:1; text-xs needs 4.5:1).
- **Tab a11y**: `Tabs` now implements the WAI-ARIA tablist keyboard pattern (roving tabindex + Arrow/Home/End) and restores the accessible count label.
- **gaps layout**: restored `table-fixed` + column widths + `truncate` so a long query can't reflow the table.
- **join-requests**: distinct "no matching" empty state on a search miss.
- docs + tests updated.

All green: tsc + eslint + 424 tests (same 3 pre-existing `main` failures, 0 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)