### PR TITLE
fix(alerting): replace Sprig 'default' with if/else in email subjects

### DIFF
--- a/deploy/grafana/provisioning/alerting/contact-points.yaml
+++ b/deploy/grafana/provisioning/alerting/contact-points.yaml
@@ -41,7 +41,12 @@ contactPoints:
         settings:
           addresses: hello@getklai.com
           singleEmail: false
-          subject: '[KLAI-ALERT fallback] {{ .CommonLabels.alertname | default "unknown" }}'
+          # NOTE: `| default "x"` is a Sprig function that Grafana's alert
+          # templating does NOT provide — it fails with `function "default"
+          # not defined` on EVERY notification through this receiver and the
+          # email falls back to partial/default content (found 2026-08-12 by
+          # live-firing the mail-chain alert). Use if/else instead.
+          subject: '[KLAI-ALERT fallback] {{ if .CommonLabels.alertname }}{{ .CommonLabels.alertname }}{{ else }}unknown{{ end }}'
         disableResolveMessage: false
 
   - orgId: 1
@@ -76,7 +81,9 @@ contactPoints:
         settings:
           addresses: hello@getklai.com
           singleEmail: false
-          subject: '[KLAI-ALERT-{{ .CommonLabels.severity | default "info" }}] {{ .CommonLabels.alertname }}'
+          # See the `default`-is-not-a-Grafana-template-function note on the
+          # fallback receiver above — same fix applied here (2026-08-12).
+          subject: '[KLAI-ALERT-{{ if .CommonLabels.severity }}{{ .CommonLabels.severity }}{{ else }}info{{ end }}] {{ .CommonLabels.alertname }}'
           message: |
             {{ range .Alerts -}}
             [{{ .Status | toUpper }}] {{ .Labels.alertname }}


### PR DESCRIPTION
Found by live-firing the mail-chain alert (2026-08-12): Grafana's alert templating has no Sprig `default` function, so both email receivers' subjects (`grafana-default-email`, `klai-ops-alerts-email`) failed to render on **every** notification:

```
logger=ngalert.notifier level=warn receiver=klai-ops-alerts-email integration=email[0] msg="failed to template email message" err="template: :1: function \"default\" not defined"
```

Grafana still sends the mail but with fallback/partial content. Fix: Go-template `{{ if }}…{{ else }}…{{ end }}` instead of `| default`. Validated: YAML parse, alerting guards, secrets audit. Post-merge: verified via a test-notification through the receiver.

Rollback: `git revert` (only re-breaks the subject rendering, mails keep flowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)