### PR TITLE
feat(partner-api): forward prompt_cache_key to Mistral via LiteLLM extra_body

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -105,6 +105,7 @@ _OPENAI_COMPAT_MAX_BODY_BYTES = 131_072
 _OPENAI_COMPAT_DEFAULT_MAX_TOKENS = 2048
 _OPENAI_COMPAT_MAX_TOKENS = 4096
 _OPENAI_COMPAT_MAX_N = 1
+_OPENAI_COMPAT_MAX_PROMPT_CACHE_KEY_CHARS = 256
 _OPENAI_COMPAT_FORWARD_FIELDS = {
     "frequency_penalty",
     "logit_bias",
@@ -116,6 +117,7 @@ _OPENAI_COMPAT_FORWARD_FIELDS = {
     "n",
     "parallel_tool_calls",
     "presence_penalty",
+    "prompt_cache_key",
     "reasoning_effort",
     "response_format",
     "seed",
@@ -690,6 +692,26 @@ def _validated_openai_compatible_body(body: dict[str, Any]) -> dict[str, Any]:
             )
     if forwarded.get("max_tokens") is None and forwarded.get("max_completion_tokens") is None:
         forwarded["max_tokens"] = _OPENAI_COMPAT_DEFAULT_MAX_TOKENS
+
+    if "prompt_cache_key" in forwarded:
+        prompt_cache_key = forwarded["prompt_cache_key"]
+        if (
+            not isinstance(prompt_cache_key, str)
+            or not prompt_cache_key
+            or len(prompt_cache_key) > _OPENAI_COMPAT_MAX_PROMPT_CACHE_KEY_CHARS
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": {
+                        "type": "invalid_request",
+                        "message": (
+                            "prompt_cache_key must be a non-empty string of at most "
+                            f"{_OPENAI_COMPAT_MAX_PROMPT_CACHE_KEY_CHARS} characters"
+                        ),
+                    }
+                },
+            )
 
     return forwarded
 

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -1253,9 +1253,19 @@ def _sse_error_frame(message: str) -> bytes:
 
 
 def _with_openai_passthrough_metadata(body: dict[str, Any]) -> dict[str, Any]:
-    """Mark portal-proxied OpenAI-compatible calls so LiteLLM hooks stay transparent."""
+    """Mark portal-proxied OpenAI-compatible calls so LiteLLM hooks stay transparent.
+
+    Also translates the OpenAI-style top-level ``prompt_cache_key`` into
+    ``extra_body`` so LiteLLM delivers it to Mistral (LiteLLM's mistral chat
+    transformation drops the top-level field under ``drop_params: true``).
+    The translation OVERWRITES ``extra_body`` — caller-supplied ``extra_body``
+    is never merged or forwarded.
+    """
     forwarded = dict(body)
     forwarded["metadata"] = {"_klai_openai_passthrough": True}
+    prompt_cache_key = forwarded.pop("prompt_cache_key", None)
+    if prompt_cache_key is not None:
+        forwarded["extra_body"] = {"prompt_cache_key": prompt_cache_key}
     return forwarded
 
 

--- a/klai-portal/backend/tests/test_partner_openai_compat.py
+++ b/klai-portal/backend/tests/test_partner_openai_compat.py
@@ -142,6 +142,162 @@ async def test_openai_compatible_chat_defaults_output_cap(monkeypatch):
     assert forwarded.await_args.args[0]["max_tokens"] == 2048
 
 
+def test_openai_passthrough_metadata_translates_prompt_cache_key_to_extra_body():
+    from app.services.partner_chat import _with_openai_passthrough_metadata
+
+    body = {"prompt_cache_key": "abc", "messages": [{"role": "user", "content": "hi"}]}
+
+    forwarded = _with_openai_passthrough_metadata(body)
+
+    assert forwarded["extra_body"] == {"prompt_cache_key": "abc"}
+    assert "prompt_cache_key" not in forwarded
+    assert body["prompt_cache_key"] == "abc"
+
+
+def test_openai_passthrough_metadata_overwrites_caller_extra_body():
+    from app.services.partner_chat import _with_openai_passthrough_metadata
+
+    body = {
+        "prompt_cache_key": "abc",
+        "extra_body": {"api_key": "sk-attacker", "prompt_cache_key": "other"},
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    forwarded = _with_openai_passthrough_metadata(body)
+
+    assert forwarded["extra_body"] == {"prompt_cache_key": "abc"}
+
+
+def test_openai_passthrough_metadata_no_extra_body_when_key_absent():
+    from app.services.partner_chat import _with_openai_passthrough_metadata
+
+    forwarded = _with_openai_passthrough_metadata({"messages": [{"role": "user", "content": "hi"}]})
+
+    assert "extra_body" not in forwarded
+
+
+@pytest.mark.asyncio
+async def test_openai_non_streaming_sends_prompt_cache_key_as_extra_body_to_litellm(monkeypatch):
+    from types import SimpleNamespace
+
+    from app.services import partner_chat
+
+    captured: dict = {}
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"choices": []}
+    resp.raise_for_status = MagicMock()
+
+    client = MagicMock()
+
+    async def post(url, json=None, headers=None):
+        captured["json"] = json
+        return resp
+
+    client.post = post
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(partner_chat.httpx, "AsyncClient", MagicMock(return_value=client))
+
+    settings = SimpleNamespace(
+        litellm_base_url="http://litellm",
+        litellm_general_chat_key="general-key",
+        litellm_master_key="master-key",
+    )
+
+    await partner_chat.openai_chat_completion_non_streaming(
+        {"messages": [{"role": "user", "content": "hi"}], "prompt_cache_key": "abc"},
+        settings,
+    )
+
+    assert captured["json"]["extra_body"] == {"prompt_cache_key": "abc"}
+    assert "prompt_cache_key" not in captured["json"]
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_forwards_prompt_cache_key(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    await partner.openai_compatible_chat_completions(
+        http_request=_request(
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "prompt_cache_key": "partner-1-conv-42",
+            }
+        ),
+        auth=_auth(),
+    )
+
+    sent = forwarded.await_args.args[0]
+    assert sent["prompt_cache_key"] == "partner-1-conv-42"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["", 123, "x" * 257])
+async def test_openai_compatible_chat_rejects_invalid_prompt_cache_key(value):
+    from app.api.partner import openai_compatible_chat_completions
+
+    with pytest.raises(HTTPException) as exc:
+        await openai_compatible_chat_completions(
+            http_request=_request(
+                {
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "prompt_cache_key": value,
+                }
+            ),
+            auth=_auth(),
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail["error"]["type"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_absent_prompt_cache_key_sends_no_extra_body(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    await partner.openai_compatible_chat_completions(
+        http_request=_request({"messages": [{"role": "user", "content": "hi"}]}),
+        auth=_auth(),
+    )
+
+    sent = forwarded.await_args.args[0]
+    assert "prompt_cache_key" not in sent
+    assert "extra_body" not in sent
+
+    from app.services.partner_chat import _with_openai_passthrough_metadata
+
+    assert "extra_body" not in _with_openai_passthrough_metadata(sent)
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_chat_drops_caller_extra_body(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    await partner.openai_compatible_chat_completions(
+        http_request=_request(
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "extra_body": {"prompt_cache_key": "attacker", "api_key": "sk-attacker"},
+            }
+        ),
+        auth=_auth(),
+    )
+
+    sent = forwarded.await_args.args[0]
+    assert "extra_body" not in sent
+
+
 @pytest.mark.asyncio
 async def test_openai_compatible_chat_rejects_invalid_json():
     from app.api.partner import openai_compatible_chat_completions


### PR DESCRIPTION
## Why

Mistral prompt caching bills cached input tokens at 10% of the normal price. For partner integrations with growing conversation prefixes (chatbots resending full history every turn), this is a direct cost reduction — but only if the cache actually engages.

## Proven facts (live-tested on production, 2026-08-13)

1. Mistral prompt caching REQUIRES `prompt_cache_key` in the request; identical calls without it never cache (verified: `cached_tokens` stays 0).
2. LiteLLM 1.91.0 (our proxy) DROPS a top-level `prompt_cache_key` for Mistral — its mistral chat transformation doesn't map the field and `drop_params: true` eats it.
3. Sending `extra_body: {"prompt_cache_key": "..."}` in the JSON body to the LiteLLM proxy DOES reach Mistral and caching engages (verified: `cached_tokens` 1968 on second call).

## What

- `_OPENAI_COMPAT_FORWARD_FIELDS` (allowlist) now includes `prompt_cache_key`, so OpenAI SDKs sending the standard top-level field work unchanged.
- `_validated_openai_compatible_body` rejects invalid values with the standard openai error envelope (400): non-string, empty string, > 256 chars.
- `_with_openai_passthrough_metadata` (the single translation point, used by both the non-streaming and streaming send paths) pops the top-level field and sets `extra_body = {"prompt_cache_key": value}` on the outbound LiteLLM request. It OVERWRITES `extra_body`; caller-supplied `extra_body` is never in the allowlist and never merged.

Scope deliberately excluded:
- `/responses` endpoint: `prompt_cache_key` stays on `_OPENAI_RESPONSES_UNSUPPORTED_FIELDS` (rejected). Possible follow-up to support it there too.
- Knowledge path (`chat_completions` / `retrieve_context`): untouched.

## Test evidence

Tests written first; 7 failed pre-implementation (`DID NOT RAISE HTTPException`, missing `extra_body`, etc.), then:

```
$ uv run pytest tests/test_partner_openai_compat.py -q
53 passed in 0.16s
$ uv run pytest tests/ -q -k "partner"
282 passed, 3141 deselected
$ uv run ruff check . && uv run ruff format --check .
All checks passed! / 668 files already formatted
```

Covers: happy path (outbound body has `extra_body`, no top-level field — asserted against a mocked httpx client on the real send function), 400 on empty/non-string/oversized values, absent key produces no `extra_body`, caller-supplied top-level `extra_body` is dropped, caller `extra_body` never merged into the translation.

## Rollback

```
git revert b102f2871
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)