### PR TITLE
fix(crawl): make slow JS-rendered helpdesks indexable

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -198,6 +198,13 @@ _AI_SELECTOR_CANDIDATE_LIMIT = 6
 # ---------------------------------------------------------------------------
 _SAMPLE_PAGE_BUDGET = 8
 _SAMPLE_DEPTH = 1
+# Hard wall-clock budget for the sample. portal-api gives the whole preview
+# call 20s by default, and the seed crawl has already spent part of that
+# before we get here. Without this ceiling a slow site turns a working
+# preview into "Preview service did not respond" — strictly worse than the
+# thin-content verdict we are trying to improve on. On expiry we keep the
+# single-page verdict.
+_SAMPLE_TIMEOUT_SECONDS = 15.0
 # Two usable pages is enough signal that the site has real content behind the
 # hub. One could be a fluke (e.g. a single "about" page on an empty shell).
 _SAMPLE_MIN_USABLE = 2
@@ -222,13 +229,23 @@ async def _sample_site_for_classification(
     slow sample degrades to today's behaviour instead of erroring the preview.
     """
     try:
-        results, _outcomes = await crawl_site(
-            url,
-            selector,
-            max_depth=_SAMPLE_DEPTH,
-            max_pages=_SAMPLE_PAGE_BUDGET,
-            cookies=cookies,
+        results, _outcomes = await asyncio.wait_for(
+            crawl_site(
+                url,
+                selector,
+                max_depth=_SAMPLE_DEPTH,
+                max_pages=_SAMPLE_PAGE_BUDGET,
+                cookies=cookies,
+            ),
+            timeout=_SAMPLE_TIMEOUT_SECONDS,
         )
+    except TimeoutError:
+        logger.info(
+            "crawl_preview_site_sample_timeout",
+            url=url,
+            budget_seconds=_SAMPLE_TIMEOUT_SECONDS,
+        )
+        return (0, 0)
     except Exception as exc:
         logger.warning("crawl_preview_site_sample_failed", url=url, error=str(exc))
         return (0, 0)

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -26,7 +26,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from knowledge_ingest import pg_store
-from knowledge_ingest.crawl4ai_client import crawl_dom_summary, crawl_page
+from knowledge_ingest.crawl4ai_client import crawl_dom_summary, crawl_page, crawl_site
 from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.domain_selectors import (
     extract_domain,
@@ -128,6 +128,11 @@ class CrawlPreviewResponse(BaseModel):
     # when the upstream crawl service errors before classification runs.
     classification: str = "unknown"
     classification_reason: str | None = None
+    # Site-sample fallback: how many pages a shallow crawl of the site
+    # reached, and how many of those carried usable content. Both stay 0
+    # when the seed page already classified as success (no sample is run).
+    sample_pages_crawled: int = 0
+    sample_pages_usable: int = 0
 
 
 # SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3 — distinguish "selector matched
@@ -178,6 +183,58 @@ _AI_SELECTOR_EMPTY_REASON = (
     "Try a different URL or enter a selector manually."
 )
 _AI_SELECTOR_CANDIDATE_LIMIT = 6
+
+# ---------------------------------------------------------------------------
+# Site-sample fallback
+#
+# The seed URL a user types is almost always a homepage or hub, which is
+# navigation by nature and therefore fails the single-page thresholds above.
+# ``crawl_site()`` handles such seeds correctly (links are followed even when
+# the seed itself is not ingestable), so the preview must ask the same
+# question the sync does: does this SITE yield usable pages?
+#
+# Budget: one shallow crawl. crawl4ai parallelises server-side, so 8 pages
+# cost roughly one page's wall-clock, not eight.
+# ---------------------------------------------------------------------------
+_SAMPLE_PAGE_BUDGET = 8
+_SAMPLE_DEPTH = 1
+# Two usable pages is enough signal that the site has real content behind the
+# hub. One could be a fluke (e.g. a single "about" page on an empty shell).
+_SAMPLE_MIN_USABLE = 2
+# Classifications worth a second opinion from a site sample. ``auth_wall_detected``
+# is deliberately absent: that is a real blocker the user must resolve with
+# cookies, and sampling would both waste crawls and hide the cause.
+_SAMPLE_ELIGIBLE_CLASSIFICATIONS = frozenset(
+    {"selector_required", "selector_returns_empty", "requires_javascript"}
+)
+
+
+async def _sample_site_for_classification(
+    *,
+    url: str,
+    selector: str | None,
+    cookies: list[dict] | None,
+) -> tuple[int, int]:
+    """Shallow-crawl the site and count pages carrying usable content.
+
+    Returns ``(pages_crawled, pages_usable)``. Returns ``(0, 0)`` on any
+    failure — the caller then keeps the single-page verdict, so a broken or
+    slow sample degrades to today's behaviour instead of erroring the preview.
+    """
+    try:
+        results, _outcomes = await crawl_site(
+            url,
+            selector,
+            max_depth=_SAMPLE_DEPTH,
+            max_pages=_SAMPLE_PAGE_BUDGET,
+            cookies=cookies,
+        )
+    except Exception as exc:
+        logger.warning("crawl_preview_site_sample_failed", url=url, error=str(exc))
+        return (0, 0)
+
+    usable = sum(1 for r in results if r.word_count >= _MIN_WORD_COUNT)
+    return (len(results), usable)
 
 
 def _dom_word_count(item: dict) -> int:
@@ -506,6 +563,32 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
         }:
             classification_reason = _AI_SELECTOR_EMPTY_REASON
 
+        # Site-sample fallback. The seed page failed the single-page bar, but
+        # that bar answers the wrong question for a hub URL. Ask whether the
+        # SITE yields content — the same thing the sync crawl will do.
+        sample_pages_crawled = 0
+        sample_pages_usable = 0
+        if classification in _SAMPLE_ELIGIBLE_CLASSIFICATIONS:
+            sample_pages_crawled, sample_pages_usable = await _sample_site_for_classification(
+                url=body.url,
+                selector=effective_selector,
+                cookies=body.cookies,
+            )
+            if sample_pages_usable >= _SAMPLE_MIN_USABLE:
+                classification = "success"
+                classification_reason = (
+                    f"The entry page is mostly navigation, but {sample_pages_usable} of "
+                    f"{sample_pages_crawled} linked pages contain real content. "
+                    "Crawling this site will index those pages."
+                )
+            logger.info(
+                "crawl_preview_site_sample",
+                url=body.url,
+                pages_crawled=sample_pages_crawled,
+                pages_usable=sample_pages_usable,
+                classification=classification,
+            )
+
         # SPEC-CONNECTOR-INPUT-VALIDATION-001 — completion log for production
         # debugging. Without this, a 200 with classification='unknown' or
         # 'requires_javascript' is invisible in logs (only the 'started' event
@@ -531,6 +614,8 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
             auth_guard=auth_guard,
             classification=classification,
             classification_reason=classification_reason,
+            sample_pages_crawled=sample_pages_crawled,
+            sample_pages_usable=sample_pages_usable,
         )
     except Exception as exc:
         logger.warning("crawl_preview_failed", url=body.url, error=str(exc))

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -198,13 +198,17 @@ _AI_SELECTOR_CANDIDATE_LIMIT = 6
 # ---------------------------------------------------------------------------
 _SAMPLE_PAGE_BUDGET = 8
 _SAMPLE_DEPTH = 1
-# Hard wall-clock budget for the sample. portal-api gives the whole preview
-# call 20s by default, and the seed crawl has already spent part of that
-# before we get here. Without this ceiling a slow site turns a working
-# preview into "Preview service did not respond" — strictly worse than the
-# thin-content verdict we are trying to improve on. On expiry we keep the
-# single-page verdict.
-_SAMPLE_TIMEOUT_SECONDS = 15.0
+# Hard wall-clock budget for the sample. Without a ceiling a slow site turns
+# a working preview into "Preview service did not respond" — strictly worse
+# than the thin-content verdict the sample is meant to improve on. On expiry
+# we keep the single-page verdict.
+#
+# 25s is sized against crawl4ai, not raw HTTP: pages are rendered in a
+# browser, so a page that curls in 200ms can take seconds. crawl4ai's bulk
+# endpoint dispatches the batch in parallel, so the cost is roughly the
+# slowest page rather than the sum — bounded by its own 30s page_timeout.
+# 25s therefore covers the normal case and cuts off the pathological one.
+_SAMPLE_TIMEOUT_SECONDS = 25.0
 # Two usable pages is enough signal that the site has real content behind the
 # hub. One could be a fluke (e.g. a single "about" page on an empty shell).
 _SAMPLE_MIN_USABLE = 2

--- a/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
+++ b/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
@@ -1,0 +1,188 @@
+"""Preview must judge the SITE, not just the seed page.
+
+Regression context (2026-08-06, support.ascendcloud.com):
+
+A user adds a helpdesk whose entry URL is an SPA navigation hub. After JS
+rendering the hub yields ~92 visible words — eight short of
+``_MIN_WORD_COUNT`` — while its ~20 outgoing links each lead to articles of
+900-1600 words. The single-page classifier returned
+``selector_returns_empty`` and the wizard refused to save the connector,
+even though ``crawl_site()`` indexes such a site without trouble (see
+``test_crawl_site_frontier_fetches_listing_children``, which follows links
+from a seed of word_count=1).
+
+The seed URL a user types is almost always a homepage or hub — precisely
+the page type that is navigation by nature. Judging the whole site by that
+one page fails hardest on the most common input.
+
+These tests pin the contract: when the seed is thin but a shallow sample of
+the site yields usable pages, the preview reports ``success`` and explains
+that the entry page itself is navigation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+# The hub: rich raw HTML (so it is not classified as an SPA shell), thin
+# rendered text. Mirrors the measured ascendcloud /app/main page.
+_HUB_HTML = "<html>" + ("<div>nav</div>" * 1000) + "</html>"
+
+
+def _page(url: str, *, words: int, text: str | None = None) -> CrawlResult:
+    md = text if text is not None else ("Real article prose about the product. " * (words // 6))
+    return CrawlResult(
+        url=url,
+        fit_markdown=md,
+        raw_markdown=md,
+        html=_HUB_HTML,
+        word_count=words,
+        success=True,
+        metadata={"status_code": 200},
+        response_headers={},
+    )
+
+
+def _hub() -> CrawlResult:
+    return _page(
+        "https://example.com/app/main",
+        words=92,
+        text="Welcome to the Support Center. Get support by product.",
+    )
+
+
+def test_thin_hub_seed_is_success_when_site_sample_has_usable_pages(
+    client: TestClient,
+) -> None:
+    """The Ascend case: hub seed below the word threshold, articles behind it.
+
+    Before the site-sample fallback this returned ``selector_returns_empty``
+    and the wizard blocked the save.
+    """
+    sample = [
+        _page("https://example.com/app/articles/detail/a_id/16781", words=900),
+        _page("https://example.com/app/articles/detail/a_id/15937", words=1370),
+        _page("https://example.com/app/articles/detail/a_id/16048", words=1532),
+    ]
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=_hub()),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_site",
+            new=AsyncMock(return_value=(sample, [])),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/app/main"},
+        )
+    body = resp.json()
+    assert body["classification"] == "success", body
+    assert body["sample_pages_usable"] == 3
+    # The reason must explain the entry page is navigation — the user needs to
+    # understand why the preview text looks empty while the verdict is green.
+    assert body["classification_reason"]
+    assert "3" in body["classification_reason"]
+
+
+def test_thin_seed_stays_blocked_when_site_sample_is_also_thin(
+    client: TestClient,
+) -> None:
+    """A genuinely empty site must still surface the actionable classification."""
+    sample = [_page("https://example.com/a", words=10)]
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=_hub()),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_site",
+            new=AsyncMock(return_value=(sample, [])),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/app/main"},
+        )
+    body = resp.json()
+    assert body["classification"] == "selector_returns_empty", body
+    assert body["sample_pages_usable"] == 0
+
+
+def test_auth_wall_seed_never_triggers_site_sample(client: TestClient) -> None:
+    """An auth wall is a real blocker — sampling would waste crawls and could
+    mask the fact that the user must supply cookies."""
+    walled = CrawlResult(
+        url="https://example.com/app/main",
+        fit_markdown="Please log in to view this content.",
+        raw_markdown="Please log in to view this content.",
+        html="<html><input type='password'/></html>",
+        word_count=7,
+        success=True,
+        metadata={"status_code": 401},
+        response_headers={},
+    )
+    sample_mock = AsyncMock(return_value=([], []))
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=walled),
+        ),
+        patch("knowledge_ingest.routes.crawl.crawl_site", new=sample_mock),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/app/main"},
+        )
+    body = resp.json()
+    assert body["classification"] == "auth_wall_detected", body
+    sample_mock.assert_not_awaited()
+
+
+def test_healthy_seed_never_triggers_site_sample(client: TestClient) -> None:
+    """A seed that already passes must not pay for an extra crawl."""
+    md = "Real article with proper prose. " * 60
+    sample_mock = AsyncMock(return_value=([], []))
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=_page("https://example.com/a", words=600)),
+        ),
+        patch("knowledge_ingest.routes.crawl.crawl_site", new=sample_mock),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/a", "content_selector": "article"},
+        )
+    assert resp.json()["classification"] == "success"
+    assert md  # keep the fixture intent explicit
+    sample_mock.assert_not_awaited()
+
+
+def test_site_sample_failure_falls_back_to_single_page_verdict(
+    client: TestClient,
+) -> None:
+    """A crashing sample crawl must not turn the preview into a 500."""
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=_hub()),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_site",
+            new=AsyncMock(side_effect=RuntimeError("crawl4ai down")),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/app/main"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "selector_returns_empty", body

--- a/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
+++ b/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
@@ -165,6 +165,36 @@ def test_healthy_seed_never_triggers_site_sample(client: TestClient) -> None:
     sample_mock.assert_not_awaited()
 
 
+def test_site_sample_timeout_falls_back_to_single_page_verdict(
+    client: TestClient,
+) -> None:
+    """A slow site must not turn a working preview into "did not respond".
+
+    portal-api caps the whole preview call, and the seed crawl has already
+    spent part of that budget. If the sample ran unbounded it would push slow
+    sites past that ceiling — replacing an actionable thin-content verdict
+    with a generic service error, which is strictly worse than before.
+    """
+    with (
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_page",
+            new=AsyncMock(return_value=_hub()),
+        ),
+        patch(
+            "knowledge_ingest.routes.crawl.crawl_site",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ),
+    ):
+        resp = client.post(
+            "/ingest/v1/crawl/preview",
+            json={"url": "https://example.com/app/main"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["classification"] == "selector_returns_empty", body
+    assert body["sample_pages_crawled"] == 0
+
+
 def test_site_sample_failure_falls_back_to_single_page_verdict(
     client: TestClient,
 ) -> None:

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -2080,6 +2080,11 @@ class CrawlPreviewResponse(BaseModel):
     # never be treated as success.
     classification: str = "unknown"
     classification_reason: str | None = None
+    # Site-sample fallback: a hub/homepage seed is thin by nature, so the
+    # preview also samples pages behind it. These counts back the wizard's
+    # explanation of why a green verdict can accompany empty preview text.
+    sample_pages_crawled: int = 0
+    sample_pages_usable: int = 0
 
 
 async def _load_saved_web_crawler_cookies(
@@ -2207,6 +2212,8 @@ async def crawl_preview(
         selector_source=result.get("selector_source"),
         classification=result.get("classification", "unknown"),
         classification_reason=result.get("classification_reason"),
+        sample_pages_crawled=result.get("sample_pages_crawled", 0),
+        sample_pages_usable=result.get("sample_pages_usable", 0),
     )
 
 

--- a/klai-portal/backend/app/services/knowledge_ingest_client.py
+++ b/klai-portal/backend/app/services/knowledge_ingest_client.py
@@ -202,11 +202,11 @@ async def preview_crawl(
                 **get_trace_headers(),
             },
             # Seed crawl (page_timeout 30s upstream) plus, when the seed reads
-            # thin, a site sample capped at 15s on the ingest side. 20s used to
-            # cut the seed crawl off on slow sites; 50s covers both phases so a
+            # thin, a site sample capped at 25s on the ingest side. 20s used to
+            # cut the seed crawl off on slow sites; 60s covers both phases so a
             # slow-but-working site returns a verdict instead of "Preview
             # service did not respond".
-            timeout=50.0,
+            timeout=60.0,
         ) as client:
             payload: dict = {
                 "url": url,

--- a/klai-portal/backend/app/services/knowledge_ingest_client.py
+++ b/klai-portal/backend/app/services/knowledge_ingest_client.py
@@ -201,7 +201,12 @@ async def preview_crawl(
                 "X-Caller-Service": "portal-api",
                 **get_trace_headers(),
             },
-            timeout=20.0,
+            # Seed crawl (page_timeout 30s upstream) plus, when the seed reads
+            # thin, a site sample capped at 15s on the ingest side. 20s used to
+            # cut the seed crawl off on slow sites; 50s covers both phases so a
+            # slow-but-working site returns a verdict instead of "Preview
+            # service did not respond".
+            timeout=50.0,
         ) as client:
             payload: dict = {
                 "url": url,

--- a/klai-portal/backend/app/services/source_extractors/url.py
+++ b/klai-portal/backend/app/services/source_extractors/url.py
@@ -23,8 +23,17 @@ from app.services.source_extractors.exceptions import SourceFetchError
 
 logger = structlog.get_logger()
 
-# crawl4ai returns within ~15s for most pages; 30 is a safety ceiling.
-_CRAWL4AI_TIMEOUT = 30.0
+# Most pages come back in ~15s, but heavy JS apps are far slower and the old
+# 30s ceiling cut them off mid-flight. Measured on support.ascendcloud.com
+# (Oracle B2C / AngularJS) 2026-08-06: crawl4ai logged [COMPLETE] ✓ at
+# 34-35s on six consecutive attempts while portal-api gave up at 30s, 4-6s
+# short each time. The crawl succeeded every time; only the client quit
+# early, and the user saw "Pagina onbereikbaar - probeer opnieuw".
+#
+# 60s keeps a comfortable margin above that measured worst case. It is a
+# client-side ceiling only — a genuinely unreachable host still fails fast
+# via connect error rather than burning the full budget.
+_CRAWL4AI_TIMEOUT = 60.0
 
 _TITLE_MAX_CHARS = 120
 

--- a/klai-portal/backend/tests/test_source_extractors_url.py
+++ b/klai-portal/backend/tests/test_source_extractors_url.py
@@ -246,3 +246,29 @@ class TestSourceRef:
         mock_httpx_factory(_crawl_response("# Page"))
         _, _, source_ref = await extract_url("https://example.com/archive?page=2")
         assert source_ref == "https://example.com/archive?page=2"
+
+
+# ---------------------------------------------------------------------------
+# Client timeout budget
+# ---------------------------------------------------------------------------
+
+
+def test_crawl4ai_timeout_covers_slow_javascript_sites() -> None:
+    """The client ceiling must sit above real-world slow-render timings.
+
+    Regression (2026-08-06, support.ascendcloud.com): the budget was 30s while
+    crawl4ai logged [COMPLETE] ✓ at 34-35s on six consecutive attempts. The
+    crawl succeeded every time; portal-api quit 4-6s early and the user got
+    "Pagina onbereikbaar - probeer opnieuw" — a fetch-failure message for a
+    fetch that worked.
+
+    Pinned so a future "tighten the timeout" cleanup has to confront the
+    measurement instead of the intuition that 30s is generous.
+    """
+    from app.services.source_extractors.url import _CRAWL4AI_TIMEOUT
+
+    measured_worst_case_seconds = 35.0
+    assert _CRAWL4AI_TIMEOUT > measured_worst_case_seconds, (
+        f"_CRAWL4AI_TIMEOUT={_CRAWL4AI_TIMEOUT}s is at or below the measured "
+        f"{measured_worst_case_seconds}s worst case; slow JS sites will 502 again"
+    )

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -1183,7 +1183,7 @@ function AddConnectorPage() {
                       <Button
                         type="button"
                         size="sm"
-                        disabled={previewResult?.classification !== 'success'}
+                        disabled={!previewResult || previewResult.classification === 'auth_wall_detected'}
                         onClick={() => setWcStep('settings')}
                       >
                         {m.admin_connectors_webcrawler_next()}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -23,7 +23,6 @@ import type {
   ConnectorType,
   GitHubConfig,
   NotionAddConfig,
-  PreviewClassification,
   PreviewResult,
   WcStep,
   WebCrawlerConfig,
@@ -283,13 +282,10 @@ function AddConnectorPage() {
 
   const previewMutation = useMutation({
     mutationFn: async ({ url, content_selector, try_ai, cookies }: { url: string; content_selector?: string; try_ai?: boolean; cookies?: unknown[] }) => {
-      return apiFetch<{
-        fit_markdown: string; word_count: number; warnings: string[]; url: string
-        content_selector: string | null; selector_source: string | null
-        auth_guard: AuthGuardSuggestion | null
-        classification: PreviewClassification
-        classification_reason: string | null
-      }>(`/api/app/knowledge-bases/${kbSlug}/connectors/crawl-preview`, {
+      // Use PreviewResult itself rather than restating its shape: this
+      // duplicate silently drifted when the backend gained the site-sample
+      // counts, and only surfaced as a type error at build time.
+      return apiFetch<PreviewResult & { url: string }>(`/api/app/knowledge-bases/${kbSlug}/connectors/crawl-preview`, {
         method: 'POST',
         body: JSON.stringify({ url, content_selector: content_selector || null, try_ai: try_ai ?? false, cookies: cookies || null }),
       })

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -1175,7 +1175,7 @@ function EditConnectorPage() {
                     <Button
                       type="button"
                       size="sm"
-                      disabled={previewResult?.classification !== 'success'}
+                      disabled={!previewResult || previewResult.classification === 'auth_wall_detected'}
                       onClick={() => setWcStep('settings')}
                     >
                       {m.admin_connectors_webcrawler_next()}
@@ -1205,7 +1205,8 @@ function EditConnectorPage() {
                       size="sm"
                       disabled={
                         updateMutation.isPending ||
-                        previewResult?.classification !== 'success' ||
+                        !previewResult ||
+                        previewResult.classification === 'auth_wall_detected' ||
                         (requiresLogin === true && authProbeResult?.classification !== 'auth_ok')
                       }
                     >

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
@@ -72,7 +72,10 @@ export function PreviewClassificationFeedback({
   if (classification === 'success') {
     return (
       <Alert variant="success" size="sm">
-        <span>Selector matches real article content. You can save the connector.</span>
+        {/* When the verdict came from the site sample, `reason` explains that the
+            entry page is navigation while the pages behind it hold content. Without
+            it a green check above an empty preview body reads as a bug. */}
+        <span>{reason ?? 'Selector matches real article content. You can save the connector.'}</span>
       </Alert>
     )
   }
@@ -104,6 +107,15 @@ export function PreviewClassificationFeedback({
       <Alert variant="warning" size="sm">
         <span>{message}</span>
       </Alert>
+      {/* The check is advice, not a verdict. A crawl that looks poor on the entry
+          page can still index the site, and the user — not the preview — decides
+          whether this source belongs in their knowledge base. */}
+      {classification !== 'auth_wall_detected' && classification !== 'unknown' && (
+        <p className="text-xs text-gray-500">
+          You can still save this connector. Klai will crawl the pages it can reach and
+          report what it indexed after the first sync.
+        </p>
+      )}
       {classification === 'unknown' && onRetry && (
         <button
           type="button"

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-types.ts
@@ -63,6 +63,10 @@ export type PreviewResult = {
   auth_guard: AuthGuardSuggestion | null
   classification: PreviewClassification
   classification_reason: string | null
+  // Set when the seed page was thin and the backend sampled pages behind it.
+  // Both 0 when the seed passed on its own (no sample was run).
+  sample_pages_crawled: number
+  sample_pages_usable: number
 }
 
 // Per-connector form-state shapes.


### PR DESCRIPTION
Twee losse bugs blokkeerden het indexeren van `support.ascendcloud.com` (Oracle B2C / AngularJS). Ze zitten in verschillende codepaden.

---

## Bug 1 — losse URL toevoegen 502't terwijl de crawl slaagt

**Dit is de bug die de gebruiker raakte.** `/app/knowledge/{kb}/add-source` gaf "Pagina onbereikbaar - probeer opnieuw".

Productielogs, zes pogingen door één gebruiker op 2026-08-06, allemaal identiek. crawl4ai logde `[COMPLETE] ✓` voor élke poging:

| portal-api gaf op | crawl4ai klaar | te vroeg |
|---|---|---|
| 11:21:00.28 | 11:21:04.69 | 4,4s |
| 11:18:28.56 | 11:18:33.98 | 5,4s |
| 11:02:25.83 | 11:02:31.90 | 6,1s |
| 11:00:47.52 | 11:00:52.25 | 4,7s |
| 11:00:01.23 | 11:00:06.03 | 4,8s |
| 10:58:09.69 | 10:58:16.28 | 6,6s |

De site rendert consistent in 34–35s. `_CRAWL4AI_TIMEOUT` stond op 30s, dus httpx gooide ReadTimeout en `extract_url` maakte van een geslaagde crawl een `SourceFetchError`.

Verhoogd naar 60s. Onbereikbare hosts falen nog steeds snel op connect-error. Een regressietest pint de waarde tegen de meting.

---

## Bug 2 — connector-wizard weigert hub-pagina's

`crawl_site()` volgt links prima vanaf een magere seed (`test_crawl_site_frontier_fetches_listing_children` doet dat vanaf `word_count=1`) en `create_connector` kent geen preview-gate. De blokkade waren drie React `disabled`-attributen, gevoed door een heuristiek die één pagina beoordeelt.

`/app/main` levert na chrome-strip ~92 woorden op tegen `_MIN_WORD_COUNT` 100 — acht woorden tekort, terwijl de artikelen erachter 481–1611 woorden bevatten. De seed die een gebruiker intypt is vrijwel altijd een hub, dus de check faalde het hardst op de meest voorkomende invoer.

- Preview valt terug op een ondiepe site-sample (8 pagina's, depth 1) als de seed thin classificeert. Twee bruikbare pagina's is genoeg voor `success`, met uitleg dat de startpagina navigatie is.
- `auth_wall_detected` sampelt nooit — dat is een echte blokkade die cookies vereist.
- De sample is begrensd op 25s (`asyncio.wait_for`); bij overschrijding blijft het single-page oordeel staan. Zonder die grens zou de sample de preview over portal-api's ceiling duwen en "Preview service did not respond" opleveren — slechter dan de melding die hij vervangt.
- Preview-timeout 20s → 60s, want de seed alleen kon al timeouten (zie bug 1: 34s is normaal voor deze site).
- De gate blokkeert alleen nog op `auth_wall_detected`; de rest is advies.

---

## Tests

7 nieuwe tests (site-sample scenario's, timeout-fallback, crawl4ai-budget). knowledge-ingest 1183 passed, portal-api 3374 passed, frontend 469 passed over 72 bestanden. ruff + tsc schoon.

## Niet geverifieerd

Geen lokale end-to-end run — Docker draait niet in de workspace. Bug 1 is wel gediagnosticeerd op echte productielogs, niet op code-inspectie.

## Bekend, buiten scope

De site zet session-tokens in het URL-pad (`/session/L2F2LzEv…`); `_canonicalise_url()` strippt die niet, dus elke sync ziet dezelfde artikelen als nieuwe URLs. Raakt elke Oracle-B2C-helpdesk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)