### PR TITLE
fix(partner-api): clip retrieval conversation history to 7800 chars

### DIFF
--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -152,10 +152,39 @@ def _normalize_llm_message(message: dict) -> dict[str, str] | None:
     return None
 
 
+# Mirrors RETRIEVE_HISTORY_MAX_CONTENT_CHARS in deploy/litellm/klai_kb_request_context.py:
+# retrieval-api hard-rejects conversation_history content > 8000 chars with 422
+# (SPEC-SEC-010 REQ-2.5) and deliberately never truncates server-side, so callers
+# must clip below that limit before sending.
+_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS = 7800
+_RETRIEVAL_HISTORY_OMISSION_MARKER = "\n\n[... content omitted from retrieval conversation history ...]\n\n"
+
+
+def _clip_retrieval_history_content(content: str) -> str:
+    """Mirror of clip_retrieval_history_content in deploy/litellm/klai_kb_request_context.py.
+
+    Keeps the head and tail of oversized content with an omission marker in the
+    middle, so coreference resolution still sees how the turn started and ended.
+    """
+    max_chars = _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS
+    if len(content) <= max_chars:
+        return content
+
+    marker = _RETRIEVAL_HISTORY_OMISSION_MARKER
+    remaining = max_chars - len(marker)
+    head_chars = remaining // 2
+    tail_chars = remaining - head_chars
+    return content[:head_chars].rstrip() + marker + content[-tail_chars:].lstrip()
+
+
 def _build_conversation_history(messages: list[dict]) -> list[dict]:
-    """Return up to the last 6 turns (3 exchanges), excluding the last user message."""
+    """Return up to the last 6 turns (3 exchanges), excluding the last user message.
+
+    Content is clipped per entry so retrieval-api's 8000-char 422 guard never
+    trips; the messages sent to the LLM are untouched.
+    """
     history = [msg for m in messages[:-1] if (msg := _normalize_llm_message(m)) is not None]
-    return history[-6:]
+    return [{**msg, "content": _clip_retrieval_history_content(msg["content"])} for msg in history[-6:]]
 
 
 def _clean_page_context(page_context: PageContext | None) -> PageContext | None:

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -2956,3 +2956,66 @@ async def test_retrieve_context_omits_user_id_when_partner_user_id_none(monkeypa
     assert "user_id" not in captured["body"], (
         f"user_id leaked into body without explicit partner_user_id: {captured['body']}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Retrieval conversation-history clipping (fix/partner-history-clip-502)
+# ---------------------------------------------------------------------------
+
+
+def test_build_conversation_history_clips_oversized_content():
+    """retrieval-api 422-rejects any conversation_history content > 8000 chars
+    (SPEC-SEC-010 REQ-2.5) and deliberately never truncates server-side, so
+    portal-api must clip before sending — otherwise the partner gets a 502."""
+    from app.services.partner_chat import _build_conversation_history
+
+    long_content = "A" * 4500 + "B" * 4500  # 9000 chars, distinct head/tail
+    messages = [
+        {"role": "user", "content": long_content},
+        {"role": "assistant", "content": "short answer"},
+        {"role": "user", "content": "current question"},
+    ]
+
+    history = _build_conversation_history(messages)
+
+    assert len(history) == 2
+    assert len(history[0]["content"]) <= 7800, (
+        f"history content must be clipped to <= 7800 chars, got {len(history[0]['content'])}"
+    )
+    # Mirrors clip_retrieval_history_content semantics: keep head + tail,
+    # mark the omitted middle.
+    assert history[0]["content"].startswith("A")
+    assert history[0]["content"].endswith("B")
+    assert "omitted" in history[0]["content"]
+    assert history[1]["content"] == "short answer"
+
+
+def test_build_conversation_history_keeps_content_at_clip_boundary():
+    """Content exactly at the 7800-char clip boundary passes through untouched."""
+    from app.services.partner_chat import _build_conversation_history
+
+    boundary_content = "y" * 7800
+    messages = [
+        {"role": "user", "content": boundary_content},
+        {"role": "user", "content": "current question"},
+    ]
+
+    history = _build_conversation_history(messages)
+
+    assert history[0]["content"] == boundary_content
+
+
+def test_build_conversation_history_window_and_role_filtering():
+    """Last-6 window and user/assistant role filtering are unchanged."""
+    from app.services.partner_chat import _build_conversation_history
+
+    messages: list[dict] = [{"role": "system", "content": "sys"}]
+    for i in range(5):
+        messages.append({"role": "user", "content": f"q{i}"})
+        messages.append({"role": "assistant", "content": f"a{i}"})
+    messages.append({"role": "user", "content": "current"})
+
+    history = _build_conversation_history(messages)
+
+    assert [m["content"] for m in history] == ["q2", "a2", "q3", "a3", "q4", "a4"]
+    assert all(m["role"] in ("user", "assistant") for m in history)


### PR DESCRIPTION
## Root cause

POST `/partner/v1/chat/completions` (knowledge path) forwards up to the last 6 prior user/assistant turns to retrieval-api for coreference resolution. `_build_conversation_history` in `klai-portal/backend/app/services/partner_chat.py` did **not** clip per-entry content length. retrieval-api hard-rejects any `conversation_history[i].content` longer than 8000 chars with HTTP 422 and deliberately refuses to truncate server-side (`klai-retrieval-api/retrieval_api/models.py`, `_CONVERSATION_CONTENT_MAX_CHARS` + `_validate_conversation_content_length`, SPEC-SEC-010 REQ-2.5/2.6). portal-api's retrieve call raises on 4xx, so the partner got HTTP 502 "Retrieval service error".

Real-world trigger: a partner puts a call transcript (>8000 chars) in a prior turn.

## Fix

Mirror the existing LiteLLM-side solution (`clip_retrieval_history_content` in `deploy/litellm/klai_kb_request_context.py`, `RETRIEVE_HISTORY_MAX_CONTENT_CHARS` = 7800): clip each history entry to 7800 chars, keeping head + tail with an omission marker in the middle. Implemented locally in `partner_chat.py` (no import from `deploy/litellm` — separate deployable), with a comment referencing the mirrored constant. Only the retrieval `conversation_history` is clipped; the messages sent to the LLM are untouched.

## Failing-test-first evidence

New test `test_build_conversation_history_clips_oversized_content` on pre-fix code:

```
E       AssertionError: history content must be clipped to <= 7800 chars, got 9000
E       assert 9000 <= 7800
FAILED tests/test_partner_chat.py::test_build_conversation_history_clips_oversized_content
1 failed, 2 passed, 81 deselected
```

## Test results (post-fix)

- `uv run pytest tests/test_partner_chat.py -q` → **84 passed** (includes 3 new tests: oversized clip, exact-7800 boundary untouched, last-6 window + role filtering unchanged)
- Adjacent files `tests/test_partner_openai_compat.py tests/test_partner_chat_upstream_errors.py tests/test_partner_chat_web_search.py` → **78 passed**
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 668 files already formatted

## Rollback

```
git revert e610a05f8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)