### PR TITLE
fix dead M1 zitadel-webhook alert (field-qualified query never matched) + add mailer error-log alert

### DIFF
--- a/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
@@ -1,21 +1,10 @@
-# SPEC-OBS-001 follow-up — mail-chain notification-failure detection
-# (LogsQL via VictoriaLogs).
+# SPEC-OBS-001 follow-up — klai-mailer error-log alert (LogsQL via
+# VictoriaLogs).
 #
 # Routed via spec=SPEC-OBS-001 → klai-ops-alerts-email (see policies.yaml).
 #
-#   Z1  zitadel_notification_failed_count_high   CRIT  Any "sending
-#                                                        notification failed"
-#                                                        line from zitadel
-#                                                        in the last 15m.
-#   Z2  mailer_error_log_count_high              CRIT  Any level:error line
-#                                                        from klai-mailer in
-#                                                        the last 15m.
-#
-# Why a new file instead of extending mailer-rules.yaml:
-#
-# Per minimal-changes discipline this SPEC-follow-up adds detection only —
-# the existing mailer-rules.yaml (M1/M2, closes the 2026-04-29 signal gap)
-# is left untouched.
+#   Z2  mailer_error_log_count_high   CRIT  Any level:error line from
+#                                            klai-mailer in the last 15m.
 #
 # Incident context (2026-08-12): Zitadel v4.15.2+ ships a default SSRF
 # denylist that blocks outbound HTTP to RFC1918 ranges, including the
@@ -25,36 +14,36 @@
 # 8 July until discovery on 12 August 2026 (~5 weeks). Root cause is
 # already fixed via the `ZITADEL_HTTPCLIENT_DENYLIST` override in
 # deploy/docker-compose.yml (removes 172.16.0.0/12 from the denylist).
-# This file is the detection-layer half of the incident response.
 #
-# IMPORTANT — why Z1 does NOT reuse M1's `msg:"..."` field-qualified
-# query shape: Zitadel emits logfmt lines to stdout, not JSON —
-#   time=... level=WARN msg="sending notification failed" ... error="..."
-# Alloy's `loki.process "extract_level"` pipeline (deploy/alloy/config.alloy)
-# only runs `stage.json` (JSON-field extraction) before forwarding to
-# VictoriaLogs. A logfmt line is not valid JSON, so no `msg` field is ever
-# lifted out of it — only the raw line lands in `_msg`. A LogsQL filter of
-# the SHAPE `msg:"..."` (field-qualified) therefore matches a field that
-# does not exist for zitadel log lines and silently returns zero hits —
-# this is the most likely reason the existing M1 rule
-# (obs-001-mailer-zitadel-webhook-failed, same log line, same text) did not
-# fire during the 5-week outage despite looking correct on paper. Per the
-# README pitfall "VictoriaLogs unqualified text-search only scans `_msg`",
-# Z1 uses an UNQUALIFIED phrase filter instead — that searches `_msg`
-# directly and works regardless of whether structured-field extraction
-# happened. klai-mailer (Z2), by contrast, emits structlog JSON, so
-# `level:error` is a real extracted field per the extract_level stage —
+# The Zitadel-side detection half of this incident response
+# (zitadel_notification_failed_count_high, previously drafted here as
+# "Z1") was folded into the EXISTING `mailer-rules.yaml` instead of
+# shipping as a new parallel rule. That file already had an alert with
+# the identical intent — M1 `mailer_zitadel_webhook_failed` — but its
+# query was dead: field-qualified `msg:"..."` against a field Alloy
+# never extracts from Zitadel's logfmt log lines (see mailer-rules.yaml
+# header for the full analysis, externally verified via VictoriaLogs MCP
+# against the real outage window: field-qualified query = 0 hits,
+# unqualified query = 140 hits over 13 Jul – 12 Aug). Fixing M1's `expr`
+# and threshold in place — keeping its UID
+# `obs-001-mailer-zitadel-webhook-failed` — avoids shipping a working
+# alert next to a permanently-dead duplicate with the same intent
+# ("old and new flow living side by side").
+#
+# This file now carries ONLY Z2, which is genuinely new coverage: M2 (in
+# mailer-rules.yaml) watches mailer's uvicorn ACCESS log for 5xx on
+# /notify; Z2 watches mailer's own structlog ERROR-level lines directly
+# (SMTP send failures, Redis fail-closed 503s, template/render
+# exceptions) — a request can fail inside mailer without necessarily
+# producing a 5xx access-log line matched by M2 (e.g. an async
+# post-response failure), so Z2 is complementary, not redundant.
+#
+# Field shape for Z2: klai-mailer emits structlog JSON, so `level` is a
+# real extracted field via Alloy's `loki.process "extract_level"` stage
+# (deploy/alloy/config.alloy, `stage.json` + `stage.labels`) —
 # consistent with the documented pattern `service:portal-api AND
-# level:error` in .claude/rules/klai/infra/observability.md.
-#
-# This finding about M1 is reported as a residual risk for a possible
-# separate fast-follow fix to mailer-rules.yaml; it is NOT touched here.
-#
-# Field shapes verified by direct source-code read (2026-08-12), not by
-# a live VictoriaLogs query (no query tool available in this session):
-#   deploy/alloy/config.alloy                — only stage.json extraction
-#   deploy/docker-compose.yml (zitadel svc)  — ZITADEL_HTTPCLIENT_DENYLIST
-#   deploy/grafana/provisioning/alerting/mailer-rules.yaml — M1/M2 precedent
+# level:error` in .claude/rules/klai/infra/observability.md. Unlike
+# Zitadel's logfmt output, this field-qualified filter is safe.
 #
 # Pitfalls inherited from caddy-rules.yaml / mailer-rules.yaml:
 #   - Always go through `reduce` between LogsQL output and SSE math
@@ -70,108 +59,15 @@ groups:
     interval: 1m
     rules:
 
-      # ── Z1: zitadel_notification_failed_count_high ──────────────────────
-      #
-      # Fires on ANY "sending notification failed" line from zitadel in the
-      # last 15 minutes. Unqualified phrase filter — matches `_msg` — is
-      # deliberately used instead of a field-qualified `msg:"..."` filter;
-      # see the file header for why. Threshold is `> 0` (not `> 5` like M1)
-      # because the operational goal here is "catch a silent 5-week outage
-      # within the alert's evaluation interval", not "filter retry noise" —
-      # a single failed notification webhook call is already abnormal.
-      - uid: obs-zitadel-notif-fail-high
-        title: zitadel_notification_failed_count_high
-        condition: threshold
-        data:
-          - refId: query
-            datasourceUid: victorialogs
-            queryType: instant
-            relativeTimeRange:
-              from: 900
-              to: 0
-            model:
-              refId: query
-              datasource:
-                type: victoriametrics-logs-datasource
-                uid: victorialogs
-              expr: 'service:zitadel AND "sending notification failed"'
-              queryType: instant
-          - refId: reduce
-            datasourceUid: __expr__
-            relativeTimeRange:
-              from: 900
-              to: 0
-            model:
-              refId: reduce
-              type: reduce
-              reducer: count
-              expression: query
-          - refId: threshold
-            datasourceUid: __expr__
-            relativeTimeRange:
-              from: 900
-              to: 0
-            model:
-              refId: threshold
-              type: threshold
-              expression: reduce
-              conditions:
-                - evaluator: { params: [0], type: gt }
-                  operator: { type: and }
-                  reducer: { params: [], type: last }
-                  type: query
-        noDataState: OK
-        execErrState: OK
-        for: 0s
-        keepFiringFor: 30m
-        isPaused: false
-        labels:
-          severity: critical
-          spec: SPEC-OBS-001
-          service_group: mailer-chain
-        annotations:
-          summary: 'Zitadel notification webhook to klai-mailer failed (>0 in 15m)'
-          runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
-          description: |
-            At least one `sending notification failed` line was logged by
-            zitadel in the last 15 minutes. This means invite codes,
-            password-reset codes, or email-verification codes are not
-            reaching klai-mailer — the exact failure mode that went
-            undetected for 5 weeks (8 July → 12 August 2026) when
-            Zitadel v4.15.2+'s SSRF denylist started blocking the
-            internal-network webhook call to klai-mailer
-            (172.16.0.0/12 RFC1918 range). Root cause is fixed via
-            `ZITADEL_HTTPCLIENT_DENYLIST` in deploy/docker-compose.yml;
-            this alert exists so any recurrence — same cause or a new
-            one — pages within minutes instead of weeks.
-
-            Investigate (Grafana → Explore → VictoriaLogs, or the
-            VictoriaLogs MCP `query` tool):
-              service:zitadel AND "sending notification failed"
-
-            The `error=` field on the matching log lines contains the
-            HTTP status/dial error and target URL — that tells you
-            which webhook target and failure mode this is (SSRF
-            denylist block, connection refused, timeout, non-2xx from
-            mailer, etc.). Cross-check klai-mailer's own error logs:
-              service:klai-mailer AND level:error
-
-            If the error text mentions "address is denied by" — this is
-            the SSRF-denylist class again. Check
-            ZITADEL_HTTPCLIENT_DENYLIST is still present and correctly
-            scoped in deploy/docker-compose.yml (zitadel service) and
-            that the deployed container actually has it
-            (`docker exec klai-core-zitadel-1 printenv
-            ZITADEL_HTTPCLIENT_DENYLIST`).
-
       # ── Z2: mailer_error_log_count_high ──────────────────────────────────
       #
       # Direct signal from klai-mailer's own error-level logs (SMTP send
       # failures, Redis fail-closed 503s, template/render errors). Same
-      # shape as Z1: unbounded threshold (>0), 15m window, immediate fire.
-      # Independent of zitadel's logging so this still fires if the failure
-      # originates purely on the mailer side (e.g. SMTP provider outage)
-      # with no corresponding zitadel-side symptom.
+      # shape as M1's fixed threshold: unbounded threshold (>0), 15m
+      # window, immediate fire. Independent of zitadel's logging so this
+      # still fires if the failure originates purely on the mailer side
+      # (e.g. SMTP provider outage) with no corresponding zitadel-side
+      # symptom.
       - uid: obs-mailer-error-log-high
         title: mailer_error_log_count_high
         condition: threshold
@@ -231,14 +127,15 @@ groups:
             503 (nonce/idempotency store unreachable), template render
             error, or any other unhandled exception in the mail-send path.
 
-            This complements Z1 (zitadel_notification_failed_count_high):
-            Z1 catches failures BEFORE the request reaches mailer (network,
-            SSRF denylist, DNS); Z2 catches failures INSIDE mailer once the
-            request arrives. Both firing together points at a mailer-side
-            root cause. Only Z2 firing (Z1 quiet) points at a mailer-
-            internal issue with no upstream symptom (e.g. SMTP provider
-            outage while Zitadel's own webhook call still succeeds with a
-            2xx and mailer fails asynchronously).
+            This complements `mailer_zitadel_webhook_failed` (M1, in
+            mailer-rules.yaml): M1 catches failures BEFORE the request
+            reaches mailer (network, SSRF denylist, DNS); Z2 catches
+            failures INSIDE mailer once the request arrives. Both firing
+            together points at a mailer-side root cause. Only Z2 firing
+            (M1 quiet) points at a mailer-internal issue with no upstream
+            symptom (e.g. SMTP provider outage while Zitadel's own
+            webhook call still succeeds with a 2xx and mailer fails
+            asynchronously).
 
             Investigate (Grafana → Explore → VictoriaLogs, or the
             VictoriaLogs MCP `query` tool):

--- a/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
@@ -1,0 +1,248 @@
+# SPEC-OBS-001 follow-up — mail-chain notification-failure detection
+# (LogsQL via VictoriaLogs).
+#
+# Routed via spec=SPEC-OBS-001 → klai-ops-alerts-email (see policies.yaml).
+#
+#   Z1  zitadel_notification_failed_count_high   CRIT  Any "sending
+#                                                        notification failed"
+#                                                        line from zitadel
+#                                                        in the last 15m.
+#   Z2  mailer_error_log_count_high              CRIT  Any level:error line
+#                                                        from klai-mailer in
+#                                                        the last 15m.
+#
+# Why a new file instead of extending mailer-rules.yaml:
+#
+# Per minimal-changes discipline this SPEC-follow-up adds detection only —
+# the existing mailer-rules.yaml (M1/M2, closes the 2026-04-29 signal gap)
+# is left untouched.
+#
+# Incident context (2026-08-12): Zitadel v4.15.2+ ships a default SSRF
+# denylist that blocks outbound HTTP to RFC1918 ranges, including the
+# klai-mailer webhook target on the internal Docker network
+# (172.16.0.0/12). Every notification webhook call — invite codes,
+# password-reset codes, email verification — was silently dropped from
+# 8 July until discovery on 12 August 2026 (~5 weeks). Root cause is
+# already fixed via the `ZITADEL_HTTPCLIENT_DENYLIST` override in
+# deploy/docker-compose.yml (removes 172.16.0.0/12 from the denylist).
+# This file is the detection-layer half of the incident response.
+#
+# IMPORTANT — why Z1 does NOT reuse M1's `msg:"..."` field-qualified
+# query shape: Zitadel emits logfmt lines to stdout, not JSON —
+#   time=... level=WARN msg="sending notification failed" ... error="..."
+# Alloy's `loki.process "extract_level"` pipeline (deploy/alloy/config.alloy)
+# only runs `stage.json` (JSON-field extraction) before forwarding to
+# VictoriaLogs. A logfmt line is not valid JSON, so no `msg` field is ever
+# lifted out of it — only the raw line lands in `_msg`. A LogsQL filter of
+# the SHAPE `msg:"..."` (field-qualified) therefore matches a field that
+# does not exist for zitadel log lines and silently returns zero hits —
+# this is the most likely reason the existing M1 rule
+# (obs-001-mailer-zitadel-webhook-failed, same log line, same text) did not
+# fire during the 5-week outage despite looking correct on paper. Per the
+# README pitfall "VictoriaLogs unqualified text-search only scans `_msg`",
+# Z1 uses an UNQUALIFIED phrase filter instead — that searches `_msg`
+# directly and works regardless of whether structured-field extraction
+# happened. klai-mailer (Z2), by contrast, emits structlog JSON, so
+# `level:error` is a real extracted field per the extract_level stage —
+# consistent with the documented pattern `service:portal-api AND
+# level:error` in .claude/rules/klai/infra/observability.md.
+#
+# This finding about M1 is reported as a residual risk for a possible
+# separate fast-follow fix to mailer-rules.yaml; it is NOT touched here.
+#
+# Field shapes verified by direct source-code read (2026-08-12), not by
+# a live VictoriaLogs query (no query tool available in this session):
+#   deploy/alloy/config.alloy                — only stage.json extraction
+#   deploy/docker-compose.yml (zitadel svc)  — ZITADEL_HTTPCLIENT_DENYLIST
+#   deploy/grafana/provisioning/alerting/mailer-rules.yaml — M1/M2 precedent
+#
+# Pitfalls inherited from caddy-rules.yaml / mailer-rules.yaml:
+#   - Always go through `reduce` between LogsQL output and SSE math
+#   - SSE math has no max(), no ternary
+#   - execErrState: OK so plugin hiccups don't false-fire
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: mail-chain-notification-failures
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── Z1: zitadel_notification_failed_count_high ──────────────────────
+      #
+      # Fires on ANY "sending notification failed" line from zitadel in the
+      # last 15 minutes. Unqualified phrase filter — matches `_msg` — is
+      # deliberately used instead of a field-qualified `msg:"..."` filter;
+      # see the file header for why. Threshold is `> 0` (not `> 5` like M1)
+      # because the operational goal here is "catch a silent 5-week outage
+      # within the alert's evaluation interval", not "filter retry noise" —
+      # a single failed notification webhook call is already abnormal.
+      - uid: obs-zitadel-notif-fail-high
+        title: zitadel_notification_failed_count_high
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:zitadel AND "sending notification failed"'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-OBS-001
+          service_group: mailer-chain
+        annotations:
+          summary: 'Zitadel notification webhook to klai-mailer failed (>0 in 15m)'
+          runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
+          description: |
+            At least one `sending notification failed` line was logged by
+            zitadel in the last 15 minutes. This means invite codes,
+            password-reset codes, or email-verification codes are not
+            reaching klai-mailer — the exact failure mode that went
+            undetected for 5 weeks (8 July → 12 August 2026) when
+            Zitadel v4.15.2+'s SSRF denylist started blocking the
+            internal-network webhook call to klai-mailer
+            (172.16.0.0/12 RFC1918 range). Root cause is fixed via
+            `ZITADEL_HTTPCLIENT_DENYLIST` in deploy/docker-compose.yml;
+            this alert exists so any recurrence — same cause or a new
+            one — pages within minutes instead of weeks.
+
+            Investigate (Grafana → Explore → VictoriaLogs, or the
+            VictoriaLogs MCP `query` tool):
+              service:zitadel AND "sending notification failed"
+
+            The `error=` field on the matching log lines contains the
+            HTTP status/dial error and target URL — that tells you
+            which webhook target and failure mode this is (SSRF
+            denylist block, connection refused, timeout, non-2xx from
+            mailer, etc.). Cross-check klai-mailer's own error logs:
+              service:klai-mailer AND level:error
+
+            If the error text mentions "address is denied by" — this is
+            the SSRF-denylist class again. Check
+            ZITADEL_HTTPCLIENT_DENYLIST is still present and correctly
+            scoped in deploy/docker-compose.yml (zitadel service) and
+            that the deployed container actually has it
+            (`docker exec klai-core-zitadel-1 printenv
+            ZITADEL_HTTPCLIENT_DENYLIST`).
+
+      # ── Z2: mailer_error_log_count_high ──────────────────────────────────
+      #
+      # Direct signal from klai-mailer's own error-level logs (SMTP send
+      # failures, Redis fail-closed 503s, template/render errors). Same
+      # shape as Z1: unbounded threshold (>0), 15m window, immediate fire.
+      # Independent of zitadel's logging so this still fires if the failure
+      # originates purely on the mailer side (e.g. SMTP provider outage)
+      # with no corresponding zitadel-side symptom.
+      - uid: obs-mailer-error-log-high
+        title: mailer_error_log_count_high
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:klai-mailer AND level:error'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-OBS-001
+          service_group: mailer-chain
+        annotations:
+          summary: 'klai-mailer logged an error (>0 in 15m)'
+          runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
+          description: |
+            At least one `level:error` log line appeared from klai-mailer
+            in the last 15 minutes — SMTP send failure, Redis fail-closed
+            503 (nonce/idempotency store unreachable), template render
+            error, or any other unhandled exception in the mail-send path.
+
+            This complements Z1 (zitadel_notification_failed_count_high):
+            Z1 catches failures BEFORE the request reaches mailer (network,
+            SSRF denylist, DNS); Z2 catches failures INSIDE mailer once the
+            request arrives. Both firing together points at a mailer-side
+            root cause. Only Z2 firing (Z1 quiet) points at a mailer-
+            internal issue with no upstream symptom (e.g. SMTP provider
+            outage while Zitadel's own webhook call still succeeds with a
+            2xx and mailer fails asynchronously).
+
+            Investigate (Grafana → Explore → VictoriaLogs, or the
+            VictoriaLogs MCP `query` tool):
+              service:klai-mailer AND level:error
+
+            For a live trace while reproducing:
+              ssh core-01 "docker logs --tail 0 -f klai-core-klai-mailer-1"

--- a/deploy/grafana/provisioning/alerting/mailer-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mailer-rules.yaml
@@ -2,10 +2,12 @@
 #
 # Routed via spec=SPEC-OBS-001 → klai-ops-alerts-email.
 #
-#   M1  mailer_zitadel_webhook_failed   CRIT  Zitadel notification → klai-mailer
-#                                              returned non-2xx >5 times in 5m.
+#   M1  mailer_zitadel_webhook_failed   CRIT  Any Zitadel notification →
+#                                              klai-mailer failure in 15m.
 #                                              The 2026-04-29 four-hour outage
-#                                              would have fired in 5 minutes.
+#                                              would have fired in minutes;
+#                                              the 2026-08-12 finding (below)
+#                                              is why threshold is now >0.
 #   M2  mailer_notify_5xx_count_high   CRIT  >5 mailer access-log lines with
 #                                              5xx status on /notify in 5m.
 #                                              Direct mailer-side signal,
@@ -20,11 +22,41 @@
 # notification-channel log line. M2 doubles the signal from the mailer
 # side (now that uvicorn access logs are visible via the FU#2 logging fix).
 #
-# Field shapes verified against production VictoriaLogs (2026-04-30):
-#   service:zitadel AND msg:"sending notification failed"
+# 2026-08-12 finding — M1's query was DEAD from the day it was added:
+#
+# Zitadel had been silently dropping ALL notification emails (invite codes,
+# password-reset codes, email verification) from 8 July until discovery on
+# 12 August 2026 — a v4.15.2+ SSRF denylist blocked the internal-network
+# webhook call to klai-mailer (172.16.0.0/12 RFC1918 range; fixed via
+# `ZITADEL_HTTPCLIENT_DENYLIST` in deploy/docker-compose.yml). M1's original
+# query — `service:zitadel AND msg:"sending notification failed"` — is
+# FIELD-QUALIFIED against `msg`. Zitadel emits `logfmt` lines to stdout
+# (`time=... level=WARN msg="..." error="..."`), not JSON. Alloy's
+# `loki.process "extract_level"` stage (deploy/alloy/config.alloy) only
+# runs `stage.json`, which is a no-op on a non-JSON line — no `msg` field
+# is ever lifted out of a Zitadel log line, only the raw line lands in
+# `_msg`. A field-qualified filter against a field that was never
+# extracted matches zero rows.
+#
+# Externally verified via VictoriaLogs MCP (orchestrator session,
+# 2026-08-12) against the actual 13 Jul – 12 Aug outage window:
+#   service:zitadel AND msg:"sending notification failed"   → 0 hits
+#   service:zitadel AND "sending notification failed"       → 140 hits
+#
+# M1 has been a dead alert since it was added on 2026-04-30. The `expr`
+# below is now the unqualified form (searches `_msg` directly, per the
+# LogsQL pitfall documented at the bottom of this header and in
+# README.md) — this is the fix, applied in place so the alert-rule UID
+# stays stable and no orphaned rule is left behind in Grafana's DB.
+#
+# Field shapes verified against production VictoriaLogs (2026-04-30,
+# re-verified 2026-08-12):
+#   service:zitadel AND "sending notification failed"
 #     → matches Zitadel's `webhook didn't return a success status` log
 #       across notification types (user.human.password.code.added,
-#       user.human.invite.code.added, etc.)
+#       user.human.invite.code.added, etc.) — unqualified phrase filter,
+#       see 2026-08-12 finding above for why the field-qualified form
+#       never worked.
 #   service:klai-mailer AND _msg:"POST /notify"
 #     → matches uvicorn's access log for /notify requests after the
 #       FU#2 logging fix (PR #233) re-enabled access logs at INFO.
@@ -33,6 +65,11 @@
 #   - Always go through `reduce` between LogsQL output and SSE math
 #   - SSE math has no max(), no ternary
 #   - execErrState: OK so plugin hiccups don't false-fire
+#   - Unqualified text-search only scans `_msg` — a third-party service
+#     that logs logfmt (not JSON) will never populate a named field
+#     unless a `| unpack_logfmt` (or ingest-time extraction) is added to
+#     the query. Do not field-qualify against a field that was never
+#     extracted — this is exactly the class of bug M1 shipped with.
 
 apiVersion: 1
 
@@ -51,9 +88,23 @@ groups:
       #
       # On 2026-04-29 the broken-redis-URL outage produced ~14k of these log
       # lines over 4 hours (~1Hz retry loop), entirely invisible to existing
-      # alerts. Threshold of 5 in 5m is conservative — Zitadel retries up
-      # to ~5 times per individual notification, so 5 failures across 5
-      # minutes is the very bottom of "real outage" signal.
+      # alerts.
+      #
+      # 2026-08-12 FIX: the original `expr` here was field-qualified
+      # (`msg:"..."`) against a field Alloy never extracts from Zitadel's
+      # logfmt output — see file header for the full analysis. Verified via
+      # VictoriaLogs MCP against the real 13 Jul – 12 Aug outage window:
+      # the field-qualified query returned 0 hits, the unqualified form
+      # below returned all 140 failure lines. This rule was a dead alert
+      # for the entire 3.5 months it existed prior to this fix.
+      #
+      # Threshold is now `> 0` (was `> 5` in a 5m window) — one dropped
+      # notification produces roughly 10 retry lines from Zitadel's own
+      # retry loop, so `> 5` would still have fired eventually, but the
+      # correct contract for this signal is "any failure is abnormal",
+      # not "wait for a retry storm". Window widened to 15m to match the
+      # sibling zitadel/mailer-chain alert and give the query a larger
+      # sample without needing a tighter eval interval.
       - uid: obs-001-mailer-zitadel-webhook-failed
         title: mailer_zitadel_webhook_failed
         condition: threshold
@@ -62,29 +113,33 @@ groups:
             datasourceUid: victorialogs
             queryType: instant
             relativeTimeRange:
-              from: 300
+              from: 900
               to: 0
             model:
               refId: query
               datasource:
                 type: victoriametrics-logs-datasource
                 uid: victorialogs
-              # Match every Zitadel notification-channel failure regardless
-              # of target host:port. The earlier shape (`error:"klai-mailer:8000"`)
-              # was a literal substring on the error message that would
-              # silently break if mailer ever moves to a different host or
-              # port — exactly the regression class this SPEC is meant to
-              # close. Mailer is the only registered webhook channel today,
-              # so a Zitadel notification-failed event implies the mailer
-              # is broken; if a second channel ever exists (e.g. Slack
-              # incident-bridge), revisit this filter to restore the target
-              # narrowing.
-              expr: 'service:zitadel AND msg:"sending notification failed"'
+              # UNQUALIFIED phrase filter — searches `_msg` directly.
+              # Matches every Zitadel notification-channel failure
+              # regardless of target host:port. Do NOT change this back
+              # to a field-qualified `msg:"..."` filter: Zitadel logs
+              # logfmt (not JSON), Alloy's extract_level stage only runs
+              # `stage.json` (a no-op on logfmt input), so no `msg` field
+              # is ever populated for these log lines — a field-qualified
+              # filter here silently matches zero rows (see file header,
+              # 2026-08-12 finding). Mailer is the only registered
+              # webhook channel today, so a Zitadel notification-failed
+              # event implies the mailer is broken; if a second channel
+              # ever exists (e.g. Slack incident-bridge), revisit this
+              # filter to add target narrowing (as an additional
+              # unqualified phrase, not a field qualifier).
+              expr: 'service:zitadel AND "sending notification failed"'
               queryType: instant
           - refId: reduce
             datasourceUid: __expr__
             relativeTimeRange:
-              from: 300
+              from: 900
               to: 0
             model:
               refId: reduce
@@ -94,52 +149,70 @@ groups:
           - refId: threshold
             datasourceUid: __expr__
             relativeTimeRange:
-              from: 300
+              from: 900
               to: 0
             model:
               refId: threshold
               type: threshold
               expression: reduce
               conditions:
-                - evaluator: { params: [5], type: gt }
+                - evaluator: { params: [0], type: gt }
                   operator: { type: and }
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
         execErrState: OK
-        for: 5m
-        keepFiringFor: 10m
+        for: 0s
+        keepFiringFor: 30m
         isPaused: false
         labels:
           severity: critical
           spec: SPEC-OBS-001
           service_group: mailer
         annotations:
-          summary: 'Zitadel cannot deliver notifications to klai-mailer (>5 failures in 5m)'
+          summary: 'Zitadel notification webhook to klai-mailer failed (>0 in 15m)'
           runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md#mailer-zitadel-webhook-failed'
           description: |
-            Zitadel logged more than 5 `sending notification failed` events
-            targeting klai-mailer in the last 5 minutes. This means at
-            least one user-facing email flow is broken: password reset,
-            invitations, email-OTP codes, MFA setup mails.
+            At least one `sending notification failed` line was logged by
+            zitadel in the last 15 minutes. This means invite codes,
+            password-reset codes, or email-verification codes are not
+            reaching klai-mailer.
 
             The 2026-04-29 broken-redis-URL outage emitted ~14k of these
             log lines over 4 hours before a user reported "email not
-            arriving". This alert closes that signal gap.
+            arriving" — the incident this alert was originally built to
+            close. It then silently failed to fire on a second, much
+            longer outage: from 8 July until discovery on 12 August 2026
+            (~5 weeks), Zitadel v4.15.2+'s SSRF denylist blocked the
+            internal-network webhook call to klai-mailer
+            (172.16.0.0/12 RFC1918 range) and this rule's field-qualified
+            query never matched a single row. Root cause is fixed via
+            `ZITADEL_HTTPCLIENT_DENYLIST` in deploy/docker-compose.yml;
+            the query here is fixed to actually match Zitadel's real log
+            shape (see file header) so any recurrence pages within
+            minutes instead of weeks.
+
+            Investigate (Grafana → Explore → VictoriaLogs, or the
+            VictoriaLogs MCP `query` tool):
+              service:zitadel AND "sending notification failed"
+
+            The `error=` field on the matching log lines contains the
+            HTTP status/dial error and target URL — that tells you which
+            webhook target and failure mode this is (SSRF denylist
+            block, connection refused, timeout, non-2xx from mailer,
+            etc.). If the error text mentions "address is denied by" —
+            this is the SSRF-denylist class again; check
+            ZITADEL_HTTPCLIENT_DENYLIST is still present and correctly
+            scoped on the deployed container:
+              docker exec klai-core-zitadel-1 printenv ZITADEL_HTTPCLIENT_DENYLIST
 
             Triage:
-              1. Check the actual error from Zitadel's view:
-                   service:zitadel AND msg:"sending notification failed"
-                 The error= field on the matching log lines contains the
-                 HTTP status, target URL, and a partial reason from the
-                 receiving service's response — that tells you which
-                 webhook target is broken.
-              2. Inspect mailer's own logs for the same window (now
-                 visible after the FU#2 access-log fix):
-                   service:klai-mailer AND _time:5m
-                 If access logs show requests reaching mailer but every
-                 one returns 5xx, see step 3. If no access logs show a
-                 request reaching mailer, see step 4.
+              1. Check the actual error from Zitadel's view (query above).
+              2. Inspect mailer's own logs for the same window:
+                   service:klai-mailer AND level:error
+                 If mailer logs show requests reaching it but failing
+                 internally, see step 3. If no mailer-side error appears,
+                 see step 4.
               3. Mailer-internal failure: pull the live ASGI traceback
                  by tailing mailer logs while triggering a fresh
                  password reset:


### PR DESCRIPTION
## Problem

On 2026-08-12 we discovered that Zitadel had been silently dropping ALL notification emails (invite codes, password-reset codes, email verification) since 8 July — roughly 5 weeks. Root cause: Zitadel v4.15.2+ ships a default SSRF denylist that blocks outbound HTTP to RFC1918 ranges, including the klai-mailer webhook target on the internal Docker network (`172.16.0.0/12`). Every call to `http://klai-mailer:8000/notify` was denied and logged as a WARNING by Zitadel.

The root cause is already fixed via the `ZITADEL_HTTPCLIENT_DENYLIST` override in `deploy/docker-compose.yml`.

## What changed since the first version of this PR

The original version of this PR added a brand-new alert (`zitadel_notification_failed_count_high`) next to the existing `mailer_zitadel_webhook_failed` (M1) in `mailer-rules.yaml` — both covering the same signal. That's the "old and new flow living side by side" antipattern. Live VictoriaLogs verification (run from the orchestrator session) confirmed the better fix: **M1 was dead code, not a working alert that needed a sibling.**

**Externally verified fact** (VictoriaLogs MCP query against the real 13 Jul – 12 Aug outage window, orchestrator session, 2026-08-12):

```
service:zitadel AND msg:"sending notification failed"   → 0 hits
service:zitadel AND "sending notification failed"       → 140 hits
```

M1's query (`msg:"..."`, field-qualified) has been dead since it was added on 2026-04-30. Zitadel emits `logfmt` lines to stdout, not JSON (`time=... level=WARN msg="..." error="..."`). `deploy/alloy/config.alloy`'s `loki.process "extract_level"` stage only runs `stage.json` — a no-op on a non-JSON line — so no `msg` field is ever extracted from Zitadel's log lines; only the raw text lands in `_msg`. A field-qualified filter against a field that doesn't exist silently matches zero rows. This is now confirmed with production data, not just static analysis.

## What this PR does now

1. **Fixes M1 in place** in `deploy/grafana/provisioning/alerting/mailer-rules.yaml`:
   - `expr` changed to the unqualified form: `service:zitadel AND "sending notification failed"` (searches `_msg` directly, safe regardless of field extraction)
   - Threshold lowered to `> 0` in a 15-minute window (was `> 5` in 5m) — any single dropped notification is abnormal; no need to wait for a retry storm
   - **UID kept stable** (`obs-001-mailer-zitadel-webhook-failed`) — no `deleteRules` mechanics, no orphaned rule left in Grafana's DB
   - `runbook_url` unchanged
   - Annotations expanded with the 2026-08-12 incident context, the corrected investigation query, and an "address is denied by" → SSRF-denylist triage hint
   - File header comment documents the 2026-08-12 finding and why field-qualifying against a non-extracted field is the bug class to avoid going forward

2. **`mail-chain-notification-rules.yaml` now carries only the genuinely new coverage**: `mailer_error_log_count_high` (uid `obs-mailer-error-log-high`, 25 chars) — fires on any `service:klai-mailer AND level:error` line in a 15-minute window. This is complementary to M1 (catches failures before the request reaches mailer) and M2 (`mailer-rules.yaml`, watches mailer's uvicorn *access* log for 5xx on `/notify`) — Z2 watches mailer's own structlog *error*-level lines directly, catching failures that don't necessarily surface as a 5xx access-log line (e.g. an async post-response failure). The previously-drafted `zitadel_notification_failed_count_high` ("Z1") was removed from this file — its coverage now lives in the fixed M1.

Both rules route via `spec=SPEC-OBS-001` → `klai-ops-alerts-email`; `policies.yaml` is untouched.

## Validation

Ran locally (worktree at repo root) after the rework, on both changed files:

```
$ bash scripts/audit-alert-uid-length.sh
OK: all alert-rule and dashboard UIDs are within the 40-char limit.
  obs-001-mailer-zitadel-webhook-failed (37 chars) — unchanged UID
  obs-001-mailer-notify-5xx-count-high (36 chars) — unchanged (M2)
  obs-mailer-error-log-high (25 chars) — new (Z2)

$ bash scripts/audit-alert-secrets.sh
audit-alert-secrets: clean (deploy/grafana/provisioning/alerting)

$ bash scripts/verify-alert-runbooks.sh
verify-alert-runbooks: 0 error(s), 7 warning(s)   # warnings pre-existing, unrelated files

$ bash scripts/test-alerting-guards.sh
All alerting-guard tests passed. (10/10)

$ ruby -ryaml -e "YAML.load_file(...)"  # both files
YAML parses OK for both mailer-rules.yaml and mail-chain-notification-rules.yaml
```

Not verified in this session: the corrected M1 query and the new Z2 query have not been live-fire tested against a running Grafana instance (no server access from this session) — only validated by the VictoriaLogs MCP historical-data check cited above (externally run by the orchestrator) and by the CI guard scripts.

## Rollback

```
git revert <this-commit-sha>
```

Caveat: `deploy/grafana/provisioning/` syncs to `/opt/klai/grafana/provisioning/` via `rsync -ac` **without `--delete`**. A revert of the M1 fix restores the dead query in-repo, and a revert alone will not remove `mail-chain-notification-rules.yaml` from the server on the next sync if this PR is fully reverted post-merge — an operator would need to also run:

```
ssh core-01 "rm /opt/klai/grafana/provisioning/alerting/mail-chain-notification-rules.yaml"
```

before the next `grafana` container recreate, or the stale file keeps provisioning the (reverted) rule.

## Test plan

- [x] `audit-alert-uid-length.sh` passes
- [x] `audit-alert-secrets.sh` passes
- [x] `verify-alert-runbooks.sh` passes (0 errors)
- [x] `test-alerting-guards.sh` regression suite passes
- [x] YAML syntax validated for both files
- [x] M1's fixed query verified against real production log data (13 Jul – 12 Aug window) via VictoriaLogs MCP — 140 hits vs 0 hits for the old query
- [ ] Live-fire test on core-01 after deploy — not done in this session, no server access

🤖 Generated with [Claude Code](https://claude.com/claude-code)