### PR TITLE
harden(auth): pin project_role_scopes to the receiver's own project

### DIFF
--- a/klai-libs/service-auth/klai_service_auth/claims.py
+++ b/klai-libs/service-auth/klai_service_auth/claims.py
@@ -19,8 +19,8 @@ _ROLES_CLAIM_PREFIX = "urn:zitadel:iam:org:project:"
 _ROLES_CLAIM_SUFFIX = ":roles"
 
 
-def project_role_scopes(payload: dict[str, Any]) -> set[str]:
-    """Return granted project-role keys from a Zitadel access-token payload.
+def project_role_scopes(payload: dict[str, Any], project_id: str) -> set[str]:
+    """Return granted role keys for ``project_id`` from a Zitadel token payload.
 
     Zitadel emits granted roles in claims of shape
     ``urn:zitadel:iam:org:project:<projectId>:roles`` — a dict whose KEYS are
@@ -30,15 +30,18 @@ def project_role_scopes(payload: dict[str, Any]) -> set[str]:
     ``urn:zitadel:iam:org:projects:roles`` scope; the standard ``scope`` claim
     stays empty.
 
-    Matches any project's roles claim, so a receiver need not know its own
-    projectId. Verified against a live ``svc-litellm`` token (2026-06-07).
+    PINNED to a single project (SPEC-SEC-SERVICE-AUTH-002 hardening): a token
+    can carry roles claims for EVERY project the holder is granted on, so an
+    agnostic match would let a role key from an unrelated project inject a
+    scope here. We read ONLY ``urn:zitadel:iam:org:project:{project_id}:roles``,
+    where ``project_id`` is the receiver's own audience (== its
+    ``ZITADEL_API_AUDIENCE``). Returns an empty set when ``project_id`` is
+    falsy (JWT disabled) or the pinned claim is absent. Verified against a live
+    ``svc-litellm`` token (2026-06-07).
     """
-    scopes: set[str] = set()
-    for key, value in payload.items():
-        if (
-            key.startswith(_ROLES_CLAIM_PREFIX)
-            and key.endswith(_ROLES_CLAIM_SUFFIX)
-            and isinstance(value, dict)
-        ):
-            scopes.update(str(role_key) for role_key in value)
-    return scopes
+    if not project_id:
+        return set()
+    claim = payload.get(f"{_ROLES_CLAIM_PREFIX}{project_id}{_ROLES_CLAIM_SUFFIX}")
+    if not isinstance(claim, dict):
+        return set()
+    return {str(role_key) for role_key in claim}

--- a/klai-libs/service-auth/tests/test_claims.py
+++ b/klai-libs/service-auth/tests/test_claims.py
@@ -1,0 +1,41 @@
+"""Tests for project_role_scopes (SPEC-SEC-SERVICE-AUTH-002 REQ-4b + pin)."""
+
+from __future__ import annotations
+
+from klai_service_auth import project_role_scopes
+
+_PROJ = "362771533686374406"
+
+
+def test_pinned_project_roles_are_extracted():
+    payload = {
+        f"urn:zitadel:iam:org:project:{_PROJ}:roles": {
+            "klai:internal:retrieval:query": {"362757920133283846": "klai.localhost"}
+        }
+    }
+    assert project_role_scopes(payload, _PROJ) == {"klai:internal:retrieval:query"}
+
+
+def test_roles_from_a_different_project_are_ignored():
+    # Security pin: a roles claim for an UNRELATED project must not inject a
+    # scope, even if the role key collides with one of ours.
+    payload = {
+        "urn:zitadel:iam:org:project:999999999999999999:roles": {
+            "klai:internal:retrieval:query": {}
+        }
+    }
+    assert project_role_scopes(payload, _PROJ) == set()
+
+
+def test_empty_project_id_returns_empty():
+    payload = {f"urn:zitadel:iam:org:project:{_PROJ}:roles": {"x": {}}}
+    assert project_role_scopes(payload, "") == set()
+
+
+def test_absent_roles_claim_returns_empty():
+    assert project_role_scopes({"scope": "openid"}, _PROJ) == set()
+
+
+def test_non_dict_roles_claim_returns_empty():
+    payload = {f"urn:zitadel:iam:org:project:{_PROJ}:roles": "not-a-dict"}
+    assert project_role_scopes(payload, _PROJ) == set()

--- a/klai-retrieval-api/retrieval_api/middleware/auth.py
+++ b/klai-retrieval-api/retrieval_api/middleware/auth.py
@@ -362,7 +362,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             scopes_claim = payload.get("scope") or ""
             scopes = frozenset(
                 {s for s in str(scopes_claim).split() if s}
-                | project_role_scopes(payload)
+                | project_role_scopes(payload, settings.zitadel_api_audience)
             )
             # SPEC-SEC-IDENTITY-ASSERT-003 REQ-1.1: do NOT lift
             # `urn:zitadel:iam:user:resourceowner:id` from the JWT — the


### PR DESCRIPTION
## What

Defence-in-depth from the adversarial review (section C/4): `project_role_scopes` matched
**any** `urn:zitadel:iam:org:project:*:roles` claim. A Zitadel token can carry roles for
every project the holder is granted on, so an agnostic match would let a role key from an
**unrelated** project inject a scope at the receiver.

## Fix

Pin the parser to the receiver's own project: read only
`urn:zitadel:iam:org:project:{project_id}:roles`, where `project_id` == the receiver's
`ZITADEL_API_AUDIENCE` (which equals the Klai Platform project id). retrieval-api passes
`settings.zitadel_api_audience`.

This is defence-in-depth on top of the existing `require_scope` gate. The JWT path is still
inert in prod (audience empty) until SPEC-002 is activated.

## Tests

- 5 lib unit tests: pinned roles extracted; **cross-project roles ignored**; empty/absent/non-dict handled.
- retrieval-api auth: 34 passed (unchanged). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)