### PR TITLE
fix(partner-api): reject passthrough-only fields on knowledge path with 400

### DIFF
--- a/docs/runbooks/partner-chat-threading.md
+++ b/docs/runbooks/partner-chat-threading.md
@@ -97,5 +97,6 @@ For passthrough requests (structured output, tool calling, prompt-grounded
 tasks): omit `web_search`, `web_search_query`, `page_context` and
 `knowledge_base_ids` entirely; `knowledge: {"enabled": false}` is allowed.
 Any of those fields present — even `web_search: false` — routes the request
-to the knowledge path, where `response_format`, `tools` and
-`prompt_cache_key` do not apply.
+to the knowledge path, where `response_format`, `tools`, `tool_choice`,
+`parallel_tool_calls` and `prompt_cache_key` are rejected with a 400
+(fail-loud) instead of being silently ignored.

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -97,6 +97,18 @@ _KNOWLEDGE_CHAT_TRIGGER_FIELDS = {
     "web_search",
     "web_search_query",
 }
+# General-passthrough-only fields: ChatCompletionsRequest (the knowledge-path
+# Pydantic model) silently drops unknown fields, so a partner sending these
+# alongside a knowledge field would get HTTP 200 with their schema/tools
+# quietly ignored instead of an error. Fail loudly instead — see
+# canonical_chat_completions.
+_PASSTHROUGH_ONLY_FIELDS = {
+    "parallel_tool_calls",
+    "prompt_cache_key",
+    "response_format",
+    "tool_choice",
+    "tools",
+}
 _WIDGET_CLIENT_SESSION_RE = re.compile(r"^[A-Za-z0-9_-]{16,80}$")
 _HUBSPOT_HANDOFF_DEV_TENANT_SLUG = "getklai"
 _HUBSPOT_HANDOFF_DEV_ORIGIN = "https://getklai.getklai.com"
@@ -1505,6 +1517,17 @@ async def canonical_chat_completions(
     body = await _openai_compatible_request_body(http_request)
     if _openai_compatible_enabled(auth) and not _uses_knowledge_chat(body):
         return await _openai_compatible_chat_completions_from_body(body, auth=auth)
+
+    offending_fields = sorted(_PASSTHROUGH_ONLY_FIELDS & body.keys())
+    if offending_fields:
+        fields_str = ", ".join(offending_fields)
+        raise _openai_error(
+            status.HTTP_400_BAD_REQUEST,
+            f"{fields_str} is/are only supported on the general passthrough path. "
+            "Remove knowledge fields (knowledge_base_ids, page_context, web_search, "
+            'web_search_query; knowledge: {"enabled": false} is allowed) to use them, '
+            "or drop the field(s) for knowledge-grounded chat.",
+        )
 
     knowledge_request = _parse_knowledge_chat_request(body)
     return await chat_completions(

--- a/klai-portal/backend/tests/test_partner_openai_compat.py
+++ b/klai-portal/backend/tests/test_partner_openai_compat.py
@@ -1143,6 +1143,133 @@ async def test_canonical_chat_with_knowledge_disabled_uses_general_passthrough(m
 
 
 @pytest.mark.asyncio
+async def test_canonical_knowledge_path_rejects_response_format():
+    import app.api.partner as partner
+
+    with pytest.raises(HTTPException) as exc:
+        await partner.canonical_chat_completions(
+            http_request=_request(
+                {
+                    "model": "klai-primary",
+                    "messages": [{"role": "user", "content": "Answer from KB"}],
+                    "stream": False,
+                    "knowledge_base_ids": [1],
+                    "response_format": {"type": "json_object"},
+                }
+            ),
+            auth=_auth({"chat": True, "general_chat": True}),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    assert "response_format" in exc.value.detail["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_canonical_knowledge_path_rejects_tools():
+    import app.api.partner as partner
+
+    with pytest.raises(HTTPException) as exc:
+        await partner.canonical_chat_completions(
+            http_request=_request(
+                {
+                    "model": "klai-primary",
+                    "messages": [{"role": "user", "content": "Answer from KB"}],
+                    "stream": False,
+                    "knowledge": {"enabled": True},
+                    "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                }
+            ),
+            auth=_auth({"chat": True, "general_chat": True}),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    assert "tools" in exc.value.detail["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_canonical_knowledge_path_rejects_multiple_passthrough_fields_sorted():
+    import app.api.partner as partner
+
+    with pytest.raises(HTTPException) as exc:
+        await partner.canonical_chat_completions(
+            http_request=_request(
+                {
+                    "model": "klai-primary",
+                    "messages": [{"role": "user", "content": "Answer from KB"}],
+                    "stream": False,
+                    "knowledge_base_ids": [1],
+                    "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                    "response_format": {"type": "json_object"},
+                    "tool_choice": "auto",
+                    "parallel_tool_calls": False,
+                    "prompt_cache_key": "cache-key",
+                }
+            ),
+            auth=_auth({"chat": True, "general_chat": True}),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    message = exc.value.detail["error"]["message"]
+    # Sorted alphabetically and all listed.
+    assert message.index("parallel_tool_calls") < message.index("prompt_cache_key")
+    assert message.index("prompt_cache_key") < message.index("response_format")
+    assert message.index("response_format") < message.index("tool_choice")
+    assert message.index("tool_choice") < message.index("tools")
+
+
+@pytest.mark.asyncio
+async def test_canonical_knowledge_path_without_passthrough_fields_still_works(monkeypatch):
+    import app.api.partner as partner
+
+    knowledge_flow = AsyncMock(return_value={"choices": [{"message": {"content": "rag"}}]})
+    monkeypatch.setattr(partner, "chat_completions", knowledge_flow)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "klai-primary",
+                "messages": [{"role": "user", "content": "Answer from KB"}],
+                "stream": False,
+                "knowledge_base_ids": [1],
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "rag"}}]}
+    knowledge_flow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_passthrough_with_response_format_is_unaffected_by_knowledge_guard(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Return JSON"}],
+                "response_format": {"type": "json_object"},
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+    sent = forwarded.await_args.args[0]
+    assert sent["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.asyncio
 async def test_knowledge_chat_still_rejects_klai_large():
     from app.api.partner import ChatCompletionsRequest, chat_completions
 


### PR DESCRIPTION
## Summary

`POST /partner/v1/chat/completions` routes to one of two paths in `canonical_chat_completions`:
- **General passthrough** (key has `general_chat`, no knowledge fields in the request) — forwards `response_format`, `tools`, `tool_choice`, `parallel_tool_calls`, `prompt_cache_key`, etc. to LiteLLM as-is.
- **Knowledge path (RAG)** — otherwise. The request body is validated into `ChatCompletionsRequest`, a Pydantic model that **silently ignores unknown fields**.

A partner sending `response_format` (e.g. json_schema), `tools`, `tool_choice`, `parallel_tool_calls`, or `prompt_cache_key` *alongside* a knowledge field (`knowledge_base_ids`, `page_context`, `web_search`, `web_search_query`, or `knowledge: {"enabled": true}`) got back HTTP 200 with free-form text — their schema/tools were dropped with no error. A real partner (Nerds/Thalamus) lost days debugging this. Repo principle: fail loudly, no silent degradation.

## Fix

- New `_PASSTHROUGH_ONLY_FIELDS` constant next to `_KNOWLEDGE_CHAT_TRIGGER_FIELDS` in `klai-portal/backend/app/api/partner.py`.
- `canonical_chat_completions` now checks for these fields **after** the passthrough-routing decision (so passthrough requests are untouched) and **before** `_parse_knowledge_chat_request` — raising a 400 via the existing `_openai_error` envelope, naming the offending field(s) (sorted, deterministic) and explaining the fix.
- Confirmed `canonical_chat_completions` (`@router.post("/chat/completions")`) is the **only** HTTP entry point into the knowledge path — the legacy `chat_completions` and `openai_compatible_chat_completions` functions are internal helpers with no separate route decorator or external caller.

## Evidence: internal callers unaffected

- **Widget** (`klai-widget/src/api/chat-stream.ts`): request body is `{ messages, stream: true, page_context }` only — no offending fields.
- **HubSpot email-support** (`klai-hubspot/klai-email-support/src/app/functions/NewFunction.js`): request body is `{ model, stream, temperature, messages, knowledge: {...} }` only — no offending fields.
- Repo-wide grep for `response_format|tool_choice|parallel_tool_calls|prompt_cache_key|\btools\b` against every file that references `partner/v1/chat/completions` found matches nowhere except the partner.py route/test files themselves.

## Test plan

- [x] RED: 3 new tests fail before the fix (guard field checks not yet applied — request proceeds into `chat_completions` and blows up on the AsyncMock DB session instead of the guard)
- [x] GREEN: `uv run pytest tests/test_partner_openai_compat.py tests/test_partner_chat.py -q` → 142 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run ruff format --check .` → 668 files already formatted
- [x] Docs: one sentence in `docs/runbooks/partner-chat-threading.md` updated to describe fail-loud 400 behavior instead of silent-ignore

## Rollback

`git revert b663955ba` — this is a pure additive validation guard; reverting drops the 400 and restores prior silent-drop behavior (no other change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)