### PR TITLE
fix(alembic): drop unused imports from merge migration (unblock deploy)

### DIFF
--- a/klai-portal/backend/alembic/versions/0aac04f1bccc_merge_platform_status_drop_and_product_.py
+++ b/klai-portal/backend/alembic/versions/0aac04f1bccc_merge_platform_status_drop_and_product_.py
@@ -8,9 +8,6 @@ Create Date: 2026-06-06 17:56:30.971795
 
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision: str = "0aac04f1bccc"


### PR DESCRIPTION
The head-merge migration (0aac04f1bccc) shipped with alembic's boilerplate `op`/`sa` imports that a no-op merge never uses → ruff F401 failed quality → deploy gated → status-drop + product-updates migrations never reached prod. Removing the unused imports. Single head preserved; prod recovers on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)