### PR TITLE
refactor(portal-api): decompose partner.py god-module (1918->1746)

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -48,6 +48,11 @@ from app.services.partner_sse import (
     _extract_assistant_text_and_sources,
     _parse_audit_sse_chunk,
 )
+from app.services.partner_support import (
+    _mapping,
+    _message_payload,
+    _session_payload,
+)
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
 from app.services.retrieval_log import find_correlated_log, write_retrieval_log
@@ -378,58 +383,6 @@ def _support_user_hash(auth: PartnerAuthContext, hubspot_user_id: str | None) ->
     """Stable private key for one support rep inside one integration session."""
     raw_user = hubspot_user_id or "unknown"
     return hash_audit_value(f"{auth.org_id}:{auth.key_id}:hubspot:{raw_user}") or "unknown"
-
-
-def _mapping(row: Any) -> dict[str, Any]:
-    if row is None:
-        return {}
-    if isinstance(row, dict):
-        return row
-    if hasattr(row, "_mapping"):
-        return dict(row._mapping)
-    try:
-        return dict(row)
-    except (TypeError, ValueError):
-        return {}
-
-
-def _isoformat(value: Any) -> str | None:
-    if value is None:
-        return None
-    return str(value.isoformat())
-
-
-def _message_payload(row: Any) -> dict[str, Any]:
-    data = _mapping(row)
-    return {
-        "id": str(data.get("id")),
-        "role": data.get("role"),
-        "content": data.get("content"),
-        "draft_body": data.get("draft_body"),
-        "sources": data.get("sources") or [],
-        "model_alias": data.get("model_alias"),
-        "completion_id": data.get("completion_id"),
-        "sequence": data.get("sequence"),
-        "created_at": _isoformat(data.get("created_at")),
-    }
-
-
-def _session_payload(row: Any, messages: list[dict[str, Any]]) -> dict[str, Any]:
-    data = _mapping(row)
-    return {
-        "id": str(data.get("id")),
-        "integration_type": data.get("integration_type"),
-        "hubspot_portal_id": data.get("hubspot_portal_id"),
-        "hubspot_ticket_id": data.get("hubspot_ticket_id"),
-        "contact_id": data.get("contact_id"),
-        "subject": data.get("subject_snapshot"),
-        "status": data.get("status"),
-        "message_count": data.get("message_count") or len(messages),
-        "created_at": _isoformat(data.get("created_at")),
-        "updated_at": _isoformat(data.get("updated_at")),
-        "last_message_at": _isoformat(data.get("last_message_at")),
-        "messages": messages,
-    }
 
 
 async def _fetch_support_messages(

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -44,6 +44,10 @@ from app.services.partner_chat import (
     widget_input_safety_violation,
 )
 from app.services.partner_rate_limit import check_rate_limit
+from app.services.partner_sse import (
+    _extract_assistant_text_and_sources,
+    _parse_audit_sse_chunk,
+)
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
 from app.services.retrieval_log import find_correlated_log, write_retrieval_log
@@ -368,53 +372,6 @@ async def _audit_streaming_wrapper(
             )
             _pending.add(task)
             task.add_done_callback(_pending.discard)
-
-
-def _parse_audit_sse_chunk(chunk: bytes) -> tuple[str | None, list[dict] | None]:
-    """Pull ``delta.content`` text and ``delta.sources`` list out of one
-    SSE ``data: …\\n\\n`` block. Returns (text, sources) — either side
-    may be None when the chunk doesn't carry that field."""
-    text_part: str | None = None
-    src_part: list[dict] | None = None
-    for raw in chunk.split(b"\n"):
-        if not raw.startswith(b"data: "):
-            continue
-        payload = raw[6:].strip()
-        if payload in (b"", b"[DONE]"):
-            continue
-        try:
-            event = json.loads(payload)
-        except json.JSONDecodeError:
-            continue
-        delta = (event.get("choices") or [{}])[0].get("delta") or {}
-        if isinstance(delta.get("content"), str):
-            text_part = (text_part or "") + delta["content"]
-        srcs = delta.get("sources")
-        if isinstance(srcs, list):
-            src_part = [s for s in srcs if isinstance(s, dict)]
-    return text_part, src_part
-
-
-def _extract_assistant_text_and_sources(
-    result: Any,
-) -> tuple[str, list[dict] | None]:
-    """Pull the assistant message + sources out of a non-streaming
-    chat-completions result (a dict or Pydantic-shaped object)."""
-    payload: dict[str, Any]
-    if hasattr(result, "model_dump"):
-        payload = result.model_dump()
-    elif isinstance(result, dict):
-        payload = result
-    else:
-        return "", None
-    choices = payload.get("choices") or []
-    if not choices:
-        return "", None
-    message = choices[0].get("message") or {}
-    content = str(message.get("content") or "")
-    sources_raw = message.get("sources")
-    sources = [s for s in sources_raw if isinstance(s, dict)] if isinstance(sources_raw, list) else None
-    return content, sources
 
 
 def _support_user_hash(auth: PartnerAuthContext, hubspot_user_id: str | None) -> str:

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -69,6 +69,7 @@ from app.services.widget_handoff import (
     send_handoff_visitor_message,
     start_hubspot_handoff,
 )
+from app.services.widget_theme import _merge_css_variables
 
 logger = structlog.get_logger()
 
@@ -1347,89 +1348,6 @@ async def append_knowledge(
 # helper centralises this contract so the GET and OPTIONS handlers can
 # never drift apart.
 # ---------------------------------------------------------------------------
-
-
-_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
-
-
-def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    """Convert ``#RRGGBB`` or ``#RGB`` to an (r, g, b) tuple of 0-255 ints."""
-    h = hex_color.lstrip("#")
-    if len(h) == 3:
-        h = "".join(c * 2 for c in h)
-    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
-
-
-def _readable_text_color(primary_hex: str) -> str:
-    """Return ``#191918`` for light primaries and ``#ffffff`` for dark
-    ones using the WCAG-relative-luminance formula.
-
-    Picked thresholds match the WCAG 2.x AA cutoff (~0.179): primaries
-    brighter than that get the dark Klai foreground; darker primaries
-    get pure white. Without this the bubble icon, send-arrow, and user
-    message text inherit ``--klai-primary-text-color: var(--klai-text-color)``
-    (dark) on every brand colour — illegible the moment an admin picks a
-    dark hex like #2b32fd or any deep brown.
-    """
-
-    def _channel(c: int) -> float:
-        s = c / 255
-        return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
-
-    r, g, b = _hex_to_rgb(primary_hex)
-    lum = 0.2126 * _channel(r) + 0.7152 * _channel(g) + 0.0722 * _channel(b)
-    return "#191918" if lum > 0.179 else "#ffffff"
-
-
-def _merge_css_variables(widget_config: dict) -> dict[str, str]:
-    """Translate stored widget-config fields into CSS custom properties
-    the embed script (klai-chat.js) applies inside its Shadow DOM.
-
-    The admin "Brand kleur" field is stored as ``primary_color`` (a hex
-    string). The widget script only reads ``css_variables`` for per-widget
-    overrides — without this translation step the configured brand colour
-    silently never reaches the widget. Any keys already in
-    ``css_variables`` win over the derived ones so a power-user can still
-    override granularly.
-
-    Beside the colour itself we derive ``--klai-primary-text-color`` from
-    its luminance so the icon / arrow / user-message text rendered on top
-    of the primary surface stays legible on any brand hex the admin picks.
-
-    Validation: ``primary_color`` must match ``#RRGGBB`` or ``#RGB``.
-    Anything else (empty, invalid, attempted CSS injection) is dropped
-    silently so a malformed admin field can never poison the stylesheet.
-    """
-    css_vars: dict[str, str] = {}
-    if widget_config.get("theme") == "dark":
-        css_vars.update(
-            {
-                "--klai-text-color": "#fffef2",
-                "--klai-text-muted": "#fffef299",
-                "--klai-background-color": "#191918",
-                "--klai-card-color": "#27251f",
-                "--klai-border-color": "#3a3831",
-            }
-        )
-
-    if widget_config.get("widget_position") == "left":
-        css_vars["--klai-widget-left"] = "20px"
-        css_vars["--klai-widget-right"] = "auto"
-    elif widget_config.get("widget_position") == "right":
-        css_vars["--klai-widget-left"] = "auto"
-        css_vars["--klai-widget-right"] = "20px"
-
-    primary = widget_config.get("primary_color")
-    if isinstance(primary, str) and _HEX_COLOR_RE.match(primary):
-        css_vars["--klai-primary-color"] = primary
-        css_vars["--klai-primary-text-color"] = _readable_text_color(primary)
-
-    overrides = widget_config.get("css_variables") or {}
-    if isinstance(overrides, dict):
-        for key, value in overrides.items():
-            if isinstance(key, str) and isinstance(value, str):
-                css_vars[key] = value
-    return css_vars
 
 
 def _widget_cors_headers(origin: str, *, preflight: bool) -> dict[str, str]:

--- a/klai-portal/backend/app/services/partner_sse.py
+++ b/klai-portal/backend/app/services/partner_sse.py
@@ -1,0 +1,60 @@
+"""Chat-completion wire decoders for the partner/widget API.
+
+Two pure decoders extracted from ``app/api/partner.py``: pull ``content`` text +
+``sources`` out of an SSE ``data:`` block (streaming) and out of a non-streaming
+result dict / Pydantic-shaped object. No auth, DB, or request coupling.
+``app.api.partner`` re-imports both — the audit streaming wrapper and the
+non-streaming chat branch call them — so the call sites are unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _parse_audit_sse_chunk(chunk: bytes) -> tuple[str | None, list[dict] | None]:
+    """Pull ``delta.content`` text and ``delta.sources`` list out of one
+    SSE ``data: …\\n\\n`` block. Returns (text, sources) — either side
+    may be None when the chunk doesn't carry that field."""
+    text_part: str | None = None
+    src_part: list[dict] | None = None
+    for raw in chunk.split(b"\n"):
+        if not raw.startswith(b"data: "):
+            continue
+        payload = raw[6:].strip()
+        if payload in (b"", b"[DONE]"):
+            continue
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        delta = (event.get("choices") or [{}])[0].get("delta") or {}
+        if isinstance(delta.get("content"), str):
+            text_part = (text_part or "") + delta["content"]
+        srcs = delta.get("sources")
+        if isinstance(srcs, list):
+            src_part = [s for s in srcs if isinstance(s, dict)]
+    return text_part, src_part
+
+
+def _extract_assistant_text_and_sources(
+    result: Any,
+) -> tuple[str, list[dict] | None]:
+    """Pull the assistant message + sources out of a non-streaming
+    chat-completions result (a dict or Pydantic-shaped object)."""
+    payload: dict[str, Any]
+    if hasattr(result, "model_dump"):
+        payload = result.model_dump()
+    elif isinstance(result, dict):
+        payload = result
+    else:
+        return "", None
+    choices = payload.get("choices") or []
+    if not choices:
+        return "", None
+    message = choices[0].get("message") or {}
+    content = str(message.get("content") or "")
+    sources_raw = message.get("sources")
+    sources = [s for s in sources_raw if isinstance(s, dict)] if isinstance(sources_raw, list) else None
+    return content, sources

--- a/klai-portal/backend/app/services/partner_support.py
+++ b/klai-portal/backend/app/services/partner_support.py
@@ -1,0 +1,63 @@
+"""Support-session row -> response-payload shapers for the partner API.
+
+Pure SQLAlchemy-row / dict shaping for support sessions and messages, lifted out
+of ``app/api/partner.py``. No DB execution, no auth — the raw-SQL fetchers and
+the route handlers (which own the tenant scoping) keep calling these via the
+re-import in ``app.api.partner``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _mapping(row: Any) -> dict[str, Any]:
+    if row is None:
+        return {}
+    if isinstance(row, dict):
+        return row
+    if hasattr(row, "_mapping"):
+        return dict(row._mapping)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _isoformat(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value.isoformat())
+
+
+def _message_payload(row: Any) -> dict[str, Any]:
+    data = _mapping(row)
+    return {
+        "id": str(data.get("id")),
+        "role": data.get("role"),
+        "content": data.get("content"),
+        "draft_body": data.get("draft_body"),
+        "sources": data.get("sources") or [],
+        "model_alias": data.get("model_alias"),
+        "completion_id": data.get("completion_id"),
+        "sequence": data.get("sequence"),
+        "created_at": _isoformat(data.get("created_at")),
+    }
+
+
+def _session_payload(row: Any, messages: list[dict[str, Any]]) -> dict[str, Any]:
+    data = _mapping(row)
+    return {
+        "id": str(data.get("id")),
+        "integration_type": data.get("integration_type"),
+        "hubspot_portal_id": data.get("hubspot_portal_id"),
+        "hubspot_ticket_id": data.get("hubspot_ticket_id"),
+        "contact_id": data.get("contact_id"),
+        "subject": data.get("subject_snapshot"),
+        "status": data.get("status"),
+        "message_count": data.get("message_count") or len(messages),
+        "created_at": _isoformat(data.get("created_at")),
+        "updated_at": _isoformat(data.get("updated_at")),
+        "last_message_at": _isoformat(data.get("last_message_at")),
+        "messages": messages,
+    }

--- a/klai-portal/backend/app/services/widget_theme.py
+++ b/klai-portal/backend/app/services/widget_theme.py
@@ -1,0 +1,94 @@
+"""Widget theming: hex parsing, WCAG-luminance text color, CSS-variable derivation.
+
+Pure string -> dict transforms lifted out of ``app/api/partner.py`` — translate
+stored widget-config fields into the CSS custom properties the embed script
+applies inside its Shadow DOM. No DB, auth, or request coupling. ``app.api.partner``
+re-imports only ``_merge_css_variables`` (the widget-config / public-bot-config
+route handlers call it); the hex helpers + regex are internal to this module.
+"""
+
+from __future__ import annotations
+
+import re
+
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """Convert ``#RRGGBB`` or ``#RGB`` to an (r, g, b) tuple of 0-255 ints."""
+    h = hex_color.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def _readable_text_color(primary_hex: str) -> str:
+    """Return ``#191918`` for light primaries and ``#ffffff`` for dark
+    ones using the WCAG-relative-luminance formula.
+
+    Picked thresholds match the WCAG 2.x AA cutoff (~0.179): primaries
+    brighter than that get the dark Klai foreground; darker primaries
+    get pure white. Without this the bubble icon, send-arrow, and user
+    message text inherit ``--klai-primary-text-color: var(--klai-text-color)``
+    (dark) on every brand colour — illegible the moment an admin picks a
+    dark hex like #2b32fd or any deep brown.
+    """
+
+    def _channel(c: int) -> float:
+        s = c / 255
+        return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
+
+    r, g, b = _hex_to_rgb(primary_hex)
+    lum = 0.2126 * _channel(r) + 0.7152 * _channel(g) + 0.0722 * _channel(b)
+    return "#191918" if lum > 0.179 else "#ffffff"
+
+
+def _merge_css_variables(widget_config: dict) -> dict[str, str]:
+    """Translate stored widget-config fields into CSS custom properties
+    the embed script (klai-chat.js) applies inside its Shadow DOM.
+
+    The admin "Brand kleur" field is stored as ``primary_color`` (a hex
+    string). The widget script only reads ``css_variables`` for per-widget
+    overrides — without this translation step the configured brand colour
+    silently never reaches the widget. Any keys already in
+    ``css_variables`` win over the derived ones so a power-user can still
+    override granularly.
+
+    Beside the colour itself we derive ``--klai-primary-text-color`` from
+    its luminance so the icon / arrow / user-message text rendered on top
+    of the primary surface stays legible on any brand hex the admin picks.
+
+    Validation: ``primary_color`` must match ``#RRGGBB`` or ``#RGB``.
+    Anything else (empty, invalid, attempted CSS injection) is dropped
+    silently so a malformed admin field can never poison the stylesheet.
+    """
+    css_vars: dict[str, str] = {}
+    if widget_config.get("theme") == "dark":
+        css_vars.update(
+            {
+                "--klai-text-color": "#fffef2",
+                "--klai-text-muted": "#fffef299",
+                "--klai-background-color": "#191918",
+                "--klai-card-color": "#27251f",
+                "--klai-border-color": "#3a3831",
+            }
+        )
+
+    if widget_config.get("widget_position") == "left":
+        css_vars["--klai-widget-left"] = "20px"
+        css_vars["--klai-widget-right"] = "auto"
+    elif widget_config.get("widget_position") == "right":
+        css_vars["--klai-widget-left"] = "auto"
+        css_vars["--klai-widget-right"] = "20px"
+
+    primary = widget_config.get("primary_color")
+    if isinstance(primary, str) and _HEX_COLOR_RE.match(primary):
+        css_vars["--klai-primary-color"] = primary
+        css_vars["--klai-primary-text-color"] = _readable_text_color(primary)
+
+    overrides = widget_config.get("css_variables") or {}
+    if isinstance(overrides, dict):
+        for key, value in overrides.items():
+            if isinstance(key, str) and isinstance(value, str):
+                css_vars[key] = value
+    return css_vars

--- a/klai-portal/backend/tests/test_partner_sse_decoders.py
+++ b/klai-portal/backend/tests/test_partner_sse_decoders.py
@@ -1,0 +1,84 @@
+"""Direct characterization tests for the partner chat-completion wire decoders.
+
+Pins ``_parse_audit_sse_chunk`` (SSE ``data:`` blocks) and
+``_extract_assistant_text_and_sources`` (non-streaming result) BEFORE they are
+lifted out of ``app/api/partner.py`` into ``app/services/partner_sse.py``. They
+previously had only indirect coverage via the streaming/non-streaming chat
+tests. Reached through ``app.api.partner`` (which re-exports them) so the same
+test passes before and after the move.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.api.partner import (
+    _extract_assistant_text_and_sources,
+    _parse_audit_sse_chunk,
+)
+
+# --- _parse_audit_sse_chunk ---------------------------------------------------
+
+
+def test_parse_sse_single_content_block():
+    chunk = b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'
+    assert _parse_audit_sse_chunk(chunk) == ("Hello", None)
+
+
+def test_parse_sse_accumulates_content_across_data_lines():
+    chunk = b'data: {"choices":[{"delta":{"content":"a"}}]}\ndata: {"choices":[{"delta":{"content":"b"}}]}'
+    assert _parse_audit_sse_chunk(chunk) == ("ab", None)
+
+
+def test_parse_sse_filters_sources_to_dicts():
+    chunk = b'data: {"choices":[{"delta":{"sources":[{"id":1},"bad",{"id":2}]}}]}'
+    text, sources = _parse_audit_sse_chunk(chunk)
+    assert text is None
+    assert sources == [{"id": 1}, {"id": 2}]
+
+
+def test_parse_sse_skips_done_and_empty_and_malformed_and_non_data():
+    chunk = (
+        b"event: ping\n"  # non-data line
+        b"data: \n"  # empty payload
+        b"data: [DONE]\n"  # sentinel
+        b"data: not-json\n"  # malformed JSON
+    )
+    assert _parse_audit_sse_chunk(chunk) == (None, None)
+
+
+def test_parse_sse_no_content_or_sources_returns_none_none():
+    chunk = b'data: {"choices":[{"delta":{}}]}'
+    assert _parse_audit_sse_chunk(chunk) == (None, None)
+
+
+# --- _extract_assistant_text_and_sources -------------------------------------
+
+
+def test_extract_from_dict_result():
+    result = {"choices": [{"message": {"content": "Hi", "sources": [{"u": 1}, "x", {"u": 2}]}}]}
+    assert _extract_assistant_text_and_sources(result) == ("Hi", [{"u": 1}, {"u": 2}])
+
+
+def test_extract_from_model_dump_object():
+    payload = {"choices": [{"message": {"content": "Yo", "sources": [{"u": 9}]}}]}
+    result = SimpleNamespace(model_dump=lambda: payload)
+    assert _extract_assistant_text_and_sources(result) == ("Yo", [{"u": 9}])
+
+
+def test_extract_neither_dict_nor_model_dump_returns_empty():
+    assert _extract_assistant_text_and_sources(42) == ("", None)
+
+
+def test_extract_no_choices_returns_empty():
+    assert _extract_assistant_text_and_sources({"choices": []}) == ("", None)
+
+
+def test_extract_none_content_becomes_empty_string():
+    result = {"choices": [{"message": {"content": None}}]}
+    assert _extract_assistant_text_and_sources(result) == ("", None)
+
+
+def test_extract_sources_not_a_list_returns_none():
+    result = {"choices": [{"message": {"content": "x", "sources": "nope"}}]}
+    assert _extract_assistant_text_and_sources(result) == ("x", None)

--- a/klai-portal/backend/tests/test_partner_support_payloads.py
+++ b/klai-portal/backend/tests/test_partner_support_payloads.py
@@ -1,0 +1,124 @@
+"""Direct characterization tests for the partner support-session row shapers.
+
+Pins ``_mapping`` / ``_isoformat`` / ``_message_payload`` / ``_session_payload``
+BEFORE they are lifted out of ``app/api/partner.py`` into
+``app/services/partner_support.py``. They previously had no direct unit tests —
+support-session route tests asserted the composed response, not the shapers in
+isolation. Reached through ``app.api.partner`` (which re-exports them) so the
+same test passes before and after the move.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from app.services.partner_support import (
+    _isoformat,
+    _mapping,
+    _message_payload,
+    _session_payload,
+)
+
+# --- _mapping -----------------------------------------------------------------
+
+
+def test_mapping_none_is_empty():
+    assert _mapping(None) == {}
+
+
+def test_mapping_dict_passthrough():
+    d = {"a": 1}
+    assert _mapping(d) is d
+
+
+def test_mapping_row_with_sqlalchemy_mapping_attr():
+    row = SimpleNamespace(_mapping={"x": 2})
+    assert _mapping(row) == {"x": 2}
+
+
+def test_mapping_dict_convertible_pairs():
+    assert _mapping([("k", "v")]) == {"k": "v"}
+
+
+def test_mapping_non_convertible_is_empty():
+    assert _mapping(5) == {}
+
+
+# --- _isoformat ---------------------------------------------------------------
+
+
+def test_isoformat_none_is_none():
+    assert _isoformat(None) is None
+
+
+def test_isoformat_datetime():
+    assert _isoformat(datetime(2026, 1, 2, 3, 4, 5)) == "2026-01-02T03:04:05"
+
+
+# --- _message_payload ---------------------------------------------------------
+
+
+def test_message_payload_shapes_row():
+    row = {
+        "id": 7,
+        "role": "user",
+        "content": "hi",
+        "draft_body": None,
+        "sources": None,
+        "model_alias": "m",
+        "completion_id": "c",
+        "sequence": 3,
+        "created_at": datetime(2026, 1, 2, 3, 4, 5),
+    }
+    assert _message_payload(row) == {
+        "id": "7",
+        "role": "user",
+        "content": "hi",
+        "draft_body": None,
+        "sources": [],  # None -> []
+        "model_alias": "m",
+        "completion_id": "c",
+        "sequence": 3,
+        "created_at": "2026-01-02T03:04:05",
+    }
+
+
+# --- _session_payload ---------------------------------------------------------
+
+
+def test_session_payload_shapes_row_and_uses_subject_snapshot():
+    row = {
+        "id": 9,
+        "integration_type": "hubspot",
+        "hubspot_portal_id": "p1",
+        "hubspot_ticket_id": "t1",
+        "contact_id": "c1",
+        "subject_snapshot": "Subj",
+        "status": "open",
+        "message_count": 4,
+        "created_at": datetime(2026, 1, 2, 3, 4, 5),
+        "updated_at": datetime(2026, 1, 2, 3, 4, 6),
+        "last_message_at": None,
+    }
+    messages = [{"id": "1"}]
+    assert _session_payload(row, messages) == {
+        "id": "9",
+        "integration_type": "hubspot",
+        "hubspot_portal_id": "p1",
+        "hubspot_ticket_id": "t1",
+        "contact_id": "c1",
+        "subject": "Subj",
+        "status": "open",
+        "message_count": 4,
+        "created_at": "2026-01-02T03:04:05",
+        "updated_at": "2026-01-02T03:04:06",
+        "last_message_at": None,
+        "messages": messages,
+    }
+
+
+def test_session_payload_message_count_falls_back_to_len_messages():
+    row = {"id": 1, "message_count": None}
+    messages = [{"id": "a"}, {"id": "b"}]
+    assert _session_payload(row, messages)["message_count"] == 2

--- a/klai-portal/backend/tests/test_partner_support_payloads.py
+++ b/klai-portal/backend/tests/test_partner_support_payloads.py
@@ -45,6 +45,13 @@ def test_mapping_non_convertible_is_empty():
     assert _mapping(5) == {}
 
 
+def test_mapping_value_error_branch_is_empty():
+    # dict(["abc"]) raises ValueError ("length 3; 2 is required") — the other arm
+    # of `except (TypeError, ValueError)`. _mapping(5) above only covers the
+    # TypeError arm (an int is not iterable).
+    assert _mapping(["abc"]) == {}
+
+
 # --- _isoformat ---------------------------------------------------------------
 
 

--- a/klai-portal/backend/tests/test_widget_theme.py
+++ b/klai-portal/backend/tests/test_widget_theme.py
@@ -1,0 +1,100 @@
+"""Direct characterization tests for the widget theming helpers.
+
+Pins ``_hex_to_rgb`` / ``_readable_text_color`` (WCAG relative luminance) and
+``_merge_css_variables`` BEFORE they are lifted out of ``app/api/partner.py``
+into ``app/services/widget_theme.py``. The WCAG luminance branch, the dark-theme
+/ widget-position vars, the hex validation, and the css_variables override-merge
+previously had no isolated coverage (test_widget_config only asserts css_variables
+on the route response, mostly for empty configs).
+"""
+
+from __future__ import annotations
+
+from app.services.widget_theme import (
+    _hex_to_rgb,
+    _merge_css_variables,
+    _readable_text_color,
+)
+
+# --- _hex_to_rgb --------------------------------------------------------------
+
+
+def test_hex_to_rgb_six_digit():
+    assert _hex_to_rgb("#191918") == (25, 25, 24)
+    assert _hex_to_rgb("#ffffff") == (255, 255, 255)
+    assert _hex_to_rgb("#000000") == (0, 0, 0)
+
+
+def test_hex_to_rgb_three_digit_expands():
+    assert _hex_to_rgb("#abc") == (170, 187, 204)
+
+
+# --- _readable_text_color (WCAG relative luminance) ---------------------------
+
+
+def test_readable_text_color_light_primary_gets_dark_text():
+    assert _readable_text_color("#ffffff") == "#191918"
+    assert _readable_text_color("#fcaa2d") == "#191918"  # Klai accent (bright)
+
+
+def test_readable_text_color_dark_primary_gets_white_text():
+    assert _readable_text_color("#000000") == "#ffffff"
+    assert _readable_text_color("#2b32fd") == "#ffffff"  # deep blue (dark)
+
+
+# --- _merge_css_variables -----------------------------------------------------
+
+
+def test_merge_empty_config_is_empty():
+    assert _merge_css_variables({}) == {}
+
+
+def test_merge_dark_theme_vars():
+    assert _merge_css_variables({"theme": "dark"}) == {
+        "--klai-text-color": "#fffef2",
+        "--klai-text-muted": "#fffef299",
+        "--klai-background-color": "#191918",
+        "--klai-card-color": "#27251f",
+        "--klai-border-color": "#3a3831",
+    }
+
+
+def test_merge_widget_position_left_and_right():
+    assert _merge_css_variables({"widget_position": "left"}) == {
+        "--klai-widget-left": "20px",
+        "--klai-widget-right": "auto",
+    }
+    assert _merge_css_variables({"widget_position": "right"}) == {
+        "--klai-widget-left": "auto",
+        "--klai-widget-right": "20px",
+    }
+
+
+def test_merge_valid_primary_color_derives_text_color():
+    assert _merge_css_variables({"primary_color": "#fcaa2d"}) == {
+        "--klai-primary-color": "#fcaa2d",
+        "--klai-primary-text-color": "#191918",
+    }
+
+
+def test_merge_invalid_primary_color_dropped():
+    assert _merge_css_variables({"primary_color": "red"}) == {}
+    assert _merge_css_variables({"primary_color": "javascript:alert(1)"}) == {}
+
+
+def test_merge_css_variables_overrides_filtered_and_win():
+    out = _merge_css_variables(
+        {
+            "primary_color": "#fcaa2d",
+            "css_variables": {
+                "--klai-primary-color": "#000000",  # overrides derived
+                "--custom": "5px",
+                "--bad-value": 2,  # non-str value dropped
+                3: "y",  # non-str key dropped
+            },
+        }
+    )
+    assert out["--klai-primary-color"] == "#000000"  # override wins
+    assert out["--custom"] == "5px"
+    assert "--bad-value" not in out
+    assert 3 not in out


### PR DESCRIPTION
Behavior-preserving decomposition of the partner/widget API router
`klai-portal/backend/app/api/partner.py` (1918 -> 1746 lines), extracting three
pure helper clusters into `app/services/` (underscore names kept = pure move):

1. `services/partner_sse.py` — _parse_audit_sse_chunk, _extract_assistant_text_and_sources
   (chat-completion wire decoders)
2. `services/partner_support.py` — _mapping, _isoformat, _message_payload, _session_payload
   (support-session row -> payload shapers)
3. `services/widget_theme.py` — _HEX_COLOR_RE, _hex_to_rgb, _readable_text_color (WCAG luminance),
   _merge_css_variables (widget CSS-variable derivation)
+32 new characterization tests (the moved helpers had only indirect coverage).

STRICTER BACKEND AUTH GATE respected: every @router handler and every
auth/RLS/tenant-scoping helper (_require_widget_auth, _widget_safety_block_response,
_get_support_session_row, _fetch_support_messages, _maybe_apply_web_search,
_widget_system_prompt, _resolve_web_query, ...) stays byte-identical in partner.py.
Only pure, non-auth helpers moved. The web-search helpers were deliberately left
(_MAX_WEB_SEARCH_QUERY_CHARS anchors the ChatCompletionsRequest model + an existing
test import contract).

Independently verified by an adversarial Codex review: all 10 moved bodies + all
14 route handlers + every auth helper byte-identical to main; re-export/patch
invariant holds; no moved symbol is a test patch target. One coverage gap it found
(_mapping ValueError arm) is fixed + mutation-verified.

Full portal-backend suite: 3278 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)