### PR TITLE
fix(invite): add membership for existing initialized accounts instead of 500

### DIFF
--- a/klai-portal/backend/app/api/admin/users.py
+++ b/klai-portal/backend/app/api/admin/users.py
@@ -43,6 +43,7 @@ from app.services.kb_offboarding import (
     revoke_user_credentials,
 )
 from app.services.mcp_role_notifier import fire_role_change_notification
+from app.services.notifications import notify_user_join_approved
 from app.services.user_deletion_orchestrator import delete_user_with_state_machine
 from app.services.user_memberships import get_user_membership_summary
 from app.services.zitadel import _sync_zitadel_role_grant, zitadel
@@ -272,6 +273,12 @@ async def _reuse_existing_zitadel_user_for_invite(
     )
 
 
+def _is_already_initialized_error(exc: httpx.HTTPStatusError) -> bool:
+    """True when Zitadel refused an invite code because the account already
+    completed setup (400, COMMAND-EF34g "User is already initialized")."""
+    return exc.response.status_code == 400 and "already initialized" in exc.response.text.lower()
+
+
 def _invite_failure_detail(failure_step: str) -> str:
     if failure_step == "invite_mail":
         return "Uitnodigingsmail kon niet worden verstuurd. Probeer het opnieuw."
@@ -327,7 +334,33 @@ async def _persist_invited_user_and_send_code(
             await zitadel.unlock_user(zitadel_user_id, settings.zitadel_portal_org_id)
             reactivated_zitadel_user = True
         failure_step = "invite_mail"
-        await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+        try:
+            await zitadel.send_invite_code(zitadel_user_id, url_template=invite_url_template)
+        except httpx.HTTPStatusError as invite_exc:
+            if not _is_already_initialized_error(invite_exc):
+                raise
+            # Existing fully-initialized account (self-signup, or a member of
+            # another tenant): Zitadel refuses invite codes for accounts that
+            # already completed setup, and there is nothing to activate — the
+            # membership row above IS the actual grant. Send a "you've been
+            # added" notification instead (best-effort, same mail as
+            # join-request approval) and continue to the commit. 2026-08-12
+            # report: a voys.be self-signup could not be invited (400
+            # "User is already initialized" surfaced as a raw 500).
+            _slog.info(
+                "invite_existing_initialized_membership_added",
+                zitadel_user_id=zitadel_user_id,
+                email_hash=email_hash_for_log(str(body.email)),
+                org_id=org.id,
+            )
+            try:
+                await notify_user_join_approved(
+                    email=str(body.email),
+                    display_name=f"{body.first_name} {body.last_name}".strip() or str(body.email),
+                    workspace_url=f"https://{settings.domain}",
+                )
+            except Exception:
+                _slog.warning("invite_existing_initialized_notify_failed", exc_info=True)
         failure_step = "portal_commit"
         await db.commit()
     except Exception as exc:

--- a/klai-portal/backend/tests/test_invite_initialized_user.py
+++ b/klai-portal/backend/tests/test_invite_initialized_user.py
@@ -1,0 +1,131 @@
+"""Inviting an existing, fully-initialized account must add membership, not 500.
+
+Reproduction for the 2026-08-12 report (request f2b514c8): a voys.be user
+self-signed-up first; the admin invite then hit Zitadel 409 "User already
+exists", the identity recovery correctly reused the ACTIVE account, but
+``send_invite_code`` failed with 400 "User is already initialized
+(COMMAND-EF34g)" — Zitadel refuses invite codes for accounts that already
+completed setup. The exception leg turned that into a raw 500 in the UI and
+rolled back the membership.
+
+Contract (industry pattern — Slack/Notion/GitHub org invites): an invite for
+an existing initialized account creates the membership and sends a
+"you've been added to workspace X" notification instead of an activation
+invite. Any OTHER invite-mail failure keeps the existing rollback+cleanup leg.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+def _initialized_400() -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://auth.example.com/v2/users/1/invite_code")
+    resp = httpx.Response(
+        400,
+        request=req,
+        text='{"code":9, "message":"User is already initialized (COMMAND-EF34g)"}',
+    )
+    return httpx.HTTPStatusError("400", request=req, response=resp)
+
+
+def _other_400() -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://auth.example.com/v2/users/1/invite_code")
+    resp = httpx.Response(400, request=req, text='{"code":3, "message":"Errors.User.Code.Invalid"}')
+    return httpx.HTTPStatusError("400", request=req, response=resp)
+
+
+def _org(org_id: int = 8, slug: str = "voys") -> MagicMock:
+    org = MagicMock()
+    org.id = org_id
+    org.slug = slug
+    return org
+
+
+def _body(email: str = "thijs.joos@voys.be") -> MagicMock:
+    body = MagicMock()
+    body.email = email
+    body.first_name = "Thijs"
+    body.last_name = "Joos"
+    return body
+
+
+async def _run_persist(zit: MagicMock, notify: AsyncMock, cleanup: AsyncMock, db: AsyncMock):
+    from app.api.admin.users import _persist_invited_user_and_send_code
+
+    with (
+        patch("app.api.admin.users.zitadel", zit),
+        patch("app.api.admin.users.notify_user_join_approved", notify),
+        patch(
+            "app.services.default_knowledge_bases.create_default_personal_kb",
+            AsyncMock(),
+        ),
+    ):
+        await _persist_invited_user_and_send_code(
+            db=db,
+            org=_org(),
+            body=_body(),
+            zitadel_user_id="385955253213724721",
+            user_row=MagicMock(),
+            reactivated_membership=None,
+            reactivated_existing_zitadel_user=False,
+            invite_url_template="https://my.example.com/password/set?userID={{.UserID}}&code={{.Code}}",
+            cleanup_zitadel_user=cleanup,
+        )
+
+
+class TestInviteInitializedAccount:
+    @pytest.mark.asyncio
+    async def test_already_initialized_adds_membership_and_notifies(self) -> None:
+        zit = MagicMock()
+        zit.send_invite_code = AsyncMock(side_effect=_initialized_400())
+        notify = AsyncMock()
+        cleanup = AsyncMock()
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        await _run_persist(zit, notify, cleanup, db)
+
+        db.commit.assert_awaited_once()
+        db.rollback.assert_not_awaited()
+        cleanup.assert_not_awaited()
+        notify.assert_awaited_once()
+        kwargs = notify.await_args.kwargs
+        assert kwargs["email"] == "thijs.joos@voys.be"
+        assert kwargs["workspace_url"].startswith("https://")
+
+    @pytest.mark.asyncio
+    async def test_other_invite_mail_failure_keeps_rollback_leg(self) -> None:
+        from fastapi import HTTPException
+
+        zit = MagicMock()
+        zit.send_invite_code = AsyncMock(side_effect=_other_400())
+        notify = AsyncMock()
+        cleanup = AsyncMock()
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        with pytest.raises(HTTPException):
+            await _run_persist(zit, notify, cleanup, db)
+
+        db.rollback.assert_awaited_once()
+        cleanup.assert_awaited_once()
+        notify.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_notify_failure_does_not_block_membership(self) -> None:
+        """The membership grant is the real mutation; the mail is best-effort."""
+        zit = MagicMock()
+        zit.send_invite_code = AsyncMock(side_effect=_initialized_400())
+        notify = AsyncMock(side_effect=RuntimeError("mailer down"))
+        cleanup = AsyncMock()
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        await _run_persist(zit, notify, cleanup, db)
+
+        db.commit.assert_awaited_once()
+        cleanup.assert_not_awaited()


### PR DESCRIPTION
## Problem (user report 2026-08-12, request `f2b514c8`)

A voys.be colleague self-signed-up first; the admin invite then dead-ends with a raw **500** in the invite form. Trace:

1. Invite → Zitadel create → 409 "User already exists" (expected — identity recovery reuses the ACTIVE account)
2. `send_invite_code` → **400 "User is already initialized" (COMMAND-EF34g)** — Zitadel refuses invite codes for accounts that completed setup
3. Unhandled → rollback membership → HTTP 500 → UI shows "500"

The identity-lifecycle matrix was missing the leg: **Zitadel identity exists + fully initialized + no membership in this org.** The recovery service treats every ACTIVE account as invite-code-ready, which only holds for stuck invitees (no auth methods).

## Fix

In `_persist_invited_user_and_send_code`: catch exactly the already-initialized 400 → keep the membership (that row IS the grant), skip the activation mail, and send the existing `join_request_approved` "you've been added to workspace" notification instead (best-effort, same mail as join-request approval). Structured event `invite_existing_initialized_membership_added` for observability. All other invite-mail failures keep the rollback+cleanup leg — pinned by test.

This is the standard multi-workspace pattern (Slack/Notion/GitHub): inviting an existing account grants membership + notifies; it never re-onboards the identity.

## Safety check performed

The failure cleanup did NOT delete the reporter's account: `_cleanup_zitadel_user` skips pre-existing identities (`invite_zitadel_cleanup_skipped_existing_user`). Verified in code; account intact.

## Tests

`tests/test_invite_initialized_user.py` (reproduction-first — failed pre-fix):
- already-initialized → membership committed + notify sent + no cleanup
- any other invite-mail 400 → rollback + cleanup leg unchanged
- notify failure does not block the membership commit

Full backend suite: **3405 passed**. ruff + format clean, pyright 0 errors.

## Post-merge verification

Admin retries the invite from the UI → should return success; invitee receives "you've been added" mail and logs in with their existing credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)