### PR TITLE
fix(chat): keep language reminder as final prompt anchor across chat paths

### DIFF
--- a/.claude/rules/klai/projects/knowledge.md
+++ b/.claude/rules/klai/projects/knowledge.md
@@ -55,12 +55,18 @@ that mistake cost a full audit cycle to detect.
 
 **Detection in production:** `event:chat_synthesis_complete` events in
 VictoriaLogs carry `query_language_detected`,
-`response_language_detected`, and `language_correctness`. The
-`service:` field tells you which path emitted the event (`litellm`
-for path A, `portal-api` for path B, `retrieval-api` for path C). A
-drop in language-correctness rate for one language on one specific
-service is the signal that ONE of the three locations drifted —
-correlate with recent PRs touching that file.
+`response_language_detected`, `language_correctness`, and
+`chunks_injected` (added 2026-07-07; `None` on call sites that cannot
+determine the count). A drop in language-correctness rate is the
+signal that a prompt location drifted — correlate with recent PRs.
+
+**Coverage gap (verified 2026-07-07):** only path B (`portal-api`)
+emits this event. Path A (litellm hook) has NO language-correctness
+telemetry — `detect_language` does not exist in `deploy/litellm/` and
+VictoriaLogs shows zero `chat_synthesis_complete` events with
+`service:litellm`. A path-A language regression is invisible in
+telemetry today; audit path A by prompt-content tests
+(`deploy/litellm/tests/`) until litellm-side emission lands.
 
 **See:** SPEC-RAG-MULTILINGUAL-CHAT-001 (HISTORY v1.2 has the
 post-merge audit that uncovered the three-paths confusion),

--- a/.github/workflows/litellm-tests.yml
+++ b/.github/workflows/litellm-tests.yml
@@ -13,11 +13,17 @@ on:
       - 'deploy/litellm/**'
       - 'klai-libs/citations/**'
       - 'klai-libs/service-auth/**'
+      # chat-prompts is compared byte-for-byte against the vendored
+      # deploy/litellm/klai_chat_prompts.py by test_klai_chat_prompts_drift.py.
+      # Without this trigger a canonical-only edit lands without ever running
+      # the drift gate, and the NEXT unrelated litellm PR fails on it.
+      - 'klai-libs/chat-prompts/**'
   pull_request:
     paths:
       - 'deploy/litellm/**'
       - 'klai-libs/citations/**'
       - 'klai-libs/service-auth/**'
+      - 'klai-libs/chat-prompts/**'
 
 jobs:
   litellm-tests:
@@ -33,9 +39,12 @@ jobs:
       # must run from the deploy/litellm working directory.
       - name: Test (pytest)
         working-directory: deploy/litellm
+        # pyyaml: test_litellm_config_provider_guard.py imports yaml; missing
+        # dep kept this workflow red on main from 2026-06-18 to 2026-07-07.
         run: >
           uv run --no-project --python 3.13
           --with pytest --with pytest-asyncio --with httpx --with structlog
+          --with pyyaml
           --with ../../klai-libs/citations
           --with ../../klai-libs/service-auth
           python -m pytest tests/ -q --tb=short

--- a/deploy/litellm/klai_chat_prompts.py
+++ b/deploy/litellm/klai_chat_prompts.py
@@ -79,6 +79,7 @@ __all__ = [
     "DUTCH_QUERY_MARKERS",
     "GENERAL_CHAT_SYSTEM_PROMPT",
     "GROUNDED_CHAT_SYSTEM_PROMPT",
+    "KB_CONTEXT_LANGUAGE_REMINDER",
     "META_CHAT_SYSTEM_PROMPT",
     "OPEN_KB_CHAT_SYSTEM_PROMPT",
     "no_citable_sources_message",
@@ -177,6 +178,14 @@ _LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "- A clearly switched substantive message (a full-sentence question or statement in a "
     "different language) DOES switch the response language and stays switched until another "
     "substantive switch."
+)
+
+KB_CONTEXT_LANGUAGE_REMINDER: Final[str] = (
+    "[LANGUAGE REMINDER] The knowledge-base chunks above may be in a "
+    "different language than the user's question. Always respond in "
+    "the language of the user's most recent substantive question, "
+    "NOT the language of the source documents. Translate cited "
+    "content into the user's language without translator disclaimers."
 )
 
 _GROUNDED_BODY: Final[str] = (

--- a/deploy/litellm/klai_kb_confidence_policy.py
+++ b/deploy/litellm/klai_kb_confidence_policy.py
@@ -11,28 +11,33 @@ import os
 
 from klai_citations import extract_salient_query_tokens
 
+# English on purpose: every other instruction block in the prompt stack is
+# English-wrapped (SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-10). A Dutch guard here
+# was the last strong language anchor before generation and pulled English
+# questions into Dutch answers when the low-confidence band fired.
 LOW_CONFIDENCE_INJECTION_TEXT = (
-    "[Klai retrieval — lage relevantie]\n"
-    "Het opgehaalde KB-materiaal heeft een lage relevantie-score voor "
-    "deze vraag. Citeer alleen wat letterlijk in de chunks staat. Verzin "
-    "GEEN integratie-routes, productnamen, stappen, bedragen, of "
-    "technische details die niet expliciet in de chunks voorkomen. "
-    "Sluit af met een vraag om verduidelijking aan de gebruiker als het "
-    "materiaal de vraag niet volledig dekt — dat is beter dan een "
-    "verzonnen antwoord."
+    "[Klai retrieval — low relevance]\n"
+    "The retrieved KB material has a low relevance score for this "
+    "question. Cite only what is literally in the chunks. Do NOT "
+    "invent integration routes, product names, steps, amounts, or "
+    "technical details that do not explicitly appear in the chunks. "
+    "If the material does not fully cover the question, close with a "
+    "clarifying question to the user — in the user's language — "
+    "rather than giving a fabricated answer."
 )
 LOW_CONFIDENCE_OPEN_CONTEXT_TEXT = (
-    "[Klai retrieval — lage relevantie in Open modus]\n"
-    "Het opgehaalde KB-materiaal heeft een lage relevantie-score voor "
-    "deze vraag. Behandel de chunks als zwakke aanvullende context. "
-    "Open mode blijft actief: weiger niet alleen omdat KB-bewijs zwak, "
-    "tangentieel, of afwezig is. Antwoord vanuit algemene kennis of "
-    "zichtbare gebruikerscontext wanneer de vraag daarmee betrouwbaar te "
-    "beantwoorden is. Presenteer zulke delen expliciet als algemene kennis "
-    "of als afgeleid uit de gebruikerscontext, niet als iets dat uit de "
-    "kennisbank komt. Voor organisatie-specifieke feiten, prijzen, routes, "
-    "productnamen, stappen, of bronclaims: verzin ze niet en zeg kort dat "
-    "de kennisbank die specifieke claim niet ondersteunt."
+    "[Klai retrieval — low relevance in Open mode]\n"
+    "The retrieved KB material has a low relevance score for this "
+    "question. Treat the chunks as weak supplementary context. Open "
+    "mode stays active: do not refuse solely because KB evidence is "
+    "weak, tangential, or absent. Answer from general knowledge or "
+    "visible user context when the question can be answered reliably "
+    "that way. Present such parts explicitly as general knowledge or "
+    "as derived from the user context, not as something that comes "
+    "from the knowledge base. For organisation-specific facts, "
+    "prices, routes, product names, steps, or source claims: do not "
+    "invent them and say briefly that the knowledge base does not "
+    "support that specific claim."
 )
 LOW_CONFIDENCE_INJECTION_DISABLED = (
     os.getenv("KNOWLEDGE_DISABLE_LOW_CONFIDENCE_INJECTION", "0") == "1"

--- a/deploy/litellm/klai_kb_context_prompt.py
+++ b/deploy/litellm/klai_kb_context_prompt.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from klai_citations import render_evidence_context
+from klai_chat_prompts import KB_CONTEXT_LANGUAGE_REMINDER
 from klai_kb_answer_policy import kb_chunks_present_header
 from klai_kb_urls import absolute_image_url, chunk_source_url
 
@@ -54,14 +55,6 @@ KB_ANSWER_FORMAT_INSTRUCTION = (
     "not define how user-provided attachments may be used — see the "
     "[User-provided content] note above.\n"
     "- Do NOT add images in the TL;DR (section 1).]\n"
-)
-
-KB_LANGUAGE_REMINDER = (
-    "[LANGUAGE REMINDER] The knowledge-base chunks above may be in a "
-    "different language than the user's question. Always respond in "
-    "the language of the user's most recent substantive question, "
-    "NOT the language of the source documents. Translate cited "
-    "content into the user's language without translator disclaimers."
 )
 
 @dataclass(frozen=True)
@@ -121,12 +114,12 @@ def build_kb_context_prompt(
             lines.append(f"![afbeelding {i}]({img_url})")
         lines.append("")
 
-    lines.append("[End knowledge base context]")
-    lines.append(KB_LANGUAGE_REMINDER)
-
     low_confidence_applied = low_confidence_inject and not low_confidence_injection_disabled
+    lines.append("[End knowledge base context]")
     if low_confidence_applied:
         lines.append(low_confidence_strict_text if kb_narrow else low_confidence_open_text)
+
+    lines.append(KB_CONTEXT_LANGUAGE_REMINDER)
 
     return KbContextPrompt(
         context_block="\n".join(lines),

--- a/deploy/litellm/tests/test_kb_context_prompt.py
+++ b/deploy/litellm/tests/test_kb_context_prompt.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from klai_chat_prompts import KB_CONTEXT_LANGUAGE_REMINDER
 from klai_kb_context_prompt import (
     KB_ANSWER_FORMAT_INSTRUCTION,
-    KB_LANGUAGE_REMINDER,
     build_kb_context_prompt,
 )
 
@@ -42,9 +42,10 @@ def test_context_prompt_keeps_template_between_format_rules_and_chunks():
         "[Template]"
     )
     assert result.context_block.index("[Template]") < result.context_block.index("Chunk body")
-    assert result.context_block.index(KB_LANGUAGE_REMINDER) > result.context_block.index(
+    assert result.context_block.index(KB_CONTEXT_LANGUAGE_REMINDER) > result.context_block.index(
         "[End knowledge base context]"
     )
+    assert result.context_block.endswith(KB_CONTEXT_LANGUAGE_REMINDER)
     assert result.allowed_source_urls == ["https://example.com/docs/course"]
     assert result.citation_source_urls == {"1": "https://example.com/docs/course?x=1"}
     assert result.low_confidence_injection_applied is False
@@ -96,6 +97,15 @@ def test_low_confidence_injection_tracks_mode_and_disabled_flag():
     )
     assert "[open low]" in open_result.context_block
     assert "[strict low]" not in open_result.context_block
+    assert open_result.context_block.index(
+        "[End knowledge base context]"
+    ) < open_result.context_block.index("[open low]")
+    assert open_result.context_block.rindex(
+        KB_CONTEXT_LANGUAGE_REMINDER
+    ) > open_result.context_block.index("[open low]")
+    # The reminder must be the FINAL element: any block appended after it
+    # becomes the model's last language anchor and reopens the NL-bias bug.
+    assert open_result.context_block.endswith(KB_CONTEXT_LANGUAGE_REMINDER)
     assert open_result.low_confidence_injection_applied is True
 
     disabled_result = build_kb_context_prompt(

--- a/deploy/litellm/tests/test_klai_chat_prompts_drift.py
+++ b/deploy/litellm/tests/test_klai_chat_prompts_drift.py
@@ -122,6 +122,27 @@ def test_vendored_meta_prompt_matches_canonical() -> None:
     )
 
 
+def test_vendored_kb_context_language_reminder_matches_canonical() -> None:
+    """``KB_CONTEXT_LANGUAGE_REMINDER`` MUST be byte-identical between
+    vendored and canonical copies. Path A (LiteLLM hook) appends the
+    vendored copy as the final block of the KB context; path B
+    (partner_chat) appends the canonical one after its Context block.
+    The ``__all__`` test only catches a missing NAME — content drift
+    here would silently give the two chat surfaces different final
+    language anchors.
+    """
+    vendored = _load("_drift_vendored_kb_reminder", _VENDORED_PATH)
+    canonical = _load("_drift_canonical_kb_reminder", _CANONICAL_PATH)
+
+    assert (
+        vendored.KB_CONTEXT_LANGUAGE_REMINDER == canonical.KB_CONTEXT_LANGUAGE_REMINDER
+    ), (
+        "KB_CONTEXT_LANGUAGE_REMINDER drift between vendored and canonical.\n"
+        "  Update deploy/litellm/klai_chat_prompts.py to match "
+        "klai-libs/chat-prompts/klai_chat_prompts/__init__.py."
+    )
+
+
 def test_vendored_dutch_markers_match_canonical() -> None:
     """``DUTCH_QUERY_MARKERS`` MUST be set-equal between vendored and
     canonical. The set drives the language choice for the strict-mode

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -6743,15 +6743,15 @@ class TestKlaiKnowledgeHookOpenMode:
             )
 
         sys_content = self._system_msg(result)
-        assert "lage relevantie in Open modus" in sys_content
-        assert "Open mode blijft actief" in sys_content
-        assert "weiger niet alleen omdat KB-bewijs zwak" in sys_content
+        assert "low relevance in Open mode" in sys_content
+        assert "Open mode stays active" in sys_content
+        assert "do not refuse solely because KB evidence is weak" in sys_content
         assert (
-            "Antwoord vanuit algemene kennis of zichtbare gebruikerscontext"
+            "Answer from general knowledge or visible user context"
             in sys_content
         )
         assert "alleen een algemeen antwoord wanneer dat veilig kan" not in sys_content
-        assert "Citeer alleen wat letterlijk in de chunks staat" not in sys_content
+        assert "Cite only what is literally in the chunks" not in sys_content
         self._assert_open_kb_foundation(sys_content)
 
     @pytest.mark.asyncio
@@ -6809,14 +6809,14 @@ class TestKlaiKnowledgeHookOpenMode:
 
         sys_content = self._system_msg(result)
         self._assert_open_kb_foundation(sys_content)
-        assert "lage relevantie in Open modus" in sys_content
+        assert "low relevance in Open mode" in sys_content
         assert "Knowledge-base images only" in sys_content
         # Screenshot = standalone user content, usable in any mode.
         assert "[User-provided content]" in sys_content
         assert "you may read and reason about" in sys_content
-        assert "Open mode blijft actief" in sys_content
+        assert "Open mode stays active" in sys_content
         assert (
-            "Antwoord vanuit algemene kennis of zichtbare gebruikerscontext"
+            "Answer from general knowledge or visible user context"
             in sys_content
         )
         assert "no image is available in the knowledge base" not in sys_content

--- a/deploy/litellm/tests/test_low_confidence_injection.py
+++ b/deploy/litellm/tests/test_low_confidence_injection.py
@@ -92,7 +92,7 @@ def _load_hook(monkeypatch, extra_env=None):
 
 
 def test_injection_text_constant_exists(monkeypatch) -> None:
-    """The Dutch injection text is defined at module level so prompt
+    """The injection text is defined at module level so prompt
     iterations are a single-file change.
     """
     klai_knowledge = _load_hook(monkeypatch)
@@ -101,8 +101,13 @@ def test_injection_text_constant_exists(monkeypatch) -> None:
     assert isinstance(text, str)
     assert len(text) > 100  # non-trivial content
     # must contain the key anti-hallucination instructions
-    assert "verzin" in text.lower() or "geen" in text.lower()
-    assert "verduidelijking" in text.lower()
+    assert "do not" in text.lower() and "invent" in text.lower()
+    assert "clarifying question" in text.lower()
+    # Instruction blocks are English-only (SPEC-RAG-MULTILINGUAL-CHAT-001
+    # REQ-10): a Dutch guard here was the last strong language anchor and
+    # pulled English questions into Dutch answers on the low-confidence band.
+    assert "verzin" not in text.lower()
+    assert "relevantie" not in text.lower()
 
 
 def test_open_low_confidence_text_preserves_open_contract(monkeypatch) -> None:
@@ -115,15 +120,14 @@ def test_open_low_confidence_text_preserves_open_contract(monkeypatch) -> None:
     klai_knowledge = _load_hook(monkeypatch)
     text = klai_knowledge._LOW_CONFIDENCE_OPEN_CONTEXT_TEXT
 
-    assert "Open mode blijft actief" in text
-    assert "weiger niet alleen omdat KB-bewijs zwak" in text
-    assert "Antwoord vanuit algemene kennis of zichtbare gebruikerscontext" in text
-    assert "de kennisbank die specifieke claim niet ondersteunt" in text
-    assert "Citeer alleen wat letterlijk in de chunks staat" not in text
+    assert "Open mode stays active" in text
+    assert "do not refuse solely because KB evidence is weak" in text
+    assert "Answer from general knowledge or visible user context" in text
+    assert "the knowledge base does not support that specific claim" in text
+    assert "Cite only what is literally in the chunks" not in text
     assert "alleen een algemeen antwoord wanneer dat veilig kan" not in text
     # Attachment policy is a cross-cutting, mode-independent concern; it lives
     # in the foundation-layer _USER_PROVIDED_CONTENT_SCOPE clause, not here.
-    # Keep this block NL-only (no mid-paragraph English sentence).
     assert "User-provided image attachments" not in text
 
 

--- a/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
+++ b/klai-libs/chat-prompts/klai_chat_prompts/__init__.py
@@ -79,6 +79,7 @@ __all__ = [
     "DUTCH_QUERY_MARKERS",
     "GENERAL_CHAT_SYSTEM_PROMPT",
     "GROUNDED_CHAT_SYSTEM_PROMPT",
+    "KB_CONTEXT_LANGUAGE_REMINDER",
     "META_CHAT_SYSTEM_PROMPT",
     "OPEN_KB_CHAT_SYSTEM_PROMPT",
     "no_citable_sources_message",
@@ -177,6 +178,14 @@ _LANGUAGE_DETECTION_PREAMBLE: Final[str] = (
     "- A clearly switched substantive message (a full-sentence question or statement in a "
     "different language) DOES switch the response language and stays switched until another "
     "substantive switch."
+)
+
+KB_CONTEXT_LANGUAGE_REMINDER: Final[str] = (
+    "[LANGUAGE REMINDER] The knowledge-base chunks above may be in a "
+    "different language than the user's question. Always respond in "
+    "the language of the user's most recent substantive question, "
+    "NOT the language of the source documents. Translate cited "
+    "content into the user's language without translator disclaimers."
 )
 
 _GROUNDED_BODY: Final[str] = (

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -30,6 +30,7 @@ from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from klai_chat_prompts import (
     GROUNDED_CHAT_SYSTEM_PROMPT,
+    KB_CONTEXT_LANGUAGE_REMINDER,
 )
 from klai_chat_prompts import (
     no_citable_sources_message as _no_citable_sources_message,
@@ -240,11 +241,16 @@ def _emit_language_correctness_log(
     org_id: int | str | None,
     query: str,
     response_text: str,
+    chunks_injected: int | None = None,
 ) -> None:
     """Emit chat_synthesis_complete with passive language metrics.
 
     SPEC-RAG-MULTILINGUAL-CHAT-001 REQ-07. Failure-safe: any exception
     inside detection MUST NOT block the chat completion path.
+
+    ``chunks_injected`` distinguishes chunks-present from no-chunks answers
+    so language mismatches can be attributed to KB-content anchoring
+    (``None`` = the call site could not determine the count).
     """
     try:
         query_lang = detect_language(query)
@@ -257,6 +263,7 @@ def _emit_language_correctness_log(
             response_language_detected=response_lang,
             language_correctness=correct,
             response_length_chars=len(response_text or ""),
+            chunks_injected=chunks_injected,
             service="portal-api",
         )
     except Exception:
@@ -1614,6 +1621,7 @@ async def _chat_completion_streaming_with_composed_citations(
             org_id=org_id,
             query=user_query,
             response_text=content,
+            chunks_injected=len(citation_chunks or []),
         )
         return
 
@@ -1634,6 +1642,7 @@ async def _chat_completion_streaming_with_composed_citations(
         org_id=org_id,
         query=user_query,
         response_text=content,
+        chunks_injected=len(citation_chunks or []),
     )
 
 
@@ -1692,7 +1701,7 @@ def _build_system_prompt(
             "- If several facts in one paragraph or list come from the same source_url, cite that source once.\n"
             "- If you cite multiple different documents at the same spot, separate citation numbers with commas.\n"
         )
-    return f"{base}\n\n{url_guard}\nContext:\n{context_block}"
+    return f"{base}\n\n{url_guard}\nContext:\n{context_block}\n\n{KB_CONTEXT_LANGUAGE_REMINDER}"
 
 
 def _is_retrieval_identity_assertion_error(exc: httpx.HTTPStatusError) -> bool:
@@ -2033,6 +2042,7 @@ async def chat_completion_non_streaming(
         org_id=org_id,
         query=user_query,
         response_text=response_text,
+        chunks_injected=len(citation_chunks or []),
     )
     return body
 
@@ -2098,6 +2108,7 @@ async def chat_completion_streaming(
         citation_source_urls=citation_source_urls,
         citation_source_metadata=citation_source_metadata,
         citation_output=citation_output,
+        chunks_injected=len(citation_chunks or []),
     ):
         yield chunk
 
@@ -2129,6 +2140,7 @@ async def _chat_completion_streaming_sanitized(  # noqa: C901 - SSE state machin
     citation_source_urls: dict[int, str] | None,
     citation_source_metadata: dict[str, dict[str, str]] | None,
     citation_output: CitationOutput,
+    chunks_injected: int | None = None,
 ) -> AsyncGenerator[bytes]:
     """Legacy partner streaming path with URL sanitization and linked citations.
 
@@ -2205,6 +2217,7 @@ async def _chat_completion_streaming_sanitized(  # noqa: C901 - SSE state machin
                         org_id=org_id,
                         query=user_query,
                         response_text=full_text,
+                        chunks_injected=chunks_injected,
                     )
                     return
                 try:
@@ -2235,6 +2248,7 @@ async def _chat_completion_streaming_sanitized(  # noqa: C901 - SSE state machin
             org_id=org_id,
             query=user_query,
             response_text=safety_refusal_message(user_query),
+            chunks_injected=chunks_injected,
         )
         return
 
@@ -2265,6 +2279,7 @@ async def _chat_completion_streaming_sanitized(  # noqa: C901 - SSE state machin
             org_id=org_id,
             query=user_query,
             response_text=safety_refusal_message(user_query),
+            chunks_injected=chunks_injected,
         )
         return
     if full_text:
@@ -2281,5 +2296,6 @@ async def _chat_completion_streaming_sanitized(  # noqa: C901 - SSE state machin
         org_id=org_id,
         query=user_query,
         response_text=full_text,
+        chunks_injected=chunks_injected,
     )
     yield b"data: [DONE]\n\n"

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -1207,6 +1207,32 @@ def test_build_system_prompt_includes_widget_system_prompt():
     assert "URL rules for citations and source links" in prompt
 
 
+def test_build_system_prompt_reinforces_user_language_after_kb_context():
+    """Widget/partner prompts must not let Dutch KB chunks be the final language anchor."""
+    from app.services.partner_chat import _build_system_prompt
+
+    prompt = _build_system_prompt(
+        [
+            {
+                "title": "Annuleren",
+                "source_url": "https://docs.example.com/annuleren",
+                "text": "Klanten kunnen reserveringen annuleren via de app.",
+            }
+        ],
+        widget_system_prompt=(
+            "Pas een klantenservice-stijl toe. Antwoord in de taal van de laatste "
+            "inhoudelijke gebruikersinput; de taal waarin deze instructie is geschreven "
+            "is niet leidend."
+        ),
+        backend_managed_citations=True,
+    )
+
+    assert "[LANGUAGE REMINDER]" in prompt
+    assert "NOT the language of the source documents" in prompt
+    assert prompt.rindex("[LANGUAGE REMINDER]") > prompt.index("Klanten kunnen reserveringen annuleren")
+    assert prompt.rstrip().endswith("without translator disclaimers.")
+
+
 def test_build_system_prompt_includes_optional_page_context_guardrails():
     from app.services.partner_chat import _build_system_prompt
 
@@ -2367,6 +2393,30 @@ def test_language_correctness_log_does_not_duplicate_structlog_event(monkeypatch
     assert args == ("chat_synthesis_complete",)
     assert "event" not in kwargs
     assert kwargs["org_id"] == 1
+    # No chunk count passed → logged as None, so no-chunks answers stay
+    # distinguishable from chunks-present answers in VictoriaLogs.
+    assert kwargs["chunks_injected"] is None
+
+
+def test_language_correctness_log_records_chunks_injected(monkeypatch):
+    """Language mismatches must be attributable to KB-content anchoring."""
+    from app.services import partner_chat
+
+    logger = MagicMock()
+    monkeypatch.setattr(partner_chat, "logger", logger)
+    monkeypatch.setattr(partner_chat, "detect_language", MagicMock(return_value="en"))
+    monkeypatch.setattr(partner_chat, "language_correctness", MagicMock(return_value=True))
+
+    partner_chat._emit_language_correctness_log(
+        org_id=1,
+        query="What does Klai collect?",
+        response_text="Klai collects account data.",
+        chunks_injected=4,
+    )
+
+    logger.info.assert_called_once()
+    _, kwargs = logger.info.call_args
+    assert kwargs["chunks_injected"] == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Wat

Gebruikers (o.a. Linda van Voys) kregen soms Nederlandse antwoorden op Engelse vragen. Oorzaak: Nederlandse promptblokken (KB chunks, low-confidence guard) waren het laatste sterke taal-anker vóór generatie.

- `KB_CONTEXT_LANGUAGE_REMINDER` gecentraliseerd in `klai-chat-prompts` (canoniek + vendored litellm-kopie, byte-identiek).
- **Path B (partner/widget)**: reminder wordt nu als allerlaatste blok na `Context:` toegevoegd — dit pad had voorheen *geen* reminder.
- **Path A (LiteLLM hook)**: low-confidence guard verplaatst naar vóór de reminder, zodat de reminder de laatste taal-instructie blijft.
- Low-confidence guard-teksten vertaald naar Engels — de laatste Nederlandstalige instructieblokken in de promptstack (REQ-10-lijn van SPEC-RAG-MULTILINGUAL-CHAT-001).
- `KB_LANGUAGE_REMINDER`-alias verwijderd; overal de canonieke naam.

## CI-fixes (meegenomen omdat ze deze gate raken)

- `litellm-tests.yml` stond **rood op main sinds 2026-06-18**: `test_litellm_config_provider_guard.py` importeert `yaml` zonder dat de workflow pyyaml meegeeft → `--with pyyaml` toegevoegd.
- Workflow triggert nu ook op `klai-libs/chat-prompts/**` — de drift-test draaide voorheen nooit bij canonieke-only edits.

## Tests & telemetrie

- Prompt-order regressietests: `endswith` pint de reminder als letterlijk laatste element (met én zonder low-confidence).
- Waarde-drift-test voor de nieuwe constante (vendored ↔ canoniek).
- `chat_synthesis_complete` logt nu `chunks_injected` zodat taalfouten toewijsbaar zijn aan KB-anchoring; geverifieerde path-A-telemetrie-gap gedocumenteerd in `knowledge.md`.

## Evidence

- Productie (VictoriaLogs 2026-06-23 → 07-07): 7× `query=en → response=nl` mismatches, allemaal `service:portal-api` (path B).
- litellm full suite met exacte CI-invocatie: **442 passed**; portal-backend: **3321 passed**, 34 failures byte-identiek aan HEAD (pre-existing, DNS/netwerk-afhankelijk); chat-prompts lib: 65 passed; ruff check + format groen.
- Vendored ↔ canoniek `diff`: byte-identiek.

## Bewust NIET gedaan

- Geen reminder op het no-chunks widget-pad (reminder verwijst naar "chunks above"; zonder chunks incoherent).
- Geen litellm-side language-correctness telemetrie (aparte feature; gap is gedocumenteerd).
- Pre-existing F841's in `test_klai_knowledge_hook.py` en de niet-in-CI-gewirede `lint-no-duplicate-chat-prompt.sh`-failure (beide falen ook op HEAD) niet aangeraakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)