### PR TITLE
feat(auth): service-principal JWT on-behalf-of end-users (SPEC-SEC-SERVICE-AUTH-002 — B)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1045,6 +1045,12 @@ services:
       INTERNAL_SECRET: ${RETRIEVAL_API_INTERNAL_SECRET}
       ZITADEL_ISSUER: https://auth.${DOMAIN}
       ZITADEL_API_AUDIENCE: ${RETRIEVAL_API_ZITADEL_AUDIENCE:-}
+      # SPEC-SEC-SERVICE-AUTH-002 (svc-onbehalf): comma-separated Zitadel
+      # machine-account sub ids allowed to act on behalf of end users via a
+      # service-principal JWT (e.g. svc-litellm). Empty default = inert (every
+      # JWT treated as a human user, body==sub). Add the value to klai-infra
+      # SOPS before relying on it (validator-env-parity).
+      SERVICE_PRINCIPAL_SUBS: ${RETRIEVAL_API_SERVICE_PRINCIPAL_SUBS:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
       RATE_LIMIT_RPM: ${RETRIEVAL_API_RATE_LIMIT_RPM:-600}
       # SPEC-SEC-IDENTITY-ASSERT-001 REQ-4: internal-secret callers'

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -108,6 +108,14 @@ class Settings(BaseSettings):
     # Zitadel issuer + audience for JWT validation (REQ-1.2, REQ-5.1).
     zitadel_issuer: str = ""
     zitadel_api_audience: str = ""
+    # SPEC-SEC-SERVICE-AUTH-002 (svc-onbehalf): comma-separated Zitadel
+    # machine-account ``sub`` ids that may act ON BEHALF OF an end-user via a
+    # service-principal JWT (e.g. svc-litellm). Raw string — NOT typed set[str]
+    # (pydantic-settings JSON-parses collection-typed env vars). Parsed by the
+    # ``service_principal_sub_set`` property below. Empty (default) = no service
+    # principals = the on-behalf-of JWT path is inert (every JWT is treated as a
+    # human user, body==sub). Env var: SERVICE_PRINCIPAL_SUBS.
+    service_principal_subs: str = ""
     # Sliding-window rate limit per caller identity (REQ-4.3).
     rate_limit_rpm: int = 600
     # Redis URL for the rate limiter (REQ-4.1). Fail-open when unreachable (REQ-4.5).
@@ -217,6 +225,17 @@ class Settings(BaseSettings):
             and self.zitadel_api_audience
             and self.zitadel_api_audience.strip()
         )
+
+    @property
+    def service_principal_sub_set(self) -> frozenset[str]:
+        """Set of Zitadel machine-account ``sub`` ids parsed from
+        ``service_principal_subs`` (comma-separated). Empty when unset.
+
+        Mirrors the imperative split used for the JWT ``scope`` claim in
+        ``middleware.auth`` rather than typing the field as a collection
+        (which pydantic-settings would JSON-parse).
+        """
+        return frozenset(s.strip() for s in self.service_principal_subs.split(",") if s.strip())
 
 
 settings = Settings()

--- a/klai-retrieval-api/retrieval_api/middleware/auth.py
+++ b/klai-retrieval-api/retrieval_api/middleware/auth.py
@@ -501,6 +501,25 @@ async def verify_body_identity(
                 )
             return
 
+        # SPEC-SEC-SERVICE-AUTH-002 (svc-onbehalf): a CONFIGURED service
+        # principal (machine account, e.g. svc-litellm) may act ON BEHALF OF an
+        # end-user. Its ``sub`` is in the explicit allowlist and — on /retrieve
+        # — it already passed require_scope("klai:internal:retrieval:query").
+        # The end-user named in the body is verified by portal membership,
+        # exactly like the internal-secret caller path (_verify_on_behalf_of).
+        # A human-user JWT (sub NOT in the allowlist) falls through to the
+        # body==sub self-assertion below, so the broad project-wide audience
+        # cannot be used to act on behalf of others.
+        if auth.sub is not None and auth.sub in settings.service_principal_sub_set:
+            logger.info(
+                "service_principal_on_behalf_of",
+                jwt_sub_hash=_hash_sub(auth.sub),
+                caller_service=request.headers.get("x-caller-service", "").strip() or None,
+                path=request.url.path,
+            )
+            await _verify_on_behalf_of(request, body_user_id, body_org_id)
+            return
+
         if body_user_id is not None and auth.sub is not None and str(body_user_id) != str(auth.sub):
             cross_user_rejected_total.inc()
             logger.warning(
@@ -572,7 +591,31 @@ async def verify_body_identity(
         )
         return
 
-    # auth.method == "internal" — REQ-4.2 portal-side verification.
+    # auth.method == "internal" — REQ-4.2 portal-side verification. Same
+    # on-behalf-of contract as the JWT service-principal path above:
+    # X-Caller-Service + portal membership verify of the body's end-user.
+    await _verify_on_behalf_of(request, body_user_id, body_org_id)
+
+
+async def _verify_on_behalf_of(
+    request: Request, body_user_id: str | None, body_org_id: str
+) -> None:
+    """Verify an end-user identity asserted by a trusted caller, then pin it.
+
+    Shared by the two callers that act ON BEHALF OF an end-user named in the
+    request body:
+
+    * the internal-secret caller (``X-Internal-Secret``), and
+    * a configured service-principal JWT (SPEC-SEC-SERVICE-AUTH-002, e.g.
+      ``svc-litellm``).
+
+    The caller is already authenticated (shared secret or a signature- and
+    audience-verified Zitadel JWT). This step verifies the END-USER
+    ``(body_user_id, body_org_id)`` against portal-api
+    ``/internal/identity/verify`` by membership and pins the portal-returned
+    tuple on ``request.state.verified_caller``. A forged body is denied at the
+    portal, never pinned here (REQ-4.2 defense-in-depth).
+    """
     if body_user_id is None:
         # Bodies that don't carry an end-user claim (admin/diagnostic style
         # calls that future code paths might add) are out of scope for the
@@ -606,20 +649,19 @@ async def verify_body_identity(
 
     # F2 fix-forward (retrieval coupling audit 2026-05-06): synthetic
     # `partner:<key_id>` identities go through the SAME portal verify path
-    # as every other internal-secret caller. Portal-side identity_verifier
-    # has a dedicated branch that resolves the key against partner_api_keys
-    # and confirms the key's owning org matches the claim — so a forged
-    # body claiming `(partner:any-key, victim-tenant)` is denied at the
-    # portal, not pinned by retrieval-api. The earlier in-process bypass
-    # was removed because it weakened defense-in-depth: an attacker
-    # holding X-Internal-Secret could pin any (synthetic_user, any_org)
-    # tuple as verified_caller and read the org's data.
+    # as every other caller. Portal-side identity_verifier has a dedicated
+    # branch that resolves the key against partner_api_keys and confirms the
+    # key's owning org matches the claim — so a forged body claiming
+    # `(partner:any-key, victim-tenant)` is denied at the portal, not pinned
+    # by retrieval-api. The earlier in-process bypass was removed because it
+    # weakened defense-in-depth: a caller could pin any (synthetic_user,
+    # any_org) tuple as verified_caller and read the org's data.
     asserter = _get_asserter()
     result = await asserter.verify(
         caller_service=caller_service,
         claimed_user_id=str(body_user_id),
         claimed_org_id=str(body_org_id),
-        bearer_jwt=None,  # internal-secret path: no end-user JWT in the call
+        bearer_jwt=None,  # on-behalf-of path: no end-user JWT in the call
         request_headers=dict(request.headers),
     )
     if not result.verified or result.user_id is None or result.org_id is None:

--- a/klai-retrieval-api/tests/test_auth.py
+++ b/klai-retrieval-api/tests/test_auth.py
@@ -545,6 +545,165 @@ class TestCrossUserOrgGuard:
         assert resp.status_code == 200
 
 
+class TestServicePrincipalOnBehalfOf:
+    """SPEC-SEC-SERVICE-AUTH-002: a CONFIGURED service-principal JWT may act on
+    behalf of an end-user (body user_id != jwt sub), verified by portal
+    membership — the litellm -> retrieval-api activation path.
+
+    A human-user JWT (sub NOT in the allowlist) is unaffected: body==sub is
+    still enforced. The empty default allowlist keeps the path inert.
+    """
+
+    _SVC_SUB = "svc-litellm-371062520670060561"
+
+    def _allowlist(self, monkeypatch, value):
+        import retrieval_api.middleware.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod.settings, "service_principal_subs", value)
+
+    def test_sub_set_parsing(self):
+        from retrieval_api.config import Settings
+
+        s = Settings(service_principal_subs=" a , b ,, c ")
+        assert s.service_principal_sub_set == frozenset({"a", "b", "c"})
+        assert Settings(service_principal_subs="").service_principal_sub_set == frozenset()
+
+    def test_service_principal_acts_on_behalf_of_end_user(
+        self, monkeypatch, sample_retrieve_request
+    ):
+        """svc sub in allowlist + body user_id != sub + X-Caller-Service ->
+        on-behalf-of path, portal-verified, 200 (NOT user_mismatch)."""
+        from retrieval_api.main import app
+
+        self._allowlist(monkeypatch, self._SVC_SUB)
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub=self._SVC_SUB)
+        sample_retrieve_request["org_id"] = "org_x"
+        sample_retrieve_request["user_id"] = "end_user_b"
+        with (
+            _patch_jwt(payload),
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="resolved",
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.0],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.gate.should_bypass",
+                new_callable=AsyncMock,
+                return_value=(True, 0.5),
+            ),
+        ):
+            resp = client.post(
+                "/retrieve",
+                json=sample_retrieve_request,
+                headers={"Authorization": "Bearer svc", "X-Caller-Service": "litellm"},
+            )
+        assert resp.status_code == 200
+
+    def test_service_principal_without_caller_service_400(self, monkeypatch):
+        """On-behalf-of requires X-Caller-Service (loud config error, not fail-open)."""
+        from retrieval_api.main import app
+
+        self._allowlist(monkeypatch, self._SVC_SUB)
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub=self._SVC_SUB)
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "org_x",
+                    "user_id": "end_user_b",
+                    "scope": "personal",
+                },
+                headers={"Authorization": "Bearer svc"},  # no X-Caller-Service
+            )
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == {"error": "missing_caller_service"}
+
+    def test_service_principal_portal_deny_403(self, monkeypatch):
+        """Portal denies the asserted end-user -> 403 identity_assertion_failed."""
+        from klai_identity_assert import VerifyResult
+
+        from retrieval_api.main import app
+
+        class _DenyAsserter:
+            async def verify(self, **_kw) -> VerifyResult:
+                return VerifyResult.deny("no_membership")
+
+        self._allowlist(monkeypatch, self._SVC_SUB)
+        monkeypatch.setattr("retrieval_api.middleware.auth._get_asserter", lambda: _DenyAsserter())
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub=self._SVC_SUB)
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "org_x",
+                    "user_id": "end_user_b",
+                    "scope": "personal",
+                },
+                headers={"Authorization": "Bearer svc", "X-Caller-Service": "litellm"},
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == {"error": "identity_assertion_failed"}
+
+    def test_non_service_principal_jwt_still_user_mismatch(self, monkeypatch):
+        """Regression: a sub NOT in the allowlist still enforces body==sub,
+        even with X-Caller-Service set (human path unchanged)."""
+        from retrieval_api.main import app
+
+        self._allowlist(monkeypatch, self._SVC_SUB)
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub="human_user_a")  # NOT the svc sub
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "org_x",
+                    "user_id": "victim_b",
+                    "scope": "personal",
+                },
+                headers={"Authorization": "Bearer human", "X-Caller-Service": "litellm"},
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == {"error": "user_mismatch"}
+
+    def test_empty_allowlist_keeps_svc_on_human_path(self, monkeypatch):
+        """Default empty allowlist (inert): the svc sub falls to body==sub and
+        a mismatched body user_id is rejected — no on-behalf-of power."""
+        from retrieval_api.main import app
+
+        self._allowlist(monkeypatch, "")  # inert
+        client = TestClient(app)
+        payload = _make_jwt_payload(sub=self._SVC_SUB)
+        with _patch_jwt(payload):
+            resp = client.post(
+                "/retrieve",
+                json={
+                    "query": "q",
+                    "org_id": "org_x",
+                    "user_id": "end_user_b",
+                    "scope": "personal",
+                },
+                headers={"Authorization": "Bearer svc", "X-Caller-Service": "litellm"},
+            )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == {"error": "user_mismatch"}
+
+
 # --------------------------------------------------------------------------- #
 # REQ-2 — Pydantic bounds
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

**Option B** of SPEC-SEC-SERVICE-AUTH-002: make the litellm → retrieval-api JWT
path able to actually carry traffic, by letting a configured **service principal**
(machine account) act **on behalf of an end-user**.

Depends conceptually on PR #802 (Option A — the litellm kill-switch). The two are
code-independent; activation needs both plus config.

## Why

litellm mints a *machine* token (`sub = svc-litellm`) but `/retrieve` runs on
behalf of an *end-user*. `verify_body_identity` rejected `body.user_id != jwt.sub`
with `user_mismatch` (only the `admin` role bypassed). So even after landing the
audience, the JWT path 403'd and fell back to legacy — the migration could never
complete. (See PR #802 description + VictoriaLogs evidence.)

## How

A service-principal on-behalf-of path, **symmetric with the existing
internal-secret caller path**:

- A JWT whose `sub` is in the new `SERVICE_PRINCIPAL_SUBS` allowlist acts on behalf
  of the end-user named in the body, verified by portal `/internal/identity/verify`
  membership — identical to the internal-secret caller, just authenticated by a
  stronger (signature + audience-verified) Zitadel JWT.
- A **human-user JWT** (`sub` NOT in the allowlist) is unaffected: `body==sub`
  stays enforced. So the broad project-wide audience (the adversarial review's
  finding 3) **cannot** be used to act on behalf of others.
- The internal-secret branch and the JWT service-principal branch now share one
  helper `_verify_on_behalf_of()` (no duplication).

### Defense-in-depth for the on-behalf-of power
1. signature + audience-verified Zitadel JWT (`_decode_jwt`)
2. `require_scope("klai:internal:retrieval:query")` on `/retrieve`
3. `sub` in the explicit `SERVICE_PRINCIPAL_SUBS` allowlist
4. portal membership verify of the asserted end-user (forged body → denied at portal)
5. retrieval → portal authenticated by `PORTAL_INTERNAL_SECRET`

## Files

- `config.py`: `service_principal_subs` (env `SERVICE_PRINCIPAL_SUBS`) + parsed
  `service_principal_sub_set` property. Empty default = path inert.
- `middleware/auth.py`: `_verify_on_behalf_of()` helper + the JWT service-principal branch.
- `docker-compose.yml`: declare `SERVICE_PRINCIPAL_SUBS` on retrieval-api (`${...:-}` = inert).
- `tests/test_auth.py`: `TestServicePrincipalOnBehalfOf` (6 cases).

## Activation (separate ops step, NOT in this PR)

1. Land `RETRIEVAL_API_ZITADEL_AUDIENCE` (blocked by the SOPS drift — review finding 6).
2. Set `RETRIEVAL_API_SERVICE_PRINCIPAL_SUBS` = svc-litellm sub in SOPS.
3. Flip litellm `KLAI_RETRIEVAL_JWT_AUTH_ENABLED=true` (PR #802).
4. Verify `auth_method=jwt > 0` + `service_principal_on_behalf_of` events.

## Verification

- retrieval-api auth + identity-assert suite green (522 passed). The 2 failing
  tests are **pre-existing / environmental**, proven unrelated:
  `test_missing_zitadel_audience_fails_import` predates the audience-optional
  validator; `test_health_all_ok` needs a live falkordb.
- `ruff check` + `ruff format --check` clean.

> Note: retrieval-api has **no pytest CI job** (only ast-grep CORS + Docker build +
> Trivy). The tests above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
