### PR TITLE
chore: sync klai-infra submodule pointer + retrieval-api lockfile

### DIFF
--- a/klai-retrieval-api/uv.lock
+++ b/klai-retrieval-api/uv.lock
@@ -803,6 +803,34 @@ dev = [
 ]
 
 [[package]]
+name = "klai-service-auth"
+version = "0.1.0"
+source = { editable = "../klai-libs/service-auth" }
+dependencies = [
+    { name = "httpx" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "structlog", specifier = ">=25.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=1" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
 name = "lingua-language-detector"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1335,6 +1363,7 @@ dependencies = [
     { name = "klai-identity-assert" },
     { name = "klai-kb-slugs" },
     { name = "klai-llm-safety" },
+    { name = "klai-service-auth" },
     { name = "lingua-language-detector" },
     { name = "prometheus-client" },
     { name = "pydantic" },
@@ -1368,6 +1397,7 @@ requires-dist = [
     { name = "klai-identity-assert", editable = "../klai-libs/identity-assert" },
     { name = "klai-kb-slugs", editable = "../klai-libs/kb-slugs" },
     { name = "klai-llm-safety", editable = "../klai-libs/llm-safety" },
+    { name = "klai-service-auth", editable = "../klai-libs/service-auth" },
     { name = "lingua-language-detector", specifier = ">=2.2.0" },
     { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic", specifier = ">=2.9" },


### PR DESCRIPTION
Two unrelated working-tree drifts cleaned up as housekeeping. Neither belongs in the alerting-runbook fix (#809), so they land separately here.

## 1. klai-infra submodule pointer `a192ccfe` → `6742683`

The commits in that range touch **only** `core-01/.env.sops` (encrypted secrets) plus one runbook doc commit:

- `7d3b02d` add `RETRIEVAL_API_ZITADEL_AUDIENCE` (SPEC-SEC-SERVICE-AUTH-002 REQ-6)
- `8945d2e` add `GETKLAI_MEILI_API_KEY`, drop JWT-migration audience debris
- `de93202` remove unused litellm JWT-mint creds (post-#804 cleanup)
- `6742683` docs: add the `mailer-zitadel-webhook-failed` section to `platform-recovery.md` (the public alert URLs in #809 deep-link to it)

All already on `klai-infra` main; the SOPS changes are applied to production via `sync-env`. This records that live state in the monorepo pointer.

## 2. retrieval-api `uv.lock` — add `klai-service-auth`

`pyproject.toml` already declares `klai-service-auth = { path = "../klai-libs/service-auth", editable = true }` (SPEC-CHAT-GUARDRAILS-001); only the lockfile lagged — `uv lock --check` **fails on main today** and passes with this entry. No version churn (single editable-dep entry added).

## Risk
Low. (1) records already-live encrypted-secret + doc state; (2) repairs existing lock↔manifest drift for an already-merged dependency.