### PR TITLE
[codex] Split transcription infra contract from private ops

### DIFF
--- a/.github/workflows/audit-compose.yml
+++ b/.github/workflows/audit-compose.yml
@@ -6,10 +6,12 @@ on:
       - 'deploy/docker-compose.yml'
       - 'deploy/caddy/Caddyfile'
       - 'deploy/volume-mounts.yaml'
+      - 'deploy/tests/**'
       - 'scripts/audit-compose-volumes.sh'
       - 'scripts/audit-compose-orphans.sh'
       - 'scripts/test-audit-compose.sh'
       - 'scripts/test-audit-compose-orphans.sh'
+      - 'klai-scribe/scribe-api/app/core/config.py'
       - '.github/workflows/audit-compose.yml'
   push:
     branches: [main]
@@ -17,10 +19,12 @@ on:
       - 'deploy/docker-compose.yml'
       - 'deploy/caddy/Caddyfile'
       - 'deploy/volume-mounts.yaml'
+      - 'deploy/tests/**'
       - 'scripts/audit-compose-volumes.sh'
       - 'scripts/audit-compose-orphans.sh'
       - 'scripts/test-audit-compose.sh'
       - 'scripts/test-audit-compose-orphans.sh'
+      - 'klai-scribe/scribe-api/app/core/config.py'
 
 jobs:
   audit:
@@ -46,8 +50,13 @@ jobs:
           yq --version
           jq --version
 
+      - uses: astral-sh/setup-uv@v7
+
       - name: Run volume audit
         run: bash scripts/audit-compose-volumes.sh
+
+      - name: Run deploy contract tests
+        run: uv run --with pytest --with pyyaml pytest deploy/tests -q
 
       - name: Volume regression test — bug must be caught
         run: bash scripts/test-audit-compose.sh

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ secret-*.*
 # ===========================================
 # Local-Only Files (never sync via git pull)
 # ===========================================
+.context/
 .moai/status_line.sh
 .moai/memory/
 .moai/worktrees/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -58,7 +58,6 @@ volumes:
   grafana-data:
   gitea-data:
   qdrant-data:
-  vexa-recordings-data:
   vexa-redis-data:
   scribe-audio-data:
   runtime-api-docker-socket:   # SPEC-SEC-021 socat bridge socket (runtime-api <-> docker-socket-proxy)

--- a/deploy/tests/test_transcription_contract.py
+++ b/deploy/tests/test_transcription_contract.py
@@ -1,0 +1,70 @@
+import ast
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+
+
+def _compose() -> dict:
+    compose_path = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+    return yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+
+
+def _whisper_allowed_hosts() -> set[str]:
+    config_path = (
+        Path(__file__).resolve().parents[2]
+        / "klai-scribe"
+        / "scribe-api"
+        / "app"
+        / "core"
+        / "config.py"
+    )
+    module = ast.parse(config_path.read_text(encoding="utf-8"))
+
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_WHISPER_ALLOWED_HOSTS"
+            for target in node.targets
+        ):
+            continue
+        if not isinstance(node.value, ast.Call) or node.value.args == []:
+            break
+        host_set = node.value.args[0]
+        if not isinstance(host_set, (ast.Set, ast.List, ast.Tuple)):
+            break
+        hosts = set()
+        for element in host_set.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                raise AssertionError("_WHISPER_ALLOWED_HOSTS must contain string literals")
+            hosts.add(element.value)
+        return hosts
+
+    raise AssertionError("_WHISPER_ALLOWED_HOSTS not found in scribe-api config")
+
+
+def test_scribe_and_vexa_share_transcription_backend_origin():
+    compose = _compose()
+
+    scribe_env = compose["services"]["scribe-api"]["environment"]
+    meeting_env = compose["services"]["meeting-api"]["environment"]
+
+    scribe_base = urlparse(scribe_env["WHISPER_SERVER_URL"])
+    meeting_endpoint = urlparse(meeting_env["TRANSCRIPTION_SERVICE_URL"])
+
+    assert meeting_endpoint.path == "/v1/audio/transcriptions"
+    assert (meeting_endpoint.scheme, meeting_endpoint.hostname, meeting_endpoint.port) == (
+        scribe_base.scheme,
+        scribe_base.hostname,
+        scribe_base.port,
+    )
+
+
+def test_scribe_compose_transcription_host_is_startup_allowed():
+    compose = _compose()
+
+    scribe_env = compose["services"]["scribe-api"]["environment"]
+    scribe_base = urlparse(scribe_env["WHISPER_SERVER_URL"])
+
+    assert scribe_base.hostname in _whisper_allowed_hosts()

--- a/docs/architecture/klai-knowledge-architecture.md
+++ b/docs/architecture/klai-knowledge-architecture.md
@@ -1617,7 +1617,7 @@ SearXNG's privacy posture is fine — self-hosted, queries routed via server IP,
 
 ### 13.9 Whisper/transcription → Knowledge pipeline [OPEN QUESTION]
 
-`whisper-server` is deployed on core-01 and used by the klai-portal Scribe/Transcribe features (audio → transcript). These transcripts are a natural feed into the helpdesk extraction adapter (§4.3). The connection between the transcription pipeline and the Knowledge ingestion pipeline is not yet designed.
+Scribe/Transcribe features use the speech-to-text backend configured through `WHISPER_SERVER_URL` / Vexa `TRANSCRIPTION_SERVICE_URL` (audio → transcript). These transcripts are a natural feed into the helpdesk extraction adapter (§4.3). The connection between the transcription pipeline and the Knowledge ingestion pipeline is not yet designed.
 
 **Open question:** Does the transcription service write transcripts to a store that the Knowledge ingestion pipeline can poll, or does it POST directly to the Unified Ingest API? The answer depends on whether the transcript pipeline is batch (end-of-call) or streaming. Design this interface before building the helpdesk adapter.
 

--- a/docs/architecture/scribe-transcription.md
+++ b/docs/architecture/scribe-transcription.md
@@ -1,8 +1,8 @@
 # Scribe And Transcription Architecture
 
 Scribe is Klai's transcription product surface. It accepts meeting and audio
-workflows through product APIs and delegates speech-to-text work to a Whisper
-service.
+workflows through product APIs and delegates speech-to-text work to a
+configurable speech-to-text backend.
 
 This document is public-safe. It describes service responsibilities and
 interfaces, not Klai's live production hosts or operator procedures.
@@ -11,8 +11,10 @@ interfaces, not Klai's live production hosts or operator procedures.
 
 | Component | Responsibility |
 |-----------|----------------|
-| `klai-scribe/whisper-server` | Containerized Whisper runtime used for speech-to-text inference. |
+| `klai-scribe/whisper-server` | Public reference image for the self-hosted Whisper-compatible speech-to-text backend. |
+| Transcription backend | OpenAI-compatible speech-to-text endpoint selected by `WHISPER_SERVER_URL` / `TRANSCRIPTION_SERVICE_URL`. Klai production operates this from private infrastructure; self-hosters can run a compatible backend behind an allowed Scribe hostname. |
 | `scribe-api` | Product API for transcription workflows, status, and integration with the portal. |
+| Vexa meeting stack | Meeting bot lifecycle and live transcript collection. |
 | `klai-portal` | User-facing transcription controls and tenant/product management. |
 | public build workflows | Build, scan, and publish container images. |
 | private infra workflows | Deploy Klai production instances and verify live service health. |
@@ -21,8 +23,8 @@ interfaces, not Klai's live production hosts or operator procedures.
 
 Contributors can work on:
 
-- Whisper image code and dependency updates
 - Scribe API behavior and tests
+- Whisper reference image code and dependency updates
 - Portal transcription UI and product flows
 - public image build and security scan workflows
 - local or self-hosted deployment templates
@@ -31,18 +33,46 @@ Contributors do not need access to Klai production servers. Production host
 inventory, SSH procedures, DNS targets, and live deployment commands are kept in
 the private infra repository.
 
+## Backend Contract
+
+The public product contract is intentionally backend-shaped instead of
+host-shaped:
+
+- `scribe-api` reads `WHISPER_SERVER_URL` as the base URL for speech-to-text.
+- `WHISPER_SERVER_URL` is validated at `scribe-api` startup against its SSRF
+  allowlist. Self-hosters should expose the backend through an allowed hostname
+  such as `whisper`, `whisper-server`, localhost, the documented bridge gateway,
+  or intentionally extend that allowlist with tests.
+- Upload transcription calls `POST {WHISPER_SERVER_URL}/v1/audio/transcriptions`.
+- Meeting transcription uses the Vexa `TRANSCRIPTION_SERVICE_URL`, which must
+  point at the same OpenAI-compatible endpoint path.
+- Requests include the OpenAI-compatible `model` form field.
+- Scribe upload traffic sends `transcription_tier=deferred` so live meeting
+  traffic can take priority when the backend supports admission tiers.
+- A busy backend should return `503` with `Retry-After`; `scribe-api` retries
+  this boundedly and surfaces a temporary-unavailable error if capacity stays
+  exhausted.
+
+The endpoint can be backed by Whisper, faster-whisper, Vexa
+`transcription-service`, or another compatible implementation that satisfies the
+Scribe URL contract. The public repo does not require a specific production
+host, SSH tunnel, or GPU layout.
+
 ## Build And Deploy Split
 
 The public repository owns build-time concerns:
 
 - source code
 - Docker image definitions
+- the public Whisper reference image
 - tests
 - vulnerability scans
 - GHCR image publication
 
 Production deployment is a private operations concern. Klai's production deploy
 automation consumes public image tags and runs from `GetKlai/klai-infra`.
+Live GPU compose files, tunnel procedures, Uptime Kuma push scripts, and
+transcription-service bump runbooks belong there, not in this public repository.
 
 Self-hosters should provide their own host inventory, secret management, and
 deployment automation. The public `deploy/` directory is a template, not a copy
@@ -53,8 +83,8 @@ of Klai's production infrastructure.
 The product contract is:
 
 - transcription jobs can be created and tracked through Scribe/portal APIs
-- the Whisper runtime is replaceable by any compatible self-hosted inference
-  backend
+- the transcription runtime is replaceable by a compatible self-hosted inference
+  backend that satisfies the configured URL and allowlist contract
 - deployment topology is environment-specific
 
 Public docs should focus on these contracts. Live production topology belongs in

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -72,6 +72,7 @@ CADDY_WHITELIST=(
     '^admin-api$'                # Vexa internal
     '^meeting-api$'              # Vexa internal
     '^runtime-api$'              # Vexa internal
+    '^portal-api-dev$'           # protected dev environment outside prod compose
 )
 
 is_whitelisted() {
@@ -121,7 +122,7 @@ if [[ -f "$CADDYFILE" ]]; then
                 if (t ~ /^@/) continue       # named matcher
                 if (t ~ /^-/) continue       # flag
                 if (t ~ /^\{/) continue      # caddy placeholder
-                sub(/^https?:\/\//, "", t)   # strip scheme
+                sub(/^[A-Za-z][A-Za-z0-9+.-]*:\/\//, "", t)   # strip scheme
                 sub(/\/.*$/, "", t)          # strip path
                 sub(/:.*$/, "", t)           # strip port
                 if (length(t) > 0) print t

--- a/scripts/test-audit-compose-orphans.sh
+++ b/scripts/test-audit-compose-orphans.sh
@@ -23,8 +23,10 @@ FAIL=0
 assert() {
     local desc="$1" expected_exit="$2" compose="$3" caddy="$4"
     local actual
-    actual=$(AUDIT_COMPOSE_FILE="$compose" AUDIT_CADDYFILE="$caddy" bash "$AUDIT" 2>&1 || true)
+    set +e
+    actual=$(AUDIT_COMPOSE_FILE="$compose" AUDIT_CADDYFILE="$caddy" bash "$AUDIT" 2>&1)
     local exit_code=$?
+    set -e
     if [ "$exit_code" = "$expected_exit" ]; then
         echo "OK   ($exit_code) $desc"
         PASS=$((PASS + 1))


### PR DESCRIPTION
## Summary

Splits the public transcription contract from private GPU/operator infrastructure and wires the new deploy contract tests into CI.

## Changes

- Documents the public Scribe transcription boundary without exposing live GPU hosts, tunnel procedures, or Kuma push details.
- Clarifies that self-hosted transcription backends must satisfy the configured URL and Scribe startup allowlist contract.
- Adds deploy contract tests for Scribe/Vexa transcription URL consistency and Scribe allowlist parity.
- Runs deploy contract tests from the existing compose audit workflow.
- Fixes existing compose orphan audit issues that would keep that workflow red:
  - parses non-HTTP Caddy schemes such as `h2c://`
  - whitelists the protected `portal-api-dev` upstream
  - removes the unused `vexa-recordings-data` top-level volume
  - fixes regression-test exit-code capture
- Ignores `.context/` repo-wide so Conductor handoff notes stay local.

## Validation

- `uv run --with pytest --with pyyaml pytest deploy/tests -q`
- `bash scripts/audit-compose-volumes.sh`
- `bash scripts/test-audit-compose.sh`
- `bash scripts/audit-compose-orphans.sh`
- `bash scripts/test-audit-compose-orphans.sh`
- `git diff --check`
- `git grep -n -E '5\.9\.10\.215|gpu-tunnel-key|KUMA_TOKEN_TRANSCRIPTION' -- .`
- `git check-ignore -v .context/private-infra-gpu-transcription-handoff.md`

## Notes

The recovered live GPU/Kuma/operator files are intentionally not committed here. They belong in `GetKlai/klai-infra`.
