### PR TITLE
fix(alembic): merge two heads (status-drop + product-updates)

### DIFF
--- a/klai-portal/backend/alembic/versions/0aac04f1bccc_merge_platform_status_drop_and_product_.py
+++ b/klai-portal/backend/alembic/versions/0aac04f1bccc_merge_platform_status_drop_and_product_.py
@@ -1,0 +1,29 @@
+"""merge platform-status-drop and product-updates heads
+
+Revision ID: 0aac04f1bccc
+Revises: c4d7e9f1a2b6, pu20260606c3
+Create Date: 2026-06-06 17:56:30.971795
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0aac04f1bccc"
+down_revision: Union[str, Sequence[str], None] = ("c4d7e9f1a2b6", "pu20260606c3")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
Two migrations landed on main off the same parent → two alembic heads → portal-api entrypoint crashloops on `alembic upgrade head`. No-op merge migration rejoins to a single head. Recovers the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)