### PR TITLE
ci(retrieval-api): add pytest gate + fix two pre-existing test failures

### DIFF
--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -12,6 +12,8 @@ on:
       - 'klai-libs/chat-prompts/**'
       - 'klai-libs/kb-slugs/**'
       - 'klai-libs/citations/**'
+      - 'klai-libs/service-auth/**'
+      - 'klai-libs/llm-safety/**'
       - '.github/workflows/retrieval-api.yml'
   pull_request:
     branches: [main]
@@ -21,6 +23,8 @@ on:
       - 'klai-libs/chat-prompts/**'
       - 'klai-libs/kb-slugs/**'
       - 'klai-libs/citations/**'
+      - 'klai-libs/service-auth/**'
+      - 'klai-libs/llm-safety/**'
       - '.github/workflows/retrieval-api.yml'
   workflow_dispatch:
 
@@ -34,6 +38,26 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # retrieval-api had NO automated test gate: its ~520 pytest tests only ran
+  # locally, so changes (incl. security-critical middleware/auth.py) merged
+  # without CI ever running them. This job closes that gap. It does not gate on
+  # `quality` (that required check is path-scoped to klai-portal/backend); it
+  # provides the missing retrieval-api pytest gate directly. All external
+  # services (Redis/Qdrant/TEI/FalkorDB/portal) are mocked, so no service
+  # containers are needed.
+  tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: klai-retrieval-api
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+      - name: Test (pytest)
+        run: uv run --extra dev pytest -q --tb=short
+
   build-push:
     runs-on: ubuntu-latest
 

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -861,6 +861,10 @@ class TestHealthEndpoint:
         with (
             patch("httpx.AsyncClient") as MockHttpxClient,
             patch("qdrant_client.AsyncQdrantClient") as MockQdrant,
+            # FalkorDB health check runs when graphiti_enabled; the default
+            # MagicMock makes db.connection.ping a sync no-op so the check
+            # passes without a live falkordb (matches the qdrant/httpx mocks).
+            patch("falkordb.FalkorDB"),
         ):
             # Mock httpx for TEI and LiteLLM health checks
             mock_http = AsyncMock()

--- a/klai-retrieval-api/tests/test_auth.py
+++ b/klai-retrieval-api/tests/test_auth.py
@@ -120,7 +120,13 @@ class TestStartupFail:
         )
         assert result.returncode != 0
 
-    def test_missing_zitadel_audience_fails_import(self):
+    def test_missing_zitadel_audience_disables_jwt_not_import(self):
+        """Empty ZITADEL_API_AUDIENCE DISABLES the JWT path (graceful degrade) —
+        it does NOT fail import. The config validator treats issuer+audience as
+        optional: when either is empty, ``jwt_auth_enabled`` is False and all
+        callers must use X-Internal-Secret. This is the supported state for the
+        internal mesh (SPEC-SEC-SERVICE-AUTH-002 dropped the per-service JWT).
+        """
         script = textwrap.dedent(
             """
             import os
@@ -128,7 +134,11 @@ class TestStartupFail:
             os.environ["ZITADEL_ISSUER"] = "https://auth.test.local"
             os.environ["ZITADEL_API_AUDIENCE"] = ""
             os.environ["REDIS_URL"] = "redis://localhost:6379/0"
-            import retrieval_api.config
+            os.environ["PORTAL_API_URL"] = "http://portal.test.local"
+            os.environ["PORTAL_INTERNAL_SECRET"] = "ok"
+            import retrieval_api.config as c
+            assert c.settings.jwt_auth_enabled is False, "empty audience must disable JWT"
+            print("OK import succeeded jwt disabled")
             """
         )
         result = subprocess.run(  # noqa: S603 — trusted input (test-authored script)
@@ -137,8 +147,8 @@ class TestStartupFail:
             text=True,
             check=False,
         )
-        assert result.returncode != 0
-        assert "ZITADEL_API_AUDIENCE" in (result.stderr + result.stdout)
+        assert result.returncode == 0, result.stderr
+        assert "OK import succeeded jwt disabled" in result.stdout
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes the Codex review finding that retrieval-api has no pytest CI. Adds a `tests` job (`uv run --extra dev pytest`, all external services mocked) and fixes the 2 pre-existing failures that blocked a green suite (FalkorDB unmocked in the health test; the obsolete audience-validator test rewritten to the real graceful-degrade contract). 518 passed, 1 skipped locally.

Companion to #804 (drop per-service JWT). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)