### PR TITLE
feat(retrieval): gate shadow mode + generic seed corpus

### DIFF
--- a/klai-retrieval-api/retrieval_api/api/chat.py
+++ b/klai-retrieval-api/retrieval_api/api/chat.py
@@ -42,10 +42,13 @@ async def chat(req: RetrieveRequest, request: Request) -> EventSourceResponse:
         # 2. Embed resolved query
         query_vector = await embed_single(query_resolved)
 
-        # 3. Gate check
-        bypassed, gate_margin = await gate.should_bypass(query_vector)
+        # 3. Gate check (shadow-aware: computes the decision but only acts on
+        # it when retrieval_gate_shadow is off — a wrong bypass silently drops
+        # all citations).
+        gate_decision = await gate.evaluate(query_vector)
+        gate_margin = gate_decision.margin
 
-        if bypassed:
+        if gate_decision.bypassed:
             # Stream a bypass done event with no tokens
             done_event = {
                 "type": "done",

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -208,14 +208,23 @@ async def retrieve(
 
     # 3. Gate check. Strict KB mode must never skip retrieval: a wrong bypass
     # would turn "answer only from selected KBs" into a plain model answer.
+    # Shadow mode (default) computes + logs the decision but never acts on it.
     if req.kb_narrow:
-        bypassed = False
-        gate_margin = None
+        gate_decision = gate.GateDecision(
+            would_bypass=False,
+            bypassed=False,
+            margin=None,
+            shadow=settings.retrieval_gate_shadow,
+        )
         decision_record["gate_skipped_reason"] = "strict_mode"
     else:
-        bypassed, gate_margin = await gate.should_bypass(query_vector)
+        gate_decision = await gate.evaluate(query_vector)
 
+    bypassed = gate_decision.bypassed
+    gate_margin = gate_decision.margin
     decision_record["gate_margin"] = round(gate_margin, 4) if gate_margin is not None else None
+    decision_record["gate_would_bypass"] = gate_decision.would_bypass
+    decision_record["gate_shadow_mode"] = gate_decision.shadow
     decision_record["gate_bypassed"] = bypassed
     decision_record["gate_ms"] = round((time.perf_counter() - t0) * 1000, 1)
 

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
 
     retrieval_gate_enabled: bool = True
     retrieval_gate_threshold: float = 0.1
+    # Shadow mode (default ON): the gate computes + logs its bypass decision
+    # (gate_would_bypass) but never acts on it, so retrieval always runs. A
+    # wrong bypass silently drops all citations, so the gate stays in shadow
+    # until production data confirms the reference corpus only catches non-KB
+    # queries. Set to False to go live.
+    retrieval_gate_shadow: bool = True
     retrieval_candidates: int = 60
     reranker_candidates: int = 20  # top-N from retrieval sent to reranker (CPU budget)
 

--- a/klai-retrieval-api/retrieval_api/data/gate_reference.jsonl
+++ b/klai-retrieval-api/retrieval_api/data/gate_reference.jsonl
@@ -1,0 +1,16 @@
+{"query": "Provide a concise, five-word-or-less title for this conversation in title case. Only return the title.", "label": "meta-title"}
+{"query": "Geef een korte titel van maximaal vijf woorden voor dit gesprek. Geef alleen de titel terug.", "label": "meta-title"}
+{"query": "Translate the following text into English.", "label": "translate"}
+{"query": "Vertaal de bovenstaande tekst naar het Nederlands.", "label": "translate"}
+{"query": "Summarize the text above in a few sentences.", "label": "summarize"}
+{"query": "Vat de bovenstaande tekst kort samen.", "label": "summarize"}
+{"query": "Convert the text above into a bulleted list.", "label": "format"}
+{"query": "Zet dit om naar opsommingstekens.", "label": "format"}
+{"query": "Rewrite this paragraph so it sounds more formal.", "label": "rewrite"}
+{"query": "Herschrijf deze tekst zodat hij vriendelijker klinkt.", "label": "rewrite"}
+{"query": "What is 15 percent of 240?", "label": "math"}
+{"query": "Bereken 47 keer 19.", "label": "math"}
+{"query": "Correct the spelling and grammar in the text above.", "label": "proofread"}
+{"query": "Write a short poem about spring.", "label": "creative"}
+{"query": "Schrijf een kort gedicht over de zee.", "label": "creative"}
+{"query": "Tell me a fun fact.", "label": "chitchat"}

--- a/klai-retrieval-api/retrieval_api/services/gate.py
+++ b/klai-retrieval-api/retrieval_api/services/gate.py
@@ -12,6 +12,7 @@ import json
 import logging
 import math
 from pathlib import Path
+from typing import NamedTuple
 
 from retrieval_api.config import settings
 
@@ -22,6 +23,20 @@ _GATE_FILE = Path(__file__).parent.parent / "data" / "gate_reference.jsonl"
 # Module-level caches
 _reference_queries: list[dict] | None = None
 _reference_vectors: list[list[float]] | None = None
+
+
+class GateDecision(NamedTuple):
+    """Outcome of a gate evaluation.
+
+    ``would_bypass`` is the raw recommendation, ignoring shadow mode.
+    ``bypassed`` is what the caller MUST act on — it is forced ``False``
+    while ``retrieval_gate_shadow`` is on, so retrieval always runs.
+    """
+
+    would_bypass: bool
+    bypassed: bool
+    margin: float | None
+    shadow: bool
 
 
 def _load_reference_queries() -> list[dict]:
@@ -102,6 +117,27 @@ async def should_bypass(query_vector: list[float]) -> tuple[bool, float | None]:
     if margin > settings.retrieval_gate_threshold:
         return True, margin
     return False, margin
+
+
+async def evaluate(query_vector: list[float]) -> GateDecision:
+    """Compute the gate recommendation and apply shadow-mode policy.
+
+    A wrong bypass silently drops every citation (the user gets a
+    model-only answer with no sources), so the gate runs in shadow by
+    default: ``would_bypass`` is computed and logged, but ``bypassed`` is
+    forced ``False`` so retrieval always runs. Keep shadow on until the
+    production ``gate_would_bypass`` rate confirms the reference corpus
+    only fires on non-KB queries, then set ``retrieval_gate_shadow`` to
+    ``False`` to go live.
+    """
+    would_bypass, margin = await should_bypass(query_vector)
+    shadow = settings.retrieval_gate_shadow
+    return GateDecision(
+        would_bypass=would_bypass,
+        bypassed=would_bypass and not shadow,
+        margin=margin,
+        shadow=shadow,
+    )
 
 
 def reset_cache() -> None:

--- a/klai-retrieval-api/tests/conftest.py
+++ b/klai-retrieval-api/tests/conftest.py
@@ -25,6 +25,12 @@ os.environ.setdefault("RATE_LIMIT_RPM", "600")
 # `_auto_allow_identity_assert` below.
 os.environ.setdefault("PORTAL_API_URL", "http://portal-api.test.local:8010")
 os.environ.setdefault("PORTAL_INTERNAL_SECRET", "test-portal-internal-secret")
+# Production defaults ``retrieval_gate_shadow`` to True (compute + log the gate
+# decision but never act on it). The pipeline tests force a bypass — patching
+# ``gate.should_bypass`` -> (True, ...) to skip the heavy qdrant/rerank path —
+# which only takes effect when the gate ACTS. Run the suite with the gate in
+# acting mode; shadow-suppression itself is covered explicitly in test_gate.py.
+os.environ.setdefault("RETRIEVAL_GATE_SHADOW", "false")
 
 import pytest
 from fastapi.testclient import TestClient

--- a/klai-retrieval-api/tests/test_gate.py
+++ b/klai-retrieval-api/tests/test_gate.py
@@ -96,3 +96,54 @@ class TestGate:
                 bypass, margin = await gate.should_bypass([0.1, 0.2])
                 assert bypass is False
                 assert margin is None
+
+
+class TestGateShadowMode:
+    """evaluate() applies the shadow-mode policy on top of should_bypass()."""
+
+    @staticmethod
+    def _seed_bypass_corpus():
+        # top-1 close, top-2 orthogonal => large margin => would_bypass True
+        gate._reference_queries = [{"query": "q1"}, {"query": "q2"}]
+        gate._reference_vectors = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+    @pytest.mark.asyncio
+    async def test_shadow_on_records_but_does_not_bypass(self):
+        """Shadow on (default): would_bypass True but bypassed forced False."""
+        self._seed_bypass_corpus()
+        with (
+            patch.object(gate.settings, "retrieval_gate_enabled", True),
+            patch.object(gate.settings, "retrieval_gate_threshold", 0.1),
+            patch.object(gate.settings, "retrieval_gate_shadow", True),
+        ):
+            decision = await gate.evaluate([0.99, 0.01, 0.0])
+            assert decision.would_bypass is True
+            assert decision.bypassed is False  # shadow suppresses the action
+            assert decision.shadow is True
+            assert decision.margin is not None and decision.margin > 0.1
+
+    @pytest.mark.asyncio
+    async def test_shadow_off_acts_on_recommendation(self):
+        """Shadow off: bypassed follows would_bypass."""
+        self._seed_bypass_corpus()
+        with (
+            patch.object(gate.settings, "retrieval_gate_enabled", True),
+            patch.object(gate.settings, "retrieval_gate_threshold", 0.1),
+            patch.object(gate.settings, "retrieval_gate_shadow", False),
+        ):
+            decision = await gate.evaluate([0.99, 0.01, 0.0])
+            assert decision.would_bypass is True
+            assert decision.bypassed is True  # acts when shadow is off
+            assert decision.shadow is False
+
+    @pytest.mark.asyncio
+    async def test_shadow_off_no_recommendation_does_not_bypass(self):
+        """Shadow off but gate disabled: nothing to act on, bypassed False."""
+        with (
+            patch.object(gate.settings, "retrieval_gate_enabled", False),
+            patch.object(gate.settings, "retrieval_gate_shadow", False),
+        ):
+            decision = await gate.evaluate([0.1, 0.2, 0.3])
+            assert decision.would_bypass is False
+            assert decision.bypassed is False
+            assert decision.margin is None


### PR DESCRIPTION
## What

The retrieval gate (`klai-retrieval-api`) was wired + enabled but **inert**: `data/gate_reference.jsonl` was never shipped (only `.gitkeep`), so `should_bypass` always returned `(False, None)` and every query ran the full pipeline.

This enables it in **shadow mode** — the safe way.

## Why shadow, not live

- A wrong bypass **silently drops every citation** (model-only answer, no sources).
- The raw query text is **not logged** (we don't log request bodies), so a curated corpus can't be mined from prod logs.
- The few logged query snippets (coreference rewrites) are **customer data** that can't ship in a public repo.

So: enable + observe before acting.

## Changes

- `retrieval_gate_shadow` (default **True**): `gate.evaluate()` computes + logs the decision (`gate_would_bypass`, `gate_shadow_mode`) but forces `bypassed=False` → retrieval always runs. **Prod behaviour unchanged.**
- Generic seed `gate_reference.jsonl` (no customer data): meta/task archetypes (title-gen, translate, summarize, format, math, creative) that never need the KB.
- Tests: shadow-on suppresses, shadow-off acts. `conftest` runs the suite in acting mode (shadow off) so the existing bypass-shortcut tests keep working.

## Rollout

Flip `retrieval_gate_shadow=False` to go live once the production `gate_would_bypass` rate confirms it only fires on non-KB queries.

## Verification

`uv run --extra dev pytest` (the retrieval-api CI gate): **550 passed, 1 skipped** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)