### PR TITLE
Conversation polish: back-right, calmer UI, admin master-detail + read-state

### DIFF
--- a/klai-portal/backend/alembic/versions/a7f3c1d9e2b4_add_admin_read_at_to_platform_threads.py
+++ b/klai-portal/backend/alembic/versions/a7f3c1d9e2b4_add_admin_read_at_to_platform_threads.py
@@ -1,0 +1,34 @@
+"""add admin_read_at to platform_message_threads
+
+Lets platform admins mark a thread as read by opening it (not only by replying),
+so the unread indicator clears on read. Nullable ADD COLUMN — metadata-only, no
+backfill, RLS-safe (no UPDATE/INSERT in upgrade). The table is owned by
+portal_api (created via op.create_table in m1n2o3p4q5r6), so ALTER TABLE here is
+permitted without a klai-superuser post-deploy step.
+
+Revision ID: a7f3c1d9e2b4
+Revises: n2o3p4q5r6s7
+Create Date: 2026-06-06
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a7f3c1d9e2b4"
+down_revision: Union[str, Sequence[str], None] = "n2o3p4q5r6s7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_message_threads",
+        sa.Column("admin_read_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_message_threads", "admin_read_at")

--- a/klai-portal/backend/app/api/admin/platform.py
+++ b/klai-portal/backend/app/api/admin/platform.py
@@ -542,14 +542,17 @@ async def platform_stats(
                               FROM platform_messages msg
                              WHERE msg.thread_id = thread.id
                                AND msg.sender_type = 'user'
-                          ) > COALESCE(
-                            (
-                              SELECT MAX(msg.created_at)
-                                FROM platform_messages msg
-                               WHERE msg.thread_id = thread.id
-                                 AND msg.sender_type IN ('platform_admin', 'system')
+                          ) > GREATEST(
+                            COALESCE(
+                              (
+                                SELECT MAX(msg.created_at)
+                                  FROM platform_messages msg
+                                 WHERE msg.thread_id = thread.id
+                                   AND msg.sender_type IN ('platform_admin', 'system')
+                              ),
+                              '-infinity'::timestamptz
                             ),
-                            '-infinity'::timestamptz
+                            COALESCE(thread.admin_read_at, '-infinity'::timestamptz)
                           )) AS unread_message_count,
                       (SELECT COUNT(*) FROM product_events
                          WHERE event_type LIKE '%error%'

--- a/klai-portal/backend/app/api/admin/platform_messages.py
+++ b/klai-portal/backend/app/api/admin/platform_messages.py
@@ -19,6 +19,7 @@ from app.platform_messaging.service import (
     add_platform_message_reply,
     create_platform_message_thread,
     get_platform_message_thread,
+    mark_platform_thread_admin_read,
 )
 from app.services.audit import log_event
 
@@ -170,6 +171,7 @@ def _thread_select():
             PlatformMessageThread.created_by.label("created_by"),
             PlatformMessageThread.created_at.label("created_at"),
             PlatformMessageThread.last_message_at.label("latest_message_at"),
+            PlatformMessageThread.admin_read_at.label("admin_read_at"),
             _latest_body_subquery().label("latest_message_body"),
             _latest_sender_type_subquery().label("latest_message_sender_type"),
             _latest_user_message_at_subquery().label("latest_user_message_at"),
@@ -182,8 +184,13 @@ def _thread_select():
 
 
 def _thread_out(row) -> PlatformMessageThreadOut:
+    # The admin has "seen" everything up to the later of their last reply and
+    # the last time they opened the thread. A newer user message = unread.
+    admin_read_at = getattr(row, "admin_read_at", None)
+    seen_candidates = [t for t in (row.latest_admin_message_at, admin_read_at) if t is not None]
+    seen_at = max(seen_candidates) if seen_candidates else None
     unread_for_admin = row.latest_user_message_at is not None and (
-        row.latest_admin_message_at is None or row.latest_user_message_at > row.latest_admin_message_at
+        seen_at is None or row.latest_user_message_at > seen_at
     )
     return PlatformMessageThreadOut(
         id=row.id,
@@ -346,6 +353,22 @@ async def platform_message_thread_reply(
                 sender_user_id=perms.user_id,
                 body=body.body,
             )
+            detail = await _load_thread_detail(db, thread_id)
+            await db.commit()
+            return detail
+        except PlatformMessageThreadNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Message thread not found") from exc
+
+
+@router.post("/threads/{thread_id}/read", response_model=PlatformMessageThreadDetailOut)
+async def platform_message_thread_mark_read(
+    thread_id: int,
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> PlatformMessageThreadDetailOut:
+    await _audit(perms, "read", str(thread_id))
+    async with cross_org_session() as db:
+        try:
+            await mark_platform_thread_admin_read(db, thread_id=thread_id)
             detail = await _load_thread_detail(db, thread_id)
             await db.commit()
             return detail

--- a/klai-portal/backend/app/platform_messaging/models.py
+++ b/klai-portal/backend/app/platform_messaging/models.py
@@ -39,6 +39,9 @@ class PlatformMessageThread(Base):
         nullable=False,
         server_default=func.now(),
     )
+    # Set when a platform admin opens the thread, so the admin unread indicator
+    # clears on read (not only when the admin replies).
+    admin_read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/klai-portal/backend/app/platform_messaging/service.py
+++ b/klai-portal/backend/app/platform_messaging/service.py
@@ -162,6 +162,15 @@ async def mark_platform_message_thread_read(
     return read_at
 
 
+async def mark_platform_thread_admin_read(db: AsyncSession, *, thread_id: int) -> datetime:
+    """Mark a thread as read by the platform admin (cross-org context)."""
+    thread = await get_platform_message_thread(db, thread_id)
+    read_at = datetime.now(UTC)
+    thread.admin_read_at = read_at
+    await db.flush()
+    return read_at
+
+
 async def user_can_access_thread(db: AsyncSession, *, thread_id: int, org_id: int, user_id: str) -> bool:
     participant = await db.scalar(
         select(PlatformMessageParticipant.thread_id).where(

--- a/klai-portal/backend/tests/test_platform_messages.py
+++ b/klai-portal/backend/tests/test_platform_messages.py
@@ -201,6 +201,69 @@ def test_platform_message_thread_out_clears_unread_after_admin_reply():
     assert result.unread_for_admin is False
 
 
+def test_platform_message_thread_out_clears_unread_after_admin_opens_thread():
+    # Admin opened (read) the thread after the user's last message, without
+    # replying. The unread indicator must clear on read, not only on reply.
+    user_reply_at = datetime(2026, 6, 6, 10, 0, tzinfo=UTC)
+    admin_read_at = datetime(2026, 6, 6, 10, 30, tzinfo=UTC)
+
+    result = platform_messages._thread_out(
+        SimpleNamespace(
+            id=99,
+            org_id=42,
+            org_name="Acme",
+            org_slug="acme",
+            subject="Vraag over je feedback",
+            status="open",
+            origin_type="direct",
+            feedback_submission_id=None,
+            feedback_item_id=None,
+            recipient_count=1,
+            latest_message_body="Reactie",
+            latest_message_sender_type="user",
+            latest_message_at=user_reply_at,
+            latest_user_message_at=user_reply_at,
+            latest_admin_message_at=None,
+            admin_read_at=admin_read_at,
+            created_by="staff",
+            created_at=user_reply_at,
+        )
+    )
+
+    assert result.unread_for_admin is False
+
+
+def test_platform_message_thread_out_unread_when_user_replies_after_admin_read():
+    # A new user message after the admin's last read re-marks the thread unread.
+    admin_read_at = datetime(2026, 6, 6, 10, 0, tzinfo=UTC)
+    user_reply_at = datetime(2026, 6, 6, 11, 0, tzinfo=UTC)
+
+    result = platform_messages._thread_out(
+        SimpleNamespace(
+            id=99,
+            org_id=42,
+            org_name="Acme",
+            org_slug="acme",
+            subject="Vraag over je feedback",
+            status="open",
+            origin_type="direct",
+            feedback_submission_id=None,
+            feedback_item_id=None,
+            recipient_count=1,
+            latest_message_body="Nog een vraag",
+            latest_message_sender_type="user",
+            latest_message_at=user_reply_at,
+            latest_user_message_at=user_reply_at,
+            latest_admin_message_at=None,
+            admin_read_at=admin_read_at,
+            created_by="staff",
+            created_at=admin_read_at,
+        )
+    )
+
+    assert result.unread_for_admin is True
+
+
 @pytest.mark.asyncio
 async def test_platform_message_thread_reply_uses_thread_org(monkeypatch):
     session = _Session()

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Loader2, Send } from 'lucide-react'
+import { ArrowLeft, Loader2, Send } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -151,13 +151,9 @@ export function ConversationTimeline({
     <div className={cn('space-y-5', className)}>
       {days.map((bucket) => (
         <div key={bucket.day} className="space-y-4">
-          <div className="flex items-center gap-3">
-            <span className="h-px flex-1 bg-gray-200" />
-            <span className="shrink-0 text-xs text-gray-400">
-              {formatDaySeparator(bucket.at, locale)}
-            </span>
-            <span className="h-px flex-1 bg-gray-200" />
-          </div>
+          <p className="text-center text-xs text-gray-400">
+            {formatDaySeparator(bucket.at, locale)}
+          </p>
 
           {bucket.blocks.map((block, index) =>
             'label' in block ? (
@@ -254,6 +250,81 @@ export function ConversationComposer({
           {sendLabel}
         </Button>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Full conversation detail surface: header (title + optional badge/actions, with
+ * the back action on the right per ui-standards "Back Actions"), the timeline,
+ * and the composer. Shared by account "Mijn meldingen"/"Berichten" and the
+ * platform-admin messages tab so the master→detail-with-back flow is identical.
+ */
+export function ConversationPanel({
+  title,
+  subtitle,
+  badge,
+  headerActions,
+  entries,
+  loading = false,
+  locale,
+  emptyLabel,
+  draft,
+  onDraftChange,
+  onSend,
+  isSending = false,
+  composerDisabled = false,
+  placeholder,
+  sendLabel,
+  onBack,
+}: {
+  title: string
+  subtitle?: string
+  badge?: React.ReactNode
+  headerActions?: React.ReactNode
+  entries: ConversationEntry[]
+  loading?: boolean
+  locale: 'nl' | 'en'
+  emptyLabel?: string
+  draft: string
+  onDraftChange: (value: string) => void
+  onSend: () => void
+  isSending?: boolean
+  composerDisabled?: boolean
+  placeholder?: string
+  sendLabel: string
+  onBack: () => void
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="truncate text-base font-display-bold text-gray-900">{title}</h2>
+            {badge}
+          </div>
+          {subtitle && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {headerActions}
+          <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            {m.account_conversation_back()}
+          </Button>
+        </div>
+      </div>
+
+      <ConversationTimeline entries={entries} locale={locale} loading={loading} emptyLabel={emptyLabel} />
+
+      <ConversationComposer
+        value={draft}
+        onChange={onDraftChange}
+        onSubmit={onSend}
+        isSubmitting={isSending}
+        disabled={composerDisabled}
+        placeholder={placeholder}
+        sendLabel={sendLabel}
+      />
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
-import { Activity, Bug, ExternalLink, Loader2, Send } from "lucide-react"
+import { Activity, Bug, ExternalLink } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { ConversationPanel, type ConversationEntry } from "@/components/ui/conversation"
 import {
   DataTable,
   DataTableBody,
@@ -11,9 +12,8 @@ import {
   DataTableHeader,
   DataTableRow,
 } from "@/components/ui/data-table"
-import { Label } from "@/components/ui/label"
 import { ListEmptyState, ListLoadingState } from "@/components/ui/list-state"
-import { Textarea } from "@/components/ui/textarea"
+import { getLocale } from "@/paraglide/runtime"
 import * as m from "@/paraglide/messages"
 import {
   usePlatformBots,
@@ -362,6 +362,71 @@ export function MessagesTab({
     )
   }
 
+  function backToList() {
+    setSelectedThreadId(null)
+    setReplyBody('')
+  }
+
+  if (selectedThreadId !== null) {
+    const detail = selectedThread.data
+    const isOpen = detail?.thread.status === 'open'
+    const entries: ConversationEntry[] = (detail?.messages ?? []).map((message) => ({
+      id: message.id,
+      side: message.sender_type === 'user' ? 'them' : 'me',
+      author:
+        message.sender_type === 'user'
+          ? m.platform_messages_sender_user()
+          : m.platform_messages_sender_admin(),
+      body: message.body,
+      at: message.created_at,
+    }))
+    const recipients = detail
+      ? detail.recipients.map((r) => r.display_name || r.email || r.user_id).join(', ')
+      : undefined
+
+    return (
+      <ConversationPanel
+        title={detail?.thread.subject ?? ''}
+        subtitle={recipients}
+        badge={
+          detail ? (
+            <Badge variant={isOpen ? 'success' : 'secondary'}>
+              {isOpen ? m.platform_messages_status_open() : m.platform_messages_status_closed()}
+            </Badge>
+          ) : undefined
+        }
+        headerActions={
+          detail ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              disabled={updateStatus.isPending}
+              onClick={() =>
+                updateStatus.mutate({
+                  threadId: detail.thread.id,
+                  status: isOpen ? 'closed' : 'open',
+                })
+              }
+            >
+              {isOpen ? m.platform_messages_close() : m.platform_messages_reopen()}
+            </Button>
+          ) : undefined
+        }
+        entries={entries}
+        loading={selectedThread.isLoading || !detail}
+        locale={getLocale() === 'en' ? 'en' : 'nl'}
+        draft={replyBody}
+        onDraftChange={setReplyBody}
+        onSend={sendReply}
+        isSending={reply.isPending}
+        placeholder={m.platform_messages_reply()}
+        sendLabel={m.platform_messages_send()}
+        onBack={backToList}
+      />
+    )
+  }
+
   return (
     <div className="space-y-6">
       {composeTarget && (
@@ -422,83 +487,6 @@ export function MessagesTab({
         </DataTable>
       )}
 
-      {selectedThreadId !== null && (
-        <section className="space-y-4 border-t border-gray-200 pt-6">
-          {selectedThread.isLoading || !selectedThread.data ? (
-            <ListLoadingState label={m.admin_shared_loading()} />
-          ) : (
-            <>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-base font-display-bold text-gray-900">
-                    {selectedThread.data.thread.subject}
-                  </h2>
-                  <p className="mt-1 text-sm text-gray-400">
-                    {selectedThread.data.recipients
-                      .map((recipient) => recipient.display_name || recipient.email || recipient.user_id)
-                      .join(', ')}
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  size="sm"
-                  disabled={updateStatus.isPending}
-                  onClick={() =>
-                    updateStatus.mutate({
-                      threadId: selectedThread.data.thread.id,
-                      status: selectedThread.data.thread.status === 'open' ? 'closed' : 'open',
-                    })
-                  }
-                >
-                  {selectedThread.data.thread.status === 'open'
-                    ? m.platform_messages_close()
-                    : m.platform_messages_reopen()}
-                </Button>
-              </div>
-              <div className="divide-y divide-gray-100 border-y border-gray-200">
-                {selectedThread.data.messages.map((message) => (
-                  <article key={message.id} className="py-4">
-                    <div className="mb-1 flex items-center gap-2 text-xs text-gray-400">
-                      <Badge variant={message.sender_type === 'user' ? 'outline' : 'secondary'}>
-                        {message.sender_type === 'user'
-                          ? m.platform_messages_sender_user()
-                          : m.platform_messages_sender_admin()}
-                      </Badge>
-                      <span>{fmtDate(message.created_at)}</span>
-                    </div>
-                    <p className="whitespace-pre-wrap text-sm leading-6 text-gray-900">
-                      {message.body}
-                    </p>
-                  </article>
-                ))}
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="platform-message-reply">{m.platform_messages_reply()}</Label>
-                <Textarea
-                  id="platform-message-reply"
-                  value={replyBody}
-                  rows={4}
-                  maxLength={4000}
-                  onChange={(event) => setReplyBody(event.target.value)}
-                />
-                <Button
-                  type="button"
-                  disabled={replyBody.trim().length === 0 || reply.isPending}
-                  onClick={sendReply}
-                >
-                  {reply.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Send className="h-4 w-4" />
-                  )}
-                  {m.platform_messages_send()}
-                </Button>
-              </div>
-            </>
-          )}
-        </section>
-      )}
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
@@ -19,6 +19,7 @@ import {
   usePlatformBots,
   usePlatformChatErrors,
   usePlatformKnowledgeBases,
+  usePlatformMarkMessageThreadRead,
   usePlatformMessageThread,
   usePlatformMessageThreads,
   usePlatformOrgs,
@@ -352,7 +353,14 @@ export function MessagesTab({
   const selectedThread = usePlatformMessageThread(selectedThreadId)
   const reply = usePlatformReplyMessageThread()
   const updateStatus = usePlatformUpdateMessageThreadStatus()
+  const markRead = usePlatformMarkMessageThreadRead()
   const [replyBody, setReplyBody] = useState('')
+
+  function openThread(thread: { id: number; unread_for_admin: boolean }) {
+    setSelectedThreadId(thread.id)
+    setReplyBody('')
+    if (thread.unread_for_admin) markRead.mutate(thread.id)
+  }
 
   function sendReply() {
     if (!selectedThreadId || replyBody.trim().length === 0) return
@@ -456,7 +464,7 @@ export function MessagesTab({
               <DataTableRow
                 key={thread.id}
                 interactive
-                onClick={() => setSelectedThreadId(thread.id)}
+                onClick={() => openThread(thread)}
               >
                 <DataTableCell>
                   <div className="flex items-center gap-2">

--- a/klai-portal/frontend/src/routes/admin/platform/-hooks.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-hooks.ts
@@ -243,6 +243,15 @@ export function usePlatformReplyMessageThread() {
   })
 }
 
+export function usePlatformMarkMessageThreadRead() {
+  const opts = usePlatformMessageMutation()
+  return useMutation({
+    mutationFn: async (threadId: number) =>
+      apiFetch(`/api/admin/platform/messages/threads/${threadId}/read`, { method: 'POST' }),
+    onSuccess: opts.onSuccess,
+  })
+}
+
 export function usePlatformUpdateMessageThreadStatus() {
   const opts = usePlatformMessageMutation()
   return useMutation({

--- a/klai-portal/frontend/src/routes/admin/route.tsx
+++ b/klai-portal/frontend/src/routes/admin/route.tsx
@@ -70,6 +70,7 @@ function AdminLayout() {
     queryFn: () =>
       apiFetch<{
         new_feedback_count: number
+        unread_message_count: number
         chat_error_count: number
       }>(
         '/api/admin/platform/stats',
@@ -88,7 +89,9 @@ function AdminLayout() {
   const unlocked = me?.platform_unlocked_features ?? []
 
   const platformAlertCount =
-    (platformStats?.new_feedback_count ?? 0) + (platformStats?.chat_error_count ?? 0)
+    (platformStats?.new_feedback_count ?? 0) +
+    (platformStats?.unread_message_count ?? 0) +
+    (platformStats?.chat_error_count ?? 0)
 
   const adminNav = ADMIN_NAV_ITEMS.filter((item) => {
     if (!meetsMinRole(effectiveRole, item.minRole)) return false

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { type ReactNode, useEffect, useState } from 'react'
 import { useAuth } from '@/lib/auth'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Bug, CheckCheck, Download, Inbox, Lightbulb, Loader2, MessageSquare, Settings, SlidersHorizontal } from 'lucide-react'
+import { Bug, CheckCheck, Download, Inbox, Lightbulb, Loader2, MessageSquare, Settings, SlidersHorizontal } from 'lucide-react'
 import { toast } from 'sonner'
 import { Badge, type BadgeProps } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -10,7 +10,7 @@ import { Tabs, type TabItem } from '@/components/ui/tabs'
 import { Label } from '@/components/ui/label'
 import { Select } from '@/components/ui/select'
 import { ListEmptyState, ListLoadingState } from '@/components/ui/list-state'
-import { ConversationComposer, ConversationTimeline, type ConversationEntry } from '@/components/ui/conversation'
+import { ConversationPanel, type ConversationEntry } from '@/components/ui/conversation'
 import { useLocale } from '@/lib/locale'
 import * as m from '@/paraglide/messages'
 import { ApiError, apiFetch } from '@/lib/apiFetch'
@@ -694,31 +694,21 @@ function ConversationDetail({
   onBack: () => void
 }) {
   return (
-    <div className="space-y-5">
-      <div className="flex items-start gap-3">
-        <Button type="button" variant="ghost" size="sm" className="-ml-2 shrink-0" onClick={onBack}>
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          {m.account_conversation_back()}
-        </Button>
-      </div>
-
-      <div className="flex items-start justify-between gap-3 border-b border-gray-200 pb-4">
-        <h2 className="min-w-0 text-base font-display-bold text-gray-900">{title}</h2>
-        {badge}
-      </div>
-      {subtitle && <p className="-mt-2 text-xs text-gray-400">{subtitle}</p>}
-
-      <ConversationTimeline entries={entries} locale={locale} loading={loading} />
-
-      <ConversationComposer
-        value={replyBody}
-        onChange={onReplyBodyChange}
-        onSubmit={onSubmitReply}
-        isSubmitting={isReplying}
-        placeholder={replyPlaceholder}
-        sendLabel={sendLabel}
-      />
-    </div>
+    <ConversationPanel
+      title={title}
+      subtitle={subtitle}
+      badge={badge}
+      entries={entries}
+      loading={loading}
+      locale={locale}
+      draft={replyBody}
+      onDraftChange={onReplyBodyChange}
+      onSend={onSubmitReply}
+      isSending={isReplying}
+      placeholder={replyPlaceholder}
+      sendLabel={sendLabel}
+      onBack={onBack}
+    />
   )
 }
 


### PR DESCRIPTION
Follow-up on the account/admin messaging UX, from screenshot feedback.

## Changes
1. **Back action placement** — moved to the right of the title per `ui-standards.md` "Back Actions" (was a loose pill above the title, the documented anti-pattern). Shared owned `ConversationPanel` now owns header + back-right + timeline + composer; account and admin both use it.
2. **Calmer chrome** — dropped the flanking lines on day separators and the header bottom border; fewer stacked hairlines, more whitespace.
3. **Platform admin "Berichten" master→detail** — click a thread → conversation with a back button (same flow as the account side), replacing the inline detail section under the table.
4. **Sidebar badge** — the Platform nav item now also counts unread platform messages (was only feedback + chat errors), so it shows a bubble when there are unread messages.
5. **Admin unread clears on read** — added `admin_read_at` on `platform_message_threads`; opening a thread marks it read (previously unread only cleared when the admin replied). `unread_for_admin` and the stats `unread_message_count` now use `GREATEST(last admin message, admin_read_at)`.

## Migration
`a7f3c1d9e2b4` — nullable `ADD COLUMN admin_read_at` on the portal_api-owned `platform_message_threads`. Metadata-only, no backfill, RLS-safe. Single alembic head.

## Tests
- Backend: `_thread_out` clears on admin-open + re-marks unread on a newer user message; existing unread tests still pass. ruff + pytest green (26).
- Frontend: conversation + feedback panel tests green (13). `tsc -b`, `eslint .` clean.

## Not in this PR (open product question)
"Sluiten" (thread close) semantics — addressed separately; see chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)