### PR TITLE
ci(knowledge-ingest): parallelize pytest with xdist (43 min -> ~25-30 min est.)

### DIFF
--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: "3.12"
           enable-cache: true
       - name: Test (pytest)
-        run: uv run --frozen --extra dev pytest -q --tb=short
+        run: uv run --frozen --extra dev pytest -q --tb=short -n auto
 
   build-push:
     needs: tests

--- a/klai-knowledge-ingest/pyproject.toml
+++ b/klai-knowledge-ingest/pyproject.toml
@@ -54,6 +54,7 @@ klai-llm-safety = { path = "../klai-libs/llm-safety", editable = true }
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
+    "pytest-xdist>=3.6",
     "httpx>=0.27",
     "ruff>=0.8",
 ]
@@ -83,5 +84,6 @@ asyncio_mode = "auto"
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "pytest-xdist>=3.6",
     "ruff>=0.15.8",
 ]

--- a/klai-knowledge-ingest/uv.lock
+++ b/klai-knowledge-ingest/uv.lock
@@ -605,6 +605,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "falkordb"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1348,6 +1357,7 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1355,6 +1365,7 @@ dev = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1381,6 +1392,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", specifier = ">=1.12" },
     { name = "ragas", specifier = ">=0.4.3" },
@@ -1397,6 +1409,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.15.8" },
 ]
 
@@ -2681,6 +2694,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- The `tests` job in `.github/workflows/knowledge-ingest.yml` runs the full
  ~1123-test pytest suite single-threaded on a 2-core GitHub runner and takes
  ~43 minutes — roughly 90% of every knowledge-ingest deploy's wall-clock
  time, since every other job in the pipeline finishes in 0-3 minutes.
- Adds `pytest-xdist` to `klai-knowledge-ingest/pyproject.toml` (both the
  `dev` optional-dependency group used by CI's `--extra dev`, and the `dev`
  dependency-group used by plain `uv sync` for local runs) and appends
  `-n auto` to the CI pytest invocation.

## Local verification (parallel-safety)

Ran the full suite twice locally (18 cores) before pushing this:

| Mode | Result | Wall time |
|---|---|---|
| Serial (current CI behavior) | 1208 passed, 4 skipped, 1 failed | 355.91s (~5:56) |
| Parallel (`-n auto`, this PR's change) | 1208 passed, 4 skipped, 1 failed | 259.20s (~4:19) |

The pass/fail/skip sets are **identical** between the two runs, so `xdist`
introduces zero additional failures or flakiness on this suite.

The single failure in both runs
(`test_ingest_caller_contract.py::test_ingest_v1_document_caller_set_is_known`)
is a pre-existing artifact specific to this local worktree: the checkout path
contains a `.claude` component, which collides with that test's own
`noise_dirs` filter (`.claude` is one of the excluded directory names), so it
scans zero files and reports every expected caller as "missing". It fails
identically with or without `-n auto`, is unrelated to this change, and will
not occur in CI, where the repo is checked out at a normal path.

## CI runtime estimate — please watch the first run

Locally, 18-way parallelism only cut wall time by ~27% (355s -> 259s), well
below the naive 18x you'd expect from core count — likely per-worker import
overhead (FastAPI, sklearn/umap/graphiti, etc.) and a handful of CPU-bound
outlier tests that don't shrink with more workers. The GitHub runner only has
2 cores, so the realistic expectation is somewhere between 1.3x and 2x, i.e.
**~22-33 minutes**, not a dramatic drop to 12-15 minutes.

**This PR should be watched on its first CI run** to confirm the actual
runner-side speedup and to catch any flakiness under the runner's real
2-core/2-worker split that didn't show up with 18 local workers.

## Test plan

- [x] `uv lock` + `uv sync` regenerate cleanly with `pytest-xdist` pinned
- [x] Full suite passes locally in parallel with the same pass/fail/skip set
      as serial
- [ ] Watch first CI run on this PR to confirm actual wall-clock improvement
      and no new flakiness under the runner's 2-core split

🤖 Generated with [Claude Code](https://claude.com/claude-code)