### PR TITLE
Fix streaming flush replaying full answer after cleaner divergence (Voys feedback #21)

### DIFF
--- a/deploy/litellm/klai_kb_citation_render.py
+++ b/deploy/litellm/klai_kb_citation_render.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from klai_chat_prompts import no_citable_sources_message
-from klai_citations import compose_answer_with_trusted_sources
+from klai_citations import (
+    compose_answer_with_trusted_sources,
+    strip_model_citation_artifacts,
+)
 from klai_kb_answer_policy import strict_kb_unavailable_message
 from klai_kb_chat_mode import prompt_mode_is_known, prompt_mode_is_strict
 from klai_kb_traceability import dedupe_strings
@@ -658,12 +661,18 @@ def _collapse_whitespace_with_index_map(text: str) -> tuple[str, list[int]]:
     return "".join(collapsed), index_map
 
 
-def remove_already_streamed_prefix(final_text: str, emitted_text: str) -> str:
+def remove_already_streamed_prefix(final_text: str, emitted_text: str) -> str | None:
     """Return only the part of final_text that has not already streamed.
 
     The deterministic citation renderer may normalize whitespace compared to
     the token stream. Use an exact cut when possible, then a whitespace-tolerant
     cut so the final source footer does not replay the full answer in LibreChat.
+
+    Returns ``None`` when the rendered text diverges from the streamed prefix
+    in non-whitespace content (e.g. the cleaner renumbered list lines). The
+    caller must then compose the flush delta from the raw un-streamed
+    remainder — replaying ``final_text`` after already-streamed text duplicates
+    the whole answer in the client (Voys feedback #21, 2026-06-11).
     """
     if not emitted_text:
         return final_text
@@ -676,7 +685,7 @@ def remove_already_streamed_prefix(final_text: str, emitted_text: str) -> str:
         cut_index = final_map[len(collapsed_emitted) - 1] + 1
         return final_text[cut_index:]
 
-    return final_text
+    return None
 
 
 def compose_non_streaming_kb_response(
@@ -875,15 +884,42 @@ def compose_streaming_kb_response(
                 no_citable_message=kb_meta.get("no_citable_message"),
             )
         )
+        tail = remove_already_streamed_prefix(rendered_content, emitted_text)
+        if tail is None and no_citable_sources:
+            # Deliberate replacement (strict refusal): the canned message is
+            # the contract and is short — append it in full after the stream.
+            tail = rendered_content
+            decision["stream_flush_alignment"] = "replacement_appended"
+        elif tail is None:
+            # The cleaner changed non-whitespace content inside the region the
+            # user already saw, so the rendered answer cannot be aligned with
+            # the stream. Never replay the full answer (Voys feedback #21,
+            # 2026-06-11: BT-ticket form restarted at "Hello BT"). Emit the
+            # raw un-streamed remainder instead, cleaned standalone so
+            # buffered model-authored links/images still cannot leak.
+            remainder = (
+                full_text[len(emitted_text) :]
+                if full_text.startswith(emitted_text)
+                else rendered_content
+            )
+            tail = strip_model_citation_artifacts(
+                remainder,
+                allowed_image_urls=allowed_image_urls,
+                source_titles={
+                    source["title"]
+                    for source in trusted_sources
+                    if isinstance(source.get("title"), str)
+                },
+            )
+            decision["stream_flush_alignment"] = "raw_remainder"
+        else:
+            decision["stream_flush_alignment"] = "prefix_cut"
         _remember_citation_decision(
             kb_meta,
             decision,
             no_citable_sources=no_citable_sources,
         )
-        final_text = _append_visible_sources_section(
-            rendered_content, sources, kb_meta=kb_meta
-        )
-        final_text = remove_already_streamed_prefix(final_text, emitted_text)
+        final_text = _append_visible_sources_section(tail, sources, kb_meta=kb_meta)
         if sources:
             set_message_field(delta, "sources", sources)
         set_message_content(delta, final_text)

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -5448,6 +5448,124 @@ class TestKlaiKnowledgeHookUrlImageGrounding:
         assert not hasattr(final.choices[0].delta, "sources")
 
     @pytest.mark.asyncio
+    async def test_streaming_flush_never_replays_streamed_answer(self, monkeypatch):
+        """The final flush delta must never repeat text the user already saw.
+
+        Live regression (Voys feedback #21, 2026-06-11): a template-driven
+        "BT ticket" form streamed up to "Date/time " (step 8), where the first
+        literal "[" made the stream guard buffer the rest. At flush the citation
+        cleaner renumbered the isolated "2."–"8." question lines and collapsed
+        blank lines, so the cleaned answer no longer matched the streamed
+        prefix and remove_already_streamed_prefix fell back to replaying the
+        FULL cleaned answer: the user saw the form restart at "Hello BT" as one
+        unformatted wall of text.
+        """
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        data = {
+            "metadata": {
+                "_klai_kb_meta": {
+                    "org_id": "org123",
+                    "user_id": "user123",
+                    "chunks_injected": 1,
+                    "retrieval_ms": 12,
+                    "gate_bypassed": False,
+                    "render_mode": "streaming_guard",
+                    "allowed_image_urls": [],
+                    "trusted_sources": [
+                        {
+                            "label": "1",
+                            "title": "BT Cloud Work",
+                            "url": "https://wiki.example/bt",
+                        }
+                    ],
+                    "citation_chunks": [
+                        {
+                            "title": "BT Cloud Work",
+                            "source_url": "https://wiki.example/bt",
+                            "text": (
+                                "BT ticket template with Corp ID examples for "
+                                "the VOYS TELECOM company name."
+                            ),
+                        }
+                    ],
+                }
+            }
+        }
+
+        chunks = [
+            # Isolated numbered question lines: the citation cleaner's
+            # ordered-list renumbering strips "2."/"8." from these, and
+            # "examples :" loses its pre-colon space — both non-whitespace
+            # changes INSIDE the already-streamed region.
+            "Hello BT,\n\n1. What is the name of your company?\nVOYS TELECOM\n\n",
+            "2. What is your Corp ID?\n01003911\n\n",
+            "8. Call examples : Please provide exact timestamps:\n\nDate/time ",
+            # First "[" → stream guard buffers from here until flush.
+            "[yyyy-mm-dd hh:mm]:\n2026-06-11 08:08\n\nKind regards,\n[name]",
+        ]
+        items = [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=chunk), finish_reason=None
+                    )
+                ]
+            )
+            for chunk in chunks
+        ]
+        items.append(
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=""), finish_reason="stop"
+                    )
+                ]
+            )
+        )
+
+        async def stream():
+            for item in items:
+                yield item
+
+        streamed = [
+            item
+            async for item in hook.async_post_call_streaming_iterator_hook(
+                None, stream(), data
+            )
+        ]
+
+        visible = "".join(
+            item.choices[0].delta.content or ""
+            for item in streamed
+            if item.choices and getattr(item.choices[0], "delta", None) is not None
+        )
+        assert visible.count("Hello BT,") == 1, (
+            "flush delta replayed the already-streamed answer:\n" + visible
+        )
+        assert visible.count("01003911") == 1
+        # The buffered tail (template bracket onward) must still be delivered.
+        assert "[yyyy-mm-dd hh:mm]:" in visible
+        assert "2026-06-11 08:08" in visible
+        assert "Kind regards," in visible
+        # Sources footer still appended exactly once.
+        assert visible.count("**Bronnen**") == 1
+        assert "- [BT Cloud Work](https://wiki.example/bt)" in visible
+
+    def test_remove_already_streamed_prefix_returns_none_on_content_mismatch(
+        self, monkeypatch
+    ):
+        """Non-whitespace divergence must be reported, never replayed."""
+        _load_hook(monkeypatch)
+        from klai_kb_citation_render import remove_already_streamed_prefix
+
+        emitted_text = "Hello BT,\n\n2. What is your Corp ID?\n01003911\n\n"
+        # Cleaner stripped the "2." numbering → prefix can no longer align.
+        final_text = "Hello BT,\nWhat is your Corp ID?\n01003911\n\n**Bronnen**"
+
+        assert remove_already_streamed_prefix(final_text, emitted_text) is None
+
+    @pytest.mark.asyncio
     async def test_streaming_strict_short_unsupported_answer_gets_activity_not_sources(
         self, monkeypatch
     ):


### PR DESCRIPTION
## Root cause (proven with production data)

Voys feedback #21 (2026-06-11 14:37 UTC): a template-driven "BT ticket" form streamed up to "Date/time " at step 8 and then restarted at "Hello BT" as one unformatted wall of text.

Traced against the actual production artifacts:
- LiteLLM spend logs: the request ran on **klai-large**, 22058→1010 tokens, HTTP 200, no retries, no errors — so this was never a truncation/output-budget issue.
- The literal assistant message in the Voys LibreChat MongoDB shows the duplication breaking exactly at the first `[` of the template's `[yyyy-mm-dd hh:mm]` placeholder.

Mechanism:
1. The citation stream guard buffers everything from the first `[` until flush.
2. At flush, `strip_model_citation_artifacts` renumbers isolated `2.`–`8.` question lines and collapses blank lines — non-whitespace changes **inside the already-streamed region**.
3. `remove_already_streamed_prefix` can no longer align and its fallback **replayed the full cleaned answer** after the already-visible text.

Reproduced byte-identically in a standalone script before fixing.

## Fix

- `remove_already_streamed_prefix` returns `None` on non-whitespace divergence instead of the full text.
- `compose_streaming_kb_response` then emits the raw un-streamed remainder (exact byte suffix), cleaned standalone so buffered model-authored links/images still cannot leak. Strict-refusal replacements keep today's behavior.
- New `stream_flush_alignment` field (`prefix_cut` / `raw_remainder` / `replacement_appended`) in the citation decision → visible in `kb_citations_rendered_structured` logs.

## Tests

- `test_streaming_flush_never_replays_streamed_answer` — drives the real streaming iterator hook with the BT-form chunk pattern (RED before the fix with the exact replay assertion).
- `test_remove_already_streamed_prefix_returns_none_on_content_mismatch`.
- Full deploy/litellm suite: 432 passed.

## Follow-up (separate PR)

The underlying cleaner aggression (`_renumber_ordered_list_runs` stripping numbers from isolated numbered lines, `\s+\n` eating blank lines) still mangles numbered forms in non-streaming answers — the render-layer cause behind feedback #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)