### PR TITLE
Polish conversation: zero-shift edit, separate Berichten/feedback, race-safe reply

### DIFF
--- a/klai-portal/backend/app/api/app_account.py
+++ b/klai-portal/backend/app/api/app_account.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import cross_org_session, get_db
@@ -419,6 +420,13 @@ async def reply_to_feedback_update(
     subject_text = feedback_row.item_title or (fallback_subject_lines[0] if fallback_subject_lines else "")
     subject = subject_text[:256] or "Feedback follow-up"
     async with cross_org_session() as message_db:
+        # Serialize concurrent first-replies for the same submission (double-click,
+        # two tabs) so they can't each create a thread. The advisory lock is held
+        # until this transaction commits; the second caller then finds the thread.
+        await message_db.execute(
+            sa_text("SELECT pg_advisory_xact_lock(:key)"),
+            {"key": submission_id},
+        )
         existing_thread = (
             (
                 await message_db.execute(
@@ -616,6 +624,10 @@ async def get_platform_messages(
             .where(
                 PlatformMessageParticipant.org_id == perms.org_id,
                 PlatformMessageParticipant.user_id == perms.user_id,
+                # Direct admin-initiated messages only. Feedback-linked threads
+                # live under "Mijn meldingen" — keep the two surfaces separate
+                # so a feedback reply never double-surfaces here.
+                PlatformMessageThread.origin_type == "direct",
             )
             .order_by(PlatformMessageThread.last_message_at.desc())
             .limit(safe_limit)

--- a/klai-portal/backend/tests/test_account_feedback_updates.py
+++ b/klai-portal/backend/tests/test_account_feedback_updates.py
@@ -128,7 +128,7 @@ class _MessageSession:
     async def __aexit__(self, *_exc):
         return None
 
-    async def execute(self, _query):
+    async def execute(self, _query, *_args, **_kwargs):
         return _Result(self.rows)
 
     def add(self, row):
@@ -306,6 +306,9 @@ async def test_account_platform_messages_returns_only_current_user_threads():
     compiled = str(session.queries[0].compile(compile_kwargs={"literal_binds": True}))
     assert "platform_message_participants.org_id = 42" in compiled
     assert "platform_message_participants.user_id = 'user-123'" in compiled
+    # Berichten shows direct messages only; feedback-linked threads live under
+    # "Mijn meldingen" so a feedback reply never double-surfaces here.
+    assert "platform_message_threads.origin_type = 'direct'" in compiled
 
 
 def test_account_platform_message_query_compiles_without_auto_correlation():

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -214,8 +214,21 @@ export function ConversationTimeline({
   )
 }
 
-/** Inline message editor that auto-grows to its content so the timeline does
- *  not jump when a (possibly long) bubble is swapped for the textarea. */
+// Shared bubble geometry. The real bubble, and the ghost that sizes the inline
+// editor, MUST use the exact same text-box classes — keeping them in one place
+// is what makes the editor truly zero-shift (and keeps them from drifting).
+const BUBBLE_TEXT = 'whitespace-pre-wrap break-words px-3.5 py-2 text-sm leading-relaxed'
+const ME_BUBBLE = 'rounded-2xl rounded-br-md bg-[var(--color-secondary)] text-[var(--color-foreground)]'
+const THEM_BUBBLE = 'rounded-2xl rounded-bl-md border border-[var(--color-border)] bg-white text-[var(--color-foreground)]'
+
+/**
+ * Inline message editor with zero layout shift (ui-standards "Inline Edit").
+ * An invisible ghost copy of the text defines the exact same box the bubble
+ * occupied (shrink-to-fit width, identical wrap and height); the textarea is
+ * painted absolutely on top. Editing never moves the message — only the
+ * Save/Cancel row is added below. The ghost grows with the draft, so the box
+ * keeps matching as you type.
+ */
 function MessageEditor({
   value,
   onChange,
@@ -227,37 +240,42 @@ function MessageEditor({
   onSave: () => void
   onCancel: () => void
 }) {
-  const ref = React.useRef<HTMLTextAreaElement | null>(null)
-  React.useLayoutEffect(() => {
-    const el = ref.current
-    if (!el) return
-    el.style.height = 'auto'
-    el.style.height = `${el.scrollHeight}px`
-  }, [value])
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault()
+      onSave()
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      onCancel()
+    }
+  }
   return (
-    <div className="w-full max-w-[85%] self-end">
-      {/* Box matches the own-message bubble exactly (same padding, line-height,
-          radius, fill, borderless) so swapping bubble→editor causes no shift;
-          the focus ring is a box-shadow and adds no layout height. */}
-      <Textarea
-        ref={ref}
-        value={value}
-        rows={1}
-        maxLength={4000}
-        autoFocus
-        className="max-h-[60vh] resize-none overflow-y-auto rounded-2xl rounded-br-md border-0 bg-[var(--color-secondary)] px-3.5 py-2 leading-relaxed"
-        onChange={(event) => onChange(event.target.value)}
-        onKeyDown={(event) => {
-          if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-            event.preventDefault()
-            onSave()
-          } else if (event.key === 'Escape') {
-            event.preventDefault()
-            onCancel()
-          }
-        }}
-      />
-      <div className="mt-1 flex justify-end gap-2">
+    <div className="flex max-w-[85%] flex-col items-end gap-1 self-end">
+      <div
+        className={cn(
+          'relative max-h-[60vh] overflow-hidden focus-within:ring-2 focus-within:ring-[var(--color-ring)]',
+          ME_BUBBLE,
+        )}
+      >
+        {/* Ghost: invisible, defines the box. Trailing ZWSP keeps a final empty
+            line from collapsing the height. */}
+        <div aria-hidden className={cn(BUBBLE_TEXT, 'invisible')}>
+          {value + '​'}
+        </div>
+        <textarea
+          value={value}
+          maxLength={4000}
+          autoFocus
+          aria-label={m.account_conversation_edit()}
+          className={cn(
+            BUBBLE_TEXT,
+            'absolute inset-0 resize-none overflow-y-auto border-0 bg-transparent text-[var(--color-foreground)] outline-none',
+          )}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      <div className="flex justify-end gap-2">
         <InlineRowButton tone="success" onClick={onSave}>
           <Check />
           {m.admin_shared_save()}
@@ -329,14 +347,7 @@ function MessageGroupView({
                 <Pencil className="h-3.5 w-3.5" />
               </button>
             )}
-            <div
-              className={cn(
-                'whitespace-pre-wrap break-words rounded-2xl px-3.5 py-2 text-sm leading-relaxed',
-                isMe
-                  ? 'rounded-br-md bg-[var(--color-secondary)] text-[var(--color-foreground)]'
-                  : 'rounded-bl-md border border-[var(--color-border)] bg-white text-[var(--color-foreground)]',
-              )}
-            >
+            <div className={cn(BUBBLE_TEXT, isMe ? ME_BUBBLE : THEM_BUBBLE)}>
               {message.body}
             </div>
           </div>


### PR DESCRIPTION
Quality pass from an honest self-review.

1. **Zero-shift inline edit** — ghost-overlay technique (ui-standards): an invisible copy of the text sizes the box exactly like the bubble; the textarea overlays it. No layout jump for any message length; bubble + ghost share one geometry constant so they can't drift.
2. **Separate messaging from feedback (F1)** — account "Berichten" filters to `origin='direct'`; feedback threads only under "Mijn meldingen" (no more double-surfacing).
3. **Race-safe first reply (F4)** — `pg_advisory_xact_lock` on the submission so concurrent first-replies can't each create a thread.

Tests: backend 30 (incl. origin filter assertion) + conversation suite green; tsc + eslint + ruff clean.

Deferred as a focused follow-up (not rushed in): admin-side feedback-conversation surface, "Sluiten" relabel, extracting account panels into tested `_components/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)