### PR TITLE
fix(portal): language save 500 (RLS WITH CHECK) + dead NL/EN toggle on set-password page

### DIFF
--- a/klai-portal/backend/app/api/me.py
+++ b/klai-portal/backend/app/api/me.py
@@ -493,6 +493,13 @@ async def update_my_language(
     if not user:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
+    # portal_users is Category-A RLS: the SELECT above is allowed without
+    # tenant context (permissive IS-NULL branch), but the UPDATE below is
+    # checked against the strict WITH CHECK policy — without set_tenant the
+    # commit raises InsufficientPrivilegeError and every language save 500s
+    # ("Save failed", 2026-08-12 user report).
+    await set_tenant(db, user.org_id)
+
     user.preferred_language = body.preferred_language
     await db.commit()
 

--- a/klai-portal/backend/tests/test_me_language_rls.py
+++ b/klai-portal/backend/tests/test_me_language_rls.py
@@ -1,0 +1,96 @@
+"""PATCH /api/me/language must set tenant context before writing portal_users.
+
+Reproduction for the 2026-08-12 "Save failed" report: portal_users is a
+Category-A RLS table — SELECT has the permissive IS-NULL branch (auth runs
+before tenant context exists), but WITH CHECK is strict. The handler looked
+the user up via the permissive read and then committed an UPDATE without ever
+calling set_tenant, so every language save failed with
+InsufficientPrivilegeError: new row violates row-level security policy for
+table "portal_users" (portal-api logs 12:31 UTC, PATCH /api/me/language 500).
+
+Contract: after resolving the caller's portal_users row, the handler calls
+set_tenant(db, user.org_id) BEFORE the mutating commit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _db_returning_user(user: MagicMock) -> AsyncMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestUpdateMyLanguageTenantContext:
+    @pytest.mark.asyncio
+    async def test_set_tenant_called_with_user_org_before_commit(self) -> None:
+        from app.api.me import LanguageUpdate, update_my_language
+
+        user = MagicMock()
+        user.org_id = 8
+        db = _db_returning_user(user)
+
+        call_order: list[str] = []
+        set_tenant_mock = AsyncMock(side_effect=lambda *_a, **_k: call_order.append("set_tenant"))
+        db.commit = AsyncMock(side_effect=lambda: call_order.append("commit"))
+
+        creds = MagicMock()
+        creds.credentials = "token"
+
+        zit = MagicMock()
+        zit.get_userinfo = AsyncMock(return_value={"sub": "zuser-1"})
+        zit.update_user_language = AsyncMock()
+
+        with (
+            patch("app.api.me.zitadel", zit),
+            patch("app.api.me.set_tenant", set_tenant_mock),
+        ):
+            resp = await update_my_language(
+                body=LanguageUpdate(preferred_language="en"),
+                credentials=creds,
+                db=db,
+            )
+
+        set_tenant_mock.assert_awaited_once_with(db, 8)
+        assert call_order == ["set_tenant", "commit"], (
+            "set_tenant must run BEFORE the mutating commit — a commit without "
+            "tenant context trips portal_users' strict WITH CHECK policy"
+        )
+        assert user.preferred_language == "en"
+        assert resp.message
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_404s_without_tenant_or_commit(self) -> None:
+        from fastapi import HTTPException
+
+        from app.api.me import LanguageUpdate, update_my_language
+
+        db = _db_returning_user(None)  # type: ignore[arg-type]
+        set_tenant_mock = AsyncMock()
+
+        creds = MagicMock()
+        creds.credentials = "token"
+
+        zit = MagicMock()
+        zit.get_userinfo = AsyncMock(return_value={"sub": "zuser-unknown"})
+
+        with (
+            patch("app.api.me.zitadel", zit),
+            patch("app.api.me.set_tenant", set_tenant_mock),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await update_my_language(
+                body=LanguageUpdate(preferred_language="en"),
+                credentials=creds,
+                db=db,
+            )
+
+        assert exc.value.status_code == 404
+        set_tenant_mock.assert_not_awaited()
+        db.commit.assert_not_awaited()

--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { KeyRound } from 'lucide-react'
 import * as m from '@/paraglide/messages'
+import { useLocale } from '@/lib/locale'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
 import { API_BASE } from '@/lib/api'
 import { readCsrfCookie } from '@/lib/auth'
@@ -34,6 +35,10 @@ export const Route = createFileRoute('/password/set')({
 })
 
 function PasswordSetPage() {
+  // Subscribe to the locale context so the NL/EN switcher re-renders this
+  // page's m.* strings. Without this the toggle silently does nothing here
+  // (2026-08-12 user report) — same bare-call pattern as verify.tsx.
+  useLocale()
   const { userID, code } = Route.useSearch()
 
   const [password, setPassword] = useState('')


### PR DESCRIPTION
User report 2026-08-12 (first activated re-invitee, voys.co.za):

## Bug 1 — "Save failed" on account language setting (backend, affects ALL users)

`PATCH /api/me/language` 500s on every call. Traced via caddy access logs (3× 500, 12:31 UTC) + portal-api traceback:

```
UPDATE portal_users SET preferred_language='en' WHERE id=142
→ InsufficientPrivilegeError: new row violates row-level security policy for table "portal_users"
```

portal_users is **Category-A RLS**: SELECT is permissive without tenant context (auth-path), but WITH CHECK on writes is strict. The handler did the permissive lookup and committed without `set_tenant`. Fix: `await set_tenant(db, user.org_id)` before the mutation. Reproduction-first test (`tests/test_me_language_rls.py`) asserts set_tenant-before-commit ordering; failed pre-fix with the exact missing-call, passes post-fix.

Why no test caught it: `test_rls_callsite_audit.py` audits Cat-D models only, and ORM attribute-mutation+commit is statically invisible to it. Cat-A writes remain a review surface (see pitfall `rls-with-check-blocks-migration-update` — this is its runtime sibling).

## Bug 2 — NL/EN toggle dead on /password/set (frontend)

The set-password page renders paraglide `m.*` strings but never subscribes to the locale context; `switchLocale()` only re-renders subscribed components (login subscribes → works). Fix: bare `useLocale()` call, same precedent as `verify.tsx:40`. Audit of all `showLocale` pages: this was the only unsubscribed one.

## Validation

- Backend: new tests pass (2), `ruff check` + `format --check` clean; full suite in CI
- Frontend: `eslint` clean; `tsc` deprecation warning is pre-existing (local TS 6.0.3, also on untouched main)
- Post-deploy plan: Playwright click-through of the EN toggle on the live page; watch `/api/me/language` for 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)