### PR TITLE
Fuse raw_query RRF leg so literal terms survive query rewrite

### DIFF
--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -321,15 +321,25 @@ async def retrieve(
     decision_record["coreference_rewrite"] = {"original": req.query, "resolved": query_resolved}
     decision_record["coreference_ms"] = round(coref_ms, 1)
 
-    # 2. Embed resolved query (dense + sparse in parallel)
+    # 2. Embed resolved query (dense + sparse in parallel). When coreference /
+    # query rewrite changed the query, also embed the user's pre-rewrite
+    # raw_query so the search can fuse a literal-term RRF leg (see
+    # search._search_knowledge). This rescues exact matches — e.g. a product
+    # name like "Salesforce" — that an over-eager rewrite would otherwise drop
+    # from the candidate pool, where the reranker can no longer recover them.
     t_embed = time.perf_counter()
-    query_vector, sparse_vector = await asyncio.gather(
-        embed_single(query_resolved),
-        embed_sparse(query_resolved),
-    )
+    raw_query = req.raw_query if req.raw_query and req.raw_query != query_resolved else None
+    embed_coros = [embed_single(query_resolved), embed_sparse(query_resolved)]
+    if raw_query is not None:
+        embed_coros += [embed_single(raw_query), embed_sparse(raw_query)]
+    embedded = await asyncio.gather(*embed_coros)
+    query_vector, sparse_vector = embedded[0], embedded[1]
+    raw_query_vector = embedded[2] if raw_query is not None else None
+    raw_sparse_vector = embedded[3] if raw_query is not None else None
     embed_ms = (time.perf_counter() - t_embed) * 1000
     step_latency_seconds.labels(step="embed").observe(time.perf_counter() - t_embed)
     decision_record["embedding_ms"] = round(embed_ms, 1)
+    decision_record["raw_query_leg_applied"] = raw_query is not None
 
     # 3. Gate check. Strict KB mode must never skip retrieval: a wrong bypass
     # would turn "answer only from selected KBs" into a plain model answer.
@@ -406,7 +416,12 @@ async def retrieve(
         # 4. Search — Qdrant + Graphiti in parallel (AC-5)
         t_qdrant = time.perf_counter()
         qdrant_coro = search.hybrid_search(
-            query_vector, req, settings.retrieval_candidates, sparse_vector
+            query_vector,
+            req,
+            settings.retrieval_candidates,
+            sparse_vector,
+            raw_query_vector=raw_query_vector,
+            raw_sparse_vector=raw_sparse_vector,
         )
 
         graph_task: asyncio.Task[list[dict]] | None = None

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -168,11 +168,23 @@ async def _search_knowledge(
     request: RetrieveRequest,
     candidates: int,
     sparse_vector: SparseVector | None = None,
+    raw_query_vector: list[float] | None = None,
+    raw_sparse_vector: SparseVector | None = None,
 ) -> list[dict]:
     """3-leg RRF hybrid search on klai_knowledge (named vectors).
 
     Prefetch legs: vector_chunk + vector_questions (always) + vector_sparse (when available).
     Falls back to 2-leg RRF when sparse_vector is None.
+
+    When ``raw_query_vector`` is supplied (the embedding of the user's
+    pre-rewrite ``raw_query``), two extra prefetch legs are fused in: a dense
+    ``vector_chunk`` leg and, when available, a ``vector_sparse`` leg on the raw
+    query. This guarantees that a literal-term match (e.g. a product name) still
+    enters the candidate pool even when an over-eager coreference/query rewrite
+    steered the resolved query away from it. The reranker (which already scores
+    against ``raw_query`` + resolved) then promotes the genuinely relevant hit.
+    Pass ``raw_query_vector`` only when the rewrite changed the query, so the
+    no-rewrite path keeps its 2/3-leg shape and adds no extra Qdrant work.
     """
     client = _get_client()
 
@@ -229,6 +241,24 @@ async def _search_knowledge(
                 filter=query_filter,
             )
         )
+    if raw_query_vector is not None:
+        prefetch.append(
+            Prefetch(
+                query=raw_query_vector,
+                using="vector_chunk",
+                limit=prefetch_limit,
+                filter=query_filter,
+            )
+        )
+        if raw_sparse_vector is not None:
+            prefetch.append(
+                Prefetch(
+                    query=raw_sparse_vector,
+                    using="vector_sparse",
+                    limit=prefetch_limit,
+                    filter=query_filter,
+                )
+            )
 
     try:
         result = await asyncio.wait_for(
@@ -359,11 +389,23 @@ async def hybrid_search(
     request: RetrieveRequest,
     candidates: int,
     sparse_vector: SparseVector | None = None,
+    raw_query_vector: list[float] | None = None,
+    raw_sparse_vector: SparseVector | None = None,
 ) -> list[dict]:
     """Run Qdrant search appropriate for the request scope.
 
     Returns raw result dicts with text, score, and payload fields.
     sparse_vector is forwarded to _search_knowledge for 3-leg RRF.
+    raw_query_vector / raw_sparse_vector add pre-rewrite RRF legs (see
+    _search_knowledge) and should be passed only when the rewrite changed the
+    query.
     """
     # org, personal, both
-    return await _search_knowledge(query_vector, request, candidates, sparse_vector)
+    return await _search_knowledge(
+        query_vector,
+        request,
+        candidates,
+        sparse_vector,
+        raw_query_vector=raw_query_vector,
+        raw_sparse_vector=raw_sparse_vector,
+    )

--- a/klai-retrieval-api/tests/test_search.py
+++ b/klai-retrieval-api/tests/test_search.py
@@ -33,9 +33,11 @@ class TestSearch:
     async def test_org_search(self):
         """Org scope uses dense cosine search on klai_knowledge (single unnamed vector)."""
         mock_client = AsyncMock()
-        mock_client.query_points.return_value = _make_query_response([
-            _make_point("c1", "knowledge chunk", 0.8, org_id="org-1"),
-        ])
+        mock_client.query_points.return_value = _make_query_response(
+            [
+                _make_point("c1", "knowledge chunk", 0.8, org_id="org-1"),
+            ]
+        )
 
         with patch.object(search, "_get_client", return_value=mock_client):
             req = RetrieveRequest(query="test", org_id="org-1", scope="org")
@@ -53,9 +55,11 @@ class TestSearch:
         # Mock returns only the chunk that Qdrant would keep after applying the filter.
         # We verify that the Qdrant call includes the kb_slug MatchAny condition.
         mock_client = AsyncMock()
-        mock_client.query_points.return_value = _make_query_response([
-            _make_point("c1", "intern chunk", 0.8, org_id="org-1", kb_slug="intern"),
-        ])
+        mock_client.query_points.return_value = _make_query_response(
+            [
+                _make_point("c1", "intern chunk", 0.8, org_id="org-1", kb_slug="intern"),
+            ]
+        )
 
         with patch.object(search, "_get_client", return_value=mock_client):
             req = RetrieveRequest(
@@ -89,7 +93,9 @@ class TestSearch:
     async def test_knowledge_search_passes_through_evidence_metadata(self):
         """Search result dicts include ingested_at, assertion_mode from payload (R4)."""
         point = _make_point(
-            "c1", "chunk text", 0.8,
+            "c1",
+            "chunk text",
+            0.8,
             org_id="org-1",
             ingested_at=1711843200,
             assertion_mode="fact",
@@ -135,3 +141,95 @@ class TestSearch:
             results = await search.hybrid_search([0.1, 0.2], req, 10)
 
         assert results[0]["heading_path"] == "Admin > Mensen"
+
+    @pytest.mark.asyncio
+    async def test_raw_query_adds_literal_term_rrf_leg(self):
+        """A differing raw_query adds dense + sparse RRF legs so literal-term
+        matches survive an over-eager coreference/query rewrite.
+
+        Contract: candidate retrieval must not depend solely on the rewritten
+        query. Without the raw leg, an exact term the user typed (e.g. a product
+        name like "Salesforce") that the rewrite paraphrased away never enters
+        the candidate pool, and the reranker cannot recover it (bounded recall).
+        """
+        from qdrant_client.models import SparseVector
+
+        mock_client = AsyncMock()
+        mock_client.query_points.return_value = _make_query_response(
+            [
+                _make_point("c1", "Salesforce CRM-configuratie", 1.0, org_id="org-1"),
+            ]
+        )
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="rewritten", org_id="org-1", scope="org")
+            await search.hybrid_search(
+                [0.1, 0.2],
+                req,
+                10,
+                SparseVector(indices=[1], values=[0.9]),
+                raw_query_vector=[0.3, 0.4],
+                raw_sparse_vector=SparseVector(indices=[2], values=[0.8]),
+            )
+
+        prefetches = mock_client.query_points.call_args.kwargs["prefetch"]
+        using = [pf.using for pf in prefetches]
+        # resolved query: chunk + questions + sparse; raw query: chunk + sparse.
+        assert using == [
+            "vector_chunk",
+            "vector_questions",
+            "vector_sparse",
+            "vector_chunk",
+            "vector_sparse",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_raw_query_dense_leg_without_sparse(self):
+        """raw_query adds a dense leg even when the raw sparse vector is absent."""
+        from qdrant_client.models import SparseVector
+
+        mock_client = AsyncMock()
+        mock_client.query_points.return_value = _make_query_response(
+            [
+                _make_point("c1", "chunk", 0.8, org_id="org-1"),
+            ]
+        )
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="rewritten", org_id="org-1", scope="org")
+            await search.hybrid_search(
+                [0.1, 0.2],
+                req,
+                10,
+                SparseVector(indices=[1], values=[0.9]),
+                raw_query_vector=[0.3, 0.4],
+            )
+
+        prefetches = mock_client.query_points.call_args.kwargs["prefetch"]
+        using = [pf.using for pf in prefetches]
+        assert using == [
+            "vector_chunk",
+            "vector_questions",
+            "vector_sparse",
+            "vector_chunk",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_no_raw_query_keeps_baseline_leg_shape(self):
+        """Without a raw_query vector the prefetch shape is unchanged (no extra legs)."""
+        from qdrant_client.models import SparseVector
+
+        mock_client = AsyncMock()
+        mock_client.query_points.return_value = _make_query_response(
+            [
+                _make_point("c1", "chunk", 0.8, org_id="org-1"),
+            ]
+        )
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await search.hybrid_search([0.1, 0.2], req, 10, SparseVector(indices=[1], values=[0.9]))
+
+        prefetches = mock_client.query_points.call_args.kwargs["prefetch"]
+        using = [pf.using for pf in prefetches]
+        assert using == ["vector_chunk", "vector_questions", "vector_sparse"]


### PR DESCRIPTION
## Probleem
De retrieval candidate-search embedde alléén de coreference/rewrite-resolved query. `raw_query` werd wel meegedragen maar pas downstream voor de reranker gebruikt. Een over-eager rewrite ("salesforce" → "koppelen van Voys Freedom aan Salesforce") stuurde vector-search weg van de letterlijk-matchende doc, die nooit in de kandidatenpool kwam — en de reranker kan niet terughalen wat nooit is opgehaald (bounded recall). Voys support: de Salesforce-config-pagina (48 chunks, correct geïndexeerd) werd niet gevonden → confidence low → strict refusal.

## Fix
Wanneer de rewrite de query veranderde: embed ook de rauwe `raw_query` en fuseer 2 extra RRF-legs (dense `vector_chunk` + sparse `vector_sparse`) in de bestaande hybrid search. De letterlijke-term-leg garandeert dat de exacte-match-doc in de kandidatenpool komt; de reranker (die al tegen raw_query+resolved scoort) promoot 'm. No-rewrite pad ongewijzigd; `raw_query` optioneel → andere callers onaangetast.

## Verificatie
- Productie-Qdrant: drifted resolved-only → 0 salesforce in top20; gefuseerd resolved+raw → 8 (config-pagina rang 4).
- Unit: 3 nieuwe tests (raw dense+sparse / raw-dense-only / no-raw baseline); ruff check+format clean.

Industry pattern: multi-query + RRF is de standaard mitigatie voor conversational rewrite-drift / bounded recall.

Follow-ups (niet in deze PR): dubbele rewrite (litellm-hook + retrieval-api coreference) collapsen; rewrite-prompt-hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)