### PR TITLE
fix(auth): link IdP identity to existing account instead of 409 dead-end

### DIFF
--- a/klai-portal/backend/app/api/auth.py
+++ b/klai-portal/backend/app/api/auth.py
@@ -2286,6 +2286,52 @@ async def _create_idp_session_with_cqrs_retry(
     return None, 4, last_exc
 
 
+async def _create_or_link_idp_user(intent_data: dict) -> str:
+    """Resolve a Zitadel user id for an IdP intent that has no linked user.
+
+    Create-first; on 409 "User already exists" attach the IdP identity to the
+    existing account with the intent's email and return that account's id. The
+    409 leg is the invited-but-not-yet-activated collision: the portal invite
+    already created the Zitadel account (username = email), so "log in with
+    Google" must link instead of failing (2026-08-12 incident). Also heals
+    dangling identities and password users choosing social for the first time.
+
+    Trust model matches ``create_zitadel_user_from_idp``, which already accepts
+    the IdP-asserted email as a verified mailbox (Google/Microsoft verify it).
+
+    Raises the original error when no account matches the intent email, so
+    callers keep their flow-specific failure events unchanged.
+    """
+    try:
+        return await zitadel.create_zitadel_user_from_idp(intent_data, settings.zitadel_portal_org_id)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code != 409:
+            raise
+        conflict = exc
+    idp_info = intent_data.get("idpInformation", {})
+    raw_user = idp_info.get("rawInformation", {}).get("User", {})
+    email: str = raw_user.get("email", "") or idp_info.get("userName", "")
+    found = await zitadel.find_user_by_email(email) if email else None
+    if found is None:
+        raise conflict
+    existing_user_id, _ = found
+    try:
+        await zitadel.link_idp_to_user(existing_user_id, intent_data)
+    except httpx.HTTPStatusError as link_exc:
+        # 409 = this IdP identity is already linked (half-completed earlier
+        # attempt) — the session check will succeed, so continue.
+        if link_exc.response.status_code != 409:
+            raise
+    _slog.info("idp_linked_existing_user", zitadel_user_id=existing_user_id)
+    _emit_auth_event(
+        "idp_linked_existing_user",
+        reason="create_user_409_existing_account",
+        outcome="link-and-continue",
+        level="info",
+    )
+    return existing_user_id
+
+
 @router.get("/auth/idp-callback")
 async def idp_callback(  # noqa: C901 - callback flow has many external failure legs.
     id: str,
@@ -2332,11 +2378,13 @@ async def idp_callback(  # noqa: C901 - callback flow has many external failure 
     # chose "log in with Google/Microsoft". Pre-SPEC this raised and bounced
     # them back to /login with no explanation; now we provision the user (same
     # path as idp_signup_callback) so they reach the domain-match matrix below.
+    # An existing unlinked account (invited-not-activated, password user) gets
+    # the IdP linked instead — see _create_or_link_idp_user.
     idp_user_id: str | None = intent_data.get("userId")
     if not idp_user_id:
         try:
-            idp_user_id = await zitadel.create_zitadel_user_from_idp(intent_data, settings.zitadel_portal_org_id)
-            _slog.info("idp_callback_user_created", zitadel_user_id=idp_user_id)
+            idp_user_id = await _create_or_link_idp_user(intent_data)
+            _slog.info("idp_callback_user_resolved", zitadel_user_id=idp_user_id)
         except Exception:
             _slog.exception("idp_callback_create_user_failed")
             _emit_auth_event(
@@ -2661,11 +2709,13 @@ async def idp_signup_callback(
 
     idp_user_id: str | None = intent_data.get("userId")
 
-    # 1b. New user — no Zitadel account yet. Create one from the IDP profile.
+    # 1b. New user — no Zitadel account yet. Create one from the IDP profile;
+    # an existing unlinked account (invited-not-activated) gets the IdP linked
+    # instead — see _create_or_link_idp_user.
     if not idp_user_id:
         try:
-            idp_user_id = await zitadel.create_zitadel_user_from_idp(intent_data, settings.zitadel_portal_org_id)
-            _slog.info("idp_signup_callback_user_created", zitadel_user_id=idp_user_id)
+            idp_user_id = await _create_or_link_idp_user(intent_data)
+            _slog.info("idp_signup_callback_user_resolved", zitadel_user_id=idp_user_id)
         except httpx.HTTPStatusError as exc:
             _slog.exception("idp_signup_callback_create_user_failed", zitadel_status=exc.response.status_code)
             _emit_auth_event(

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -921,6 +921,28 @@ class ZitadelClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def link_idp_to_user(self, user_id: str, intent_data: dict) -> None:
+        """Link the IdP identity from a completed intent to an existing Zitadel user.
+
+        POST /v2/users/{userId}/links — used when ``create_zitadel_user_from_idp``
+        hits 409 "User already exists": the account was created earlier (portal
+        invite, password signup) without this IdP link, so social login must
+        attach the identity instead of failing. After linking, a session can be
+        created from the same intent via ``create_session_for_user_idp``.
+        """
+        idp_info = intent_data.get("idpInformation", {})
+        resp = await self._http.post(
+            f"/v2/users/{user_id}/links",
+            json={
+                "idpLink": {
+                    "idpId": idp_info.get("idpId", ""),
+                    "userId": idp_info.get("userId", ""),
+                    "userName": idp_info.get("userName", ""),
+                }
+            },
+        )
+        resp.raise_for_status()
+
     async def create_zitadel_user_from_idp(self, intent_data: dict, org_id: str) -> str:
         """Create a Zitadel human user from IDP intent data. Returns the new Zitadel userId.
 

--- a/klai-portal/backend/tests/test_idp_link_existing_user.py
+++ b/klai-portal/backend/tests/test_idp_link_existing_user.py
@@ -1,0 +1,232 @@
+"""Invited-but-not-activated users choosing social login must not dead-end.
+
+Reproduction for the 2026-08-12 incident: a portal invite creates the Zitadel
+account (username = email) up front, so when the invitee ignores the invite
+mail and clicks "Log in / Sign up with Google", the IdP intent has no linked
+user, ``create_zitadel_user_from_idp`` returns 409 "User already exists", and
+both callbacks bounced to a generic failure page with no way forward.
+
+Contract under test: on 409 the callbacks resolve the existing account by the
+IdP-asserted email, link the IdP identity to it (POST /v2/users/{id}/links),
+and continue the normal session flow.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from helpers import make_request
+
+INTENT_EMAIL = "anne.daalman@voys.nl"
+
+# Completed Google intent for a person Zitadel has no IdP link for.
+INTENT_NO_LINKED_USER = {
+    "idpInformation": {
+        "idpId": "idp-google",
+        "userId": "google-sub-123",
+        "userName": INTENT_EMAIL,
+        "rawInformation": {
+            "User": {
+                "email": INTENT_EMAIL,
+                "given_name": "Anne",
+                "family_name": "Daalman",
+                "name": "Anne Daalman",
+            }
+        },
+    }
+}
+
+EXISTING_ZITADEL_USER_ID = "zuser-existing"
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://auth.example.com/v2/users/human")
+    return httpx.HTTPStatusError(
+        f"{status}",
+        request=req,
+        response=httpx.Response(status, request=req),
+    )
+
+
+def _zitadel_for_conflict() -> MagicMock:
+    """Zitadel client double: create → 409, existing user found by email."""
+    zit = MagicMock()
+    zit.retrieve_idp_intent = AsyncMock(return_value=dict(INTENT_NO_LINKED_USER))
+    zit.create_zitadel_user_from_idp = AsyncMock(side_effect=_http_status_error(409))
+    zit.find_user_by_email = AsyncMock(return_value=(EXISTING_ZITADEL_USER_ID, "zorg-1"))
+    zit.link_idp_to_user = AsyncMock(return_value=None)
+    zit.create_session_for_user_idp = AsyncMock(return_value={"sessionId": "sid", "sessionToken": "stk"})
+    zit.get_session = AsyncMock(
+        return_value={
+            "session": {
+                "factors": {
+                    "user": {
+                        "id": EXISTING_ZITADEL_USER_ID,
+                        "displayName": "Anne Daalman",
+                        "loginName": INTENT_EMAIL,
+                    },
+                    "intent": {"idpInformation": INTENT_NO_LINKED_USER["idpInformation"]},
+                }
+            }
+        }
+    )
+    # idp_callback (login path) fetches a flattened variant.
+    zit.get_session_details = AsyncMock(return_value={"zitadel_user_id": "", "email": INTENT_EMAIL})
+    return zit
+
+
+class TestSignupCallbackLinksExistingUser:
+    @pytest.mark.asyncio
+    async def test_409_links_idp_and_logs_invited_member_in(self) -> None:
+        """Anne's scenario: invited (portal row exists) → Google → logged in."""
+        from app.api.auth import idp_signup_callback
+
+        zit = _zitadel_for_conflict()
+        existing_member = MagicMock()
+        existing_member.org_id = 1
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=existing_member)
+
+        with (
+            patch("app.api.auth.zitadel", zit),
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.audit.log_event", AsyncMock()),
+            patch("app.api.auth._encrypt_sso", return_value="ENC"),
+        ):
+            response = await idp_signup_callback(
+                id="intent-1",
+                token="tok-1",
+                request=make_request(),
+                locale="nl",
+                invite_token=None,
+                db=mock_db,
+            )
+
+        zit.find_user_by_email.assert_awaited_once_with(INTENT_EMAIL)
+        zit.link_idp_to_user.assert_awaited_once()
+        assert zit.link_idp_to_user.await_args.args[0] == EXISTING_ZITADEL_USER_ID
+        zit.create_session_for_user_idp.assert_awaited_once()
+        assert zit.create_session_for_user_idp.await_args.args[0] == EXISTING_ZITADEL_USER_ID
+        assert response.status_code == 302
+        assert "error=idp_failed" not in response.headers["location"]
+        assert "klai_sso" in response.headers.get("set-cookie", "")
+
+    @pytest.mark.asyncio
+    async def test_409_with_dangling_identity_continues_signup(self) -> None:
+        """Zitadel identity exists but no portal row → normal social-form leg."""
+        from app.api.auth import idp_signup_callback
+
+        zit = _zitadel_for_conflict()
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=None)
+
+        with (
+            patch("app.api.auth.zitadel", zit),
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.audit.log_event", AsyncMock()),
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
+        ):
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            response = await idp_signup_callback(
+                id="intent-1",
+                token="tok-1",
+                request=make_request(),
+                locale="nl",
+                invite_token=None,
+                db=mock_db,
+            )
+
+        zit.link_idp_to_user.assert_awaited_once()
+        assert response.status_code == 302
+        assert "/signup/social" in response.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_409_without_email_match_still_fails(self) -> None:
+        """No account matches the intent email → original failure leg stays."""
+        from app.api.auth import idp_signup_callback
+
+        zit = _zitadel_for_conflict()
+        zit.find_user_by_email = AsyncMock(return_value=None)
+
+        with (
+            patch("app.api.auth.zitadel", zit),
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.audit.log_event", AsyncMock()),
+        ):
+            response = await idp_signup_callback(
+                id="intent-1",
+                token="tok-1",
+                request=make_request(),
+                locale="nl",
+                invite_token=None,
+                db=AsyncMock(),
+            )
+
+        zit.link_idp_to_user.assert_not_awaited()
+        zit.create_session_for_user_idp.assert_not_awaited()
+        assert response.status_code == 302
+        assert "error=idp_failed" in response.headers["location"]
+
+    @pytest.mark.asyncio
+    async def test_link_conflict_treated_as_already_linked(self) -> None:
+        """409 on the link call (half-completed earlier attempt) → proceed."""
+        from app.api.auth import idp_signup_callback
+
+        zit = _zitadel_for_conflict()
+        zit.link_idp_to_user = AsyncMock(side_effect=_http_status_error(409))
+        existing_member = MagicMock()
+        existing_member.org_id = 1
+        mock_db = AsyncMock()
+        mock_db.scalar = AsyncMock(return_value=existing_member)
+
+        with (
+            patch("app.api.auth.zitadel", zit),
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.audit.log_event", AsyncMock()),
+            patch("app.api.auth._encrypt_sso", return_value="ENC"),
+        ):
+            response = await idp_signup_callback(
+                id="intent-1",
+                token="tok-1",
+                request=make_request(),
+                locale="nl",
+                invite_token=None,
+                db=mock_db,
+            )
+
+        zit.create_session_for_user_idp.assert_awaited_once()
+        assert response.status_code == 302
+        assert "error=idp_failed" not in response.headers["location"]
+
+
+class TestLoginCallbackLinksExistingUser:
+    @pytest.mark.asyncio
+    async def test_409_links_idp_and_creates_session_for_existing_user(self) -> None:
+        """Login-with-Google (SPEC-AUTH-010 R3 leg) resolves the 409 the same way."""
+        from app.api.auth import idp_callback
+
+        zit = _zitadel_for_conflict()
+
+        with (
+            patch("app.api.auth.zitadel", zit),
+            patch("app.api.auth.emit_event"),
+            patch("app.api.auth.audit.log_event", AsyncMock()),
+            patch("app.api.auth._get_sso_fernet") as mock_fernet,
+        ):
+            mock_fernet.return_value.encrypt = MagicMock(return_value=b"ENCRYPTED_PENDING")
+            response = await idp_callback(
+                id="intent-1",
+                token="tok-1",
+                auth_request_id="ar-1",
+                request=make_request(),
+                db=AsyncMock(),
+            )
+
+        zit.find_user_by_email.assert_awaited_once_with(INTENT_EMAIL)
+        zit.link_idp_to_user.assert_awaited_once()
+        zit.create_session_for_user_idp.assert_awaited_once()
+        assert zit.create_session_for_user_idp.await_args.args[0] == EXISTING_ZITADEL_USER_ID
+        assert response.status_code == 302
+        assert response.headers["location"] != "/login?authRequest=ar-1"


### PR DESCRIPTION
## Problem

An invited-but-not-yet-activated user who clicks **Log in / Sign up with Google** dead-ends: the portal invite already created the Zitadel account (username = email), so the IdP intent has no linked user, `create_zitadel_user_from_idp` returns 409 "User already exists", and both `idp_callback` (SPEC-AUTH-010 R3) and `idp_signup_callback` redirect to a generic failure page with no way forward.

Observed in production today (09:27 UTC): event `idp_signup_callback_create_user_failed`, zitadel_status 409, for an invited voys user. With domain-match join now live (#841), "just sign in with your work Google account" is the natural first touch for invited users — this collision becomes the most likely path.

## Fix

New shared helper `_create_or_link_idp_user`: create-first; on 409 resolve the existing account via `find_user_by_email` (intent email — same trust model as create, which already accepts the IdP-asserted email as verified) and attach the IdP identity via `POST /v2/users/{userId}/links` (new `ZitadelClient.link_idp_to_user`), then continue the normal session flow.

Downstream already handles both outcomes correctly:
- existing portal member → direct SSO login (the invited-user case)
- Zitadel identity without portal row (dangling identity) → signup/social leg incl. AUTH-010 domain-match matrix

Non-409 errors and no-email-match re-raise, keeping every existing failure leg and auth event unchanged.

## Identity lifecycle matrix (backend AGENTS.md gate)

| portal_users | Zitadel | Before | After |
|---|---|---|---|
| row exists (invited) | account, no IdP link | 409 → failure page | link → SSO login |
| missing (dangling identity) | account, no IdP link | 409 → failure page | link → signup/social + domain-match |
| missing | no account | create → signup/social | unchanged |
| any | no email match on 409 | failure page | unchanged (original 409 re-raised) |

## Tests

`tests/test_idp_link_existing_user.py` — 5 tests, reproduction-first (first test reproduced the exact production traceback before the fix). Full backend suite: **3400 passed**. ruff check + format clean, pyright 0 errors.

## Rollback

`git revert` — helper is additive; call sites fall back to the previous create-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)