### PR TITLE
feat(crawl): 5x faster crawls on hidden-body sites + strip template residue

### DIFF
--- a/deploy/crawl4ai/Dockerfile
+++ b/deploy/crawl4ai/Dockerfile
@@ -1,0 +1,24 @@
+# Klai build of crawl4ai with an env-tunable body-visibility wait.
+#
+# Stock crawl4ai spends up to 30s waiting for document.body to become
+# visible and then ignores the answer (ignore_body_visibility defaults to
+# True). On ng-cloak/v-cloak pages whose app never bootstraps, that is a
+# fixed 30s tax per page. See apply_body_visibility_patch.py and
+# https://github.com/unclecode/crawl4ai/issues/2129 for the upstream report.
+#
+# Build (on core-01, where the compose stack runs):
+#   docker build -t ghcr.io/getklai/crawl4ai:0.8.9-local-<YYMMDD-HHMM> deploy/crawl4ai/
+#
+# The tag follows the locally-built convention accepted by
+# deploy/check-image-pullable.sh (`<semver>-local-YYMMDD-HHMM`) — this image
+# is never pushed to a registry.
+#
+# Tune at runtime via docker-compose.yml:
+#   CRAWL4AI_BODY_VISIBILITY_TIMEOUT: "2000"   # ms; unset = stock 30000
+FROM unclecode/crawl4ai:0.8.9
+
+# site-packages is root-owned; the base image runs as appuser.
+USER root
+COPY apply_body_visibility_patch.py /tmp/apply_body_visibility_patch.py
+RUN python /tmp/apply_body_visibility_patch.py && rm /tmp/apply_body_visibility_patch.py
+USER appuser

--- a/deploy/crawl4ai/apply_body_visibility_patch.py
+++ b/deploy/crawl4ai/apply_body_visibility_patch.py
@@ -1,0 +1,63 @@
+"""Patch crawl4ai's hardcoded 30s body-visibility wait to be env-tunable.
+
+Why this exists: crawl4ai waits up to 30s for document.body to become
+visible, then discards the result because ignore_body_visibility defaults to
+True (async_crawler_strategy.py, the csp_compliant_wait call). On pages
+whose body never becomes visible — AngularJS ng-cloak / Vue v-cloak sites
+where the app fails to bootstrap — every crawl pays the full 30s for a value
+nobody reads. Measured on support.ascendcloud.com: 34.7s per page of which
+30.1s is this single wait; with the wait capped at 2s the output is
+byte-identical in 6.5s.
+
+Reported upstream with a config-field proposal:
+https://github.com/unclecode/crawl4ai/issues/2129
+
+This image-build patch is the minimal deployment variant of that proposal:
+one call site changes from a hardcoded 30000 to an env-var lookup
+(CRAWL4AI_BODY_VISIBILITY_TIMEOUT, default 30000 = stock behaviour). Set
+the env var in docker-compose.yml to tune it without rebuilding. Drop this
+patch when upstream ships a configurable timeout.
+
+Fails the build loudly when the anchor is missing or ambiguous, so a
+crawl4ai base-image bump can never silently ship an unpatched image.
+"""
+
+import pathlib
+import sys
+
+import crawl4ai
+
+STRATEGY = pathlib.Path(crawl4ai.__file__).parent / "async_crawler_strategy.py"
+
+ANCHOR = (
+    'return isVisible;\n'
+    '                    }""",\n'
+    '                    timeout=30000,\n'
+    '                )'
+)
+REPLACEMENT = (
+    'return isVisible;\n'
+    '                    }""",\n'
+    '                    timeout=int(os.environ.get('
+    '"CRAWL4AI_BODY_VISIBILITY_TIMEOUT", "30000")),\n'
+    '                )'
+)
+
+text = STRATEGY.read_text()
+count = text.count(ANCHOR)
+if count != 1:
+    sys.exit(
+        f"REFUSING TO BUILD: body-visibility anchor found {count}x in "
+        f"{STRATEGY} (expected exactly 1). The crawl4ai base image changed; "
+        "re-verify the patch against the new source."
+    )
+if "import os" not in text.split("\n\n")[0] and "\nimport os\n" not in text:
+    sys.exit(f"REFUSING TO BUILD: 'import os' not found in {STRATEGY}.")
+
+STRATEGY.write_text(text.replace(ANCHOR, REPLACEMENT, 1))
+
+# Read back and verify — do not trust the write.
+patched = STRATEGY.read_text()
+if 'CRAWL4AI_BODY_VISIBILITY_TIMEOUT' not in patched or ANCHOR in patched:
+    sys.exit("REFUSING TO BUILD: patch verification failed after write.")
+print(f"patched OK: {STRATEGY}")

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1671,12 +1671,22 @@ services:
         condition: service_healthy
 
   # ─── Crawl4AI (internal web crawler for klai-connector) ─────────────────────
+  # Klai-built image (deploy/crawl4ai/Dockerfile, built on core-01): stock
+  # 0.8.9 plus an env-tunable body-visibility wait. Stock crawl4ai burns a
+  # fixed 30s per page on sites whose <body> never becomes visible
+  # (AngularJS ng-cloak et al.) and then discards the result. Upstream
+  # report: https://github.com/unclecode/crawl4ai/issues/2129 — drop this
+  # local build when a configurable timeout ships upstream.
   crawl4ai:
-    image: unclecode/crawl4ai:0.8.9
+    image: ghcr.io/getklai/crawl4ai:0.8.9-local-260806-1448
     restart: unless-stopped
     environment:
       CRAWL4AI_API_TOKEN: ${CRAWL4AI_INTERNAL_KEY}
       CRAWL4AI_HOOKS_ENABLED: "false"
+      # Max ms to wait for <body> visibility. 2000 measured byte-identical
+      # to the stock 30000 on affected sites, ~5x faster wall-clock; pages
+      # with a visible body exit this wait immediately and are unaffected.
+      CRAWL4AI_BODY_VISIBILITY_TIMEOUT: "2000"
     networks:
       - klai-net
     deploy:

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -623,6 +623,48 @@ async def _crawl_sync(
     return resp.json()
 
 
+# Unrendered client-side template token: ``{{item.Name}}``, ``{{ x }}``.
+# Left behind by AngularJS/Vue/Handlebars pages whose app failed to render
+# in the crawler browser — the tokens are markup residue, never content.
+_MUSTACHE_TOKEN_RE = re.compile(r"\{\{[^{}]*\}\}")
+_MD_LINK_URL_RE = re.compile(r"\]\([^)]*\)")
+
+
+def strip_unrendered_template_lines(markdown: str) -> str:
+    """Drop lines that are (almost) entirely unrendered ``{{...}}`` tokens.
+
+    Conservative by design: a line is removed only when, after taking out
+    template tokens and markdown link URLs, at most two words remain — i.e.
+    the line carries no prose of its own. Lines with real prose that merely
+    mention a token are kept UNCHANGED (think documentation about
+    templating), as is everything inside fenced code blocks.
+
+    Keep in sync with the same-named helper in
+    ``klai-portal/backend/app/services/source_extractors/url.py``.
+    """
+    if "{{" not in markdown:
+        return markdown
+    kept: list[str] = []
+    in_fence = False
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            kept.append(line)
+            continue
+        if in_fence or "{{" not in line:
+            kept.append(line)
+            continue
+        # Words that remain once tokens and link URLs are gone — the text a
+        # human would actually read on this line.
+        remainder = _MUSTACHE_TOKEN_RE.sub(" ", _MD_LINK_URL_RE.sub("]", line))
+        words = re.findall(r"\w+", remainder, flags=re.UNICODE)
+        if len(words) <= 2:
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
 def _extract_result(url: str, page: dict[str, Any]) -> CrawlResult:
     """Parse a single page result from the REST API response."""
     md = page.get("markdown", "")
@@ -638,6 +680,9 @@ def _extract_result(url: str, page: dict[str, Any]) -> CrawlResult:
         fit = md_v2.get("fit_markdown", "") or ""
     if not raw:
         raw = md_v2.get("raw_markdown", "") or ""
+
+    fit = strip_unrendered_template_lines(fit)
+    raw = strip_unrendered_template_lines(raw)
 
     text = fit or raw
     return CrawlResult(

--- a/klai-knowledge-ingest/tests/test_strip_unrendered_templates.py
+++ b/klai-knowledge-ingest/tests/test_strip_unrendered_templates.py
@@ -1,0 +1,71 @@
+"""Unrendered ``{{...}}`` template residue must not reach the KB.
+
+Regression context (2026-08-06, support.ascendcloud.com): the site is an
+AngularJS app that fails to bootstrap in the crawler browser, so nav items
+arrive as literal ``{{item.Name}}`` bullets and ``{{selectedCountryPhone...}}``
+fragments — which then showed up verbatim in the connector preview and would
+be ingested as document content.
+"""
+
+from __future__ import annotations
+
+from knowledge_ingest.crawl4ai_client import (
+    _extract_result,
+    strip_unrendered_template_lines,
+)
+
+# Mirrors the actual junk observed in the ascendcloud preview.
+_ASCEND_LIKE = """# Welcome to the Support Center!
+Dedicated and reliable support, accessible from anywhere.
+Get Support by Product
+* {{item.Name}}
+* {{item.Name}}
+{{selectedCountryPhone.countryCode}} {{selectedCountryPhone.text}} [ {{selectedLanguage.text}} ]
+[Cloud telefooncentrale voor Ascend](https://example.com/articles/detail/a_id/{{item.ID}})
+Top Answers Across Products"""
+
+
+def test_pure_token_lines_are_dropped() -> None:
+    cleaned = strip_unrendered_template_lines(_ASCEND_LIKE)
+    assert "{{item.Name}}" not in cleaned
+    assert "{{selectedCountryPhone" not in cleaned
+    assert "Welcome to the Support Center!" in cleaned
+    assert "Top Answers Across Products" in cleaned
+
+
+def test_link_with_real_anchor_text_survives() -> None:
+    # The anchor text is genuine content even though the URL holds a token;
+    # only the URL is blanked for the word count, the line itself is kept
+    # verbatim.
+    cleaned = strip_unrendered_template_lines(_ASCEND_LIKE)
+    assert "Cloud telefooncentrale voor Ascend" in cleaned
+
+
+def test_prose_mentioning_tokens_is_kept_unchanged() -> None:
+    md = "Use {{name}} to insert the customer name into the template."
+    assert strip_unrendered_template_lines(md) == md
+
+
+def test_fenced_code_is_never_touched() -> None:
+    md = "intro\n```\n{{item.Name}}\n```\nafter"
+    assert strip_unrendered_template_lines(md) == md
+
+
+def test_markdown_without_tokens_is_returned_as_is() -> None:
+    md = "# Title\n\nPlain prose only."
+    assert strip_unrendered_template_lines(md) is md
+
+
+def test_extract_result_cleans_and_recounts() -> None:
+    page = {
+        "url": "https://example.com/hub",
+        "markdown": {"fit_markdown": _ASCEND_LIKE, "raw_markdown": _ASCEND_LIKE},
+        "html": "<html></html>",
+        "success": True,
+    }
+    result = _extract_result("https://example.com/hub", page)
+    assert "{{item.Name}}" not in result.fit_markdown
+    assert "{{item.Name}}" not in result.raw_markdown
+    # word_count is computed AFTER cleaning, so token junk no longer pads a
+    # thin page over the preview threshold.
+    assert result.word_count == len(result.fit_markdown.split())

--- a/klai-portal/backend/app/services/source_extractors/url.py
+++ b/klai-portal/backend/app/services/source_extractors/url.py
@@ -40,6 +40,43 @@ _TITLE_MAX_CHARS = 120
 # First ATX-style H1 in the markdown — greedy match on the heading line only.
 _H1_PATTERN = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
 
+# Unrendered client-side template token: ``{{item.Name}}``, ``{{ x }}``.
+_MUSTACHE_TOKEN_RE = re.compile(r"\{\{[^{}]*\}\}")
+_MD_LINK_URL_RE = re.compile(r"\]\([^)]*\)")
+
+
+def strip_unrendered_template_lines(markdown: str) -> str:
+    """Drop lines that are (almost) entirely unrendered ``{{...}}`` tokens.
+
+    AngularJS/Vue/Handlebars pages whose app fails to render in the crawler
+    browser leave literal template tokens in the DOM; those lines are markup
+    residue, never content. A line is removed only when, after taking out
+    template tokens and markdown link URLs, at most two words remain. Lines
+    with real prose are kept unchanged, as is fenced code.
+
+    Keep in sync with the same-named helper in
+    ``klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py``.
+    """
+    if "{{" not in markdown:
+        return markdown
+    kept: list[str] = []
+    in_fence = False
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            kept.append(line)
+            continue
+        if in_fence or "{{" not in line:
+            kept.append(line)
+            continue
+        remainder = _MUSTACHE_TOKEN_RE.sub(" ", _MD_LINK_URL_RE.sub("]", line))
+        words = re.findall(r"\w+", remainder, flags=re.UNICODE)
+        if len(words) <= 2:
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
 
 def _crawl_config() -> dict[str, Any]:
     """Crawler config for a single user-supplied URL source.
@@ -115,7 +152,7 @@ def _extract_markdown_from_response(payload: dict[str, Any]) -> str:
     if not raw:
         raw = md_v2.get("raw_markdown") or ""
 
-    return fit or raw
+    return strip_unrendered_template_lines(fit or raw)
 
 
 def _derive_title(markdown: str, hostname: str | None) -> str:

--- a/klai-portal/backend/tests/test_source_extractors_url.py
+++ b/klai-portal/backend/tests/test_source_extractors_url.py
@@ -272,3 +272,26 @@ def test_crawl4ai_timeout_covers_slow_javascript_sites() -> None:
         f"_CRAWL4AI_TIMEOUT={_CRAWL4AI_TIMEOUT}s is at or below the measured "
         f"{measured_worst_case_seconds}s worst case; slow JS sites will 502 again"
     )
+
+
+# ---------------------------------------------------------------------------
+# Unrendered template residue (see also knowledge-ingest's twin helper)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_unrendered_template_lines_drops_token_junk() -> None:
+    from app.services.source_extractors.url import strip_unrendered_template_lines
+
+    md = (
+        "# Welcome\n"
+        "Real prose stays here.\n"
+        "* {{item.Name}}\n"
+        "{{selectedCountryPhone.countryCode}} {{selectedCountryPhone.text}}\n"
+        "Use {{name}} to insert the customer name into the template.\n"
+    )
+    cleaned = strip_unrendered_template_lines(md)
+    assert "{{item.Name}}" not in cleaned
+    assert "{{selectedCountryPhone" not in cleaned
+    assert "Real prose stays here." in cleaned
+    # Prose that merely mentions a token is kept unchanged.
+    assert "Use {{name}} to insert the customer name into the template." in cleaned


### PR DESCRIPTION
## Wat

Twee generieke fixes voor JS-sites waarvan de app niet opstart in de crawler-browser (AngularJS `ng-cloak`-klasse, zoals Oracle B2C helpdesks):

**1. Eigen crawl4ai-image** (`deploy/crawl4ai/`) — stock 0.8.9 plus een env-tunable body-visibility wait. Stock crawl4ai wacht hardcoded 30s tot `document.body` zichtbaar is en gooit het antwoord weg (`ignore_body_visibility` default `True`). Upstream gemeld als [unclecode/crawl4ai#2129](https://github.com/unclecode/crawl4ai/issues/2129); deze lokale build draagt de minimale variant tot upstream het oplost.

Gemeten op core-01 tegen de gebouwde image, vóór het omzetten van compose:

| pagina | stock | gepatcht (2000ms) | woorden |
|---|---|---|---|
| ascend hub | ~35s | 8,6s | 259 = 259 |
| ascend artikel | ~35s | 6,6s | 962 = 962 |
| intermedia.com (zichtbare body) | 2,3s | 2,3s | onaangetast |

De patch-script weigert de build als het anchor ontbreekt — een base-image bump kan nooit stilzwijgend ongepatcht shippen. Image-tag volgt de `-local-YYMMDD-HHMM` conventie van `check-image-pullable.sh` (guard lokaal gedraaid: OK).

**2. `strip_unrendered_template_lines`** in beide markdown-extractiepaden — verwijdert regels die vrijwel volledig uit ongerenderde `{{...}}`-tokens bestaan (de `{{item.Name}}`-bullets uit de connector-preview). Conservatief: regels met echte tekst blijven onaangeroerd, code-fences worden nooit geraakt, en `word_count` wordt ná het schonen berekend.

## Deploy-volgorde

De image staat al gebouwd op core-01 (`ghcr.io/getklai/crawl4ai:0.8.9-local-260806-1448`); de deploy-compose workflow recreëert crawl4ai na merge via de bestaande `up -d`-stap.

## Tests

6 nieuwe knowledge-ingest + 1 portal-api; crawl-suites 80 passed; ruff + format schoon; beide compose-guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)