### PR TITLE
perf(crawl-preview): sample linked pages in one bulk request

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -1048,6 +1048,83 @@ def _relax_seed_crawl_config(crawler_config: dict[str, Any]) -> dict[str, Any]:
     return relaxed
 
 
+@dataclass
+class LinkedPageSample:
+    """Outcome of sampling pages linked from an already-crawled page."""
+
+    pages_crawled: int
+    pages_usable: int
+
+
+def _sample_candidates(seed: CrawlResult, *, base_domain: str, limit: int) -> list[str]:
+    """Pick which linked URLs to sample, deepest-looking pages first.
+
+    A hub links to both sibling hubs (``/support``) and leaf articles
+    (``/articles/detail/a_id/123``). Leaves answer "does this site hold real
+    content?" far better than more hubs, and they are what a sync would
+    actually index — so prefer more path segments, then declaration order for
+    a stable, testable result.
+    """
+    seen: set[str] = set()
+    candidates: list[str] = []
+    for href in _extract_bfs_seeds(seed, base_domain=base_domain):
+        canonical = _canonicalise_url(href)
+        if canonical in seen or canonical == _canonicalise_url(seed.url):
+            continue
+        seen.add(canonical)
+        candidates.append(href)
+    candidates.sort(key=lambda u: -len(_path_segments(u)))
+    return candidates[:limit]
+
+
+async def sample_linked_pages(
+    seed: CrawlResult,
+    *,
+    selector: str | None = None,
+    cookies: list[dict[str, Any]] | None = None,
+    max_pages: int = 5,
+) -> LinkedPageSample:
+    """Fetch pages linked from ``seed`` and count how many carry real content.
+
+    Answers "is this SITE worth crawling?" when the seed page alone cannot —
+    a navigation hub is thin by nature, yet the pages behind it are exactly
+    what a sync would index.
+
+    Deliberately reuses ``seed``'s already-extracted links and issues a
+    SINGLE bulk request. Routing this through :func:`crawl_site` instead
+    would re-crawl the seed and probe sitemaps first — three sequential
+    network phases for a question one parallel batch answers.
+
+    Never raises: a transport failure yields a zero sample so callers can
+    fall back to their single-page verdict.
+    """
+    base_domain = urlparse(seed.url).netloc.lower()
+    candidates = _sample_candidates(seed, base_domain=base_domain, limit=max_pages)
+    if not candidates:
+        return LinkedPageSample(0, 0)
+
+    raw_results, transport_error = await _chunked_bulk_fetch(
+        urls=candidates,
+        crawler_config=build_crawl_config(selector),
+        cookies=cookies,
+    )
+    results, _outcomes = _combine_bulk_responses(
+        candidates=candidates,
+        raw_results=raw_results,
+        transport_error=transport_error,
+        base_domain=base_domain,
+    )
+    usable = sum(1 for r in results if r.word_count >= _THIN_CONTENT_WORD_COUNT)
+    logger.info(
+        "crawl_sample_linked_pages",
+        seed_url=seed.url,
+        candidates=len(candidates),
+        fetched=len(results),
+        usable=usable,
+    )
+    return LinkedPageSample(pages_crawled=len(results), pages_usable=usable)
+
+
 async def crawl_site(
     start_url: str,
     selector: str | None = None,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl.py
@@ -26,7 +26,12 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from knowledge_ingest import pg_store
-from knowledge_ingest.crawl4ai_client import crawl_dom_summary, crawl_page, crawl_site
+from knowledge_ingest.crawl4ai_client import (
+    CrawlResult,
+    crawl_dom_summary,
+    crawl_page,
+    sample_linked_pages,
+)
 from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.domain_selectors import (
     extract_domain,
@@ -189,26 +194,25 @@ _AI_SELECTOR_CANDIDATE_LIMIT = 6
 #
 # The seed URL a user types is almost always a homepage or hub, which is
 # navigation by nature and therefore fails the single-page thresholds above.
-# ``crawl_site()`` handles such seeds correctly (links are followed even when
-# the seed itself is not ingestable), so the preview must ask the same
-# question the sync does: does this SITE yield usable pages?
+# The sync crawl handles such seeds correctly (links are followed even when
+# the seed itself is not ingestable), so the preview asks the same question:
+# does this SITE yield usable pages?
 #
-# Budget: one shallow crawl. crawl4ai parallelises server-side, so 8 pages
-# cost roughly one page's wall-clock, not eight.
+# ``sample_linked_pages`` reuses the links the seed crawl already returned and
+# issues ONE parallel bulk request — the seed is not re-fetched and no sitemap
+# probing happens, so the sample costs roughly one page's wall-clock.
 # ---------------------------------------------------------------------------
-_SAMPLE_PAGE_BUDGET = 8
-_SAMPLE_DEPTH = 1
+_SAMPLE_PAGE_BUDGET = 5
 # Hard wall-clock budget for the sample. Without a ceiling a slow site turns
 # a working preview into "Preview service did not respond" — strictly worse
 # than the thin-content verdict the sample is meant to improve on. On expiry
 # we keep the single-page verdict.
 #
-# 25s is sized against crawl4ai, not raw HTTP: pages are rendered in a
-# browser, so a page that curls in 200ms can take seconds. crawl4ai's bulk
-# endpoint dispatches the batch in parallel, so the cost is roughly the
-# slowest page rather than the sum — bounded by its own 30s page_timeout.
-# 25s therefore covers the normal case and cuts off the pathological one.
-_SAMPLE_TIMEOUT_SECONDS = 25.0
+# The sample is ONE bulk request that crawl4ai dispatches in parallel, so the
+# cost is roughly the slowest page (bounded by crawl4ai's own 30s
+# page_timeout) rather than the sum. 35s leaves headroom above that ceiling
+# for request overhead without letting a pathological page stall the preview.
+_SAMPLE_TIMEOUT_SECONDS = 35.0
 # Two usable pages is enough signal that the site has real content behind the
 # hub. One could be a fluke (e.g. a single "about" page on an empty shell).
 _SAMPLE_MIN_USABLE = 2
@@ -222,40 +226,38 @@ _SAMPLE_ELIGIBLE_CLASSIFICATIONS = frozenset(
 
 async def _sample_site_for_classification(
     *,
-    url: str,
+    seed: CrawlResult,
     selector: str | None,
     cookies: list[dict] | None,
 ) -> tuple[int, int]:
-    """Shallow-crawl the site and count pages carrying usable content.
+    """Sample pages linked from the seed and count those carrying content.
 
     Returns ``(pages_crawled, pages_usable)``. Returns ``(0, 0)`` on any
     failure — the caller then keeps the single-page verdict, so a broken or
     slow sample degrades to today's behaviour instead of erroring the preview.
     """
     try:
-        results, _outcomes = await asyncio.wait_for(
-            crawl_site(
-                url,
-                selector,
-                max_depth=_SAMPLE_DEPTH,
-                max_pages=_SAMPLE_PAGE_BUDGET,
+        sample = await asyncio.wait_for(
+            sample_linked_pages(
+                seed,
+                selector=selector,
                 cookies=cookies,
+                max_pages=_SAMPLE_PAGE_BUDGET,
             ),
             timeout=_SAMPLE_TIMEOUT_SECONDS,
         )
     except TimeoutError:
         logger.info(
             "crawl_preview_site_sample_timeout",
-            url=url,
+            url=seed.url,
             budget_seconds=_SAMPLE_TIMEOUT_SECONDS,
         )
         return (0, 0)
-    except Exception as exc:
-        logger.warning("crawl_preview_site_sample_failed", url=url, error=str(exc))
+    except Exception:
+        logger.warning("crawl_preview_site_sample_failed", url=seed.url, exc_info=True)
         return (0, 0)
 
-    usable = sum(1 for r in results if r.word_count >= _MIN_WORD_COUNT)
-    return (len(results), usable)
+    return (sample.pages_crawled, sample.pages_usable)
 
 
 def _dom_word_count(item: dict) -> int:
@@ -591,7 +593,7 @@ async def preview_crawl(body: CrawlPreviewRequest, request: Request) -> CrawlPre
         sample_pages_usable = 0
         if classification in _SAMPLE_ELIGIBLE_CLASSIFICATIONS:
             sample_pages_crawled, sample_pages_usable = await _sample_site_for_classification(
-                url=body.url,
+                seed=last_result,
                 selector=effective_selector,
                 cookies=body.cookies,
             )

--- a/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
+++ b/klai-knowledge-ingest/tests/test_crawl_preview_site_sample.py
@@ -7,7 +7,7 @@ rendering the hub yields ~92 visible words — eight short of
 ``_MIN_WORD_COUNT`` — while its ~20 outgoing links each lead to articles of
 900-1600 words. The single-page classifier returned
 ``selector_returns_empty`` and the wizard refused to save the connector,
-even though ``crawl_site()`` indexes such a site without trouble (see
+even though the sync crawl indexes such a site without trouble (see
 ``test_crawl_site_frontier_fetches_listing_children``, which follows links
 from a seed of word_count=1).
 
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
-from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.crawl4ai_client import CrawlResult, LinkedPageSample
 
 # The hub: rich raw HTML (so it is not classified as an SPA shell), thin
 # rendered text. Mirrors the measured ascendcloud /app/main page.
@@ -45,6 +45,12 @@ def _page(url: str, *, words: int, text: str | None = None) -> CrawlResult:
         metadata={"status_code": 200},
         response_headers={},
     )
+
+
+def _as_sample(pages: list[CrawlResult]) -> LinkedPageSample:
+    """Mirror what ``sample_linked_pages`` reports for these pages."""
+    usable = sum(1 for p in pages if p.word_count >= 100)
+    return LinkedPageSample(pages_crawled=len(pages), pages_usable=usable)
 
 
 def _hub() -> CrawlResult:
@@ -74,8 +80,8 @@ def test_thin_hub_seed_is_success_when_site_sample_has_usable_pages(
             new=AsyncMock(return_value=_hub()),
         ),
         patch(
-            "knowledge_ingest.routes.crawl.crawl_site",
-            new=AsyncMock(return_value=(sample, [])),
+            "knowledge_ingest.routes.crawl.sample_linked_pages",
+            new=AsyncMock(return_value=_as_sample(sample)),
         ),
     ):
         resp = client.post(
@@ -102,8 +108,8 @@ def test_thin_seed_stays_blocked_when_site_sample_is_also_thin(
             new=AsyncMock(return_value=_hub()),
         ),
         patch(
-            "knowledge_ingest.routes.crawl.crawl_site",
-            new=AsyncMock(return_value=(sample, [])),
+            "knowledge_ingest.routes.crawl.sample_linked_pages",
+            new=AsyncMock(return_value=_as_sample(sample)),
         ),
     ):
         resp = client.post(
@@ -128,13 +134,13 @@ def test_auth_wall_seed_never_triggers_site_sample(client: TestClient) -> None:
         metadata={"status_code": 401},
         response_headers={},
     )
-    sample_mock = AsyncMock(return_value=([], []))
+    sample_mock = AsyncMock(return_value=LinkedPageSample(0, 0))
     with (
         patch(
             "knowledge_ingest.routes.crawl.crawl_page",
             new=AsyncMock(return_value=walled),
         ),
-        patch("knowledge_ingest.routes.crawl.crawl_site", new=sample_mock),
+        patch("knowledge_ingest.routes.crawl.sample_linked_pages", new=sample_mock),
     ):
         resp = client.post(
             "/ingest/v1/crawl/preview",
@@ -148,13 +154,13 @@ def test_auth_wall_seed_never_triggers_site_sample(client: TestClient) -> None:
 def test_healthy_seed_never_triggers_site_sample(client: TestClient) -> None:
     """A seed that already passes must not pay for an extra crawl."""
     md = "Real article with proper prose. " * 60
-    sample_mock = AsyncMock(return_value=([], []))
+    sample_mock = AsyncMock(return_value=LinkedPageSample(0, 0))
     with (
         patch(
             "knowledge_ingest.routes.crawl.crawl_page",
             new=AsyncMock(return_value=_page("https://example.com/a", words=600)),
         ),
-        patch("knowledge_ingest.routes.crawl.crawl_site", new=sample_mock),
+        patch("knowledge_ingest.routes.crawl.sample_linked_pages", new=sample_mock),
     ):
         resp = client.post(
             "/ingest/v1/crawl/preview",
@@ -181,7 +187,7 @@ def test_site_sample_timeout_falls_back_to_single_page_verdict(
             new=AsyncMock(return_value=_hub()),
         ),
         patch(
-            "knowledge_ingest.routes.crawl.crawl_site",
+            "knowledge_ingest.routes.crawl.sample_linked_pages",
             new=AsyncMock(side_effect=TimeoutError()),
         ),
     ):
@@ -205,7 +211,7 @@ def test_site_sample_failure_falls_back_to_single_page_verdict(
             new=AsyncMock(return_value=_hub()),
         ),
         patch(
-            "knowledge_ingest.routes.crawl.crawl_site",
+            "knowledge_ingest.routes.crawl.sample_linked_pages",
             new=AsyncMock(side_effect=RuntimeError("crawl4ai down")),
         ),
     ):

--- a/klai-knowledge-ingest/tests/test_sample_linked_pages.py
+++ b/klai-knowledge-ingest/tests/test_sample_linked_pages.py
@@ -1,0 +1,161 @@
+"""``sample_linked_pages`` — answer "is this SITE worth crawling?" in one request.
+
+A navigation hub is thin by nature, so the seed page alone cannot decide
+whether a site holds content. Sampling the pages behind it can — but only if
+it is cheap: routing through ``crawl_site`` re-fetched the seed and probed
+sitemaps first, three sequential network phases that blew the preview's
+wall-clock budget on support.ascendcloud.com (2026-08-06) and left the
+verdict at the very thin-content classification the sample exists to fix.
+
+These tests pin the contract: reuse the seed's links, issue exactly ONE bulk
+request, and never raise.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from knowledge_ingest.crawl4ai_client import (
+    CrawlResult,
+    _sample_candidates,
+    sample_linked_pages,
+)
+
+
+def _seed(*hrefs: str, url: str = "https://example.com/app/main") -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        fit_markdown="hub",
+        raw_markdown="hub",
+        html="<html></html>",
+        word_count=92,
+        success=True,
+        links={"internal": [{"href": h} for h in hrefs]},
+    )
+
+
+def _page(url: str, words: int) -> dict:
+    md = "Real article prose about the product. " * max(1, words // 6)
+    return {
+        "url": url,
+        "markdown": {"fit_markdown": md, "raw_markdown": md},
+        "html": "<html></html>",
+        "success": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Candidate selection
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_prefer_deep_pages_over_sibling_hubs() -> None:
+    """Leaf articles answer the question; more hubs do not."""
+    seed = _seed(
+        "https://example.com/support",
+        "https://example.com/app/articles/detail/a_id/16781",
+        "https://example.com/app/articles/detail/a_id/15937",
+    )
+    candidates = _sample_candidates(seed, base_domain="example.com", limit=2)
+    assert all("/articles/detail/" in c for c in candidates), candidates
+
+
+def test_candidates_skip_the_seed_itself_and_duplicates() -> None:
+    seed = _seed(
+        "https://example.com/app/main",  # the seed
+        "https://example.com/app/main/",  # same after canonicalisation
+        "https://example.com/a/b/c",
+    )
+    assert _sample_candidates(seed, base_domain="example.com", limit=5) == [
+        "https://example.com/a/b/c"
+    ]
+
+
+def test_candidates_skip_other_domains() -> None:
+    seed = _seed("https://elsewhere.test/a/b", "https://example.com/a/b")
+    candidates = _sample_candidates(seed, base_domain="example.com", limit=5)
+    assert candidates == ["https://example.com/a/b"]
+
+
+def test_candidates_respect_the_limit() -> None:
+    seed = _seed(*[f"https://example.com/a/b/{i}" for i in range(20)])
+    assert len(_sample_candidates(seed, base_domain="example.com", limit=5)) == 5
+
+
+# ---------------------------------------------------------------------------
+# Sampling behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sample_counts_only_pages_with_real_content() -> None:
+    seed = _seed(
+        "https://example.com/a/b/1",
+        "https://example.com/a/b/2",
+        "https://example.com/a/b/3",
+    )
+    raw = [
+        _page("https://example.com/a/b/1", 900),
+        _page("https://example.com/a/b/2", 5),  # thin — must not count
+        _page("https://example.com/a/b/3", 1200),
+    ]
+    with patch(
+        "knowledge_ingest.crawl4ai_client._chunked_bulk_fetch",
+        new=AsyncMock(return_value=(raw, None)),
+    ):
+        sample = await sample_linked_pages(seed, max_pages=3)
+    assert sample.pages_crawled == 3
+    assert sample.pages_usable == 2
+
+
+@pytest.mark.asyncio
+async def test_sample_issues_exactly_one_bulk_request() -> None:
+    """The whole point: one parallel batch, no seed re-fetch, no sitemap probe."""
+    seed = _seed(*[f"https://example.com/a/b/{i}" for i in range(5)])
+    bulk = AsyncMock(
+        return_value=([_page(f"https://example.com/a/b/{i}", 900) for i in range(5)], None)
+    )
+    with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
+        await sample_linked_pages(seed, max_pages=5)
+    assert bulk.await_count == 1
+    assert len(bulk.await_args.kwargs["urls"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_seed_without_links_costs_no_request() -> None:
+    bulk = AsyncMock(return_value=([], None))
+    with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
+        sample = await sample_linked_pages(_seed(), max_pages=5)
+    assert (sample.pages_crawled, sample.pages_usable) == (0, 0)
+    bulk.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_seed_yields_empty_sample() -> None:
+    dead = CrawlResult(
+        url="https://example.com/app/main",
+        fit_markdown="",
+        raw_markdown="",
+        html="",
+        word_count=0,
+        success=False,
+    )
+    bulk = AsyncMock(return_value=([], None))
+    with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
+        sample = await sample_linked_pages(dead, max_pages=5)
+    assert (sample.pages_crawled, sample.pages_usable) == (0, 0)
+    bulk.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transport_error_degrades_to_zero_sample() -> None:
+    """Callers fall back to their single-page verdict; the preview must not error."""
+    seed = _seed("https://example.com/a/b/1")
+    with patch(
+        "knowledge_ingest.crawl4ai_client._chunked_bulk_fetch",
+        new=AsyncMock(return_value=([], RuntimeError("crawl4ai down"))),
+    ):
+        sample = await sample_linked_pages(seed, max_pages=5)
+    assert (sample.pages_crawled, sample.pages_usable) == (0, 0)


### PR DESCRIPTION
## Wat

De site-sample-fallback (uit #838) routeerde via `crawl_site()`, dat de seed **opnieuw** crawlt en sitemaps probeert vóór het bij de pagina's komt die we willen — drie sequentiële netwerkfases voor een vraag die één parallelle batch beantwoordt. Op `support.ascendcloud.com` liep dat over het 25s-budget en timede het uit met `pages_crawled=0`, waardoor de preview bleef hangen op precies het thin-content-oordeel dat de sample moet oplossen.

Nieuwe `sample_linked_pages()` hergebruikt de links die de seed-crawl al teruggaf en doet **één** bulk-request. Kandidaten kiezen diepere paden eerst, want een hub linkt naar zowel zusterhubs als artikelen, en alleen de artikelen beantwoorden "heeft deze site inhoud" — precies wat een sync ook zou indexeren.

- budget 25s → 35s (één batch, begrensd door crawl4ai's eigen 30s page_timeout)
- sample 8 → 5 pagina's; met één round-trip kochten de extra pagina's niets
- faalt nooit: geen links, gefaalde seed of transport-error geven allemaal een lege sample en de caller houdt zijn single-page-oordeel

## Tests

9 nieuwe (kandidaat-selectie incl. seed/duplicaat/cross-domain uitsluiting, one-request-garantie, thin-page-telling, faalpaden); bestaande preview-sample-suite gemigreerd naar de nieuwe API. Volledige suite: **1199 passed**.

## Live geverifieerd

Image gebouwd van deze branch en op productie gedraaid — de container draait deze code al. De meting legde tegelijk een site-eigenschap bloot die losstaat van deze wijziging: op de Ascend-hub zijn de artikel-links zélf ongerenderde `{{item.URL}}`-templates (AngularJS start niet op in de crawler), dus die specifieke hub heeft geen echte links om te samplen. Dat is geen regressie — de sample degradeert netjes naar het single-page-oordeel. Aparte follow-up: een betere ingang voor dit type site vinden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)