### PR TITLE
[codex] Add chat retrieval policy for KB hook

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -242,6 +242,7 @@ services:
       - ./litellm/klai_knowledge.py:/app/klai_knowledge.py:ro
       - ./litellm/klai_context.py:/app/klai_context.py:ro
       - ./litellm/klai_kb_answer_policy.py:/app/klai_kb_answer_policy.py:ro
+      - ./litellm/klai_kb_chat_mode.py:/app/klai_kb_chat_mode.py:ro
       - ./litellm/klai_kb_citation_render.py:/app/klai_kb_citation_render.py:ro
       - ./litellm/klai_kb_confidence_policy.py:/app/klai_kb_confidence_policy.py:ro
       - ./litellm/klai_kb_context_prompt.py:/app/klai_kb_context_prompt.py:ro

--- a/deploy/litellm/klai_kb_answer_policy.py
+++ b/deploy/litellm/klai_kb_answer_policy.py
@@ -40,6 +40,12 @@ KB_ANSWER_POLICY_STATES = (
     "zero_chunks",
     "chunks_present",
 )
+KB_ANSWER_POLICY_PROMPT_MODES = frozenset(
+    {
+        "open_kb",
+        "strict_kb",
+    }
+)
 KB_ANSWER_POLICY_SUPPRESS_CITATION_STATES = frozenset(
     {
         "zero_chunks",
@@ -164,6 +170,15 @@ class KbAnswerPolicy:
     prompt_mode: ChatRetrievalPromptMode
     user_provided_content_context: bool
     low_confidence_inject: bool = False
+
+    def __post_init__(self) -> None:
+        if self.state not in KB_ANSWER_POLICY_STATES:
+            raise ValueError(f"unknown KB answer policy state: {self.state!r}")
+        if self.prompt_mode not in KB_ANSWER_POLICY_PROMPT_MODES:
+            raise ValueError(
+                "KbAnswerPolicy requires a retrieval prompt mode; "
+                f"got {self.prompt_mode!r}"
+            )
 
     @property
     def kb_narrow(self) -> bool:

--- a/deploy/litellm/klai_kb_answer_policy.py
+++ b/deploy/litellm/klai_kb_answer_policy.py
@@ -27,6 +27,11 @@ from klai_context import (
     STALE_ATTACHMENT_CONTEXT_PLACEHOLDER as _STALE_ATTACHMENT_CONTEXT_PLACEHOLDER,
     STALE_LIBRECHAT_UPLOAD_PREFIX as _STALE_LIBRECHAT_UPLOAD_PREFIX,
 )
+from klai_kb_chat_mode import (
+    ChatRetrievalPromptMode,
+    prompt_mode_answer_mode,
+    prompt_mode_is_strict,
+)
 
 KB_ANSWER_POLICY_STATES = (
     "retrieval_failure",
@@ -156,13 +161,17 @@ class KbAnswerPolicy:
     """Single source of truth for prompt/post-call answer policy flags."""
 
     state: str
-    kb_narrow: bool
+    prompt_mode: ChatRetrievalPromptMode
     user_provided_content_context: bool
     low_confidence_inject: bool = False
 
     @property
+    def kb_narrow(self) -> bool:
+        return prompt_mode_is_strict(self.prompt_mode)
+
+    @property
     def mode(self) -> str:
-        return "strict" if self.kb_narrow else "open"
+        return prompt_mode_answer_mode(self.prompt_mode)
 
     @property
     def allow_uncited_user_content(self) -> bool:
@@ -179,6 +188,7 @@ class KbAnswerPolicy:
     def metadata(self) -> dict[str, bool | str]:
         return {
             "answer_policy_state": self.state,
+            "chat_retrieval_prompt_mode": self.prompt_mode,
             "answer_policy_mode": self.mode,
             "user_provided_content_context": self.user_provided_content_context,
             "low_confidence_inject": self.low_confidence_inject,

--- a/deploy/litellm/klai_kb_chat_mode.py
+++ b/deploy/litellm/klai_kb_chat_mode.py
@@ -1,0 +1,64 @@
+"""Shared chat-mode contract for the regular KB chat path."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ChatRetrievalPromptMode = Literal[
+    "general",
+    "open_kb",
+    "strict_kb",
+    "strict_no_kb",
+    "open_unavailable",
+    "strict_unavailable",
+]
+
+PROMPT_MODES = frozenset(
+    {
+        "general",
+        "open_kb",
+        "strict_kb",
+        "strict_no_kb",
+        "open_unavailable",
+        "strict_unavailable",
+    }
+)
+STRICT_PROMPT_MODES = frozenset(
+    {
+        "strict_kb",
+        "strict_no_kb",
+        "strict_unavailable",
+    }
+)
+RETRIEVAL_PROMPT_MODES = frozenset(
+    {
+        "open_kb",
+        "strict_kb",
+    }
+)
+UNAVAILABLE_PROMPT_MODES = frozenset(
+    {
+        "open_unavailable",
+        "strict_unavailable",
+    }
+)
+
+
+def prompt_mode_is_strict(prompt_mode: ChatRetrievalPromptMode) -> bool:
+    return prompt_mode in STRICT_PROMPT_MODES
+
+
+def prompt_mode_is_known(prompt_mode: object) -> bool:
+    return prompt_mode in PROMPT_MODES
+
+
+def prompt_mode_should_retrieve(prompt_mode: ChatRetrievalPromptMode) -> bool:
+    return prompt_mode in RETRIEVAL_PROMPT_MODES
+
+
+def prompt_mode_is_unavailable(prompt_mode: ChatRetrievalPromptMode) -> bool:
+    return prompt_mode in UNAVAILABLE_PROMPT_MODES
+
+
+def prompt_mode_answer_mode(prompt_mode: ChatRetrievalPromptMode) -> str:
+    return "strict" if prompt_mode_is_strict(prompt_mode) else "open"

--- a/deploy/litellm/klai_kb_citation_render.py
+++ b/deploy/litellm/klai_kb_citation_render.py
@@ -12,6 +12,7 @@ from typing import Any
 from klai_chat_prompts import no_citable_sources_message
 from klai_citations import compose_answer_with_trusted_sources
 from klai_kb_answer_policy import strict_kb_unavailable_message
+from klai_kb_chat_mode import prompt_mode_is_known, prompt_mode_is_strict
 from klai_kb_traceability import dedupe_strings
 from klai_kb_urls import normalise_guard_url
 from klai_litellm_response import (
@@ -115,6 +116,13 @@ def _citation_render_inputs(
         )
     ]
     return allowed_image_urls, citation_chunks, trusted_sources
+
+
+def _kb_meta_is_strict(kb_meta: dict[str, Any]) -> bool:
+    prompt_mode = kb_meta.get("chat_retrieval_prompt_mode")
+    if prompt_mode_is_known(prompt_mode):
+        return prompt_mode_is_strict(prompt_mode)
+    return bool(kb_meta.get("kb_narrow", False))
 
 
 def _render_kb_citation_content(
@@ -508,7 +516,7 @@ def _has_visible_agent_activity(kb_meta: dict[str, Any] | None) -> bool:
     if has_kb_trace_labels:
         return True
     if isinstance(kb_meta.get("chunks_injected"), int):
-        return bool(kb_meta.get("kb_narrow")) or bool(kb_meta.get("no_citable_reason"))
+        return _kb_meta_is_strict(kb_meta) or bool(kb_meta.get("no_citable_reason"))
     return False
 
 
@@ -532,7 +540,7 @@ def _format_visible_agent_activity(
     retrieval_ms = kb_meta.get("retrieval_ms")
     citable_sources_count = kb_meta.get("citable_sources_count")
     no_citable_reason = kb_meta.get("no_citable_reason")
-    kb_narrow = bool(kb_meta.get("kb_narrow", False))
+    kb_narrow = _kb_meta_is_strict(kb_meta)
     confidence_band = kb_meta.get("confidence_band")
 
     lines: list[str] = []
@@ -761,7 +769,7 @@ def compose_non_streaming_kb_response(
                     user_query=kb_meta.get("user_query"),
                     trusted_sources=trusted_sources,
                     evidence_chunks=citation_chunks,
-                    kb_narrow=bool(kb_meta.get("kb_narrow", False)),
+                    kb_narrow=_kb_meta_is_strict(kb_meta),
                     retrieval_confidence_band=kb_meta.get("confidence_band"),
                     allow_uncited_user_content=allow_uncited_user_content,
                     suppress_citations_for_user_content=suppress_user_content_citations,
@@ -819,7 +827,7 @@ def compose_streaming_kb_response(
     if kb_meta.get("_citation_stream_sources_appended"):
         return stats
 
-    kb_narrow = bool(kb_meta.get("kb_narrow", False))
+    kb_narrow = _kb_meta_is_strict(kb_meta)
     allow_uncited_user_content, suppress_user_content_citations = (
         _citation_user_content_flags(kb_meta)
     )

--- a/deploy/litellm/klai_kb_scope_policy.py
+++ b/deploy/litellm/klai_kb_scope_policy.py
@@ -6,6 +6,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
+from klai_kb_chat_mode import (
+    ChatRetrievalPromptMode,
+    prompt_mode_is_strict,
+    prompt_mode_should_retrieve,
+)
+
 KbGateAction = Literal["continue", "general", "strict_no_kb"]
 
 
@@ -35,6 +41,24 @@ class KbTaxonomyDecision:
     skip_reason: str | None = None
 
 
+@dataclass(frozen=True)
+class ChatRetrievalPolicy:
+    """Resolved gate/scope/identity decision for one LiteLLM request."""
+
+    prompt_mode: ChatRetrievalPromptMode
+    scope_decision: KbRetrievalScopeDecision | None = None
+    user_id: str | None = None
+    user_visible_failure_reason: str | None = None
+
+    @property
+    def should_retrieve(self) -> bool:
+        return prompt_mode_should_retrieve(self.prompt_mode)
+
+    @property
+    def kb_narrow(self) -> bool:
+        return prompt_mode_is_strict(self.prompt_mode)
+
+
 def resolve_kb_feature_gate(feature: Mapping[str, object]) -> KbFeatureGateDecision:
     """Resolve whether the feature-level gate should continue into retrieval."""
     kb_narrow = bool(feature.get("kb_narrow", False))
@@ -51,6 +75,51 @@ def resolve_kb_feature_gate(feature: Mapping[str, object]) -> KbFeatureGateDecis
             strict_no_kb_reason="kb-retrieval-disabled" if kb_narrow else None,
         )
     return KbFeatureGateDecision(action="continue", kb_narrow=kb_narrow)
+
+
+def resolve_chat_retrieval_policy(
+    feature: Mapping[str, object],
+) -> ChatRetrievalPolicy:
+    """Resolve feature, preference, and identity state into a hook plan."""
+    feature_gate = resolve_kb_feature_gate(feature)
+    if feature_gate.action == "general":
+        return ChatRetrievalPolicy(
+            prompt_mode="general",
+        )
+    if feature_gate.action == "strict_no_kb":
+        return ChatRetrievalPolicy(
+            prompt_mode="strict_no_kb",
+            user_visible_failure_reason=feature_gate.strict_no_kb_reason,
+        )
+
+    scope_decision = resolve_kb_retrieval_scope(feature)
+    if scope_decision.action == "general":
+        return ChatRetrievalPolicy(
+            prompt_mode="general",
+            scope_decision=scope_decision,
+        )
+    if scope_decision.action == "strict_no_kb":
+        return ChatRetrievalPolicy(
+            prompt_mode="strict_no_kb",
+            scope_decision=scope_decision,
+            user_visible_failure_reason=scope_decision.strict_no_kb_reason,
+        )
+
+    user_id = feature.get("zitadel_user_id")
+    if not user_id:
+        return ChatRetrievalPolicy(
+            prompt_mode=(
+                "strict_unavailable" if scope_decision.kb_narrow else "open_unavailable"
+            ),
+            scope_decision=scope_decision,
+            user_visible_failure_reason="identity-resolve-failed",
+        )
+
+    return ChatRetrievalPolicy(
+        prompt_mode="strict_kb" if scope_decision.kb_narrow else "open_kb",
+        scope_decision=scope_decision,
+        user_id=str(user_id),
+    )
 
 
 def resolve_kb_retrieval_scope(feature: Mapping[str, object]) -> KbRetrievalScopeDecision:

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1350,6 +1350,47 @@ class KlaiKnowledgeHook(CustomLogger):
 
         retrieval_ms = int((time.monotonic() - t0) * 1000)
 
+        if kb_narrow and result.get("retrieval_bypassed"):
+            logger.error(
+                "KlaiKnowledgeHook: strict KB retrieval returned retrieval_bypassed=True "
+                "org_id=%s user_id=%s — failing closed",
+                org_id,
+                user_id,
+            )
+            strict_bypass_failure = "strict_retrieval_bypassed"
+            kb_unavailable_notice = _kb_retrieval_failure_notice(
+                kb_narrow, strict_bypass_failure
+            )
+            prefix = _compose_kb_mode_chat_prefix(
+                kb_narrow, templates_block, kb_unavailable_notice
+            )
+            _prepend_system_prefix(messages, prefix)
+            data["messages"] = messages
+            original_stream = data.get("stream")
+            render_strategy = _select_kb_render_strategy(original_stream)
+            if render_strategy.force_non_streaming:
+                data["stream"] = False
+            answer_policy = KbAnswerPolicy(
+                state="retrieval_failure",
+                prompt_mode=chat_retrieval_policy.prompt_mode,
+                user_provided_content_context=user_provided_content_context,
+            )
+            data.setdefault("metadata", {})["_klai_kb_meta"] = answer_policy.to_kb_meta(
+                org_id=org_id,
+                user_id=user_id,
+                user_query=query,
+                retrieval_ms=retrieval_ms,
+                no_citable_sources=True,
+                no_citable_reason=strict_bypass_failure,
+                no_citable_message=_strict_kb_unavailable_message(query),
+                original_stream=original_stream,
+                render_mode=render_strategy.mode,
+                retrieval_failure=strict_bypass_failure,
+                kb_scope_mode=kb_scope_mode,
+                kbs_in_scope=kbs_in_scope,
+            )
+            return data
+
         # If the retrieval-gate determined no KB context is needed, skip injection.
         # Multilingual foundation still applies — REQ-10.
         if result.get("retrieval_bypassed"):

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -82,6 +82,9 @@ from klai_kb_answer_policy import (
 from klai_kb_context_prompt import (
     build_kb_context_prompt as _build_kb_context_prompt,
 )
+from klai_kb_chat_mode import (
+    prompt_mode_is_unavailable as _prompt_mode_is_unavailable,
+)
 from klai_kb_query_rewrite import (
     KLAI_TAXONOMY_COVERAGE_THRESHOLD,
     TAXONOMY_ENABLED,
@@ -133,8 +136,7 @@ from klai_kb_render_policy import (
 )
 from klai_kb_scope_policy import (
     build_retrieve_body as _build_retrieve_body,
-    resolve_kb_feature_gate as _resolve_kb_feature_gate,
-    resolve_kb_retrieval_scope as _resolve_kb_retrieval_scope,
+    resolve_chat_retrieval_policy as _resolve_chat_retrieval_policy,
     resolve_kb_taxonomy_decision as _resolve_kb_taxonomy_decision,
 )
 from klai_kb_traceability import (
@@ -1067,24 +1069,25 @@ class KlaiKnowledgeHook(CustomLogger):
             )
             return data
 
-        # Feature gate + KB scope preference (version-based cache, 30s propagation)
+        # Feature, KB scope, identity, and request-mode policy.
         feature = await _get_kb_feature(librechat_user_id, org_id, cache)
-        feature_gate = _resolve_kb_feature_gate(feature)
-        feature_kb_narrow = feature_gate.kb_narrow
-        if feature_gate.action == "strict_no_kb":
-            if feature_gate.strict_no_kb_reason is None:
-                raise RuntimeError("strict KB feature gate decision has no reason")
+        chat_retrieval_policy = _resolve_chat_retrieval_policy(feature)
+        if chat_retrieval_policy.prompt_mode == "strict_no_kb":
+            if chat_retrieval_policy.user_visible_failure_reason is None:
+                raise RuntimeError("strict KB chat retrieval policy has no reason")
             _prepend_system_prefix(
                 messages,
                 _compose_kb_mode_chat_prefix(
                     True,
                     templates_block,
-                    _strict_no_kb_scope_notice(feature_gate.strict_no_kb_reason),
+                    _strict_no_kb_scope_notice(
+                        chat_retrieval_policy.user_visible_failure_reason
+                    ),
                 ),
             )
             data["messages"] = messages
             return data
-        if feature_gate.action == "general":
+        if chat_retrieval_policy.prompt_mode == "general":
             _prepend_system_prefix(
                 messages,
                 _compose_general_chat_prefix(
@@ -1092,6 +1095,29 @@ class KlaiKnowledgeHook(CustomLogger):
                     templates_block,
                 ),
             )
+            data["messages"] = messages
+            return data
+        if _prompt_mode_is_unavailable(chat_retrieval_policy.prompt_mode):
+            failure_reason = (
+                chat_retrieval_policy.user_visible_failure_reason or "kb-unavailable"
+            )
+            if failure_reason == "identity-resolve-failed":
+                logger.error(
+                    "KlaiKnowledgeHook: portal returned no zitadel_user_id for "
+                    "librechat_user_id=%s org_id=%s — failing loud",
+                    librechat_user_id,
+                    org_id,
+                )
+            kb_unavailable_notice = _kb_retrieval_failure_notice(
+                chat_retrieval_policy.kb_narrow,
+                failure_reason,
+            )
+            prefix = _compose_kb_mode_chat_prefix(
+                chat_retrieval_policy.kb_narrow,
+                templates_block,
+                kb_unavailable_notice,
+            )
+            _prepend_system_prefix(messages, prefix)
             data["messages"] = messages
             return data
 
@@ -1108,59 +1134,17 @@ class KlaiKnowledgeHook(CustomLogger):
         # stamped with the same Zitadel sub at ingest time
         # (klai-portal/backend/app/api/knowledge.py:172-204) so the
         # personal-scope filter matches.
-        user_id: str | None = feature.get("zitadel_user_id")
-        if not user_id:
-            # portal-api couldn't resolve the LibreChat ObjectId → Zitadel sub.
-            # Without it, retrieval-api's identity-verify denies. Surface to
-            # the user via the existing fail-loud path instead of degrading.
-            logger.error(
-                "KlaiKnowledgeHook: portal returned no zitadel_user_id for "
-                "librechat_user_id=%s org_id=%s — failing loud",
-                librechat_user_id,
-                org_id,
-            )
-            # The warning the model emits is in the user's detected language
-            # thanks to the mode-specific chat foundation.
-            kb_unavailable_notice = _kb_retrieval_failure_notice(
-                feature_kb_narrow,
-                "identity-resolve-failed",
-            )
-            prefix = _compose_kb_mode_chat_prefix(
-                feature_kb_narrow, templates_block, kb_unavailable_notice
-            )
-            _prepend_system_prefix(messages, prefix)
-            data["messages"] = messages
-            return data
-
-        scope_decision = _resolve_kb_retrieval_scope(feature)
-        kb_narrow = scope_decision.kb_narrow
-        if scope_decision.action == "strict_no_kb":
-            if scope_decision.strict_no_kb_reason is None:
-                raise RuntimeError("strict KB scope decision has no reason")
-            _prepend_system_prefix(
-                messages,
-                _compose_kb_mode_chat_prefix(
-                    True,
-                    templates_block,
-                    _strict_no_kb_scope_notice(scope_decision.strict_no_kb_reason),
-                ),
-            )
-            data["messages"] = messages
-            return data
-        if scope_decision.action == "general":
-            _prepend_system_prefix(
-                messages,
-                _compose_general_chat_prefix(
-                    _general_runtime_capabilities_block(data),
-                    templates_block,
-                ),
-            )
-            data["messages"] = messages
-            return data
-
+        user_id = chat_retrieval_policy.user_id
+        scope_decision = chat_retrieval_policy.scope_decision
+        if (
+            user_id is None
+            or scope_decision is None
+            or scope_decision.scope is None
+            or not chat_retrieval_policy.should_retrieve
+        ):
+            raise RuntimeError("KB chat retrieval policy continued without retrieval inputs")
+        kb_narrow = chat_retrieval_policy.kb_narrow
         scope = scope_decision.scope
-        if scope is None:
-            raise RuntimeError("KB scope decision continued without retrieval scope")
 
         conversation_history = _build_conversation_history(messages)
 
@@ -1343,7 +1327,7 @@ class KlaiKnowledgeHook(CustomLogger):
                 data["stream"] = False
             answer_policy = KbAnswerPolicy(
                 state="retrieval_failure",
-                kb_narrow=kb_narrow,
+                prompt_mode=chat_retrieval_policy.prompt_mode,
                 user_provided_content_context=user_provided_content_context,
             )
             data.setdefault("metadata", {})["_klai_kb_meta"] = answer_policy.to_kb_meta(
@@ -1375,7 +1359,7 @@ class KlaiKnowledgeHook(CustomLogger):
             data["messages"] = messages
             answer_policy = KbAnswerPolicy(
                 state="gate_bypassed",
-                kb_narrow=kb_narrow,
+                prompt_mode=chat_retrieval_policy.prompt_mode,
                 user_provided_content_context=user_provided_content_context,
             )
             data.setdefault("metadata", {})["_klai_kb_meta"] = answer_policy.to_kb_meta(
@@ -1410,7 +1394,7 @@ class KlaiKnowledgeHook(CustomLogger):
                 data["stream"] = False
             answer_policy = KbAnswerPolicy(
                 state="missing_evidence_pack",
-                kb_narrow=kb_narrow,
+                prompt_mode=chat_retrieval_policy.prompt_mode,
                 user_provided_content_context=user_provided_content_context,
             )
             data.setdefault("metadata", {})["_klai_kb_meta"] = answer_policy.to_kb_meta(
@@ -1552,7 +1536,7 @@ class KlaiKnowledgeHook(CustomLogger):
                     data["stream"] = False
                 answer_policy = KbAnswerPolicy(
                     state="zero_chunks",
-                    kb_narrow=kb_narrow,
+                    prompt_mode=chat_retrieval_policy.prompt_mode,
                     user_provided_content_context=user_provided_content_context,
                     low_confidence_inject=low_confidence_inject,
                 )
@@ -1645,7 +1629,7 @@ class KlaiKnowledgeHook(CustomLogger):
             data["stream"] = False
         answer_policy = KbAnswerPolicy(
             state="chunks_present",
-            kb_narrow=kb_narrow,
+            prompt_mode=chat_retrieval_policy.prompt_mode,
             user_provided_content_context=user_provided_content_context,
             low_confidence_inject=low_confidence_inject,
         )

--- a/deploy/litellm/tests/test_kb_answer_policy.py
+++ b/deploy/litellm/tests/test_kb_answer_policy.py
@@ -137,6 +137,32 @@ def test_policy_module_declares_every_pre_call_answer_state():
     assert tuple(_ALL_STATES) == _policy_module().KB_ANSWER_POLICY_STATES
 
 
+def test_answer_policy_rejects_non_retrieval_prompt_modes():
+    policy_module = _policy_module()
+    for prompt_mode in (
+        "general",
+        "strict_no_kb",
+        "open_unavailable",
+        "strict_unavailable",
+    ):
+        with pytest.raises(ValueError, match="retrieval prompt mode"):
+            policy_module.KbAnswerPolicy(
+                state="chunks_present",
+                prompt_mode=prompt_mode,
+                user_provided_content_context=False,
+            )
+
+
+def test_answer_policy_rejects_unknown_state():
+    policy_module = _policy_module()
+    with pytest.raises(ValueError, match="unknown KB answer policy state"):
+        policy_module.KbAnswerPolicy(
+            state="not_a_real_state",
+            prompt_mode="open_kb",
+            user_provided_content_context=False,
+        )
+
+
 def test_answer_policy_matrix_is_independent_of_renderer_state():
     policy_module = _policy_module()
     for state in policy_module.KB_ANSWER_POLICY_STATES:
@@ -322,9 +348,7 @@ def test_to_kb_meta_minimal_call_defaults_are_safe():
 
 def test_mode_follows_prompt_mode():
     assert _policy("chunks_present", prompt_mode="strict_kb").mode == "strict"
-    assert _policy("chunks_present", prompt_mode="strict_unavailable").mode == "strict"
     assert _policy("chunks_present", prompt_mode="open_kb").mode == "open"
-    assert _policy("chunks_present", prompt_mode="open_unavailable").mode == "open"
 
 
 def test_allow_uncited_user_content_tracks_user_provided_context():

--- a/deploy/litellm/tests/test_kb_answer_policy.py
+++ b/deploy/litellm/tests/test_kb_answer_policy.py
@@ -106,6 +106,7 @@ _EXPECTED_KEYS = {
     "kbs_used_as_sources",
     # policy-derived
     "answer_policy_state",
+    "chat_retrieval_prompt_mode",
     "answer_policy_mode",
     "user_provided_content_context",
     "low_confidence_inject",
@@ -117,7 +118,7 @@ _EXPECTED_KEYS = {
 def _policy(state: str, **kw):
     return _kk().KbAnswerPolicy(
         state=state,
-        kb_narrow=kw.get("kb_narrow", False),
+        prompt_mode=kw.get("prompt_mode", "open_kb"),
         user_provided_content_context=kw.get("upc", False),
         low_confidence_inject=kw.get("low_conf", False),
     )
@@ -139,16 +140,18 @@ def test_policy_module_declares_every_pre_call_answer_state():
 def test_answer_policy_matrix_is_independent_of_renderer_state():
     policy_module = _policy_module()
     for state in policy_module.KB_ANSWER_POLICY_STATES:
-        for kb_narrow in (False, True):
+        for prompt_mode in ("open_kb", "strict_kb"):
             for user_content in (False, True):
                 for low_confidence in (False, True):
                     policy = policy_module.KbAnswerPolicy(
                         state=state,
-                        kb_narrow=kb_narrow,
+                        prompt_mode=prompt_mode,
                         user_provided_content_context=user_content,
                         low_confidence_inject=low_confidence,
                     )
-                    assert policy.mode == ("strict" if kb_narrow else "open")
+                    assert policy.mode == (
+                        "strict" if prompt_mode == "strict_kb" else "open"
+                    )
                     assert policy.allow_uncited_user_content is user_content
                     assert policy.suppress_kb_citations is (
                         user_content
@@ -163,6 +166,7 @@ def test_answer_policy_matrix_is_independent_of_renderer_state():
                         render_mode="deterministic_non_streaming",
                     )
                     assert meta["answer_policy_mode"] == policy.mode
+                    assert meta["chat_retrieval_prompt_mode"] == prompt_mode
                     assert meta["allow_uncited_user_content"] is user_content
                     assert meta["render_mode"] == "deterministic_non_streaming"
 
@@ -316,9 +320,11 @@ def test_to_kb_meta_minimal_call_defaults_are_safe():
     assert meta["kbs_used_as_sources"] == []
 
 
-def test_mode_follows_kb_narrow():
-    assert _policy("chunks_present", kb_narrow=True).mode == "strict"
-    assert _policy("chunks_present", kb_narrow=False).mode == "open"
+def test_mode_follows_prompt_mode():
+    assert _policy("chunks_present", prompt_mode="strict_kb").mode == "strict"
+    assert _policy("chunks_present", prompt_mode="strict_unavailable").mode == "strict"
+    assert _policy("chunks_present", prompt_mode="open_kb").mode == "open"
+    assert _policy("chunks_present", prompt_mode="open_unavailable").mode == "open"
 
 
 def test_allow_uncited_user_content_tracks_user_provided_context():
@@ -357,9 +363,10 @@ def test_suppress_kb_citations_only_on_low_conf_chunk_states():
 
 def test_to_kb_meta_propagates_policy_flags_into_metadata():
     meta = _policy(
-        "chunks_present", kb_narrow=True, upc=True, low_conf=True
+        "chunks_present", prompt_mode="strict_kb", upc=True, low_conf=True
     ).to_kb_meta(org_id="o", user_id="u", retrieval_ms=1)
     assert meta["answer_policy_state"] == "chunks_present"
+    assert meta["chat_retrieval_prompt_mode"] == "strict_kb"
     assert meta["answer_policy_mode"] == "strict"
     assert meta["kb_narrow"] is True
     assert meta["user_provided_content_context"] is True

--- a/deploy/litellm/tests/test_kb_citation_render_mode.py
+++ b/deploy/litellm/tests/test_kb_citation_render_mode.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from klai_kb_citation_render import compose_non_streaming_kb_response
+
+
+def _response(content: str) -> dict:
+    return {"choices": [{"message": {"content": content}}]}
+
+
+def _meta(**overrides) -> dict:
+    return {
+        "chat_retrieval_prompt_mode": "strict_kb",
+        "kb_narrow": False,
+        "allowed_image_urls": [],
+        "citation_chunks": [],
+        "trusted_sources": [],
+        "no_citable_sources": True,
+        "user_query": "Wat is het beleid?",
+        **overrides,
+    }
+
+
+def test_prompt_mode_overrides_legacy_kb_narrow_for_strict_no_sources():
+    response = _response("Model answer without sources.")
+
+    stats = compose_non_streaming_kb_response(response, _meta())
+
+    content = response["choices"][0]["message"]["content"]
+    assert stats.no_citable_sources is True
+    assert content != "Model answer without sources."
+
+
+def test_prompt_mode_overrides_legacy_kb_narrow_for_open_no_sources():
+    response = _response("Model answer without sources.")
+
+    stats = compose_non_streaming_kb_response(
+        response,
+        _meta(chat_retrieval_prompt_mode="open_kb", kb_narrow=True),
+    )
+
+    content = response["choices"][0]["message"]["content"]
+    assert stats.no_citable_sources is False
+    assert content == "Model answer without sources."

--- a/deploy/litellm/tests/test_kb_scope_policy.py
+++ b/deploy/litellm/tests/test_kb_scope_policy.py
@@ -6,6 +6,128 @@ import klai_kb_scope_policy as policy
 
 
 @pytest.mark.parametrize(
+    (
+        "kb_narrow",
+        "kb_personal_enabled",
+        "kb_slugs_filter",
+        "should_retrieve",
+        "prompt_mode",
+        "scope",
+        "failure_reason",
+    ),
+    [
+        (
+            False,
+            False,
+            [],
+            False,
+            "general",
+            None,
+            None,
+        ),
+        (
+            True,
+            False,
+            [],
+            False,
+            "strict_no_kb",
+            None,
+            "kb-scopes-disabled",
+        ),
+        (
+            False,
+            False,
+            ["engineering"],
+            True,
+            "open_kb",
+            "org",
+            None,
+        ),
+        (
+            True,
+            False,
+            ["engineering"],
+            True,
+            "strict_kb",
+            "org",
+            None,
+        ),
+    ],
+)
+def test_chat_retrieval_policy_prompt_scope_matrix(
+    kb_narrow,
+    kb_personal_enabled,
+    kb_slugs_filter,
+    should_retrieve,
+    prompt_mode,
+    scope,
+    failure_reason,
+):
+    plan = policy.resolve_chat_retrieval_policy(
+        {
+            "enabled": True,
+            "kb_retrieval_enabled": True,
+            "kb_personal_enabled": kb_personal_enabled,
+            "kb_slugs_filter": kb_slugs_filter,
+            "kb_narrow": kb_narrow,
+            "zitadel_user_id": "user-sub",
+        }
+    )
+
+    assert plan.should_retrieve is should_retrieve
+    assert plan.prompt_mode == prompt_mode
+    assert plan.user_visible_failure_reason == failure_reason
+    if should_retrieve:
+        assert plan.user_id == "user-sub"
+        assert plan.scope_decision is not None
+        assert plan.scope_decision.scope == scope
+    else:
+        assert plan.user_id is None
+
+
+def test_chat_retrieval_policy_missing_user_id_is_unavailable_only_with_kb_scope():
+    no_kb = policy.resolve_chat_retrieval_policy(
+        {
+            "enabled": True,
+            "kb_retrieval_enabled": True,
+            "kb_personal_enabled": False,
+            "kb_slugs_filter": [],
+            "kb_narrow": True,
+        }
+    )
+    strict_with_kb = policy.resolve_chat_retrieval_policy(
+        {
+            "enabled": True,
+            "kb_retrieval_enabled": True,
+            "kb_personal_enabled": False,
+            "kb_slugs_filter": ["engineering"],
+            "kb_narrow": True,
+        }
+    )
+    open_with_kb = policy.resolve_chat_retrieval_policy(
+        {
+            "enabled": True,
+            "kb_retrieval_enabled": True,
+            "kb_personal_enabled": False,
+            "kb_slugs_filter": ["engineering"],
+            "kb_narrow": False,
+        }
+    )
+
+    assert no_kb.prompt_mode == "strict_no_kb"
+    assert no_kb.kb_narrow is True
+    assert no_kb.user_visible_failure_reason == "kb-scopes-disabled"
+    assert strict_with_kb.prompt_mode == "strict_unavailable"
+    assert strict_with_kb.should_retrieve is False
+    assert strict_with_kb.kb_narrow is True
+    assert strict_with_kb.user_visible_failure_reason == "identity-resolve-failed"
+    assert open_with_kb.prompt_mode == "open_unavailable"
+    assert open_with_kb.should_retrieve is False
+    assert open_with_kb.kb_narrow is False
+    assert open_with_kb.user_visible_failure_reason == "identity-resolve-failed"
+
+
+@pytest.mark.parametrize(
     ("feature", "action", "reason"),
     [
         ({"enabled": False, "kb_retrieval_enabled": True, "kb_narrow": False}, "general", None),

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -5983,6 +5983,47 @@ class TestKlaiKnowledgeHookOpenMode:
         assert result["metadata"]["_klai_kb_meta"]["gate_bypassed"] is True
 
     @pytest.mark.asyncio
+    async def test_strict_retrieval_bypassed_fails_closed(self, monkeypatch):
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(feature={"kb_narrow": True})
+
+        data = {
+            "user": "aabbcc112233445566778899",
+            "messages": [{"role": "user", "content": "Wat zegt de kennisbank?"}],
+        }
+        retrieval_resp = _make_resp({"chunks": [], "retrieval_bypassed": True})
+
+        with _patch_http(monkeypatch, retrieval_resp=retrieval_resp):
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        sys_content = self._system_msg(result)
+        assert "Strict mode" in sys_content
+        assert "Answer using your general knowledge" not in sys_content
+
+        kb_meta = result["metadata"]["_klai_kb_meta"]
+        assert kb_meta["kb_narrow"] is True
+        assert kb_meta["gate_bypassed"] is False
+        assert kb_meta["retrieval_failure"] == "strict_retrieval_bypassed"
+        assert kb_meta["no_citable_sources"] is True
+        assert kb_meta["no_citable_reason"] == "strict_retrieval_bypassed"
+        assert kb_meta["answer_policy_state"] == "retrieval_failure"
+        assert kb_meta["chat_retrieval_prompt_mode"] == "strict_kb"
+
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content="A model fallback answer"))
+            ]
+        )
+        await hook.async_post_call_success_hook(result, None, response)
+        assert response.choices[0].message.content.startswith(
+            "De kennisbank is tijdelijk niet bereikbaar, dus ik kan dit niet "
+            "betrouwbaar beantwoorden op basis van je kennisbronnen."
+        )
+
+    @pytest.mark.asyncio
     async def test_no_entitlement_uses_general_prompt_not_grounded(self, monkeypatch):
         mod = _load_hook(monkeypatch)
         hook = mod.KlaiKnowledgeHook()

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -975,6 +975,91 @@ class TestKlaiKnowledgeHookSlugsTriState:
         assert "use the available Web Search tool" in content
         assert "Do NOT tell the user to enable Search" in content
 
+    @pytest.mark.asyncio
+    async def test_empty_slugs_personal_off_missing_identity_still_uses_general_prompt(
+        self, monkeypatch
+    ):
+        """No KB selected means identity is irrelevant in Open/general mode."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": False,
+                "kb_slugs_filter": [],
+                "kb_narrow": False,
+                "version": 0,
+                "zitadel_user_id": None,
+            }
+        )
+        data = {
+            "user": "u1" * 12,
+            "messages": [{"role": "user", "content": "Wat is je algemene advies?"}],
+        }
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        system_msg = next((m for m in data["messages"] if m["role"] == "system"), None)
+        assert system_msg is not None
+        assert mc.post.call_count == 0
+        assert "general-purpose assistant" in system_msg["content"]
+        assert "TEMPORARILY UNAVAILABLE" not in system_msg["content"]
+        assert "identity-resolve-failed" not in system_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_strict_empty_slugs_personal_off_missing_identity_refuses_no_scope(
+        self, monkeypatch
+    ):
+        """No KB selected in Strict refuses because scope is empty, not identity."""
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache(
+            feature={
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": False,
+                "kb_slugs_filter": [],
+                "kb_narrow": True,
+                "version": 0,
+                "zitadel_user_id": None,
+            }
+        )
+        data = {
+            "user": "u1" * 12,
+            "messages": [{"role": "user", "content": "Wat zegt de kennisbank?"}],
+        }
+
+        with patch("klai_knowledge.httpx.AsyncClient") as cls:
+            mc = AsyncMock()
+            mc.get = AsyncMock(return_value=_make_resp({"instructions": []}))
+            mc.post = AsyncMock(return_value=_make_resp({"chunks": []}))
+            mc.__aenter__ = AsyncMock(return_value=mc)
+            mc.__aexit__ = AsyncMock(return_value=None)
+            cls.return_value = mc
+
+            await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        system_msg = next((m for m in data["messages"] if m["role"] == "system"), None)
+        assert system_msg is not None
+        assert mc.post.call_count == 0
+        assert "no knowledge base evidence is available" in system_msg["content"]
+        assert "technical reason: kb-scopes-disabled" in system_msg["content"]
+        assert "TEMPORARILY UNAVAILABLE" not in system_msg["content"]
+        assert "identity-resolve-failed" not in system_msg["content"]
+
     def test_search_knowledge_tool_is_not_treated_as_web_search(self, monkeypatch):
         """KB/MCP search tools must not trip the web-search runtime override."""
         mod = _load_hook(monkeypatch)

--- a/deploy/litellm/tests/test_low_confidence_injection.py
+++ b/deploy/litellm/tests/test_low_confidence_injection.py
@@ -154,7 +154,7 @@ def test_kb_answer_policy_matrix_user_content_citation_suppression(monkeypatch) 
     for state in ("zero_chunks", "chunks_present"):
         policy = klai_knowledge.KbAnswerPolicy(
             state=state,
-            kb_narrow=False,
+            prompt_mode="open_kb",
             user_provided_content_context=True,
             low_confidence_inject=True,
         )
@@ -168,7 +168,7 @@ def test_kb_answer_policy_matrix_user_content_citation_suppression(monkeypatch) 
     for state in ("retrieval_failure", "gate_bypassed", "missing_evidence_pack"):
         policy = klai_knowledge.KbAnswerPolicy(
             state=state,
-            kb_narrow=True,
+            prompt_mode="strict_kb",
             user_provided_content_context=True,
             low_confidence_inject=True,
         )
@@ -181,7 +181,7 @@ def test_kb_answer_policy_matrix_user_content_citation_suppression(monkeypatch) 
 
     policy = klai_knowledge.KbAnswerPolicy(
         state="chunks_present",
-        kb_narrow=True,
+        prompt_mode="strict_kb",
         user_provided_content_context=False,
         low_confidence_inject=True,
     )


### PR DESCRIPTION
## Summary

- Add a shared regular-chat KB prompt mode contract in `klai_kb_chat_mode.py`.
- Keep `ChatRetrievalPolicy` narrow: it now returns prompt mode, scope decision, user id, and failure reason only.
- Route the same prompt mode into `KbAnswerPolicy` and `_klai_kb_meta`, then have the citation renderer prefer that mode over legacy `kb_narrow`.
- Add hook and renderer tests for the adversarial review gaps: no-KB plus missing identity, and post-call mode overriding stale/contradictory `kb_narrow`.

## Why

The initial policy object was too broad: several fields looked like enforceable contract but were not consumed by the hook. This version removes those dead contract fields and makes one prompt-mode value flow through pre-call policy, retrieval branch handling, answer policy metadata, and post-call citation rendering.

`kb_narrow` remains in `_klai_kb_meta` for compatibility and existing telemetry, but the renderer now derives strict/open behavior from `chat_retrieval_prompt_mode` when present.

## Validation

- `PYTHONPATH=$PWD/deploy/litellm uv run --project klai-retrieval-api --extra dev pytest deploy/litellm/tests/test_kb_scope_policy.py deploy/litellm/tests/test_kb_answer_policy.py deploy/litellm/tests/test_kb_citation_render_mode.py deploy/litellm/tests/test_low_confidence_injection.py deploy/litellm/tests/test_klai_knowledge_hook.py::TestKlaiKnowledgeHookSlugsTriState deploy/litellm/tests/test_klai_knowledge_hook.py::TestKlaiKnowledgeHookOpenMode deploy/litellm/tests/test_klai_knowledge_hook.py::TestKlaiKnowledgeHookZeroChunksMode -q`
- `PYTHONPATH=$PWD/deploy/litellm uv run --project klai-retrieval-api --extra dev pytest deploy/litellm/tests -q`
- `cd klai-retrieval-api && uv run --extra dev pytest tests/test_scope_filter.py tests/test_evidence_pack.py -q`
- `cd klai-libs/citations && uv run --extra dev pytest tests/test_citations.py -q`
- `git diff --check`
- `PYTHONPATH=$PWD/deploy/litellm uv run --project klai-retrieval-api --extra dev python -m py_compile deploy/litellm/klai_kb_chat_mode.py deploy/litellm/klai_kb_scope_policy.py deploy/litellm/klai_kb_answer_policy.py deploy/litellm/klai_kb_citation_render.py deploy/litellm/klai_knowledge.py`

Note: the full LiteLLM test run passed with one existing coroutine warning in `deploy/litellm/tests/test_taxonomy_classify.py::TestRewriteAndClassifySkips::test_skips_empty_query`.
