### PR TITLE
fix(alerting): stats-shape LogsQL queries so mail-chain alerts can actually fire

### DIFF
--- a/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mail-chain-notification-rules.yaml
@@ -48,7 +48,13 @@
 # Pitfalls inherited from caddy-rules.yaml / mailer-rules.yaml:
 #   - Always go through `reduce` between LogsQL output and SSE math
 #   - SSE math has no max(), no ternary
-#   - execErrState: OK so plugin hiccups don't false-fire
+#   - LogsQL queries feeding SSE MUST end in `| stats count() ...` with
+#     queryType `stats` — a bare filter query returns log-row frames that
+#     error the reduce step precisely when rows match (2026-08-12 live
+#     test; see mailer-rules.yaml M1). This file deviates from the older
+#     execErrState: OK convention for the same reason: with the stats
+#     shape the known error class is gone, so eval errors are real and
+#     fail-loud (Alerting).
 
 apiVersion: 1
 
@@ -74,7 +80,7 @@ groups:
         data:
           - refId: query
             datasourceUid: victorialogs
-            queryType: instant
+            queryType: stats
             relativeTimeRange:
               from: 900
               to: 0
@@ -83,8 +89,15 @@ groups:
               datasource:
                 type: victoriametrics-logs-datasource
                 uid: victorialogs
-              expr: 'service:klai-mailer AND level:error'
-              queryType: instant
+              # `| stats count()` + queryType `stats` is REQUIRED — the
+              # bare-filter + instant + reduce:count shape errors with
+              # "input data must be a wide series but got type long" as
+              # soon as the query matches rows. Live-verified 2026-08-12
+              # via /api/ds/query (plugin v0.31.0): matches → Value=N,
+              # zero matches → Value=0 (no NoData). See mailer-rules.yaml
+              # M1 for the full analysis.
+              expr: 'service:klai-mailer AND level:error | stats count() as errors'
+              queryType: stats
           - refId: reduce
             datasourceUid: __expr__
             relativeTimeRange:
@@ -93,7 +106,9 @@ groups:
             model:
               refId: reduce
               type: reduce
-              reducer: count
+              # `last`, not `count`: the stats query already returns the
+              # count as a single Time/Value point.
+              reducer: last
               expression: query
           - refId: threshold
             datasourceUid: __expr__
@@ -109,8 +124,10 @@ groups:
                   operator: { type: and }
                   reducer: { params: [], type: last }
                   type: query
-        noDataState: OK
-        execErrState: OK
+        # Fail-loud for the mail-chain rules — a masked eval error is how
+        # M1's defect stayed invisible for 3.5 months (see mailer-rules.yaml).
+        noDataState: Alerting
+        execErrState: Alerting
         for: 0s
         keepFiringFor: 30m
         isPaused: false

--- a/deploy/grafana/provisioning/alerting/mailer-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/mailer-rules.yaml
@@ -111,7 +111,7 @@ groups:
         data:
           - refId: query
             datasourceUid: victorialogs
-            queryType: instant
+            queryType: stats
             relativeTimeRange:
               from: 900
               to: 0
@@ -134,8 +134,22 @@ groups:
               # ever exists (e.g. Slack incident-bridge), revisit this
               # filter to add target narrowing (as an additional
               # unqualified phrase, not a field qualifier).
-              expr: 'service:zitadel AND "sending notification failed"'
-              queryType: instant
+              #
+              # `| stats count()` + queryType `stats` is REQUIRED, not
+              # style: a live-fire test on 2026-08-12 (10 real failure
+              # lines injected via a controlled mailer stop) proved that
+              # the bare-filter + `queryType: instant` + `reduce: count`
+              # shape ERRORS at evaluation with "input data must be a
+              # wide series but got type long" the moment the query
+              # matches rows — i.e. exactly when the alert must fire —
+              # and `execErrState: OK` then masked that error as Normal.
+              # With plugin v0.31.0, `| stats count()` + queryType
+              # `stats` returns a numeric Time/Value frame (verified via
+              # /api/ds/query: 10 matches → Value=10, zero matches →
+              # Value=0, no NoData), which the reduce/threshold chain
+              # consumes correctly.
+              expr: 'service:zitadel AND "sending notification failed" | stats count() as failures'
+              queryType: stats
           - refId: reduce
             datasourceUid: __expr__
             relativeTimeRange:
@@ -144,7 +158,10 @@ groups:
             model:
               refId: reduce
               type: reduce
-              reducer: count
+              # `last`, not `count`: the stats query already returns the
+              # count as a single Time/Value point; `count` here would
+              # count frame rows (always 1) instead of reading the value.
+              reducer: last
               expression: query
           - refId: threshold
             datasourceUid: __expr__
@@ -160,8 +177,14 @@ groups:
                   operator: { type: and }
                   reducer: { params: [], type: last }
                   type: query
-        noDataState: OK
-        execErrState: OK
+        # Fail-loud (Alerting), deviating from the execErrState: OK
+        # convention in this file's other rules: for the mail-chain rules
+        # specifically, a broken evaluation masked as Normal is exactly how
+        # this alert's own defect stayed invisible for 3.5 months. The
+        # stats-shape fix above removes the known plugin error class, so a
+        # remaining eval error or missing data is a real signal.
+        noDataState: Alerting
+        execErrState: Alerting
         for: 0s
         keepFiringFor: 30m
         isPaused: false


### PR DESCRIPTION
## Problem — found by live-fire testing the alert

After #846 fixed M1's dead query, a controlled live-fire test (26s mailer stop + e2e-bot password reset → 10 real failure lines in zitadel logs) showed M1 **still cannot fire**: evaluation errors with `input data must be a wide series but got type long`, masked to Normal by `execErrState: OK`. Root cause: a bare LogsQL filter with `queryType: instant` returns log-row frames; Grafana SSE `reduce` chokes on them **precisely when rows match** — i.e. when the alert should fire. Same limitation already documented in caddy-rules.yaml (2026-04-22); it affects the whole LogsQL-count alert family.

## Fix (verified against the live datasource, plugin v0.31.0)

Via `POST /api/ds/query`:
- `... | stats count() as failures` + `queryType: stats` → numeric Time/Value frame: **10 matches → Value=10, zero matches → Value=0** (no NoData)
- bare filter + instant → logs frame (breaks reduce)

Applied to both mail-chain rules (M1 `obs-001-mailer-zitadel-webhook-failed`, Z2 `obs-mailer-error-log-high`):
1. stats-pipe expr + `queryType: stats`
2. `reduce: count → last` (the value already is the count)
3. `noDataState`/`execErrState`: OK → **Alerting** — fail-loud; a masked eval error is how M1's defect stayed invisible for 3.5 months

## Validation

- `audit-alert-uid-length.sh` OK, `test-alerting-guards.sh` all pass, YAML parse OK
- Post-merge plan: re-inject a controlled failure and confirm the rule reaches `Alerting` + ops email

## Follow-up (out of scope)

All other LogsQL count alerts (caddy, portal-events, portal-auth, mailer M2, ingest, litellm, …) share the broken instant+reduce:count shape and only work in a narrow row-count regime. They need the same stats-shape treatment — tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)