### PR TITLE
Revert LibreChat v0.8.7 bump — patches need a rebase first

### DIFF
--- a/deploy/VERSIONS.md
+++ b/deploy/VERSIONS.md
@@ -47,7 +47,7 @@ GPU production image pins are intentionally not listed in this public repo becau
 |---|---|---|
 | `litellm` | `ghcr.io/berriai/litellm:v1.96.2` | Pinned explicitly (moved from rolling `:main-stable` on 2026-04-19). Re-assess monthly. Note: upstream discontinued the `-stable` tag suffix family — plain tags on non-prerelease GitHub releases are the stable line now (verified 2026-08-13). |
 | `ollama` | `ollama/ollama:0.32.9` | CPU fallback for LLM inference. |
-| `librechat` | `ghcr.io/danny-avila/librechat:v0.8.7` | LibreChat UI for all tenants. Compose-managed `librechat-getklai` and provisioning-managed tenant containers are pinned to the same image. Mounted v0.8.6 patches live under `deploy/librechat/patches/`; getklai keeps an identical canary copy under `deploy/librechat/getklai/patches/` until the separate compose service is folded back into provisioning. The entrypoints also patch LibreChat Meili runtime paths to tenant-scoped indexes when tenant index envs are configured; verify this block against the image on every LibreChat upgrade. |
+| `librechat` | `ghcr.io/danny-avila/librechat:v0.8.6` | LibreChat UI for all tenants. Compose-managed `librechat-getklai` and provisioning-managed tenant containers are pinned to the same image. Mounted v0.8.6 patches live under `deploy/librechat/patches/`; getklai keeps an identical canary copy under `deploy/librechat/getklai/patches/` until the separate compose service is folded back into provisioning. The entrypoints also patch LibreChat Meili runtime paths to tenant-scoped indexes when tenant index envs are configured; verify this block against the image on every LibreChat upgrade. |
 
 ### Document + search
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -359,7 +359,7 @@ services:
 
   # ─── LibreChat (tenant: getklai) ─────────────────────────────────────────
   librechat-getklai:
-    image: ghcr.io/danny-avila/librechat:v0.8.7
+    image: ghcr.io/danny-avila/librechat:v0.8.6
     container_name: librechat-getklai
     restart: unless-stopped
     # Force light theme via the Klai entrypoint wrapper (LibreChat has no

--- a/deploy/librechat/check-patch-drift.sh
+++ b/deploy/librechat/check-patch-drift.sh
@@ -11,7 +11,7 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 MANIFEST="$ROOT_DIR/deploy/librechat/patch-manifest.txt"
 GETKLAI_MANIFEST="$ROOT_DIR/deploy/librechat/getklai/patch-manifest.txt"
-LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-ghcr.io/danny-avila/librechat:v0.8.7}"
+LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-ghcr.io/danny-avila/librechat:v0.8.6}"
 FAIL=0
 
 COMPOSE_IMAGE=$(awk '

--- a/deploy/librechat/tests/global_rollout_config.test.cjs
+++ b/deploy/librechat/tests/global_rollout_config.test.cjs
@@ -27,7 +27,7 @@ assert.match(workflow, /recreate_containers:/);
 assert.match(workflow, /RECREATE_CONTAINERS=/);
 assert.doesNotMatch(workflow, /regenerate\?recreate_containers=true/);
 assert.match(workflow, /timeout=600\.0/);
-assert.match(drift, /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-ghcr\.io\/danny-avila\/librechat:v0\.8\.7\}"/);
-assert.match(portalConfig, /librechat_image: str = "ghcr\.io\/danny-avila\/librechat:v0\.8\.7"/);
+assert.match(drift, /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-ghcr\.io\/danny-avila\/librechat:v0\.8\.6\}"/);
+assert.match(portalConfig, /librechat_image: str = "ghcr\.io\/danny-avila\/librechat:v0\.8\.6"/);
 
 console.log('OK: global LibreChat rollout config enables OCR/artifacts and keeps risky capabilities disabled.');

--- a/deploy/librechat/tests/meili_tenant_indexes.test.cjs
+++ b/deploy/librechat/tests/meili_tenant_indexes.test.cjs
@@ -67,7 +67,7 @@ assert.match(dockerCompose, /MEILI_DB_PATH: \/meili_data/);
 assert.match(dockerCompose, /MEILI_MASTER_KEY: "\$\{GETKLAI_MEILI_API_KEY:\?set a Meili key scoped to getklai_messages,getklai_convos\}"/);
 assert.match(dockerCompose, /MEILI_MESSAGES_INDEX: getklai_messages/);
 assert.match(dockerCompose, /MEILI_CONVOS_INDEX: getklai_convos/);
-assert.match(dockerCompose, /ghcr\.io\/danny-avila\/librechat:v0\.8\.7/);
+assert.match(dockerCompose, /ghcr\.io\/danny-avila\/librechat:v0\.8\.6/);
 assert.match(dockerCompose, /librechat\/getklai\/entrypoint\.sh:\/klai-entrypoint\.sh:ro/);
 assert.match(devCompose, /image: getmeili\/meilisearch:v1\.45\.2/);
 assert.match(devCompose, /MEILI_DB_PATH: \/meili_data/);

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -116,7 +116,7 @@ class Settings(BaseSettings):
     caddy_tenants_path: str = "/caddy/tenants"  # per-tenant .caddyfile dir (caddy-tenants volume)
     librechat_container_data_path: str = "/librechat"  # base dir for per-tenant librechat files
     librechat_host_data_path: str = "/opt/klai/librechat"  # HOST path for Docker volume mounts
-    librechat_image: str = "ghcr.io/danny-avila/librechat:v0.8.7"
+    librechat_image: str = "ghcr.io/danny-avila/librechat:v0.8.6"
     caddy_container_name: str = "klai-core-caddy-1"  # Docker container name for Caddy reload
     redis_container_name: str = "klai-core-redis-1"  # Docker container name; legacy operational reference
 


### PR DESCRIPTION
The drift guard did its job; see commit message. Follow-up task: rebase the four mounted patches onto v0.8.7 bundles, then re-attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)