### PR TITLE
[codex] Extract still-valid PR fixes

### DIFF
--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -21,6 +21,24 @@ paths:
 
 Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
 
+## Headless is default — `--headed` alleen bij human-in-the-loop
+
+Agent Browser draait headless tenzij je `--headed` of `AGENT_BROWSER_HEADED=1`
+meegeeft. Dat is voor AI-runs meestal correct: lichter, geen dock-icoon, geen
+focus-stealing, en de agent leest het DOM via `snapshot` in plaats van pixels.
+
+| Situatie | Headed nodig? |
+|---|---|
+| Smoke test, audit, snapshot-driven flow door AI | Nee — headless |
+| Authenticated session draaien met `--state` | Nee — cookies werken headless |
+| Eenmalige login om `state save` te doen | Ja — mens moet typen |
+| Captcha / 2FA-prompt die je niet kunt scripten | Ja |
+| Live debugging waarbij de mens meekijkt | Ja |
+
+Anti-pattern: `--headed` als default in scripts/agents zetten. Dat opent bij
+elke AI-actie een Chrome-venster en steelt focus. Reserveer headed voor
+expliciet menselijk handelen.
+
 ## Parallel sessions [HARD]
 
 Elke Claude sessie MOET een unieke `--session` naam gebruiken. Anders leakt cookies/localStorage tussen sessies (issue [#1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
@@ -61,23 +79,28 @@ Agent Browser kan **niet** de Playwright `~/.claude/mcp-storageState.json` direc
 **One-time setup** (eenmalig, of refresh wanneer sessie verloopt):
 
 ```bash
-# 1. Open portal headed (zonder --session-name = ephemeral, dan via state save)
-agent-browser open https://app.getklai.com
-# 2. Log in handmatig in geopende browser
-# 3. Save state
+# 1. Open portal headed — mens moet inloggen, dus venster moet zichtbaar zijn
+agent-browser --headed open https://app.getklai.com
+# 2. Log in handmatig in geopende browser (Google SSO + 2FA)
+# 3. Save state (gebruikt huidige sessie, --headed flag niet nodig)
 agent-browser state save ~/.claude/agent-browser-state.json
 chmod 600 ~/.claude/agent-browser-state.json
 agent-browser close
 ```
 
-**Daily use** in scripts/agents:
+**Daily use** in scripts/agents (headless, geen `--headed`):
 
 ```bash
 SESSION="klai-portal-${CLAUDE_SESSION_ID:-$(date +%s)}"
 agent-browser --session "$SESSION" \
               --state ~/.claude/agent-browser-state.json \
-              open https://app.getklai.com/dashboard
+              open https://voys.getklai.com
 ```
+
+Gebruik voor authenticated SPA-flows de workspace-URL (`<slug>.getklai.com`),
+niet `app.getklai.com`. Een ingelogde request op `app.getklai.com` kan op een
+`/api/me`-style JSON-payload landen; de tenant-SPA leeft op het
+workspace-subdomein. De workspace-URL staat in die JSON onder `workspace_url`.
 
 Refresh `~/.claude/agent-browser-state.json` om de paar weken wanneer Google's session cookies verlopen. (Dit geldt voor Agent Browser; Playwright MCP heeft die cadens niet meer — die gebruikt sinds 2026-05-13 een workspace-hashed persistent profile dat zichzelf onderhoudt.) Als Agent Browser sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
 
@@ -136,6 +159,8 @@ agent-browser --session "$SESSION" eval "
 - **agent-browser-session-shell-expansion** — `$$` of `$RANDOM` per command-aanroep = nieuwe sessie elke keer. Gebruik een env var die je vóór de chain set.
 - **agent-browser-storage-state-mismatch** — Niet de Playwright `~/.claude/mcp-storageState.json` proberen te laden. Eigen file `~/.claude/agent-browser-state.json` aanmaken via `state save`.
 - **agent-browser-stale-refs** — `@e1`, `@e2` zijn **fresh per snapshot**. Re-snapshot na elke navigation/click die de DOM wijzigt.
+- **agent-browser-headed-as-default** — `--headed` toevoegen aan elk script omdat "de mens dan kan meekijken" steelt focus en is voor AI-runs onnodig. Headless is correct default; `--headed` alleen voor login en interactieve debug.
+- **agent-browser-app-getklai-returns-json** — Een ingelogde sessie die `https://app.getklai.com` opent kan op een JSON-payload landen, niet de SPA. Voor authenticated flows: gebruik `<workspace>.getklai.com` uit `/api/me` `workspace_url`.
 
 ## See also
 

--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -21,24 +21,6 @@ paths:
 
 Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
 
-## Headless is default — `--headed` alleen bij human-in-the-loop
-
-Agent Browser draait headless tenzij je `--headed` of `AGENT_BROWSER_HEADED=1`
-meegeeft. Dat is voor AI-runs meestal correct: lichter, geen dock-icoon, geen
-focus-stealing, en de agent leest het DOM via `snapshot` in plaats van pixels.
-
-| Situatie | Headed nodig? |
-|---|---|
-| Smoke test, audit, snapshot-driven flow door AI | Nee — headless |
-| Authenticated session draaien met `--state` | Nee — cookies werken headless |
-| Eenmalige login om `state save` te doen | Ja — mens moet typen |
-| Captcha / 2FA-prompt die je niet kunt scripten | Ja |
-| Live debugging waarbij de mens meekijkt | Ja |
-
-Anti-pattern: `--headed` als default in scripts/agents zetten. Dat opent bij
-elke AI-actie een Chrome-venster en steelt focus. Reserveer headed voor
-expliciet menselijk handelen.
-
 ## Parallel sessions [HARD]
 
 Elke Claude sessie MOET een unieke `--session` naam gebruiken. Anders leakt cookies/localStorage tussen sessies (issue [#1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
@@ -79,28 +61,23 @@ Agent Browser kan **niet** de Playwright `~/.claude/mcp-storageState.json` direc
 **One-time setup** (eenmalig, of refresh wanneer sessie verloopt):
 
 ```bash
-# 1. Open portal headed — mens moet inloggen, dus venster moet zichtbaar zijn
-agent-browser --headed open https://app.getklai.com
-# 2. Log in handmatig in geopende browser (Google SSO + 2FA)
-# 3. Save state (gebruikt huidige sessie, --headed flag niet nodig)
+# 1. Open portal headed (zonder --session-name = ephemeral, dan via state save)
+agent-browser open https://app.getklai.com
+# 2. Log in handmatig in geopende browser
+# 3. Save state
 agent-browser state save ~/.claude/agent-browser-state.json
 chmod 600 ~/.claude/agent-browser-state.json
 agent-browser close
 ```
 
-**Daily use** in scripts/agents (headless, geen `--headed`):
+**Daily use** in scripts/agents:
 
 ```bash
 SESSION="klai-portal-${CLAUDE_SESSION_ID:-$(date +%s)}"
 agent-browser --session "$SESSION" \
               --state ~/.claude/agent-browser-state.json \
-              open https://voys.getklai.com
+              open https://app.getklai.com/dashboard
 ```
-
-Gebruik voor authenticated SPA-flows de workspace-URL (`<slug>.getklai.com`),
-niet `app.getklai.com`. Een ingelogde request op `app.getklai.com` kan op een
-`/api/me`-style JSON-payload landen; de tenant-SPA leeft op het
-workspace-subdomein. De workspace-URL staat in die JSON onder `workspace_url`.
 
 Refresh `~/.claude/agent-browser-state.json` om de paar weken wanneer Google's session cookies verlopen. (Dit geldt voor Agent Browser; Playwright MCP heeft die cadens niet meer — die gebruikt sinds 2026-05-13 een workspace-hashed persistent profile dat zichzelf onderhoudt.) Als Agent Browser sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
 
@@ -159,8 +136,6 @@ agent-browser --session "$SESSION" eval "
 - **agent-browser-session-shell-expansion** — `$$` of `$RANDOM` per command-aanroep = nieuwe sessie elke keer. Gebruik een env var die je vóór de chain set.
 - **agent-browser-storage-state-mismatch** — Niet de Playwright `~/.claude/mcp-storageState.json` proberen te laden. Eigen file `~/.claude/agent-browser-state.json` aanmaken via `state save`.
 - **agent-browser-stale-refs** — `@e1`, `@e2` zijn **fresh per snapshot**. Re-snapshot na elke navigation/click die de DOM wijzigt.
-- **agent-browser-headed-as-default** — `--headed` toevoegen aan elk script omdat "de mens dan kan meekijken" steelt focus en is voor AI-runs onnodig. Headless is correct default; `--headed` alleen voor login en interactieve debug.
-- **agent-browser-app-getklai-returns-json** — Een ingelogde sessie die `https://app.getklai.com` opent kan op een JSON-payload landen, niet de SPA. Voor authenticated flows: gebruik `<workspace>.getklai.com` uit `/api/me` `workspace_url`.
 
 ## See also
 

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -270,6 +270,20 @@ KLAI_KB_CHAT_RENDER_MODE = _resolve_kb_render_mode(
 )
 
 
+def _sanitize_upstream_body(body: str, *, max_len: int = 200) -> str:
+    """Redact local service secrets before logging an upstream error body."""
+    if not body:
+        return ""
+    safe = body
+    secret_values = (
+        os.getenv("PORTAL_INTERNAL_SECRET", ""),
+        os.getenv("RETRIEVAL_INTERNAL_SECRET", ""),
+    )
+    for secret in sorted({s for s in secret_values if len(s) >= 8}, key=len, reverse=True):
+        safe = safe.replace(secret, "<redacted>")
+    return safe[:max_len]
+
+
 def _select_kb_render_strategy(original_stream: object) -> KbCitationRenderStrategy:
     return _select_kb_render_strategy_for_mode(
         original_stream,
@@ -725,11 +739,10 @@ class KlaiKnowledgeHook(CustomLogger):
             # caller-service-header regression in production for 7 days.
             # @MX:REASON: SPEC-SEC-IDENTITY-ASSERT-001 Phase D + the
             # `retrieve-caller-service-header-mismatch` pitfall.
-            body_snippet = ""
-            try:
-                body_snippet = exc.response.text[:200]
-            except Exception:
-                pass
+            body_snippet = _sanitize_upstream_body(
+                getattr(exc.response, "text", ""),
+                max_len=200,
+            )
             logger.error(
                 "KlaiKnowledgeHook: retrieval HTTP %d — body=%r — failing loud",
                 exc.response.status_code,

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -105,6 +105,24 @@ def _load_hook(
     return klai_knowledge
 
 
+def test_sanitize_upstream_body_redacts_internal_secrets(monkeypatch):
+    mod = _load_hook(
+        monkeypatch,
+        extra_env={
+            "PORTAL_INTERNAL_SECRET": "portal-secret-12345",
+            "RETRIEVAL_INTERNAL_SECRET": "retrieval-secret-12345",
+        },
+    )
+
+    out = mod._sanitize_upstream_body(
+        "invalid secret=portal-secret-12345 retrieval-secret-12345"
+    )
+
+    assert "portal-secret-12345" not in out
+    assert "retrieval-secret-12345" not in out
+    assert out.count("<redacted>") == 2
+
+
 async def _test_get_kb_feature(user_id: str, org_id: str, cache):
     """Unit-test feature resolver backed by the existing _make_cache helper.
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -816,17 +816,16 @@ async def gitea_webhook(request: Request) -> dict:
     # Must read raw bytes before json.loads; body stream is consumed after first read
     raw_body = await request.body()
 
-    if settings.gitea_webhook_secret:
-        signature = request.headers.get("x-gitea-signature", "")
-        if not signature:
-            raise HTTPException(status_code=401, detail="Missing X-Gitea-Signature header")
-        expected = hmac.new(
-            settings.gitea_webhook_secret.encode(),
-            raw_body,
-            hashlib.sha256,
-        ).hexdigest()
-        if not hmac.compare_digest(signature, expected):
-            raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    signature = request.headers.get("x-gitea-signature", "")
+    if not signature:
+        raise HTTPException(status_code=401, detail="Missing X-Gitea-Signature header")
+    expected = hmac.new(
+        settings.gitea_webhook_secret.encode(),
+        raw_body,
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
     try:
         body = json.loads(raw_body)
@@ -1172,9 +1171,11 @@ async def _list_gitea_md_files(repo_full_name: str) -> list[str]:
 
 async def _register_gitea_webhook(gitea_repo: str, webhook_url: str) -> None:
     """Register a push webhook on a Gitea repo."""
-    config: dict = {"url": webhook_url, "content_type": "json"}
-    if settings.gitea_webhook_secret:
-        config["secret"] = settings.gitea_webhook_secret
+    config: dict = {
+        "url": webhook_url,
+        "content_type": "json",
+        "secret": settings.gitea_webhook_secret,
+    }
     async with httpx.AsyncClient(
         base_url=settings.gitea_url,
         headers={"Authorization": f"token {settings.gitea_token}"},

--- a/klai-libs/service-auth/klai_service_auth/client.py
+++ b/klai-libs/service-auth/klai_service_auth/client.py
@@ -66,6 +66,21 @@ _REFRESH_FRACTION: float = 0.8
 _MIN_TTL_SECONDS: int = 60
 
 
+def _sanitize_body_excerpt(
+    body: str,
+    secret_values: tuple[str, ...],
+    *,
+    max_len: int = 500,
+) -> str:
+    """Redact known local secrets from an IdP error body before logging."""
+    if not body:
+        return ""
+    safe = body
+    for secret in sorted({s for s in secret_values if len(s) >= 8}, key=len, reverse=True):
+        safe = safe.replace(secret, "<redacted>")
+    return safe[:max_len]
+
+
 class ZitadelTokenClient:
     """Async OAuth 2.0 Client Credentials token client.
 
@@ -194,7 +209,11 @@ class ZitadelTokenClient:
 
         if resp.status_code != 200:
             # Trim the body so we don't log a megabyte of HTML on a misrouted call.
-            body_excerpt = resp.text[:500] if resp.text else ""
+            body_excerpt = _sanitize_body_excerpt(
+                resp.text,
+                (self._client_secret,),
+                max_len=500,
+            )
             logger.warning(
                 "service_auth_token_mint_failed",
                 client_id=self._client_id,

--- a/klai-libs/service-auth/tests/test_token_client.py
+++ b/klai-libs/service-auth/tests/test_token_client.py
@@ -204,6 +204,25 @@ async def test_idp_returns_401_raises_service_auth_error():
 
 
 @pytest.mark.asyncio
+async def test_idp_error_body_redacts_client_secret():
+    client = _build_client(client_secret="super-secret-client-value")
+    bad_resp = MagicMock(spec=httpx.Response)
+    bad_resp.status_code = 401
+    bad_resp.text = '{"error":"invalid_client","echo":"super-secret-client-value"}'
+
+    with patch("httpx.AsyncClient") as mock_async_client:
+        mock_async_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=bad_resp
+        )
+        with pytest.raises(ServiceAuthError) as exc_info:
+            await client.get_token()
+
+    message = str(exc_info.value)
+    assert "super-secret-client-value" not in message
+    assert "<redacted>" in message
+
+
+@pytest.mark.asyncio
 async def test_network_error_raises_service_auth_error():
     client = _build_client()
     with patch("httpx.AsyncClient") as mock_async_client:

--- a/klai-mailer/app/schemas.py
+++ b/klai-mailer/app/schemas.py
@@ -115,6 +115,7 @@ class OnboardingInviteVars(_BaseVars):
 TEMPLATE_SCHEMAS: dict[str, type[_BaseVars]] = {
     "join_request_admin": JoinRequestAdminVars,
     "join_request_approved": JoinRequestApprovedVars,
+    "auto_join_admin_notification": AutoJoinAdminNotificationVars,
     "waitlist_confirmation": WaitlistConfirmationVars,
     "waitlist_invite": WaitlistInviteVars,
     "onboarding_invite": OnboardingInviteVars,

--- a/klai-mailer/app/schemas.py
+++ b/klai-mailer/app/schemas.py
@@ -62,12 +62,15 @@ class AutoJoinAdminNotificationVars(_BaseVars):
 
     Sent to all workspace admins when a domain_match user auto-joins.
     `admin_email` is the authoritative recipient; caller pre-resolves it.
+    `org_id` is accepted because the portal-api caller sends it in the
+    auto-join notification variables.
     """
 
     name: str
     email: EmailStr
     domain: str
     admin_email: EmailStr
+    org_id: int
 
 
 class WaitlistConfirmationVars(_BaseVars):

--- a/klai-mailer/tests/test_internal_send_recipient.py
+++ b/klai-mailer/tests/test_internal_send_recipient.py
@@ -180,7 +180,7 @@ def test_approved_recipient_from_variables_email(client, stub_smtp):
 
 
 def test_auto_join_admin_notification_recipient_from_admin_email(client, stub_smtp):
-    """auto_join_admin_notification is registered and bound to admin_email."""
+    """Portal auto-join payload with org_id is accepted and bound to admin_email."""
     resp = client.post(
         "/internal/send",
         headers={"X-Internal-Secret": "internal-test-secret"},
@@ -193,6 +193,7 @@ def test_auto_join_admin_notification_recipient_from_admin_email(client, stub_sm
                 "email": "alice@test.example",
                 "domain": "test.example",
                 "admin_email": "admin@test.example",
+                "org_id": 42,
             },
         },
     )
@@ -215,6 +216,7 @@ def test_auto_join_admin_notification_recipient_mismatch_rejected(client, stub_s
                 "email": "alice@test.example",
                 "domain": "test.example",
                 "admin_email": "admin@test.example",
+                "org_id": 42,
             },
         },
     )

--- a/klai-mailer/tests/test_internal_send_recipient.py
+++ b/klai-mailer/tests/test_internal_send_recipient.py
@@ -179,6 +179,51 @@ def test_approved_recipient_from_variables_email(client, stub_smtp):
     assert stub_smtp.sent[0]["to_address"] == "bob@test.example"
 
 
+def test_auto_join_admin_notification_recipient_from_admin_email(client, stub_smtp):
+    """auto_join_admin_notification is registered and bound to admin_email."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "auto_join_admin_notification",
+            "to": "admin@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": "alice@test.example",
+                "domain": "test.example",
+                "admin_email": "admin@test.example",
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert stub_smtp.sent[0]["to_address"] == "admin@test.example"
+
+
+def test_auto_join_admin_notification_recipient_mismatch_rejected(client, stub_smtp):
+    """auto_join_admin_notification must not relay to caller-supplied addresses."""
+    resp = client.post(
+        "/internal/send",
+        headers={"X-Internal-Secret": "internal-test-secret"},
+        json={
+            "template": "auto_join_admin_notification",
+            "to": "attacker@test.example",
+            "locale": "nl",
+            "variables": {
+                "name": "Alice",
+                "email": "alice@test.example",
+                "domain": "test.example",
+                "admin_email": "admin@test.example",
+            },
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "recipient mismatch"}
+    assert stub_smtp.sent == []
+
+
 def test_approved_to_mismatch_rejected(client, stub_smtp):
     """REQ-3.2: `to` != variables.email → 400 recipient mismatch."""
     resp = client.post(

--- a/klai-portal/backend/app/api/internal_connectors.py
+++ b/klai-portal/backend/app/api/internal_connectors.py
@@ -26,7 +26,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.database import get_db
+from app.core.database import get_db, set_tenant
 from app.models.connectors import PortalConnector
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,13 @@ async def finalize_connector_delete(
             detail=f"Connector is in state {connector.state!r}, expected 'deleting'",
         )
 
-    await db.execute(delete(PortalConnector).where(PortalConnector.id == connector_id))
+    await set_tenant(db, connector.org_id)
+    await db.execute(
+        delete(PortalConnector).where(
+            PortalConnector.id == connector_id,
+            PortalConnector.org_id == connector.org_id,
+        )
+    )
     await db.commit()
     logger.info(
         "finalize_connector_delete_completed",

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_orchestrator.py
@@ -379,7 +379,11 @@ async def _mark_failed(db: AsyncSession, org_id: int, step_name: str, error_str:
             to_state="failed_deprovisioning",
             step=step_name,
         )
-        # Populate last_failure JSONB. Use raw text() to avoid ORM RLS issues.
+        # Populate last_failure JSONB via raw text() rather than the ORM. The
+        # ORM path would layer a fresh transaction and refresh onto a session
+        # that just recovered from the failure branch. `portal_orgs` is not a
+        # Cat-D RLS table; keep text() here for explicit JSONB binding and
+        # transactional simplicity.
         # @MX:NOTE: SPEC-INFRA-TENANT-DELETE-003 Bug B — asyncpg cannot bind a
         #   Python dict to a jsonb column via text() prepared statements; it
         #   tries to call `.encode()` on the dict and raises DataError. Encode

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -33,6 +33,7 @@ from app.services.provisioning.infrastructure import (
     _sync_drop_mongodb_tenant_user,
     _sync_remove_container,
 )
+from app.utils.response_sanitizer import sanitize_response_body
 
 if TYPE_CHECKING:
     from app.services.provisioning.deprovisioning_orchestrator import _DeprovisionState
@@ -433,7 +434,7 @@ async def _wipe_knowledge_postgres(state: _DeprovisionState) -> None:
                 zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
-                body=resp.text[:500],
+                body=sanitize_response_body(resp, max_len=500),
             )
         resp.raise_for_status()
         data = resp.json()
@@ -497,7 +498,7 @@ async def _wipe_klai_connector_state(state: _DeprovisionState) -> None:
                 zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
-                body=resp.text[:500],
+                body=sanitize_response_body(resp, max_len=500),
             )
         resp.raise_for_status()
         data = resp.json()

--- a/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
+++ b/klai-portal/backend/app/services/provisioning/deprovisioning_steps.py
@@ -539,7 +539,7 @@ async def _wipe_scribe_state(state: _DeprovisionState) -> None:
                 zitadel_org_id=state.zitadel_org_id,
                 slug=state.slug,
                 status=resp.status_code,
-                body=resp.text[:500],
+                body=sanitize_response_body(resp, max_len=500),
             )
         resp.raise_for_status()
         data = resp.json()

--- a/klai-portal/backend/tests/test_connector_lifecycle.py
+++ b/klai-portal/backend/tests/test_connector_lifecycle.py
@@ -24,9 +24,10 @@ from tests.conftest import make_perms
 class _FakeConnector:
     """Minimal stand-in for ``PortalConnector`` in unit tests."""
 
-    def __init__(self, *, id: str, kb_id: int, state: str = "active") -> None:
+    def __init__(self, *, id: str, kb_id: int, org_id: int = 8, state: str = "active") -> None:
         self.id = id
         self.kb_id = kb_id
+        self.org_id = org_id
         self.state = state
 
 
@@ -222,6 +223,8 @@ async def test_finalize_delete_drops_row_when_state_deleting(
     )
     connector = _FakeConnector(id="conn-uuid", kb_id=42, state="deleting")
     db = _FakeDB(fetch_value=connector)
+    set_tenant = AsyncMock()
+    monkeypatch.setattr("app.api.internal_connectors.set_tenant", set_tenant)
 
     result = await finalize_connector_delete(
         connector_id="conn-uuid",
@@ -232,6 +235,7 @@ async def test_finalize_delete_drops_row_when_state_deleting(
     assert result is None  # 204 No Content
     # Two executes: SELECT then DELETE
     assert len(db.executes) == 2
+    set_tenant.assert_awaited_once_with(db, 8)
     assert db.commits == 1
 
 

--- a/klai-portal/backend/tests/test_deprovisioning_orchestrator.py
+++ b/klai-portal/backend/tests/test_deprovisioning_orchestrator.py
@@ -14,6 +14,7 @@ All external calls (DB, LiteLLM, Zitadel, step functions) are mocked.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -274,6 +275,19 @@ class TestMarkFailed:
         # JSON-string bind reaches the column as jsonb (REQ-2 AC-2.1).
         stmt_text = str(captured["stmt"])
         assert "jsonb" in stmt_text.lower(), f"UPDATE statement must cast bind to jsonb, got: {stmt_text!r}"
+
+        failure_str = params["failure"]
+        assert isinstance(failure_str, str), (
+            f"`failure` bind must be a JSON string after json.dumps(), got {type(failure_str).__name__}"
+        )
+        payload = json.loads(failure_str)
+        assert payload.keys() == {"step", "error", "attempt", "failed_at"}, (
+            f"_mark_failed payload keys drifted from SPEC contract: got {sorted(payload.keys())}"
+        )
+        assert payload["step"] == "_delete_meilisearch_index"
+        assert payload["error"] == "connection refused"
+        assert payload["attempt"] == 3
+        assert isinstance(payload["failed_at"], str) and "T" in payload["failed_at"]
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_deprovisioning_steps.py
+++ b/klai-portal/backend/tests/test_deprovisioning_steps.py
@@ -844,6 +844,36 @@ class TestWipeScribeState:
             with pytest.raises(RuntimeError, match="scribe_api_url"):
                 await _wipe_scribe_state(state)
 
+    @pytest.mark.asyncio
+    async def test_failure_log_redacts_internal_secret(self) -> None:
+        """Scribe wipe failure logs must not include secret-bearing response bodies."""
+        state = _make_state(org_id=42, slug="acme")
+        secret = "portal-secret-123456789"
+
+        with (
+            patch("app.services.provisioning.deprovisioning_steps.settings") as mock_settings,
+            patch("app.utils.response_sanitizer.settings.internal_secret", secret),
+            patch("app.services.provisioning.deprovisioning_steps.logger") as mock_logger,
+        ):
+            mock_settings.scribe_api_url = "http://scribe-api:8020"
+            mock_settings.internal_secret = secret
+            with patch("app.trace.get_trace_headers", return_value={}):
+                with respx_router(base_url="http://scribe-api:8020") as router:
+                    router.post("/internal/v1/orgs/zitadel-org-abc/wipe-state").mock(
+                        return_value=httpx.Response(
+                            500,
+                            text=f"upstream rejected X-Internal-Secret={secret}",
+                        )
+                    )
+                    from app.services.provisioning.deprovisioning_steps import _wipe_scribe_state
+
+                    with pytest.raises(httpx.HTTPStatusError):
+                        await _wipe_scribe_state(state)
+
+        body = mock_logger.error.call_args.kwargs["body"]
+        assert secret not in body
+        assert "<redacted>" in body
+
 
 # ---------------------------------------------------------------------------
 # Step 11 — _delete_scribe_artifacts

--- a/klai-portal/frontend/.gitignore
+++ b/klai-portal/frontend/.gitignore
@@ -16,6 +16,12 @@ dist-ssr
 # TanStack Router local cache (router tree generator temp files)
 .tanstack/
 
+# Playwright run output. Failure snapshots can include filled password fields.
+test-results/
+playwright-report/
+playwright-report-prod-tenant/
+e2e/prod-tenant/_config/playwright-report-prod-tenant/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import warnings
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import structlog
 from klai_kb_slugs import personal_kb_slug
@@ -35,6 +35,8 @@ warnings.filterwarnings("ignore", message="Api key is used with an insecure conn
 logger = structlog.get_logger()
 
 _client: AsyncQdrantClient | None = None
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+_ACTIVE_UNTIL_SENTINEL = 253402300800
 
 
 def _get_client() -> AsyncQdrantClient:
@@ -48,20 +50,63 @@ def _get_client() -> AsyncQdrantClient:
     return _client
 
 
-def _invalid_at_filter() -> Filter:
-    """Build a filter that excludes chunks where invalid_at is set and in the past.
+def _epoch_seconds_to_iso(value: object, *, open_ended_sentinel: bool = False) -> str | None:
+    """Convert epoch-second temporal payload values to API ISO strings."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        if open_ended_sentinel and value >= _ACTIVE_UNTIL_SENTINEL:
+            return None
+        try:
+            return (_EPOCH + timedelta(seconds=float(value))).isoformat()
+        except (OverflowError, ValueError):
+            return None
+    return None
 
-    Uses must_not with a range filter: a chunk is excluded only when invalid_at
-    is present AND <= now. Absent invalid_at fields pass through because Qdrant
-    range filters on absent fields return no match (so must_not = pass).
-    The old is_null=True approach did not match absent fields in Qdrant 1.17+.
+
+def _payload_valid_at(payload: dict) -> str | None:
+    return payload.get("valid_at") or _epoch_seconds_to_iso(payload.get("valid_from"))
+
+
+def _payload_invalid_at(payload: dict) -> str | None:
+    return payload.get("invalid_at") or _epoch_seconds_to_iso(
+        payload.get("valid_until"),
+        open_ended_sentinel=True,
+    )
+
+
+def _temporal_validity_filter() -> Filter:
+    """Exclude chunks outside either supported temporal payload contract.
+
+    Retrieval historically used ``valid_at``/``invalid_at`` while
+    knowledge-ingest writes ``valid_from``/``valid_until`` from
+    ``belief_time_start``/``belief_time_end``. Support both so stale points are
+    filtered even when old Qdrant payloads were not physically deleted.
     """
-    now_iso = datetime.now(UTC).isoformat()
+    now = datetime.now(UTC)
+    now_iso = now.isoformat()
+    now_epoch = int(now.timestamp())
     return Filter(
         must_not=[
             FieldCondition(
                 key="invalid_at",
                 range={"lte": now_iso},
+            ),
+            FieldCondition(
+                key="valid_until",
+                range={"lte": now_epoch},
+            ),
+            FieldCondition(
+                key="valid_at",
+                range={"gt": now_iso},
+            ),
+            FieldCondition(
+                key="valid_from",
+                range={"gt": now_epoch},
             ),
         ]
     )
@@ -189,7 +234,7 @@ async def _search_knowledge(
     client = _get_client()
 
     scope_conditions = _scope_filter(request)
-    must_conditions = [*scope_conditions, _invalid_at_filter()]
+    must_conditions = [*scope_conditions, _temporal_validity_filter()]
 
     # SPEC-KB-022 R3: taxonomy filter with backward-compatible fallback.
     # OR: match on new taxonomy_node_ids (array) OR old taxonomy_node_id (int).
@@ -288,8 +333,8 @@ async def _search_knowledge(
             "heading_path": r.payload.get("heading_path"),
             "parent_chunk_id": r.payload.get("parent_chunk_id"),
             "scope": r.payload.get("scope"),
-            "valid_at": r.payload.get("valid_at"),
-            "invalid_at": r.payload.get("invalid_at"),
+            "valid_at": _payload_valid_at(r.payload),
+            "invalid_at": _payload_invalid_at(r.payload),
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),
@@ -330,7 +375,7 @@ async def fetch_chunks_by_urls(
         must=[
             *scope_conditions,
             FieldCondition(key="source_url", match=MatchAny(any=urls)),
-            _invalid_at_filter(),
+            _temporal_validity_filter(),
         ]
     )
 
@@ -363,8 +408,8 @@ async def fetch_chunks_by_urls(
             "heading_path": r.payload.get("heading_path"),
             "parent_chunk_id": r.payload.get("parent_chunk_id"),
             "scope": r.payload.get("scope"),
-            "valid_at": r.payload.get("valid_at"),
-            "invalid_at": r.payload.get("invalid_at"),
+            "valid_at": _payload_valid_at(r.payload),
+            "invalid_at": _payload_invalid_at(r.payload),
             "ingested_at": r.payload.get("ingested_at"),
             "assertion_mode": r.payload.get("assertion_mode"),
             "entity_pagerank_max": r.payload.get("entity_pagerank_max"),

--- a/klai-retrieval-api/tests/test_search.py
+++ b/klai-retrieval-api/tests/test_search.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -123,6 +124,119 @@ class TestSearch:
 
         assert results[0]["ingested_at"] is None
         assert results[0]["assertion_mode"] is None
+
+    @pytest.mark.asyncio
+    async def test_qdrant_temporal_filter_respects_valid_until_invalid_at_and_valid_from(self):
+        """The live Qdrant filter excludes stale ingest-contract temporal payloads."""
+        from qdrant_client import AsyncQdrantClient
+        from qdrant_client.models import Distance, PointStruct, VectorParams
+
+        client = AsyncQdrantClient(location=":memory:")
+        await client.create_collection(
+            "klai_knowledge",
+            vectors_config={
+                "vector_chunk": VectorParams(size=2, distance=Distance.COSINE),
+                "vector_questions": VectorParams(size=2, distance=Distance.COSINE),
+            },
+        )
+
+        now = int(time.time())
+        vector = {"vector_chunk": [1.0, 0.0], "vector_questions": [1.0, 0.0]}
+        await client.upsert(
+            "klai_knowledge",
+            points=[
+                PointStruct(
+                    id=1,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "expired by valid_until",
+                        "valid_from": now - 7200,
+                        "valid_until": now - 3600,
+                    },
+                ),
+                PointStruct(
+                    id=2,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "expired by invalid_at",
+                        "invalid_at": "2000-01-01T00:00:00+00:00",
+                    },
+                ),
+                PointStruct(
+                    id=3,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "not yet valid",
+                        "valid_from": now + 3600,
+                        "valid_until": now + 7200,
+                    },
+                ),
+                PointStruct(
+                    id=4,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "active by valid_until",
+                        "valid_from": now - 3600,
+                        "valid_until": now + 3600,
+                    },
+                ),
+                PointStruct(
+                    id=5,
+                    vector=vector,
+                    payload={
+                        "org_id": "org-1",
+                        "kb_slug": "kb-1",
+                        "text": "timeless legacy",
+                    },
+                ),
+            ],
+        )
+
+        try:
+            with patch.object(search, "_get_client", return_value=client):
+                req = RetrieveRequest(
+                    query="test",
+                    org_id="org-1",
+                    scope="org",
+                    kb_slugs=["kb-1"],
+                )
+                results = await search.hybrid_search([1.0, 0.0], req, 10)
+        finally:
+            await client.close()
+
+        assert {r["text"] for r in results} == {
+            "active by valid_until",
+            "timeless legacy",
+        }
+
+    @pytest.mark.asyncio
+    async def test_knowledge_search_aliases_valid_from_until_to_api_fields(self):
+        """Retrieval API response fields expose ingest-contract temporal payloads."""
+        point = _make_point(
+            "c1",
+            "chunk text",
+            0.8,
+            org_id="org-1",
+            valid_from=1_700_000_000,
+            valid_until=253_402_300_800,
+        )
+        mock_client = AsyncMock()
+        mock_client.query_points.return_value = _make_query_response([point])
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="test", org_id="org-1", scope="org")
+            results = await search.hybrid_search([0.1, 0.2], req, 10)
+
+        assert results[0]["valid_at"] == "2023-11-14T22:13:20+00:00"
+        assert results[0]["invalid_at"] is None
 
     @pytest.mark.asyncio
     async def test_knowledge_search_passes_heading_path(self):


### PR DESCRIPTION
## Summary

This replaces the remaining useful parts of several stale/conflicting open PRs with a current-main patch set:

- retrieval-api now honors both temporal payload contracts (`valid_at`/`invalid_at` and ingest's `valid_from`/`valid_until`) and maps ingest epoch fields back to API fields
- mailer registers `auto_join_admin_notification` in `TEMPLATE_SCHEMAS`, with recipient-binding tests
- deprovisioning failure JSONB payload gets a stronger shape-lock test; failure HTTP body logging now uses the portal response sanitizer
- connector finalize-delete sets tenant context before deleting `portal_connectors`
- Gitea webhook verification/registration now uses the fail-closed configured HMAC secret unconditionally
- service-auth and LiteLLM retrieval error-body logging redact local secrets before logging/surfacing excerpts
- Playwright prod-E2E output directories are ignored because failure artifacts can contain filled password fields
- agent-browser docs carry forward the headless-default and workspace-URL guidance from the old docs PR

## What was deliberately not merged

- PR #671's “TOTP optional” change: stale and weaker than current behavior. Recent main production-E2E run `27126489486` on 2026-06-08 passed `J01 - login + TOTP and persist storage-state` with `E2E_TOTP_SECRET` present.
- PR #525's old `kb_images` patch: it failed portal RLS audit in CI. This PR does not attempt that redesign.
- PR #664's mailer copy/rebrand churn: only the objective schema-registration bug is included.
- PR #668 as-is: the old branch would overwrite newer retrieval behavior, so this is a current-main reimplementation of the temporal-validity fix.

## Advisory / review notes

- CodeIndex impact checks were run for `_invalid_at_filter`, `_mark_failed`, `gitea_webhook`, `_register_gitea_webhook`, and `ZitadelTokenClient`; all reported low risk/no affected processes where the symbol was available.
- CodeIndex could not disambiguate portal `app/api/internal_connectors.py::finalize_connector_delete`; reviewed manually against source, `tests/test_connector_lifecycle.py`, and RLS audit/hygiene tests.
- CodeIndex `detect_changes` over the worktree reported low risk/no affected processes, but its file list included stale/index-overlay noise. The authoritative git diff is the 16 files in this PR.
- No code should be merged to `main` until GitHub advisory/CI checks on this PR are green.

## Validation

- `git diff --check`
- `uv run --extra dev pytest tests/test_search.py` in `klai-retrieval-api` — 10 passed
- `uv run --extra dev ruff check retrieval_api/services/search.py tests/test_search.py` in `klai-retrieval-api`
- `uv run --extra dev pytest tests/test_internal_send_recipient.py tests/test_internal_send_auth.py` in `klai-mailer` — 21 passed
- `uv run --extra dev ruff check app/schemas.py tests/test_internal_send_recipient.py` in `klai-mailer`
- `uv run --extra dev pytest tests/test_deprovisioning_steps.py -k 'WipeKnowledgePostgres or WipeKlaiConnectorState'` in `klai-portal/backend` — 9 passed
- `uv run --extra dev pytest tests/test_deprovisioning_orchestrator.py -k mark_failed` in `klai-portal/backend` — 3 passed
- `uv run --extra dev pytest tests/test_connector_lifecycle.py` in `klai-portal/backend` — 8 passed
- `uv run --extra dev pytest tests/test_rls_audit.py tests/test_rls_hygiene.py` in `klai-portal/backend` — 24 passed
- `uv run --extra dev ruff check app/services/provisioning/deprovisioning_orchestrator.py tests/test_deprovisioning_orchestrator.py app/services/provisioning/deprovisioning_steps.py app/api/internal_connectors.py tests/test_connector_lifecycle.py` in `klai-portal/backend`
- `uv run --extra dev pytest tests/test_webhook_hmac.py tests/test_gitea_webhook_secret_validator.py` in `klai-knowledge-ingest` — 11 passed, 1 existing pydantic warning
- `uv run --extra dev ruff check knowledge_ingest/routes/ingest.py tests/test_webhook_hmac.py tests/test_gitea_webhook_secret_validator.py` in `klai-knowledge-ingest`
- `uv run pytest tests/test_token_client.py` in `klai-libs/service-auth` — 16 passed
- `uv run ruff check klai_service_auth/client.py tests/test_token_client.py` in `klai-libs/service-auth`
- `PYTHONPATH=.:../../klai-libs/citations uv run --with pytest --with httpx --with structlog pytest tests/test_klai_knowledge_hook.py -k sanitize_upstream_body_redacts_internal_secrets` in `deploy/litellm` — 1 passed, existing pytest mark warnings
- `PYTHONPATH=.:../../klai-libs/citations uv run --with ruff ruff check klai_knowledge.py tests/test_klai_knowledge_hook.py --extend-ignore F841` in `deploy/litellm`

## Known test/lint caveat

A first LiteLLM one-test run without `PYTHONPATH=.:../../klai-libs/citations` failed with `ModuleNotFoundError: klai_citations`; rerun with the required path passed. Plain ruff on the entire `tests/test_klai_knowledge_hook.py` also reports pre-existing `F841` unused variables outside this patch, so the targeted lint run used `--extend-ignore F841` rather than doing an unrelated cleanup.
