### PR TITLE
fix(litellm): use stale KB-feature cache when PORTAL_INTERNAL_SECRET is missing

### DIFF
--- a/.github/workflows/litellm-tests.yml
+++ b/.github/workflows/litellm-tests.yml
@@ -1,0 +1,41 @@
+name: litellm hook tests
+
+# deploy/litellm (the path-A LiteLLM KB chat hook) had NO automated test gate:
+# its 400+ pytest tests only ran locally, so changes merged without CI ever
+# running them. This workflow closes that gap. It does not gate on `quality`
+# (that required check is path-scoped to klai-portal/backend); it provides the
+# missing litellm pytest gate directly.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/litellm/**'
+      - 'klai-libs/citations/**'
+      - 'klai-libs/service-auth/**'
+  pull_request:
+    paths:
+      - 'deploy/litellm/**'
+      - 'klai-libs/citations/**'
+      - 'klai-libs/service-auth/**'
+
+jobs:
+  litellm-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+      # deploy/litellm has no pyproject; the hook's deps + the klai-libs
+      # path-deps are supplied ad-hoc (klai-libs referenced by repo-relative
+      # path). The tests import `from tests.klai_module_reset import …`, so they
+      # must run from the deploy/litellm working directory.
+      - name: Test (pytest)
+        working-directory: deploy/litellm
+        run: >
+          uv run --no-project --python 3.13
+          --with pytest --with pytest-asyncio --with httpx --with structlog
+          --with ../../klai-libs/citations
+          --with ../../klai-libs/service-auth
+          python -m pytest tests/ -q --tb=short

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -577,8 +577,21 @@ async def _get_kb_feature(user_id: str, org_id: str, cache) -> dict:
     Backward compatible: handles old {"enabled": bool} portal responses gracefully.
     """
     if not PORTAL_INTERNAL_SECRET:
+        # We cannot reach portal-api — but a recent successful fetch may still
+        # be cached (kb_feature_latest, 24h). Prefer the user's last-known
+        # settings (which preserve their Strict/Open mode) over a hard refusal,
+        # exactly like the portal-fetch-failure path below. Only refuse when
+        # there is genuinely nothing cached to fall back on.
+        stale = await cache.async_get_cache(f"kb_feature_latest:{org_id}:{user_id}")
+        if isinstance(stale, dict):
+            logger.warning(
+                "KlaiKnowledgeHook: PORTAL_INTERNAL_SECRET not set — using stale "
+                "feature cache"
+            )
+            return stale
         logger.warning(
-            "KlaiKnowledgeHook: PORTAL_INTERNAL_SECRET not set — fail-closed"
+            "KlaiKnowledgeHook: PORTAL_INTERNAL_SECRET not set and no cached "
+            "settings — fail-closed"
         )
         return {
             "enabled": False,

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -7080,3 +7080,52 @@ class TestStrictModeCodeEnforcement:
             system_msg is None
             or "general-purpose assistant" not in system_msg.get("content", "")
         )
+
+
+class TestMissingSecretStaleCache:
+    """Bug D regression: when PORTAL_INTERNAL_SECRET is absent, the hook must
+    still honour the user's last-known settings from the 24h stale cache
+    (preserving their Strict/Open mode) instead of hard-refusing. It may only
+    refuse when there is genuinely nothing cached to fall back on."""
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_uses_stale_cache_instead_of_refusing(
+        self, monkeypatch
+    ):
+        mod = _load_hook(monkeypatch, extra_env={"PORTAL_INTERNAL_SECRET": ""})
+        stale_feature = {
+            "enabled": True,
+            "kb_retrieval_enabled": True,
+            "kb_personal_enabled": True,
+            "kb_slugs_filter": None,
+            "kb_narrow": True,
+            "version": 3,
+            "zitadel_user_id": "300000000000000002",
+            "telemetry_level": "shadow",
+        }
+        cache = MagicMock()
+        cache.async_set_cache = AsyncMock()
+
+        async def _get(key: str) -> object:
+            if key == "kb_feature_latest:org1:user1":
+                return stale_feature
+            return None
+
+        cache.async_get_cache = AsyncMock(side_effect=_get)
+
+        feature = await mod._get_kb_feature("user1", "org1", cache)
+        # Not refused — last-known settings used, Strict mode preserved.
+        assert feature.get("settings_unavailable") is not True
+        assert feature["kb_narrow"] is True
+        assert feature is stale_feature
+
+    @pytest.mark.asyncio
+    async def test_missing_secret_no_cache_still_refuses(self, monkeypatch):
+        mod = _load_hook(monkeypatch, extra_env={"PORTAL_INTERNAL_SECRET": ""})
+        cache = MagicMock()
+        cache.async_set_cache = AsyncMock()
+        cache.async_get_cache = AsyncMock(return_value=None)
+
+        feature = await mod._get_kb_feature("user1", "org1", cache)
+        # Truly cold: nothing to fall back on -> deterministic refusal stands.
+        assert feature["settings_unavailable"] is True


### PR DESCRIPTION
## What

Forward-fix for **bug D** found by the adversarial review: the missing-`PORTAL_INTERNAL_SECRET`
branch of `_get_kb_feature` returned `settings_unavailable=True` immediately, **without checking
the 24h `kb_feature_latest` stale cache**. A user with valid cached settings was hard-refused
whenever the portal secret was absent — even though the code's own comment claimed it only
refuses when there are "no cached settings".

This is a regression introduced by the cold-cache refusal change (947603ee).

## Fix

On the missing-secret path, read `kb_feature_latest` first and return it when present
(preserving the user's Strict/Open mode), mirroring the existing portal-fetch-failure path.
Refuse only when nothing is cached.

## Tests

- `test_missing_secret_uses_stale_cache_instead_of_refusing` (RED→GREEN — reproduces the bug)
- `test_missing_secret_no_cache_still_refuses` (truly-cold path still refuses)
- Full litellm suite: 410 passed · ruff clean

## Process note

Routed through a PR (not admin-push) so the required `quality` gate runs — per the corrected
workflow after several commits bypassed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)