### PR TITLE
SPEC-CHAT-SOURCE-DISCLOSURE-001 Fase 2: multilingual footer strippers (path A)

### DIFF
--- a/.moai/specs/SPEC-CHAT-SOURCE-DISCLOSURE-001/spec.md
+++ b/.moai/specs/SPEC-CHAT-SOURCE-DISCLOSURE-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-CHAT-SOURCE-DISCLOSURE-001
-version: 0.1.0
+version: 0.2.0
 status: draft
 created: 2026-07-08
 updated: 2026-07-08
@@ -16,6 +16,44 @@ issue_number: 0
 | Versie | Datum | Wijziging |
 |---|---|---|
 | 0.1.0 | 2026-07-08 | Eerste draft n.a.v. de Engelse-footer-bug (share aZIY-N3YZSqGHh3qsrcs1) |
+| 0.2.0 | 2026-07-08 | REQ-DISC-06 reproductie-notitie: flush-pad vereist géén extra fix (zie onder). |
+
+## Reproductie-notitie (REQ-DISC-06, 2026-07-08)
+
+Bron: request `a8e26845-f23a-4670-acd0-5f5bac858890` (org `368884765035593759`).
+Getraceerd via VictoriaLogs (retrieval-api) + directe source-analyse van
+`deploy/litellm/klai_kb_citation_render.py`.
+
+**Bewezen (source):**
+1. De zichtbare footer wordt geëmit door `_append_visible_sources_section`
+   (`:453`). De koppen zijn taal-afhankelijk: `_visible_trace_language`
+   (`:379`) is een **query-token-heuristiek** — een vraag zónder Nederlandse
+   markers levert `"en"` → backend schrijft `**Sources**` / `**Agent activity**`.
+   De aanleiding-tekst ("hardcoded Nederlands") is dus achterhaald: de footer
+   is al server-side tweetalig; dát is precies de bron van de mismatch met het
+   NL-only script (`H=new Set(["Bronnen","Agent activiteit"])`, v8).
+2. Het streaming-flush-pad zet `stream_flush_alignment` op één van
+   `replacement_appended` (`:1003`), `raw_remainder` (`:1025`) of `prefix_cut`
+   (`:1027`). **Alle drie de takken convergeren op `:1033`**, waar de footer
+   wordt aangehangen. `raw_remainder` bepaalt alleen hoe de *antwoordtekst*
+   wordt uitgelijnd (Voys #21-regressie), niet hoe de footer wordt toegevoegd.
+3. De footer landt in één finale delta (`set_message_content`, `:1036`) met een
+   dubbel-append-guard (`_citation_stream_sources_appended`, `:1037`). Het
+   opgeslagen bericht == het gestreamde bericht, footer incluis. De history-
+   stripper `KLAI_BACKEND_FOOTER_HEADING_RE` matcht alleen NL en verwijdert de
+   EN-footer dus niet uit history.
+
+**Conclusie:** het streaming-flush-pad heeft **geen** extra fix nodig. De bug is
+puur presentatie-taal (EN-kop onherkend door NL-only script) + strip-taal
+(NL-only strippers). **REQ-DISC-05** (bold-tolerant + meertalige strippers) en de
+structurele marker-omzetting (**REQ-DISC-01/02/03/04**, Fase 3) volstaan.
+
+**Niet geverifieerd:** de exacte bytes van het opgeslagen bericht en een live
+EN-Playwright-reproductie zijn niet apart opgehaald; dit wordt gedekt door de
+Fase 3-acceptance (Playwright nl+en panelen) en de nieuwe unit-tests. De
+litellm `citation_decisions` (waarin `stream_flush_alignment` zit) worden als
+printf-`_msg` gelogd (`:691`), niet als los queryable veld — vandaar dat een
+field-query op `stream_flush_alignment` leeg blijft.
 
 ## Aanleiding (bewezen, 2026-07-08)
 

--- a/deploy/litellm/klai_kb_request_context.py
+++ b/deploy/litellm/klai_kb_request_context.py
@@ -70,9 +70,15 @@ KLAI_SOURCES_METADATA_MARKER_RE = re.compile(
     r"\n?<!--\s*klai_sources=[A-Za-z0-9_-]+={0,2}\s*-->\n?",
     re.IGNORECASE,
 )
+# Multilingual: an English chat emits an English footer (**Sources** / **Agent
+# activity**). Match those too so a backend or model-imitated English footer is
+# stripped from history before the next model input.
+# SPEC-CHAT-SOURCE-DISCLOSURE-001 REQ-DISC-05.
 KLAI_BACKEND_FOOTER_HEADING_RE = re.compile(
-    r"(?im)^[ \t]*(?:\*\*)?(Bronnen|Agent activiteit)(?:\*\*)?[ \t]*$"
+    r"(?im)^[ \t]*(?:\*\*)?(Bronnen|Sources|Agent activiteit|Agent activity)(?:\*\*)?[ \t]*$"
 )
+_FOOTER_SOURCES_HEADINGS = {"bronnen", "sources"}
+_FOOTER_ACTIVITY_HEADINGS = {"agent activiteit", "agent activity"}
 
 
 def is_trivial(text: str) -> bool:
@@ -265,7 +271,7 @@ def strip_klai_backend_footer_from_text(text: str) -> str:
         (
             index
             for index, match in enumerate(matches)
-            if match.group(1).lower() == "agent activiteit"
+            if match.group(1).lower() in _FOOTER_ACTIVITY_HEADINGS
         ),
         None,
     )
@@ -274,7 +280,7 @@ def strip_klai_backend_footer_from_text(text: str) -> str:
 
     cut_match = matches[first_activity_index]
     for match in reversed(matches[:first_activity_index]):
-        if match.group(1).lower() == "bronnen":
+        if match.group(1).lower() in _FOOTER_SOURCES_HEADINGS:
             cut_match = match
             break
     return without_marker[: cut_match.start()].rstrip()

--- a/deploy/litellm/tests/test_klai_knowledge_hook.py
+++ b/deploy/litellm/tests/test_klai_knowledge_hook.py
@@ -468,6 +468,30 @@ class TestKlaiKnowledgeHookLegacy:
             "Het antwoord zelf blijft beschikbaar."
         )
 
+    def test_strips_backend_footer_english_variant_from_history_text(self, monkeypatch):
+        """SPEC-CHAT-SOURCE-DISCLOSURE-001 REQ-DISC-05.
+
+        An English chat emits an English footer (**Sources** / **Agent
+        activity**). The history stripper must remove it too, otherwise a
+        model-imitated or backend English footer survives into the next
+        model input.
+        """
+        mod = _load_hook(monkeypatch)
+
+        content = (
+            "The answer itself stays available.\n\n"
+            "**Sources**\n"
+            "- [Manual](https://docs.example/manual)\n\n"
+            "**Agent activity**\n"
+            "- Mode: Strict, knowledge base only.\n"
+            "- Knowledge base queried: 9 chunks retrieved in 1004 ms.\n\n"
+            "<!-- klai_sources=eyJ0ZXN0IjpbXX0 -->"
+        )
+
+        assert mod._strip_klai_backend_footer_from_text(content) == (
+            "The answer itself stays available."
+        )
+
     def test_sanitizes_assistant_history_content_parts(self, monkeypatch):
         """LibreChat can send text content as parts; strip those too."""
         mod = _load_hook(monkeypatch)

--- a/klai-libs/citations/klai_citations/__init__.py
+++ b/klai-libs/citations/klai_citations/__init__.py
@@ -64,7 +64,18 @@ _PAREN_CITATION_RE = re.compile(r"\(\s*\d{1,3}(?:\s*[,;]\s*\d{1,3})*\s*\)")
 _MALFORMED_NUMBER_URL_RE = re.compile(r"\b\d{1,3}\(https?://[^)\s]+\)")
 _BARE_NUMBER_RUN_RE = re.compile(r"(?<![\w/])\b\d{1,3}(?:\s*[,;]\s*\d{1,3})+\b(?=(?:[.!?])?(?:\s|$))")
 _TOKEN_RE = re.compile(r"[a-z0-9À-ÿ][a-z0-9À-ÿ_-]{2,}", re.IGNORECASE)
-_SOURCE_HEADING_RE = re.compile(r"^\s*(?:bronnen?|sources?|references?)\s*:?\s*$", re.IGNORECASE)
+# Bold-tolerant + multilingual: the model imitates our footer with bold and/or
+# English headings (**Sources**, **Bronnen**). Match those the same as a plain
+# Dutch heading so a fabricated footer never survives into the saved answer.
+# SPEC-CHAT-SOURCE-DISCLOSURE-001 REQ-DISC-05.
+_SOURCE_HEADING_RE = re.compile(
+    r"^\s*(?:\*\*|__)?\s*(?:bronnen?|sources?|references?)\s*:?\s*(?:\*\*|__)?\s*$",
+    re.IGNORECASE,
+)
+_ACTIVITY_HEADING_RE = re.compile(
+    r"^\s*(?:\*\*|__)?\s*agent\s+(?:activiteit|activity)\s*:?\s*(?:\*\*|__)?\s*$",
+    re.IGNORECASE,
+)
 _SOURCE_LIST_LINE_RE = re.compile(r"^\s*(?:\(\s*\d{1,3}\s*\)|\[\s*\d{1,3}\s*\]|\d{1,3}[.)])\s*(.+)$")
 _BULLET_LINE_RE = re.compile(r"^\s*[-*+•]\s+(.+?)\s*$")
 _DEFAULT_MAX_SOURCES = 4
@@ -502,14 +513,14 @@ def strip_model_citation_artifacts(
         return match.group(1).strip() or "[image unavailable in knowledge base]"
 
     kept_lines: list[str] = []
-    skipping_source_section = False
+    skipping_footer_section = False
     for line in _MARKDOWN_IMAGE_RE.sub(_replace_image, text).splitlines():
-        if _SOURCE_HEADING_RE.match(line):
-            skipping_source_section = True
+        if _SOURCE_HEADING_RE.match(line) or _ACTIVITY_HEADING_RE.match(line):
+            skipping_footer_section = True
             continue
-        if skipping_source_section:
+        if skipping_footer_section:
             if not line.strip():
-                skipping_source_section = False
+                skipping_footer_section = False
             continue
         if _looks_like_source_list_line(line) or _looks_like_model_source_title_line(line, normalised_source_titles):
             continue

--- a/klai-libs/citations/tests/test_citations.py
+++ b/klai-libs/citations/tests/test_citations.py
@@ -1279,3 +1279,45 @@ def test_strip_still_renumbers_unanchored_mid_document_excerpt() -> None:
     assert "1. Typ het werk-emailadres." in cleaned
     assert "2. Selecteer de startrol." in cleaned
     assert "3. De gebruiker klikt op de link." in cleaned
+
+
+def test_strip_removes_bold_and_multilingual_source_heading_block() -> None:
+    """SPEC-CHAT-SOURCE-DISCLOSURE-001 REQ-DISC-05.
+
+    A model that imitates our footer with a bold and/or English source heading
+    (**Sources** / **Bronnen** / Sources / Bronnen) must have that block
+    stripped exactly like a plain Dutch one, so a fabricated footer never
+    survives into the saved answer regardless of chat language or bold markers.
+    """
+    from klai_citations import strip_model_citation_artifacts
+
+    for heading in ("**Sources**", "**Bronnen**", "Sources", "Bronnen"):
+        text = f"Klai is steward-owned.\n\n{heading}\n- [Doc](https://made-up.example/doc)"
+        cleaned = strip_model_citation_artifacts(text)
+        assert cleaned == "Klai is steward-owned.", f"heading={heading!r} -> {cleaned!r}"
+        assert "made-up.example" not in cleaned
+
+
+def test_strip_removes_agent_activity_heading_block_nl_en() -> None:
+    """SPEC-CHAT-SOURCE-DISCLOSURE-001 REQ-DISC-05.
+
+    'Agent activity' / 'Agent activiteit' is a footer heading the model can
+    imitate; there is no strip pattern for it today. It must be removed in NL
+    and EN, with and without bold, keeping the answer body intact.
+    """
+    from klai_citations import strip_model_citation_artifacts
+
+    for heading in (
+        "**Agent activity**",
+        "Agent activity",
+        "**Agent activiteit**",
+        "Agent activiteit",
+    ):
+        text = (
+            f"Het antwoord blijft staan.\n\n{heading}\n"
+            "- Mode: Strict, knowledge base only.\n"
+            "- Knowledge base queried: 9 chunks retrieved in 1004 ms."
+        )
+        cleaned = strip_model_citation_artifacts(text)
+        assert cleaned == "Het antwoord blijft staan.", f"heading={heading!r} -> {cleaned!r}"
+        assert "Knowledge base queried" not in cleaned


### PR DESCRIPTION
## Wat & waarom (SPEC-CHAT-SOURCE-DISCLOSURE-001, Fase 2 — REQ-DISC-05 + Fase 1 REQ-DISC-06)

Pad A (LibreChat → LiteLLM). Een **Engelstalige** chat emit een **Engelse** footer
(`**Sources**` / `**Agent activity**`) via de query-token-taalheuristiek
(`_visible_trace_language`). Het disclosure-script (v8) kent alleen de Nederlandse
koppen, en de strippers matchten alleen Nederlands — dus een door het model
nagebootste óf backend Engelse footer overleefde in het antwoord én in de
opgeslagen history.

Deze PR is de **deploy-first** kleine stap uit de SPEC-fasering: hij stopt de
zichtbare bug-klasse vóór de structurele marker-omzetting (Fase 3, aparte PR).

## Wijzigingen
- `klai_citations.strip_model_citation_artifacts`: `_SOURCE_HEADING_RE` is nu
  bold-tolerant + meertalig; nieuwe `_ACTIVITY_HEADING_RE` stript
  `Agent activity`/`Agent activiteit`-blokken (NL/EN, met/zonder bold).
- `klai_kb_request_context`: `KLAI_BACKEND_FOOTER_HEADING_RE` matcht dezelfde
  meertalige set; de sources/activity-cut-logica keyt op lowercase sets.
- SPEC `spec.md`: REQ-DISC-06 reproductie-notitie in HISTORY (acceptance #6):
  het streaming-flush-pad heeft **geen** extra fix nodig — alle drie de
  `stream_flush_alignment`-takken convergeren op één footer-append-site.

## Shared-helper stopgate (klai AGENTS.md)
`strip_model_citation_artifacts` is een multi-path helper (citation rendering).
- **Directe callers:** `klai_kb_citation_render.py:1016` + 2 interne compose-flows
  in `klai_citations/__init__.py` (`:945`, `:1278`). Allen draaien op *model*-tekst
  vóór onze eigen footer wordt aangehangen (`:1033`), dus geen self-cannibalisatie.
- **Getest:** volledige citations-suite (43) + volledige litellm-suite (449),
  NL én EN, met/zonder bold.
- **Bewust conservatief:** de history-stripper cut alleen bij de volledige
  footer-vorm (sources→activity); een losse `Sources`-kop wordt niet gecut.

## Bewijs
- citations: `43 passed` (2 nieuwe RED→GREEN)
- litellm: `449 passed` (1 nieuwe RED→GREEN)
- ruff check + ruff format --check: clean op alle gewijzigde bestanden
- pyright citations: geen regressie (baseline 129 == current 129)

## Deploy
LiteLLM hook-deploy + citations bind/install; recreate met `--force-recreate`
(module-cache pitfall). Geen env/compose-wijziging.

## Scope-grens
Fase 3 (marker `klai_kb_meta_v1` + footer-reductie + script v9 + client-side
locale) volgt als **aparte PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)