### PR TITLE
refactor(retrieval-api): decompose retrieve.py god-module (929->759)

### DIFF
--- a/klai-retrieval-api/retrieval_api/api/decision_log.py
+++ b/klai-retrieval-api/retrieval_api/api/decision_log.py
@@ -1,0 +1,33 @@
+"""Decision-record logging projection for the /retrieve pipeline.
+
+Extracts the log-safe source-provenance projection from ``retrieve.py``. Pure
+(getattr-only, no I/O) and now directly characterization-tested
+(tests/test_evidence_pack_decision_sources.py). ``retrieve`` re-imports
+``_evidence_pack_decision_sources`` so the orchestrator's decision_record
+assembly is unchanged.
+"""
+
+from __future__ import annotations
+
+
+def _evidence_pack_decision_sources(evidence_pack: object) -> list[dict[str, object]]:
+    """Return source provenance that is safe and useful in retrieval logs."""
+    sources = getattr(evidence_pack, "sources", None)
+    if not isinstance(sources, list):
+        return []
+    decision_sources: list[dict[str, object]] = []
+    for source in sources[:5]:
+        relevance_score = getattr(source, "relevance_score", None)
+        if isinstance(relevance_score, (int, float)):
+            relevance_score = round(float(relevance_score), 4)
+        decision_sources.append(
+            {
+                "source_id": getattr(source, "source_id", None),
+                "title": getattr(source, "title", None),
+                "url": getattr(source, "source_url", None),
+                "source_label": getattr(source, "source_label", None),
+                "evidence_ids": getattr(source, "evidence_ids", None) or [],
+                "relevance_score": relevance_score,
+            }
+        )
+    return decision_sources

--- a/klai-retrieval-api/retrieval_api/api/page_context.py
+++ b/klai-retrieval-api/retrieval_api/api/page_context.py
@@ -1,0 +1,80 @@
+"""Page-context URL matching + same-page score boost for the /retrieve pipeline.
+
+A self-contained cluster: canonicalise an http(s) URL, decide whether a source
+URL sits in the same page-context subtree, and boost (and re-sort) the chunks
+whose source matches the caller's current page. Lifted out of ``retrieve.py``
+(behavior-preserving). The two URL helpers and the tuning constant are internal
+to this module; ``retrieve`` re-imports only ``_apply_page_context_boost`` so
+the orchestrator call sites and the
+``from retrieval_api.api.retrieve import _apply_page_context_boost`` test import
+are unchanged.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse, urlunparse
+
+_PAGE_CONTEXT_SCORE_BOOST = 1.08
+
+
+def _normalise_page_context_url(raw_url: str | None) -> str:
+    if not raw_url:
+        return ""
+    try:
+        parsed = urlparse(raw_url.strip())
+    except ValueError:
+        return ""
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    path = parsed.path.rstrip("/") or "/"
+    return urlunparse((parsed.scheme.lower(), parsed.netloc.lower(), path, "", "", ""))
+
+
+def _same_page_context_path(source_url: str, page_url: str) -> bool:
+    source = urlparse(source_url)
+    page = urlparse(page_url)
+    if source.scheme != page.scheme or source.netloc != page.netloc:
+        return False
+    source_path = source.path.rstrip("/") or "/"
+    page_path = page.path.rstrip("/") or "/"
+    if source_path == "/" or page_path == "/":
+        return source_path == page_path
+    return source_path.startswith(f"{page_path}/") or page_path.startswith(f"{source_path}/")
+
+
+def _apply_page_context_boost(
+    chunks: list[dict],
+    page_context: dict[str, str] | None,
+    *,
+    mark: bool = True,
+) -> tuple[list[dict], int]:
+    page_url = _normalise_page_context_url((page_context or {}).get("url"))
+    if not page_url:
+        return chunks, 0
+
+    boosted_count = 0
+    for chunk in chunks:
+        source_url = _normalise_page_context_url(chunk.get("source_url"))
+        if not source_url:
+            continue
+        if source_url != page_url and not _same_page_context_path(source_url, page_url):
+            continue
+
+        boosted_count += 1
+        score_key = (
+            "reranker_score" if isinstance(chunk.get("reranker_score"), (int, float)) else "score"
+        )
+        if isinstance(chunk.get(score_key), (int, float)):
+            boosted_score = chunk[score_key] * _PAGE_CONTEXT_SCORE_BOOST
+            chunk[score_key] = (
+                min(boosted_score, 1.0) if score_key == "reranker_score" else boosted_score
+            )
+            if mark:
+                chunk["_page_context_boosted"] = True
+
+    if boosted_count:
+        chunks.sort(
+            key=lambda c: c.get("reranker_score") or c.get("score") or 0.0,
+            reverse=True,
+        )
+    return chunks, boosted_count

--- a/klai-retrieval-api/retrieval_api/api/ranking.py
+++ b/klai-retrieval-api/retrieval_api/api/ranking.py
@@ -1,0 +1,105 @@
+"""Pure scoring / ranking helpers for the /retrieve pipeline.
+
+Side-effect-free operations over the in-flight ``list[dict]`` chunk lists:
+Reciprocal Rank Fusion of qdrant + graph results, the link-expand reranker
+boost, and the served-result confidence band. Lifted out of ``retrieve.py``
+(behavior-preserving) so the orchestrator keeps pipeline wiring, not ranking
+math. Each already has dedicated unit tests; ``retrieve`` re-imports all three
+so the existing call sites and the
+``from retrieval_api.api.retrieve import _rrf_merge`` /
+``_compute_confidence_band`` / ``_apply_link_expand_boost`` test imports are
+unchanged.
+"""
+
+from __future__ import annotations
+
+from retrieval_api.models import ConfidenceBand
+
+
+def _compute_confidence_band(
+    chunks: list[dict],
+    *,
+    high_threshold: float,
+    low_threshold: float,
+    reranker_enabled: bool,
+) -> ConfidenceBand:
+    """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: bucket the served result by
+    max(reranker_score). Driven by the litellm-hook anti-hallucination
+    injection (REQ-2).
+
+    Returns:
+        - ``unknown`` when reranker is disabled, every chunk's reranker_score
+          is None (fallback path), or the served list is empty
+        - ``high`` when max ≥ high_threshold
+        - ``low`` when max < low_threshold
+        - ``medium`` otherwise
+
+    Operates on the raw served list of dicts (post quality-floor +
+    source-aware-select + quality-boost), NOT on the ChunkResult objects —
+    boosted scores from REQ-3 must be reflected.
+    """
+    if not reranker_enabled or not chunks:
+        return "unknown"
+    scores = [c.get("reranker_score") for c in chunks]
+    valid_scores = [s for s in scores if isinstance(s, (int, float))]
+    if not valid_scores:
+        return "unknown"
+    max_score = max(valid_scores)
+    if max_score >= high_threshold:
+        return "high"
+    if max_score < low_threshold:
+        return "low"
+    return "medium"
+
+
+def _apply_link_expand_boost(
+    chunks: list[dict],
+    *,
+    boost: float,
+    enabled: bool,
+) -> list[dict]:
+    """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-3: multiplicative reranker-score
+    boost (capped at 1.0) for chunks whose ``_link_expanded`` flag is set.
+
+    Applied AFTER rerank and BEFORE source-aware-select + quality-boost so
+    expanded neighbours get a fair shot at the served top-K. With
+    ``boost=1.0`` (default) this is a no-op; the SPEC ships safe and
+    operators tune via env var once the eval baseline is captured.
+
+    Mutates the input list in place (matches the surrounding pipeline's
+    style) and returns the same list for ergonomic chaining.
+    """
+    if not enabled or boost <= 1.0:
+        return chunks
+    for chunk in chunks:
+        if chunk.get("_link_expanded") and isinstance(chunk.get("reranker_score"), (int, float)):
+            boosted = chunk["reranker_score"] * boost
+            chunk["reranker_score"] = min(boosted, 1.0)
+    # Re-sort by boosted reranker_score so downstream pickers see the new order.
+    chunks.sort(
+        key=lambda c: c.get("reranker_score") or c.get("score") or 0.0,
+        reverse=True,
+    )
+    return chunks
+
+
+def _rrf_merge(qdrant_results: list[dict], graph_results: list[dict], k: int = 60) -> list[dict]:
+    """Reciprocal Rank Fusion merge of two ranked result lists (AC-5)."""
+    scores: dict[str, float] = {}
+    items: dict[str, dict] = {}
+
+    for rank, result in enumerate(qdrant_results):
+        cid = result["chunk_id"]
+        scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + rank + 1)
+        items[cid] = result
+
+    for rank, result in enumerate(graph_results):
+        cid = result["chunk_id"]
+        scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + rank + 1)
+        if cid not in items:
+            items[cid] = result
+
+    merged = sorted(items.values(), key=lambda r: scores[r["chunk_id"]], reverse=True)
+    for result in merged:
+        result["score"] = scores[result["chunk_id"]]
+    return merged

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -8,12 +8,12 @@ import math
 import os
 import time
 import uuid
-from urllib.parse import urlparse, urlunparse
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from klai_kb_slugs import personal_kb_slug
 
+from retrieval_api.api.page_context import _apply_page_context_boost
 from retrieval_api.api.ranking import (
     _apply_link_expand_boost,
     _compute_confidence_band,
@@ -63,7 +63,6 @@ _RETRIEVAL_QUERY_SCOPE = "klai:internal:retrieval:query"
 # Module-level singleton — avoids ruff B008 ("Depends in default arg") and
 # is the FastAPI-recommended pattern for repeated dependencies.
 _REQUIRE_RETRIEVAL_SCOPE = Depends(require_scope(_RETRIEVAL_QUERY_SCOPE))
-_PAGE_CONTEXT_SCORE_BOOST = 1.08
 
 
 def _caller_pre_resolved(req: RetrieveRequest) -> bool:
@@ -76,69 +75,6 @@ def _caller_pre_resolved(req: RetrieveRequest) -> bool:
     both fall through to retrieval-side coreference resolution.
     """
     return bool(req.raw_query) and req.raw_query != req.query
-
-
-def _normalise_page_context_url(raw_url: str | None) -> str:
-    if not raw_url:
-        return ""
-    try:
-        parsed = urlparse(raw_url.strip())
-    except ValueError:
-        return ""
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return ""
-    path = parsed.path.rstrip("/") or "/"
-    return urlunparse((parsed.scheme.lower(), parsed.netloc.lower(), path, "", "", ""))
-
-
-def _same_page_context_path(source_url: str, page_url: str) -> bool:
-    source = urlparse(source_url)
-    page = urlparse(page_url)
-    if source.scheme != page.scheme or source.netloc != page.netloc:
-        return False
-    source_path = source.path.rstrip("/") or "/"
-    page_path = page.path.rstrip("/") or "/"
-    if source_path == "/" or page_path == "/":
-        return source_path == page_path
-    return source_path.startswith(f"{page_path}/") or page_path.startswith(f"{source_path}/")
-
-
-def _apply_page_context_boost(
-    chunks: list[dict],
-    page_context: dict[str, str] | None,
-    *,
-    mark: bool = True,
-) -> tuple[list[dict], int]:
-    page_url = _normalise_page_context_url((page_context or {}).get("url"))
-    if not page_url:
-        return chunks, 0
-
-    boosted_count = 0
-    for chunk in chunks:
-        source_url = _normalise_page_context_url(chunk.get("source_url"))
-        if not source_url:
-            continue
-        if source_url != page_url and not _same_page_context_path(source_url, page_url):
-            continue
-
-        boosted_count += 1
-        score_key = (
-            "reranker_score" if isinstance(chunk.get("reranker_score"), (int, float)) else "score"
-        )
-        if isinstance(chunk.get(score_key), (int, float)):
-            boosted_score = chunk[score_key] * _PAGE_CONTEXT_SCORE_BOOST
-            chunk[score_key] = (
-                min(boosted_score, 1.0) if score_key == "reranker_score" else boosted_score
-            )
-            if mark:
-                chunk["_page_context_boosted"] = True
-
-    if boosted_count:
-        chunks.sort(
-            key=lambda c: c.get("reranker_score") or c.get("score") or 0.0,
-            reverse=True,
-        )
-    return chunks, boosted_count
 
 
 def _evidence_pack_decision_sources(evidence_pack: object) -> list[dict[str, object]]:

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -13,6 +13,7 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from klai_kb_slugs import personal_kb_slug
 
+from retrieval_api.api.decision_log import _evidence_pack_decision_sources
 from retrieval_api.api.page_context import _apply_page_context_boost
 from retrieval_api.api.ranking import (
     _apply_link_expand_boost,
@@ -75,29 +76,6 @@ def _caller_pre_resolved(req: RetrieveRequest) -> bool:
     both fall through to retrieval-side coreference resolution.
     """
     return bool(req.raw_query) and req.raw_query != req.query
-
-
-def _evidence_pack_decision_sources(evidence_pack: object) -> list[dict[str, object]]:
-    """Return source provenance that is safe and useful in retrieval logs."""
-    sources = getattr(evidence_pack, "sources", None)
-    if not isinstance(sources, list):
-        return []
-    decision_sources: list[dict[str, object]] = []
-    for source in sources[:5]:
-        relevance_score = getattr(source, "relevance_score", None)
-        if isinstance(relevance_score, (int, float)):
-            relevance_score = round(float(relevance_score), 4)
-        decision_sources.append(
-            {
-                "source_id": getattr(source, "source_id", None),
-                "title": getattr(source, "title", None),
-                "url": getattr(source, "source_url", None),
-                "source_label": getattr(source, "source_label", None),
-                "evidence_ids": getattr(source, "evidence_ids", None) or [],
-                "relevance_score": relevance_score,
-            }
-        )
-    return decision_sources
 
 
 @router.post("/retrieve", response_model=RetrieveResponse)

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -14,6 +14,11 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from klai_kb_slugs import personal_kb_slug
 
+from retrieval_api.api.ranking import (
+    _apply_link_expand_boost,
+    _compute_confidence_band,
+    _rrf_merge,
+)
 from retrieval_api.config import settings
 from retrieval_api.metrics import (
     quality_floor_filtered_total,
@@ -136,73 +141,6 @@ def _apply_page_context_boost(
     return chunks, boosted_count
 
 
-def _compute_confidence_band(
-    chunks: list[dict],
-    *,
-    high_threshold: float,
-    low_threshold: float,
-    reranker_enabled: bool,
-) -> ConfidenceBand:
-    """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: bucket the served result by
-    max(reranker_score). Driven by the litellm-hook anti-hallucination
-    injection (REQ-2).
-
-    Returns:
-        - ``unknown`` when reranker is disabled, every chunk's reranker_score
-          is None (fallback path), or the served list is empty
-        - ``high`` when max ≥ high_threshold
-        - ``low`` when max < low_threshold
-        - ``medium`` otherwise
-
-    Operates on the raw served list of dicts (post quality-floor +
-    source-aware-select + quality-boost), NOT on the ChunkResult objects —
-    boosted scores from REQ-3 must be reflected.
-    """
-    if not reranker_enabled or not chunks:
-        return "unknown"
-    scores = [c.get("reranker_score") for c in chunks]
-    valid_scores = [s for s in scores if isinstance(s, (int, float))]
-    if not valid_scores:
-        return "unknown"
-    max_score = max(valid_scores)
-    if max_score >= high_threshold:
-        return "high"
-    if max_score < low_threshold:
-        return "low"
-    return "medium"
-
-
-def _apply_link_expand_boost(
-    chunks: list[dict],
-    *,
-    boost: float,
-    enabled: bool,
-) -> list[dict]:
-    """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-3: multiplicative reranker-score
-    boost (capped at 1.0) for chunks whose ``_link_expanded`` flag is set.
-
-    Applied AFTER rerank and BEFORE source-aware-select + quality-boost so
-    expanded neighbours get a fair shot at the served top-K. With
-    ``boost=1.0`` (default) this is a no-op; the SPEC ships safe and
-    operators tune via env var once the eval baseline is captured.
-
-    Mutates the input list in place (matches the surrounding pipeline's
-    style) and returns the same list for ergonomic chaining.
-    """
-    if not enabled or boost <= 1.0:
-        return chunks
-    for chunk in chunks:
-        if chunk.get("_link_expanded") and isinstance(chunk.get("reranker_score"), (int, float)):
-            boosted = chunk["reranker_score"] * boost
-            chunk["reranker_score"] = min(boosted, 1.0)
-    # Re-sort by boosted reranker_score so downstream pickers see the new order.
-    chunks.sort(
-        key=lambda c: c.get("reranker_score") or c.get("score") or 0.0,
-        reverse=True,
-    )
-    return chunks
-
-
 def _evidence_pack_decision_sources(evidence_pack: object) -> list[dict[str, object]]:
     """Return source provenance that is safe and useful in retrieval logs."""
     sources = getattr(evidence_pack, "sources", None)
@@ -224,28 +162,6 @@ def _evidence_pack_decision_sources(evidence_pack: object) -> list[dict[str, obj
             }
         )
     return decision_sources
-
-
-def _rrf_merge(qdrant_results: list[dict], graph_results: list[dict], k: int = 60) -> list[dict]:
-    """Reciprocal Rank Fusion merge of two ranked result lists (AC-5)."""
-    scores: dict[str, float] = {}
-    items: dict[str, dict] = {}
-
-    for rank, result in enumerate(qdrant_results):
-        cid = result["chunk_id"]
-        scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + rank + 1)
-        items[cid] = result
-
-    for rank, result in enumerate(graph_results):
-        cid = result["chunk_id"]
-        scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + rank + 1)
-        if cid not in items:
-            items[cid] = result
-
-    merged = sorted(items.values(), key=lambda r: scores[r["chunk_id"]], reverse=True)
-    for result in merged:
-        result["score"] = scores[result["chunk_id"]]
-    return merged
 
 
 @router.post("/retrieve", response_model=RetrieveResponse)

--- a/klai-retrieval-api/tests/test_evidence_pack_decision_sources.py
+++ b/klai-retrieval-api/tests/test_evidence_pack_decision_sources.py
@@ -1,0 +1,93 @@
+"""Direct characterization tests for _evidence_pack_decision_sources.
+
+Pins the log-safe source-provenance projection BEFORE it is lifted out of
+retrieve.py into api/decision_log.py (it previously had only indirect coverage
+via the decision_record substring assert in test_api.py). Reached through the
+``retrieval_api.api.retrieve`` namespace (which re-exports it) so the same test
+passes before and after the move.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from retrieval_api.api.retrieve import _evidence_pack_decision_sources
+
+
+def _source(**kw):
+    return SimpleNamespace(**kw)
+
+
+def _pack(sources):
+    return SimpleNamespace(sources=sources)
+
+
+def test_no_sources_attr_returns_empty():
+    assert _evidence_pack_decision_sources(object()) == []
+
+
+def test_sources_none_returns_empty():
+    assert _evidence_pack_decision_sources(_pack(None)) == []
+
+
+def test_sources_not_a_list_returns_empty():
+    assert _evidence_pack_decision_sources(_pack({"a": 1})) == []
+
+
+def test_full_source_projection():
+    pack = _pack(
+        [
+            _source(
+                source_id="s1",
+                title="T",
+                source_url="https://docs.getklai.com/refunds",
+                source_label="L",
+                evidence_ids=["e1", "e2"],
+                relevance_score=0.5,
+            )
+        ]
+    )
+    assert _evidence_pack_decision_sources(pack) == [
+        {
+            "source_id": "s1",
+            "title": "T",
+            "url": "https://docs.getklai.com/refunds",
+            "source_label": "L",
+            "evidence_ids": ["e1", "e2"],
+            "relevance_score": 0.5,
+        }
+    ]
+
+
+def test_relevance_score_rounded_to_4dp():
+    pack = _pack([_source(relevance_score=0.123456)])
+    assert _evidence_pack_decision_sources(pack)[0]["relevance_score"] == 0.1235
+
+
+def test_relevance_score_none_passthrough():
+    pack = _pack([_source(relevance_score=None)])
+    assert _evidence_pack_decision_sources(pack)[0]["relevance_score"] is None
+
+
+def test_evidence_ids_none_becomes_empty_list():
+    pack = _pack([_source(evidence_ids=None)])
+    assert _evidence_pack_decision_sources(pack)[0]["evidence_ids"] == []
+
+
+def test_missing_attrs_default_to_none():
+    pack = _pack([_source()])
+    assert _evidence_pack_decision_sources(pack)[0] == {
+        "source_id": None,
+        "title": None,
+        "url": None,
+        "source_label": None,
+        "evidence_ids": [],
+        "relevance_score": None,
+    }
+
+
+def test_truncates_to_first_five_sources():
+    pack = _pack([_source(source_id=f"s{i}") for i in range(8)])
+    out = _evidence_pack_decision_sources(pack)
+    assert len(out) == 5
+    assert [e["source_id"] for e in out] == ["s0", "s1", "s2", "s3", "s4"]

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -314,3 +314,32 @@ def test_rrf_merge_deduplication():
 
     chunk_ids = [r["chunk_id"] for r in merged]
     assert chunk_ids.count("shared") == 1
+
+
+def test_rrf_merge_fused_scores_pin_denominator():
+    """Pin the exact RRF denominator ``1 / (k + rank + 1)`` with k=60.
+
+    The ordering-only assertions above survive a ``k + rank + 1 -> k + rank``
+    mutation because both forms are monotonic in rank, so the sort order is
+    unchanged and only the absolute fused scores differ. This pins those scores
+    so the constant cannot silently drift.
+    """
+    base = {
+        "text": "x",
+        "score": 0.5,
+        "artifact_id": None,
+        "content_type": None,
+        "context_prefix": None,
+        "scope": "org",
+        "valid_at": None,
+        "invalid_at": None,
+    }
+    qdrant = [{**base, "chunk_id": "shared"}, {**base, "chunk_id": "q_only"}]
+    graph = [{**base, "chunk_id": "shared"}]
+    merged = _rrf_merge(qdrant, graph)
+
+    scores = {r["chunk_id"]: r["score"] for r in merged}
+    # shared: rank 0 in qdrant AND rank 0 in graph -> 1/61 + 1/61
+    assert scores["shared"] == pytest.approx(2.0 / 61.0)
+    # q_only: rank 1 in qdrant only -> 1/62
+    assert scores["q_only"] == pytest.approx(1.0 / 62.0)


### PR DESCRIPTION
Behavior-preserving decomposition of the retrieval-api `/retrieve` handler
`klai-retrieval-api/retrieval_api/api/retrieve.py` (929 -> 759 lines), extracting
the pure pre/post-pipeline helper clusters into `retrieval_api/api/` siblings
(matching the existing chat.py / taxonomy.py convention).

Commits:
1. `api/ranking.py` — _rrf_merge, _apply_link_expand_boost, _compute_confidence_band
2. `api/page_context.py` — _normalise_page_context_url, _same_page_context_path,
   _apply_page_context_boost + _PAGE_CONTEXT_SCORE_BOOST (URL helpers + constant internal)
3. `api/decision_log.py` — _evidence_pack_decision_sources (+9 NEW characterization tests;
   it previously had only indirect coverage)
4. test: pin the exact RRF denominator (adversarial Codex review found the existing
   RRF tests survive a `k+rank+1 -> k+rank` mutation — ordering-only, scores unpinned)

Guarantees (independently verified by an adversarial Codex review):
- All 7 moved bodies are byte-identical to main (kept underscore names, pure move).
- The ~678-line `retrieve` orchestrator is byte-identical — the tenant/RBAC scope
  narrowing, retention-policy, identity assertion and product_events emit are untouched.
- retrieve re-exports the orchestrator-/test-used helpers; the two URL helpers + the
  constant stay internal to page_context. No moved symbol is a test patch target
  (the 111 `retrieval_api.api.retrieve.*` patch sites are orchestrator deps).
- No circular import, no F401/F821; dropped the now-unused urllib.parse import.

retrieval-api suite: 540 passed (530 baseline + 10 new), 1 skipped. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)