### PR TITLE
docs(agent-browser): refresh auth flow guidance

### DIFF
--- a/.claude/rules/klai/lang/agent-browser.md
+++ b/.claude/rules/klai/lang/agent-browser.md
@@ -21,6 +21,23 @@ paths:
 
 Default: voor alles met "verify dat X werkt" → Playwright. Voor alles met "explore of er iets stuk is" → Agent Browser.
 
+## Headless is default voor Agent Browser
+
+Agent Browser draait headless tenzij je `--headed` of
+`AGENT_BROWSER_HEADED=1` meegeeft. Dat is de juiste default voor AI-runs:
+de agent leest het DOM via `snapshot`, en er opent geen venster dat focus
+steelt.
+
+Gebruik `--headed` alleen wanneer een mens het venster nodig heeft:
+
+| Situatie | Headed nodig? |
+|---|---|
+| Smoke test, audit, snapshot-driven flow door AI | Nee |
+| Authenticated sessie draaien met `--state` | Nee |
+| Eenmalige login om `state save` te doen | Ja |
+| Captcha / 2FA-prompt die je niet kunt scripten | Ja |
+| Live debugging waarbij iemand meekijkt | Ja |
+
 ## Parallel sessions [HARD]
 
 Elke Claude sessie MOET een unieke `--session` naam gebruiken. Anders leakt cookies/localStorage tussen sessies (issue [#1068](https://github.com/vercel-labs/agent-browser/issues/1068)).
@@ -61,8 +78,8 @@ Agent Browser kan **niet** de Playwright `~/.claude/mcp-storageState.json` direc
 **One-time setup** (eenmalig, of refresh wanneer sessie verloopt):
 
 ```bash
-# 1. Open portal headed (zonder --session-name = ephemeral, dan via state save)
-agent-browser open https://app.getklai.com
+# 1. Open portal headed; een mens moet kunnen inloggen
+agent-browser --headed open https://app.getklai.com
 # 2. Log in handmatig in geopende browser
 # 3. Save state
 agent-browser state save ~/.claude/agent-browser-state.json
@@ -70,14 +87,21 @@ chmod 600 ~/.claude/agent-browser-state.json
 agent-browser close
 ```
 
-**Daily use** in scripts/agents:
+**Daily use** in scripts/agents (headless):
 
 ```bash
 SESSION="klai-portal-${CLAUDE_SESSION_ID:-$(date +%s)}"
+WORKSPACE_URL="https://<workspace>.getklai.com"
 agent-browser --session "$SESSION" \
               --state ~/.claude/agent-browser-state.json \
-              open https://app.getklai.com/dashboard
+              open "$WORKSPACE_URL"
 ```
+
+Gebruik voor authenticated Agent Browser SPA-flows het workspace-subdomein
+(`<slug>.getklai.com`), niet `app.getklai.com/dashboard`. Een ingelogde request
+op `app.getklai.com` kan een `/api/me`-style JSON-response opleveren; de React
+app leeft op het workspace-subdomein. Dit verandert niets aan de Playwright MCP
+flow hierboven: Playwright blijft canonical voor deterministic verify-runs.
 
 Refresh `~/.claude/agent-browser-state.json` om de paar weken wanneer Google's session cookies verlopen. (Dit geldt voor Agent Browser; Playwright MCP heeft die cadens niet meer — die gebruikt sinds 2026-05-13 een workspace-hashed persistent profile dat zichzelf onderhoudt.) Als Agent Browser sessies "logged-out" starten: state file is verlopen → opnieuw `state save`.
 
@@ -136,6 +160,8 @@ agent-browser --session "$SESSION" eval "
 - **agent-browser-session-shell-expansion** — `$$` of `$RANDOM` per command-aanroep = nieuwe sessie elke keer. Gebruik een env var die je vóór de chain set.
 - **agent-browser-storage-state-mismatch** — Niet de Playwright `~/.claude/mcp-storageState.json` proberen te laden. Eigen file `~/.claude/agent-browser-state.json` aanmaken via `state save`.
 - **agent-browser-stale-refs** — `@e1`, `@e2` zijn **fresh per snapshot**. Re-snapshot na elke navigation/click die de DOM wijzigt.
+- **agent-browser-headed-as-default** — `--headed` in elk script zetten opent onnodig een browservenster. Gebruik headed alleen voor login of interactieve debug.
+- **agent-browser-app-getklai-returns-json** — Voor authenticated SPA-flows is `<workspace>.getklai.com` de juiste target; `app.getklai.com` kan JSON teruggeven.
 
 ## See also
 


### PR DESCRIPTION
Updates Agent Browser docs with the still-valid parts of old PR #528, without regressing the newer Playwright persistent-profile guidance.\n\nChanges:\n- Document that Agent Browser is headless by default and headed should be limited to human login/debug.\n- Use --headed only for the one-time state-save login example.\n- Use workspace subdomains for authenticated Agent Browser SPA flows instead of app.getklai.com/dashboard.\n- Keep the existing Playwright MCP guidance intact.\n\nVerification:\n- git diff --check\n- agent-browser --help confirms --headed, AGENT_BROWSER_HEADED, --state, and --session flags.