### PR TITLE
Show individual Klai sender name + admin inline message edit

### DIFF
--- a/klai-portal/backend/alembic/versions/b8e2d4f6a1c3_add_sender_display_name_to_platform_messages.py
+++ b/klai-portal/backend/alembic/versions/b8e2d4f6a1c3_add_sender_display_name_to_platform_messages.py
@@ -1,0 +1,37 @@
+"""add sender_display_name to platform_messages
+
+Stores a point-in-time snapshot of the sender's display name on each message, so
+the account side can show the individual Klai team member who sent a message
+(instead of a generic "Klai team") without a cross-org live lookup. Like the
+"From" line of an email, it must survive renames/offboarding.
+
+Nullable ADD COLUMN — metadata-only, no backfill, RLS-safe. platform_messages is
+portal_api-owned (created via op.create_table in m1n2o3p4q5r6), so ALTER TABLE is
+permitted without a klai-superuser post-deploy step.
+
+Revision ID: b8e2d4f6a1c3
+Revises: p1r2o3d4u5p6
+Create Date: 2026-06-06
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "b8e2d4f6a1c3"
+down_revision: Union[str, Sequence[str], None] = "p1r2o3d4u5p6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "platform_messages",
+        sa.Column("sender_display_name", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("platform_messages", "sender_display_name")

--- a/klai-portal/backend/app/api/admin/platform_messages.py
+++ b/klai-portal/backend/app/api/admin/platform_messages.py
@@ -11,7 +11,7 @@ from sqlalchemy import bindparam, func, or_, select
 
 from app.core.database import cross_org_session
 from app.core.permissions import UserPermissions, require_platform_admin
-from app.models.portal import PortalOrg
+from app.models.portal import PortalOrg, PortalUser
 from app.platform_messaging.models import PlatformMessage, PlatformMessageParticipant, PlatformMessageThread
 from app.platform_messaging.service import (
     PlatformMessageRecipientError,
@@ -37,6 +37,7 @@ class PlatformMessageOut(BaseModel):
     id: int
     sender_type: str
     sender_user_id: str | None
+    sender_display_name: str | None = None
     body: str
     created_at: datetime
 
@@ -256,6 +257,7 @@ async def _load_thread_detail(db, thread_id: int) -> PlatformMessageThreadDetail
                 id=message.id,
                 sender_type=message.sender_type,
                 sender_user_id=message.sender_user_id,
+                sender_display_name=message.sender_display_name,
                 body=message.body,
                 created_at=message.created_at,
             )
@@ -310,6 +312,11 @@ async def platform_message_thread_detail(
             raise HTTPException(status_code=404, detail="Message thread not found") from exc
 
 
+async def _resolve_admin_display_name(db, user_id: str) -> str | None:
+    """Snapshot the sending admin's display name (cross-org; Klai staff org)."""
+    return await db.scalar(select(PortalUser.display_name).where(PortalUser.zitadel_user_id == user_id))
+
+
 @router.post("/threads", response_model=PlatformMessageThreadDetailOut, status_code=status.HTTP_201_CREATED)
 async def platform_message_thread_create(
     body: PlatformMessageThreadCreateIn,
@@ -325,6 +332,7 @@ async def platform_message_thread_create(
                 subject=body.subject,
                 body=body.body,
                 created_by=perms.user_id,
+                sender_display_name=await _resolve_admin_display_name(db, perms.user_id),
                 feedback_submission_id=body.feedback_submission_id,
                 feedback_item_id=body.feedback_item_id,
             )
@@ -352,6 +360,7 @@ async def platform_message_thread_reply(
                 sender_type="platform_admin",
                 sender_user_id=perms.user_id,
                 body=body.body,
+                sender_display_name=await _resolve_admin_display_name(db, perms.user_id),
             )
             detail = await _load_thread_detail(db, thread_id)
             await db.commit()
@@ -374,6 +383,34 @@ async def platform_message_thread_mark_read(
             return detail
         except PlatformMessageThreadNotFoundError as exc:
             raise HTTPException(status_code=404, detail="Message thread not found") from exc
+
+
+@router.patch("/threads/{thread_id}/messages/{message_id}", response_model=PlatformMessageThreadDetailOut)
+async def platform_message_edit(
+    thread_id: int,
+    message_id: int,
+    body: PlatformMessageReplyIn,
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> PlatformMessageThreadDetailOut:
+    """Edit a Klai-team message the calling admin sent themselves."""
+    await _audit(perms, "edit", str(thread_id))
+    async with cross_org_session() as db:
+        message = (
+            await db.execute(
+                select(PlatformMessage).where(
+                    PlatformMessage.id == message_id,
+                    PlatformMessage.thread_id == thread_id,
+                    PlatformMessage.sender_user_id == perms.user_id,
+                    PlatformMessage.sender_type.in_(("platform_admin", "system")),
+                )
+            )
+        ).scalar_one_or_none()
+        if message is None:
+            raise HTTPException(status_code=404, detail="Message not found")
+        message.body = body.body
+        detail = await _load_thread_detail(db, thread_id)
+        await db.commit()
+        return detail
 
 
 @router.patch("/threads/{thread_id}/status", response_model=PlatformMessageThreadDetailOut)

--- a/klai-portal/backend/app/api/app_account.py
+++ b/klai-portal/backend/app/api/app_account.py
@@ -163,6 +163,7 @@ class AccountPlatformMessageOut(BaseModel):
     id: int
     sender_type: str
     sender_user_id: str | None = None
+    sender_display_name: str | None = None
     body: str
     created_at: datetime
 
@@ -572,6 +573,7 @@ async def _load_account_message_thread_detail(
                 id=message.id,
                 sender_type=message.sender_type,
                 sender_user_id=message.sender_user_id,
+                sender_display_name=message.sender_display_name,
                 body=message.body,
                 created_at=message.created_at,
             )

--- a/klai-portal/backend/app/platform_messaging/models.py
+++ b/klai-portal/backend/app/platform_messaging/models.py
@@ -94,5 +94,8 @@ class PlatformMessage(Base):
     org_id: Mapped[int] = mapped_column(Integer, ForeignKey("portal_orgs.id", ondelete="CASCADE"), nullable=False)
     sender_type: Mapped[str] = mapped_column(String(32), nullable=False)
     sender_user_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Point-in-time snapshot of the sender's display name (e.g. the Klai team
+    # member who replied), so historical attribution survives renames/offboarding.
+    sender_display_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     body: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/klai-portal/backend/app/platform_messaging/service.py
+++ b/klai-portal/backend/app/platform_messaging/service.py
@@ -33,6 +33,7 @@ async def create_platform_message_thread(
     subject: str,
     body: str,
     created_by: str,
+    sender_display_name: str | None = None,
     feedback_submission_id: int | None = None,
     feedback_item_id: int | None = None,
 ) -> PlatformMessageThread:
@@ -102,6 +103,7 @@ async def create_platform_message_thread(
             org_id=org_id,
             sender_type="platform_admin",
             sender_user_id=created_by,
+            sender_display_name=sender_display_name,
             body=body,
             created_at=now,
         )
@@ -118,6 +120,7 @@ async def add_platform_message_reply(
     sender_type: str,
     sender_user_id: str,
     body: str,
+    sender_display_name: str | None = None,
 ) -> PlatformMessage:
     thread = await get_platform_message_thread(db, thread_id)
     if thread.org_id != org_id:
@@ -128,6 +131,7 @@ async def add_platform_message_reply(
         org_id=org_id,
         sender_type=sender_type,
         sender_user_id=sender_user_id,
+        sender_display_name=sender_display_name,
         body=body,
         created_at=now,
     )

--- a/klai-portal/backend/tests/test_platform_messages.py
+++ b/klai-portal/backend/tests/test_platform_messages.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from app.api.admin import platform_messages
 from app.core import database as db_module
@@ -24,6 +25,10 @@ class _Session:
 
     async def commit(self):
         self.commits += 1
+        return None
+
+    async def scalar(self, *_args, **_kwargs):
+        # _resolve_admin_display_name() does a scalar lookup; tests don't care.
         return None
 
 
@@ -304,9 +309,90 @@ async def test_platform_message_thread_reply_uses_thread_org(monkeypatch):
         "sender_type": "platform_admin",
         "sender_user_id": "staff",
         "body": "Dank voor je reactie.",
+        "sender_display_name": None,
     }
     assert result.thread.id == 99
     assert session.commits == 1
+
+
+class _EditSession:
+    def __init__(self, message):
+        self.message = message
+        self.commits = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return None
+
+    async def execute(self, _query):
+        message = self.message
+
+        class _Res:
+            def scalar_one_or_none(self):
+                return message
+
+        return _Res()
+
+    async def commit(self):
+        self.commits += 1
+
+
+@pytest.mark.asyncio
+async def test_platform_message_edit_updates_own_message(monkeypatch):
+    now = datetime(2026, 6, 6, 10, 0, tzinfo=UTC)
+    message = SimpleNamespace(
+        id=5,
+        sender_type="platform_admin",
+        sender_user_id="staff",
+        sender_display_name="Mark",
+        body="oud",
+        created_at=now,
+    )
+    session = _EditSession(message)
+
+    async def fake_audit(*_args, **_kwargs):
+        return None
+
+    async def fake_detail(db, thread_id):
+        assert db is session
+        return _detail(thread_id)
+
+    monkeypatch.setattr(platform_messages, "_audit", fake_audit)
+    monkeypatch.setattr(platform_messages, "cross_org_session", lambda: session)
+    monkeypatch.setattr(platform_messages, "_load_thread_detail", fake_detail)
+
+    result = await platform_messages.platform_message_edit(
+        99,
+        5,
+        platform_messages.PlatformMessageReplyIn(body="nieuw"),
+        perms=SimpleNamespace(org_id=1, user_id="staff"),
+    )
+
+    assert message.body == "nieuw"
+    assert session.commits == 1
+    assert result.thread.id == 99
+
+
+@pytest.mark.asyncio
+async def test_platform_message_edit_404_when_not_own(monkeypatch):
+    session = _EditSession(None)
+
+    async def fake_audit(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(platform_messages, "_audit", fake_audit)
+    monkeypatch.setattr(platform_messages, "cross_org_session", lambda: session)
+
+    with pytest.raises(HTTPException) as exc:
+        await platform_messages.platform_message_edit(
+            99,
+            5,
+            platform_messages.PlatformMessageReplyIn(body="nieuw"),
+            perms=SimpleNamespace(org_id=1, user_id="staff"),
+        )
+    assert exc.value.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
@@ -1,5 +1,8 @@
 import { useNavigate } from "@tanstack/react-router"
+import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
+import { useAuth } from "@/lib/auth"
+import { fetchMe } from "@/lib/api-me"
 import { Activity, Bug, ExternalLink } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,6 +22,7 @@ import {
   usePlatformBots,
   usePlatformChatErrors,
   usePlatformKnowledgeBases,
+  usePlatformEditMessage,
   usePlatformMarkMessageThreadRead,
   usePlatformMessageThread,
   usePlatformMessageThreads,
@@ -354,6 +358,14 @@ export function MessagesTab({
   const reply = usePlatformReplyMessageThread()
   const updateStatus = usePlatformUpdateMessageThreadStatus()
   const markRead = usePlatformMarkMessageThreadRead()
+  const editMessage = usePlatformEditMessage()
+  const auth = useAuth()
+  const meQuery = useQuery({
+    queryKey: ['me'],
+    queryFn: ({ signal }) => fetchMe(signal),
+    enabled: auth.isAuthenticated,
+  })
+  const myUserId = meQuery.data?.user_id
   const [replyBody, setReplyBody] = useState('')
 
   function openThread(thread: { id: number; unread_for_admin: boolean }) {
@@ -384,9 +396,10 @@ export function MessagesTab({
       author:
         message.sender_type === 'user'
           ? m.platform_messages_sender_user()
-          : m.platform_messages_sender_admin(),
+          : message.sender_display_name || m.platform_messages_sender_admin(),
       body: message.body,
       at: message.created_at,
+      editable: message.sender_user_id != null && message.sender_user_id === myUserId,
     }))
     const recipients = detail
       ? detail.recipients.map((r) => r.display_name || r.email || r.user_id).join(', ')
@@ -430,6 +443,12 @@ export function MessagesTab({
         isSending={reply.isPending}
         placeholder={m.platform_messages_reply()}
         sendLabel={m.platform_messages_send()}
+        onEditMessage={
+          selectedThreadId !== null
+            ? (id, body) =>
+                editMessage.mutate({ threadId: selectedThreadId, messageId: Number(id), body })
+            : undefined
+        }
         onBack={backToList}
       />
     )

--- a/klai-portal/frontend/src/routes/admin/platform/-hooks.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-hooks.ts
@@ -252,6 +252,18 @@ export function usePlatformMarkMessageThreadRead() {
   })
 }
 
+export function usePlatformEditMessage() {
+  const opts = usePlatformMessageMutation()
+  return useMutation({
+    mutationFn: async (vars: { threadId: number; messageId: number; body: string }) =>
+      apiFetch<PlatformMessageThreadDetail>(
+        `/api/admin/platform/messages/threads/${vars.threadId}/messages/${vars.messageId}`,
+        { method: 'PATCH', body: JSON.stringify({ body: vars.body }) },
+      ),
+    onSuccess: opts.onSuccess,
+  })
+}
+
 export function usePlatformUpdateMessageThreadStatus() {
   const opts = usePlatformMessageMutation()
   return useMutation({

--- a/klai-portal/frontend/src/routes/admin/platform/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-types.ts
@@ -240,6 +240,7 @@ export interface PlatformMessage {
   id: number
   sender_type: string
   sender_user_id: string | null
+  sender_display_name: string | null
   body: string
   created_at: string
 }

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -85,6 +85,7 @@ interface AccountPlatformMessage {
   id: number
   sender_type: string
   sender_user_id?: string | null
+  sender_display_name?: string | null
   body: string
   created_at: string
 }
@@ -424,7 +425,10 @@ function AccountMessagesPanel({
     const entries: ConversationEntry[] = (detail?.messages ?? []).map((message) => ({
       id: message.id,
       side: message.sender_type === 'user' ? 'me' : 'them',
-      author: message.sender_type === 'user' ? m.account_messages_you() : m.account_messages_platform_admin(),
+      author:
+        message.sender_type === 'user'
+          ? m.account_messages_you()
+          : message.sender_display_name || m.account_messages_platform_admin(),
       body: message.body,
       at: message.created_at,
       editable: message.sender_type === 'user',
@@ -675,7 +679,10 @@ function buildFeedbackEntries(
       entries.push({
         id: message.id,
         side: message.sender_type === 'user' ? 'me' : 'them',
-        author: message.sender_type === 'user' ? m.account_messages_you() : m.account_messages_platform_admin(),
+        author:
+          message.sender_type === 'user'
+            ? m.account_messages_you()
+            : message.sender_display_name || m.account_messages_platform_admin(),
         body: message.body,
         at: message.created_at,
         editable: message.sender_type === 'user',


### PR DESCRIPTION
Follow-up: show the individual Klai team member's name on messages, and let admins edit their own messages inline (account side already shipped).

## Sender name (the "is dat de mooiste oplossing?" answer: yes — snapshot)
- New nullable `platform_messages.sender_display_name`, set at send time with the admin's display name (resolved cross-org from `portal_users`).
- Account side shows the individual sender instead of "Klai team" (fallback "Klai team" when absent).
- Point-in-time snapshot (like email "From"): survives renames/offboarding, no cross-org live lookup, no privacy leak of the Klai org's user list.
- Migration `b8e2d4f6a1c3`: nullable `ADD COLUMN`, metadata-only, RLS-safe, no backfill. Single alembic head.

## Admin inline edit
- The platform-admin Berichten tab now lets an admin edit their **own** Klai-team messages inline (same pencil → textarea → Save/Cancel as the account side), via the shared `ConversationPanel`.
- `PATCH /admin/platform/messages/threads/{id}/messages/{message_id}` edits only the caller's own `platform_admin`/`system` message; 404 otherwise.
- (Account-side inline edit shipped in the previous PR; this was account-only, hence not visible on the admin console — now both sides have it.)

## Tests
- Backend: admin edit (own + 404), `sender_display_name` plumbing through create/reply. 18 platform-message + account suites green. ruff + format clean.
- Frontend: `tsc -b`, `eslint .`, vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)