### PR TITLE
Inline-edit own messages in account conversations

### DIFF
--- a/klai-portal/backend/app/api/app_account.py
+++ b/klai-portal/backend/app/api/app_account.py
@@ -703,6 +703,47 @@ async def reply_to_platform_message_thread(
     return result
 
 
+@router.patch("/messages/{thread_id}/messages/{message_id}", response_model=AccountPlatformMessageReplyOut)
+async def edit_platform_message(
+    thread_id: int,
+    message_id: int,
+    body: AccountPlatformMessageReplyIn,
+    perms: UserPermissions = Depends(get_caller),
+    db: AsyncSession = Depends(get_db),
+) -> AccountPlatformMessageReplyOut:
+    """Edit one of the caller's own messages in a thread they participate in."""
+    text = body.body.strip()
+    if len(text) < 1 or len(text) > 4000:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Message body must be 1-4000 characters")
+    if not await user_can_access_thread(db, thread_id=thread_id, org_id=perms.org_id, user_id=perms.user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message thread not found")
+    message = (
+        await db.execute(
+            select(PlatformMessage).where(
+                PlatformMessage.id == message_id,
+                PlatformMessage.thread_id == thread_id,
+                PlatformMessage.org_id == perms.org_id,
+                PlatformMessage.sender_type == "user",
+                PlatformMessage.sender_user_id == perms.user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if message is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
+    message.body = text
+    result = AccountPlatformMessageReplyOut(
+        message=AccountPlatformMessageOut(
+            id=message.id,
+            sender_type=message.sender_type,
+            sender_user_id=message.sender_user_id,
+            body=message.body,
+            created_at=message.created_at,
+        )
+    )
+    await db.commit()
+    return result
+
+
 @router.post("/messages/{thread_id}/read", response_model=AccountPlatformMessageReadResponse)
 async def mark_platform_message_read(
     thread_id: int,

--- a/klai-portal/backend/tests/test_account_feedback_updates.py
+++ b/klai-portal/backend/tests/test_account_feedback_updates.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from app.api import app_account
 
@@ -409,3 +410,49 @@ async def test_account_platform_messages_reply_commits_after_service_helper(monk
     }
     assert result.message.body == "Dank voor je bericht."
     assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_account_edit_message_updates_own_message(monkeypatch):
+    now = datetime(2026, 6, 6, 10, 0, tzinfo=UTC)
+    message = SimpleNamespace(id=7, sender_type="user", sender_user_id="user-1", body="oud", created_at=now)
+    session = _Session([message])
+
+    async def fake_can_access(db, **_kwargs):
+        assert db is session
+        return True
+
+    monkeypatch.setattr(app_account, "user_can_access_thread", fake_can_access)
+
+    result = await app_account.edit_platform_message(
+        10,
+        7,
+        app_account.AccountPlatformMessageReplyIn(body="nieuw"),
+        perms=SimpleNamespace(org_id=1, user_id="user-1"),
+        db=session,
+    )
+
+    assert message.body == "nieuw"
+    assert result.message.body == "nieuw"
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_account_edit_message_404_when_not_owned(monkeypatch):
+    # scalar_one_or_none() returns None -> the message is not the caller's own.
+    session = _Session([])
+
+    async def fake_can_access(db, **_kwargs):
+        return True
+
+    monkeypatch.setattr(app_account, "user_can_access_thread", fake_can_access)
+
+    with pytest.raises(HTTPException) as exc:
+        await app_account.edit_platform_message(
+            10,
+            7,
+            app_account.AccountPlatformMessageReplyIn(body="x"),
+            perms=SimpleNamespace(org_id=1, user_id="user-1"),
+            db=session,
+        )
+    assert exc.value.status_code == 404

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -66,7 +66,7 @@ Build pages from these; never hand-roll a raw `<button>`, `<input>`,
 | `tooltip` | Hover/focus tooltips (used by `row-action`) | Yes |
 | `sonner` | Toasts (`toast()` feedback) | Yes |
 | `card` | Framed repeated items / stat blocks | Yes |
-| `conversation` | Message timeline + composer (`ConversationTimeline`, `ConversationComposer`): sender-grouped bubbles, day separators, quiet system lines, Cmd/Enter send. Shared by account "Mijn meldingen" + "Berichten" (and reusable by admin) | Yes |
+| `conversation` | Message timeline + composer + panel (`ConversationTimeline`, `ConversationComposer`, `ConversationPanel`): sender-grouped bubbles, day separators, quiet system lines, Cmd/Enter send, inline edit of own messages, back-right header. Shared by account "Mijn meldingen" + "Berichten" and the platform-admin messages tab | Yes |
 | `stat-card` | Metric tile (`StatCard`): uppercase label + large tabular value + optional sub. Sizes default/sm, `tone` (default/warning/destructive), `alert` frame, optional `onClick` to navigate | Yes |
 | `query-error-state` | Standard error block for failed queries | Yes |
 | `sheet` | Slide-over. **Forbidden** for admin entity detail (see Detail And Edit) | Restricted |
@@ -790,6 +790,10 @@ Rules (do not regress these):
   banner.
 - **The composer sends on Cmd/Ctrl + Enter**, clears on success, and the caller
   must surface send failures (toast) without discarding the typed text.
+- **Inline edit of own messages**: pass `onEditMessage(id, body)` and mark the
+  caller's own entries `editable`. A pencil appears on hover on the own bubble;
+  it swaps to a textarea with Save/Cancel via `InlineRowButton` (Cmd/Enter saves,
+  Esc cancels). Only `me`-side editable entries show it. No "(edited)" marker.
 - A feedback/melding conversation renders the original report and the Klai
   resolution as the first entries in the same timeline, so the report, the
   "opgelost" reply, and any follow-up read as one thread — not three stacked

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -393,6 +393,7 @@
   "account_conversation_yesterday": "Yesterday",
   "account_conversation_send_hint": "Cmd/Ctrl + Enter to send",
   "account_conversation_back": "Back to overview",
+  "account_conversation_edit": "Edit message",
   "account_messages_reply_placeholder": "Write a reply to the Klai team",
   "account_feedback_reply_placeholder": "Reply to this report",
   "account_feedback_marked_resolved": "Marked as resolved by the Klai team",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -393,6 +393,7 @@
   "account_conversation_yesterday": "Gisteren",
   "account_conversation_send_hint": "Cmd/Ctrl + Enter om te versturen",
   "account_conversation_back": "Terug naar overzicht",
+  "account_conversation_edit": "Bericht bewerken",
   "account_messages_reply_placeholder": "Schrijf een reactie aan het Klai-team",
   "account_feedback_reply_placeholder": "Reageer op deze melding",
   "account_feedback_marked_resolved": "Door het Klai-team gemarkeerd als opgelost",

--- a/klai-portal/frontend/src/components/ui/__tests__/conversation.test.tsx
+++ b/klai-portal/frontend/src/components/ui/__tests__/conversation.test.tsx
@@ -77,4 +77,42 @@ describe('ConversationTimeline', () => {
     render(<ConversationTimeline entries={[]} locale="nl" emptyLabel="Nog geen gesprek" />)
     expect(screen.getByText('Nog geen gesprek')).toBeTruthy()
   })
+
+  it('edits an editable own message via the inline editor (Cmd+Enter saves)', () => {
+    const onEditMessage = vi.fn()
+    const { container } = render(
+      <ConversationTimeline
+        entries={[{ id: 5, side: 'me', author: 'Jij', body: 'Hallo', at: '2026-06-05T11:20:00Z', editable: true }]}
+        locale="nl"
+        onEditMessage={onEditMessage}
+      />,
+    )
+    expect(container.querySelector('textarea')).toBeNull()
+    fireEvent.click(screen.getByRole('button'))
+    const textarea = container.querySelector('textarea')!
+    fireEvent.change(textarea, { target: { value: 'Aangepast bericht' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true })
+    expect(onEditMessage).toHaveBeenCalledWith(5, 'Aangepast bericht')
+  })
+
+  it('shows no edit affordance without onEditMessage', () => {
+    const { container } = render(
+      <ConversationTimeline
+        entries={[{ id: 6, side: 'me', author: 'Jij', body: 'x', at: '2026-06-05T11:20:00Z', editable: true }]}
+        locale="nl"
+      />,
+    )
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('shows no edit affordance for the other party', () => {
+    const { container } = render(
+      <ConversationTimeline
+        entries={[{ id: 7, side: 'them', author: 'Klai team', body: 'x', at: '2026-06-05T11:20:00Z', editable: true }]}
+        locale="nl"
+        onEditMessage={() => {}}
+      />,
+    )
+    expect(container.querySelector('button')).toBeNull()
+  })
 })

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import { ArrowLeft, Loader2, Send } from 'lucide-react'
+import { ArrowLeft, Check, Loader2, Pencil, Send, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { InlineRowButton } from '@/components/ui/inline-row-button'
 import { Textarea } from '@/components/ui/textarea'
 import * as m from '@/paraglide/messages'
 
@@ -19,6 +20,8 @@ export interface ConversationMessageEntry {
   author: string
   body: string
   at: string
+  /** When true and `onEditMessage` is provided, the bubble shows an edit affordance. */
+  editable?: boolean
 }
 
 export interface ConversationSystemEntry {
@@ -60,11 +63,17 @@ function formatDaySeparator(value: string, locale: 'nl' | 'en'): string {
   }).format(new Date(value))
 }
 
+interface MessageBody {
+  id: string | number
+  body: string
+  editable?: boolean
+}
+
 interface MessageGroup {
   side: 'me' | 'them'
   author: string
   at: string
-  bodies: { id: string | number; body: string }[]
+  bodies: MessageBody[]
 }
 
 /** Build day buckets, each with sender-grouped message runs and system lines. */
@@ -88,15 +97,20 @@ function buildLayout(entries: ConversationEntry[]) {
       bucket.blocks.push(entry)
       continue
     }
+    const body: MessageBody = {
+      id: entry.id,
+      body: entry.body,
+      editable: entry.editable,
+    }
     const last = bucket.blocks.at(-1)
     if (last && !('label' in last) && last.side === entry.side && last.author === entry.author) {
-      last.bodies.push({ id: entry.id, body: entry.body })
+      last.bodies.push(body)
     } else {
       bucket.blocks.push({
         side: entry.side,
         author: entry.author,
         at: entry.at,
-        bodies: [{ id: entry.id, body: entry.body }],
+        bodies: [body],
       })
     }
   }
@@ -109,6 +123,7 @@ export function ConversationTimeline({
   loading = false,
   emptyLabel,
   autoScroll = true,
+  onEditMessage,
   className,
 }: {
   entries: ConversationEntry[]
@@ -116,10 +131,25 @@ export function ConversationTimeline({
   loading?: boolean
   emptyLabel?: string
   autoScroll?: boolean
+  /** When provided, editable own messages show an inline edit affordance. */
+  onEditMessage?: (id: string | number, body: string) => void
   className?: string
 }) {
   const bottomRef = React.useRef<HTMLDivElement | null>(null)
   const count = entries.length
+  const [editingId, setEditingId] = React.useState<string | number | null>(null)
+  const [editDraft, setEditDraft] = React.useState('')
+
+  const startEdit = (id: string | number, body: string) => {
+    setEditingId(id)
+    setEditDraft(body)
+  }
+  const cancelEdit = () => setEditingId(null)
+  const saveEdit = (id: string | number) => {
+    const trimmed = editDraft.trim()
+    if (trimmed.length > 0) onEditMessage?.(id, trimmed)
+    setEditingId(null)
+  }
 
   React.useEffect(() => {
     const node = bottomRef.current
@@ -167,6 +197,13 @@ export function ConversationTimeline({
                 key={`grp-${block.side}-${index}-${block.bodies[0]?.id}`}
                 group={block}
                 locale={locale}
+                canEdit={!!onEditMessage}
+                editingId={editingId}
+                editDraft={editDraft}
+                onEditDraftChange={setEditDraft}
+                onStartEdit={startEdit}
+                onCancelEdit={cancelEdit}
+                onSaveEdit={saveEdit}
               />
             ),
           )}
@@ -177,26 +214,96 @@ export function ConversationTimeline({
   )
 }
 
-function MessageGroupView({ group, locale }: { group: MessageGroup; locale: 'nl' | 'en' }) {
+function MessageGroupView({
+  group,
+  locale,
+  canEdit,
+  editingId,
+  editDraft,
+  onEditDraftChange,
+  onStartEdit,
+  onCancelEdit,
+  onSaveEdit,
+}: {
+  group: MessageGroup
+  locale: 'nl' | 'en'
+  canEdit: boolean
+  editingId: string | number | null
+  editDraft: string
+  onEditDraftChange: (value: string) => void
+  onStartEdit: (id: string | number, body: string) => void
+  onCancelEdit: () => void
+  onSaveEdit: (id: string | number) => void
+}) {
   const isMe = group.side === 'me'
   return (
     <div className={cn('flex flex-col gap-1', isMe ? 'items-end' : 'items-start')}>
       <p className="px-1 text-xs text-gray-400">
         {group.author} · {formatTime(group.at, locale)}
       </p>
-      {group.bodies.map(({ id, body }) => (
-        <div
-          key={id}
-          className={cn(
-            'max-w-[82%] whitespace-pre-wrap break-words rounded-2xl px-3.5 py-2 text-sm leading-relaxed',
-            isMe
-              ? 'rounded-br-md bg-[var(--color-secondary)] text-[var(--color-foreground)]'
-              : 'rounded-bl-md border border-[var(--color-border)] bg-white text-[var(--color-foreground)]',
-          )}
-        >
-          {body}
-        </div>
-      ))}
+      {group.bodies.map((message) => {
+        const showEdit = canEdit && isMe && message.editable
+        if (editingId === message.id) {
+          return (
+            <div key={message.id} className="w-full max-w-[82%] self-end">
+              <Textarea
+                value={editDraft}
+                rows={2}
+                maxLength={4000}
+                autoFocus
+                onChange={(event) => onEditDraftChange(event.target.value)}
+                onKeyDown={(event) => {
+                  if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                    event.preventDefault()
+                    onSaveEdit(message.id)
+                  } else if (event.key === 'Escape') {
+                    event.preventDefault()
+                    onCancelEdit()
+                  }
+                }}
+              />
+              <div className="mt-1 flex justify-end gap-2">
+                <InlineRowButton tone="success" onClick={() => onSaveEdit(message.id)}>
+                  <Check />
+                  {m.admin_shared_save()}
+                </InlineRowButton>
+                <InlineRowButton onClick={onCancelEdit}>
+                  <X />
+                  {m.admin_users_cancel()}
+                </InlineRowButton>
+              </div>
+            </div>
+          )
+        }
+        return (
+          <div
+            key={message.id}
+            className={cn('group/bubble flex max-w-[85%] items-center gap-1.5', isMe ? 'self-end' : 'self-start')}
+          >
+            {showEdit && (
+              <button
+                type="button"
+                onClick={() => onStartEdit(message.id, message.body)}
+                aria-label={m.account_conversation_edit()}
+                title={m.account_conversation_edit()}
+                className="shrink-0 text-gray-300 opacity-0 transition-opacity hover:text-gray-600 group-hover/bubble:opacity-100"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+            )}
+            <div
+              className={cn(
+                'max-w-full whitespace-pre-wrap break-words rounded-2xl px-3.5 py-2 text-sm leading-relaxed',
+                isMe
+                  ? 'rounded-br-md bg-[var(--color-secondary)] text-[var(--color-foreground)]'
+                  : 'rounded-bl-md border border-[var(--color-border)] bg-white text-[var(--color-foreground)]',
+              )}
+            >
+              {message.body}
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }
@@ -276,6 +383,7 @@ export function ConversationPanel({
   composerDisabled = false,
   placeholder,
   sendLabel,
+  onEditMessage,
   onBack,
 }: {
   title: string
@@ -293,6 +401,7 @@ export function ConversationPanel({
   composerDisabled?: boolean
   placeholder?: string
   sendLabel: string
+  onEditMessage?: (id: string | number, body: string) => void
   onBack: () => void
 }) {
   return (
@@ -314,7 +423,13 @@ export function ConversationPanel({
         </div>
       </div>
 
-      <ConversationTimeline entries={entries} locale={locale} loading={loading} emptyLabel={emptyLabel} />
+      <ConversationTimeline
+        entries={entries}
+        locale={locale}
+        loading={loading}
+        emptyLabel={emptyLabel}
+        onEditMessage={onEditMessage}
+      />
 
       <ConversationComposer
         value={draft}

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -389,6 +389,19 @@ function AccountMessagesPanel({
     onError: () => toast.error(m.account_messages_error()),
   })
 
+  const editMutation = useMutation({
+    mutationFn: (vars: { threadId: number; messageId: number; body: string }) =>
+      apiFetch(`/api/app/account/messages/${vars.threadId}/messages/${vars.messageId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ body: vars.body }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['account-platform-messages'] })
+      void queryClient.invalidateQueries({ queryKey: ['account-platform-message-thread'] })
+    },
+    onError: () => toast.error(m.account_messages_error()),
+  })
+
   function openThread(thread: AccountPlatformMessageThread) {
     setSelectedThreadId(thread.id)
     setReplyBody('')
@@ -414,6 +427,7 @@ function AccountMessagesPanel({
       author: message.sender_type === 'user' ? m.account_messages_you() : m.account_messages_platform_admin(),
       body: message.body,
       at: message.created_at,
+      editable: message.sender_type === 'user',
     }))
 
     return (
@@ -433,6 +447,9 @@ function AccountMessagesPanel({
         isReplying={replyMutation.isPending}
         replyPlaceholder={m.account_messages_reply_placeholder()}
         sendLabel={m.account_messages_send()}
+        onEditMessage={(id, body) =>
+          editMutation.mutate({ threadId: selectedThreadId, messageId: Number(id), body })
+        }
         onBack={back}
       />
     )
@@ -536,6 +553,16 @@ function FeedbackUpdatesPanel({
     onError: () => toast.error(m.account_feedback_error()),
   })
 
+  const editMutation = useMutation({
+    mutationFn: (vars: { threadId: number; messageId: number; body: string }) =>
+      apiFetch(`/api/app/account/messages/${vars.threadId}/messages/${vars.messageId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ body: vars.body }),
+      }),
+    onSuccess: () => void queryClient.invalidateQueries({ queryKey: ['account-platform-message-thread'] }),
+    onError: () => toast.error(m.account_feedback_error()),
+  })
+
   function openItem(item: AccountFeedbackUpdate) {
     setSelectedSubmissionId(item.submission_id)
     setReplyBody('')
@@ -572,6 +599,12 @@ function FeedbackUpdatesPanel({
         isReplying={replyMutation.isPending}
         replyPlaceholder={m.account_feedback_reply_placeholder()}
         sendLabel={m.account_feedback_send()}
+        onEditMessage={
+          selectedThreadId !== null
+            ? (id, body) =>
+                editMutation.mutate({ threadId: selectedThreadId, messageId: Number(id), body })
+            : undefined
+        }
         onBack={back}
       />
     )
@@ -645,6 +678,7 @@ function buildFeedbackEntries(
         author: message.sender_type === 'user' ? m.account_messages_you() : m.account_messages_platform_admin(),
         body: message.body,
         at: message.created_at,
+        editable: message.sender_type === 'user',
       })
     }
   }
@@ -677,6 +711,7 @@ function ConversationDetail({
   isReplying,
   replyPlaceholder,
   sendLabel,
+  onEditMessage,
   onBack,
 }: {
   title: string
@@ -691,6 +726,7 @@ function ConversationDetail({
   isReplying: boolean
   replyPlaceholder: string
   sendLabel: string
+  onEditMessage?: (id: string | number, body: string) => void
   onBack: () => void
 }) {
   return (
@@ -707,6 +743,7 @@ function ConversationDetail({
       isSending={isReplying}
       placeholder={replyPlaceholder}
       sendLabel={sendLabel}
+      onEditMessage={onEditMessage}
       onBack={onBack}
     />
   )

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -259,7 +259,7 @@ const conversationEntries: ConversationEntry[] = [
   { id: 'a1', side: 'them', author: 'Klai team', body: 'Bedankt voor je melding — we kijken ernaar.', at: '2026-06-04T09:40:00Z' },
   { id: 'a2', side: 'them', author: 'Klai team', body: 'Dit is opgelost in de release van vanochtend. Wil je het nog even checken?', at: '2026-06-05T11:03:00Z' },
   { type: 'system', id: 's1', label: 'Door het Klai-team gemarkeerd als opgelost', at: '2026-06-05T11:03:30Z' },
-  { id: 'r2', side: 'me', author: 'Jij', body: 'Top, het werkt weer. Bedankt!', at: '2026-06-05T11:20:00Z' },
+  { id: 'r2', side: 'me', author: 'Jij', body: 'Top, het werkt weer. Bedankt!', at: '2026-06-05T11:20:00Z', editable: true },
 ]
 const dividerListGrid = 'lg:grid-cols-[minmax(0,1fr)_144px]'
 
@@ -792,7 +792,11 @@ function UiCatalogPage() {
 
       <Section title="Conversation">
         <div className="max-w-xl space-y-5">
-          <ConversationTimeline entries={conversationEntries} locale="nl" />
+          <ConversationTimeline
+            entries={conversationEntries}
+            locale="nl"
+            onEditMessage={() => {}}
+          />
           <ConversationComposer
             value={conversationDraft}
             onChange={setConversationDraft}
@@ -803,9 +807,10 @@ function UiCatalogPage() {
           <p className="text-xs text-gray-400">
             Eén rustige tijdlijn: gegroepeerd per afzender en dag, met
             dag-scheiders en stille systeemregels (statuswijzigingen). Eigen
-            berichten rechts (cream), Klai-team links (wit met rand). De composer
-            verstuurt met Cmd/Ctrl + Enter. Gedeeld door account-meldingen en de
-            Berichten-tab.
+            berichten rechts (cream), Klai-team links (wit met rand). Eigen
+            (editable) berichten tonen op hover een potlood voor inline bewerken
+            (Save/Cancel via InlineRowButton). De composer verstuurt met
+            Cmd/Ctrl + Enter. Gedeeld door account-meldingen en de Berichten-tab.
           </p>
         </div>
       </Section>


### PR DESCRIPTION
Account users can edit their own sent messages inline, in the existing Klai inline-edit pattern.

## UX
- Pencil appears on hover on the own bubble → swaps to a textarea with Save/Cancel via `InlineRowButton`. Cmd/Ctrl+Enter saves, Esc cancels. No "(edited)" marker (per request).
- Only the caller's own real thread messages are editable; the synthesized feedback report/resolution entries are not.
- Lives in the owned `conversation` component (`onEditMessage` + `editable` flag), so account "Berichten" and "Mijn meldingen" both get it.

## Backend
- `PATCH /api/app/account/messages/{thread_id}/messages/{message_id}` updates the body of the caller's own (`sender_type='user'`, `sender_user_id == caller`) message in a thread they participate in; 404 otherwise. No schema change.

## Tests
- Frontend: inline editor saves via Cmd+Enter; no affordance without `onEditMessage` or for the other party. (16 conversation/feedback tests green.)
- Backend: edit updates own message; 404 when not owned. (ruff + pytest green.)
- `tsc -b`, `eslint .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)