### PR TITLE
fix(retrieval-api): deflake events cap-hit test (monotonic uptime dependency)

### DIFF
--- a/klai-retrieval-api/tests/test_events_bounded.py
+++ b/klai-retrieval-api/tests/test_events_bounded.py
@@ -46,7 +46,13 @@ async def clean_events(monkeypatch):
         if not task.done():
             task.cancel()
     events._pending.clear()
-    monkeypatch.setattr(events, "_last_cap_log_time", 0.0, raising=False)
+    # Reset the cap-hit rate-limiter so the next cap-hit ALWAYS logs. NOT 0.0:
+    # the emit guard is ``time.monotonic() - _last_cap_log_time >= 60`` and
+    # ``time.monotonic()`` is "seconds since an arbitrary point" — on a freshly
+    # booted CI runner (uptime < 60s) ``now`` itself is < 60, so ``now - 0.0``
+    # is < 60 and the cap-hit log is suppressed → flaky "found none" failures.
+    # A large negative makes ``now - (-1e9)`` exceed the window for any ``now``.
+    monkeypatch.setattr(events, "_last_cap_log_time", -1e9, raising=False)
     yield events
     # Same teardown to be polite to the next test.
     for task in list(events._pending):


### PR DESCRIPTION
The new retrieval-api pytest gate (#805) went red on main on a test I did not touch: `test_pending_set_capped_at_configured_max`. Root cause: the cap-hit emit guard is `time.monotonic() - _last_cap_log_time >= 60`; the fixture reset to 0.0, but `time.monotonic()` is seconds-since-an-arbitrary-point, so on a fresh CI runner (uptime < 60s) `now - 0.0 < 60` suppresses the cap-hit log → flaky. Fixed by resetting to -1e9 (window always elapsed). Proven: with 0.0 the log does not fire at uptime 5/30/59.9s; with -1e9 it fires for all. 4 events tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)