### PR TITLE
fix(zitadel): unblock notification emails to klai-mailer (SSRF denylist)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -227,6 +227,16 @@ services:
       ZITADEL_DEFAULTINSTANCE_ORG_HUMAN_EMAIL_VERIFIED: "true"
       ZITADEL_DEFAULTINSTANCE_ORG_HUMAN_PASSWORD: ${ZITADEL_ADMIN_PASSWORD}
       ZITADEL_DEFAULTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED: "false"
+      # Zitadel >= v4.15.2 routes ALL outgoing HTTP (incl. the klai-mailer
+      # notification webhook) through an SSRF denylist that blocks RFC1918
+      # by default (CVE-2026-55671 hardening). klai-mailer lives on the
+      # Docker network inside 172.16.0.0/12, so every invite/password-reset
+      # email was silently dropped. This override is the upstream default
+      # list MINUS 172.16.0.0/12 — there is no allowlist mechanism
+      # (zitadel/zitadel#12326). Residual risk: Zitadel Actions can reach
+      # Docker-internal services in 172.16.0.0/12; acceptable because only
+      # Klai operators can configure Actions on this instance.
+      ZITADEL_HTTPCLIENT_DENYLIST: "localhost,0.0.0.0/8,10.0.0.0/8,100.64.0.0/10,127.0.0.0/8,169.254.0.0/16,192.168.0.0/16,198.18.0.0/15,::/128,::1/128,fc00::/7,fe80::/10"
     networks:
       - klai-net
       - net-postgres


### PR DESCRIPTION
## Problem

Since the Zitadel v4.15.0 → v4.15.3 bump (#829, Jul 8), **every notification email has been silently dropped**: invite codes, password-reset codes, and email verification. Within the 30-day log retention window: ~9 invites, ~4 password resets, ~1 email verification — zero successes.

Zitadel v4.15.2 introduced SSRF hardening (CVE-2026-55671) that routes all outgoing HTTP — including the HTTP notification provider — through `HTTPClient.DenyList`, which blocks all RFC1918 ranges by default. klai-mailer lives on the Docker network inside `172.16.0.0/12`:

```
Post "http://klai-mailer:8000/notify": dial tcp 172.18.0.16:8000: address is denied by '172.16.0.0/12'
```

Reported today: an invited user (voys org) never received their invite email; their password-reset attempts also produced no email.

## Fix

Override `ZITADEL_HTTPCLIENT_DENYLIST` with the upstream default list minus `172.16.0.0/12`. Upstream provides no allowlist or per-target exemption ([zitadel/zitadel#12326](https://github.com/zitadel/zitadel/issues/12326), closed as not planned).

**Residual risk:** Zitadel Actions can reach Docker-internal services in `172.16.0.0/12`. Acceptable: only Klai operators configure Actions on this instance. All other deny ranges (loopback, link-local/metadata, 10/8, 192.168/16, CGN, IPv6 equivalents) remain blocked.

## Deploy

Merging to main triggers `deploy-compose.yml`, which syncs the file and runs `docker compose up -d` — env-declaration change recreates the zitadel container automatically.

## Verification plan (post-merge)

1. `docker compose config zitadel | grep DENYLIST` on core-01
2. Resend the affected user's invite; confirm mailer receives `/notify` and SMTP send succeeds
3. Confirm no new `sending notification failed` lines in zitadel logs

## Rollback

`git revert <sha>` + push — deploy-compose re-syncs and recreates zitadel with defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)