### PR TITLE
Skip retrieval-api coreference when caller pre-resolved (kill double rewrite)

### DIFF
--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -61,6 +61,18 @@ _REQUIRE_RETRIEVAL_SCOPE = Depends(require_scope(_RETRIEVAL_QUERY_SCOPE))
 _PAGE_CONTEXT_SCORE_BOOST = 1.08
 
 
+def _caller_pre_resolved(req: RetrieveRequest) -> bool:
+    """Whether the caller already resolved coreference for this request.
+
+    True when a non-empty ``raw_query`` is present AND differs from ``query`` —
+    the litellm hook's contract: it sends the rewritten query as ``query`` and
+    the user's pre-rewrite text as ``raw_query``. knowledge-mcp sends
+    ``raw_query == query`` (no rewrite) and partner/focus omit ``raw_query``, so
+    both fall through to retrieval-side coreference resolution.
+    """
+    return bool(req.raw_query) and req.raw_query != req.query
+
+
 def _normalise_page_context_url(raw_url: str | None) -> str:
     if not raw_url:
         return ""
@@ -313,13 +325,36 @@ async def retrieve(
     # and is emitted as retrieval_decision_record at the end of the request.
     decision_record: dict = {}
 
-    # 1. Coreference resolution
-    t_coref = time.perf_counter()
-    query_resolved = await coreference.resolve(req.query, req.conversation_history)
-    coref_ms = (time.perf_counter() - t_coref) * 1000
-    step_latency_seconds.labels(step="coref").observe(time.perf_counter() - t_coref)
-    decision_record["coreference_rewrite"] = {"original": req.query, "resolved": query_resolved}
-    decision_record["coreference_ms"] = round(coref_ms, 1)
+    # 1. Coreference resolution. Skip when the caller already resolved
+    # coreference — signalled by a distinct ``raw_query`` (the pre-rewrite
+    # original) alongside an already-rewritten ``query``. Re-resolving a
+    # caller-rewritten query is a redundant second LLM rewrite that only
+    # compounds drift and adds a round-trip. Path A (litellm hook) pre-resolves
+    # via klai_kb_query_rewrite; knowledge-mcp sends raw_query==query and
+    # partner/focus omit raw_query, so both still resolve here.
+    if _caller_pre_resolved(req):
+        query_resolved = req.query
+        # No coref LLM call ran — do NOT observe the coref latency histogram
+        # (a 0.0 sample would skew p50/p95 toward zero). coref_ms stays 0.0 for
+        # the decision_record + retrieve log.
+        coref_ms = 0.0
+        decision_record["coreference_rewrite"] = {
+            "original": req.raw_query,
+            "resolved": query_resolved,
+            "source": "caller",
+        }
+        decision_record["coreference_ms"] = 0.0
+    else:
+        t_coref = time.perf_counter()
+        query_resolved = await coreference.resolve(req.query, req.conversation_history)
+        coref_ms = (time.perf_counter() - t_coref) * 1000
+        step_latency_seconds.labels(step="coref").observe(time.perf_counter() - t_coref)
+        decision_record["coreference_rewrite"] = {
+            "original": req.query,
+            "resolved": query_resolved,
+            "source": "retrieval-api",
+        }
+        decision_record["coreference_ms"] = round(coref_ms, 1)
 
     # 2. Embed resolved query (dense + sparse in parallel). When coreference /
     # query rewrite changed the query, also embed the user's pre-rewrite

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -55,7 +55,7 @@ class TestRetrieveEndpoint:
                 "retrieval_api.api.retrieve.coreference.resolve",
                 new_callable=AsyncMock,
                 return_value="resolved query",
-            ),
+            ) as mock_coref,
             patch(
                 "retrieval_api.api.retrieve.embed_single",
                 new_callable=AsyncMock,
@@ -145,18 +145,24 @@ class TestRetrieveEndpoint:
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30
             mock_settings.link_expand_score_boost = 1.00
-            request = {**sample_retrieve_request, "raw_query": "original user query"}
+            # raw_query == query → NOT caller-pre-resolved → retrieval-side
+            # coreference runs (this test is the coref-runs canary).
+            request = {
+                **sample_retrieve_request,
+                "raw_query": sample_retrieve_request["query"],
+            }
             resp = client.post("/retrieve", json=request)
 
         assert resp.status_code == 200
         data = resp.json()
+        mock_coref.assert_awaited_once()
         assert data["query_resolved"] == "resolved query"
         assert data["retrieval_bypassed"] is False
         assert len(data["chunks"]) == 1
         assert data["chunks"][0]["chunk_id"] == "c1"
         assert data["chunks"][0]["reranker_score"] == 0.95
         assert mock_evidence_pack.call_args.kwargs["query"] == (
-            "original user query\nresolved query"
+            "What is the refund policy?\nresolved query"
         )
         assert data["metadata"]["candidates_retrieved"] == 1
         assert data["metadata"]["retrieval_ms"] > 0
@@ -177,6 +183,72 @@ class TestRetrieveEndpoint:
         assert "https://docs.getklai.com/refunds" in decision_attrs
         assert "Refund policy" in decision_attrs
         assert "top_item_chunk_ids" in decision_attrs
+
+    def test_retrieve_skips_coreference_when_caller_pre_resolved(
+        self, client, sample_retrieve_request
+    ):
+        """raw_query != query → caller pre-resolved → retrieval-api does NOT
+        run a second coreference rewrite (kills the double rewrite), responds
+        200, and uses the caller's query verbatim as query_resolved.
+
+        Regression: the skip branch previously left ``coref_ms`` unbound,
+        crashing every pre-resolved request with UnboundLocalError.
+        """
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="SHOULD NOT BE USED",
+            ) as mock_coref,
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2, 0.3],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(False, 0.05),
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.reranker.rerank",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.reranker_enabled = True
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_candidates = 20
+            mock_settings.graphiti_enabled = False
+            mock_settings.link_expand_enabled = False
+            mock_settings.router_enabled = False
+            mock_settings.source_quota_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            mock_settings.link_expand_score_boost = 1.00
+            request = {
+                **sample_retrieve_request,
+                "raw_query": "totally different pre-rewrite text",
+            }
+            resp = client.post("/retrieve", json=request)
+
+        assert resp.status_code == 200
+        mock_coref.assert_not_awaited()
+        data = resp.json()
+        # query_resolved is the caller's query verbatim — NOT the coref mock value.
+        assert data["query_resolved"] == sample_retrieve_request["query"]
 
 
 class TestConfidenceBandEndToEnd:

--- a/klai-retrieval-api/tests/test_caller_pre_resolved.py
+++ b/klai-retrieval-api/tests/test_caller_pre_resolved.py
@@ -1,0 +1,40 @@
+"""Tests for the caller-pre-resolved coreference skip contract.
+
+Contract: retrieval-api must not run a second coreference rewrite when the
+caller already resolved coreference (the litellm hook's query-rewrite). The
+signal is a distinct ``raw_query`` alongside an already-rewritten ``query``.
+This eliminates the double rewrite (hook + retrieval-api) that compounded
+query-rewrite drift.
+"""
+
+from __future__ import annotations
+
+from retrieval_api.api.retrieve import _caller_pre_resolved
+from retrieval_api.models import RetrieveRequest
+
+
+def _req(query: str, raw_query: str | None) -> RetrieveRequest:
+    return RetrieveRequest(query=query, raw_query=raw_query, org_id="org-1", scope="org")
+
+
+class TestCallerPreResolved:
+    def test_distinct_raw_query_is_pre_resolved(self):
+        # litellm hook: query=rewritten, raw_query=original user text.
+        req = _req(
+            "Voys Salesforce CRM-koppeling Bubble RedCactus", "Staat er iets over salesforce?"
+        )
+        assert _caller_pre_resolved(req) is True
+
+    def test_equal_raw_query_is_not_pre_resolved(self):
+        # knowledge-mcp: raw_query == query (it does not rewrite).
+        req = _req("hoe voeg ik een gebruiker toe?", "hoe voeg ik een gebruiker toe?")
+        assert _caller_pre_resolved(req) is False
+
+    def test_absent_raw_query_is_not_pre_resolved(self):
+        # partner / focus: raw_query omitted (defaults to None).
+        req = _req("hoe voeg ik een gebruiker toe?", None)
+        assert _caller_pre_resolved(req) is False
+
+    def test_empty_raw_query_is_not_pre_resolved(self):
+        req = _req("hoe voeg ik een gebruiker toe?", "")
+        assert _caller_pre_resolved(req) is False


### PR DESCRIPTION
## Wat
retrieval-api sloeg een tweede coreference-rewrite over de hook-rewrite heen — een redundante LLM-round-trip die query-rewrite drift versterkte. Deze PR laat retrieval-api de coreference **overslaan wanneer de caller al heeft geresolved** (signaal: `raw_query` aanwezig én `!= query`).

- Path A (litellm hook): pre-resolved → skip (single rewrite).
- knowledge-mcp (`raw_query==query`), partner/focus/gap (geen `raw_query`): resolven gewoon retrieval-side.
- Composeert met de raw_query RRF-leg: `query_resolved = req.query`, en `raw_query != query_resolved` houdt de letterlijke-term-leg actief.

## Adversarial review → BLOCK → gefixt
Een vijandige review vond een echte crash (`coref_ms` UnboundLocalError op elke pre-resolved request) + metric-vervuiling. Beide gefixt; endpoint-contracttests toegevoegd (coref 0× bij skip, 1× anders).

## Bewust NIET gewijzigd
De brand-bridging rewrite in de hook (SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-5) blijft — deliberate recall-feature, complementair aan de raw-leg.

## Tests
`uv run --extra dev pytest` → gerichte set 6 passed; volledige retrieve/search/coref groen (enige rode test = `TestHealthEndpoint` → echte falkordb, infra-only). ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)