### PR TITLE
fix(partner-api): clip retrieval query + cross-deployable limit contract test

### DIFF
--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -1859,7 +1859,12 @@ async def retrieve_context(
     conversation_history = _build_conversation_history(messages)
 
     retrieve_body: dict = {
-        "query": query,
+        # Clipped below the 8000-char retrieval-api hard limit (SPEC-SEC-010
+        # REQ-2.5) using the same helper as conversation_history entries. An
+        # unclipped query has no real bound short of the 128 KB request-body
+        # cap, sends garbage into coreference + BGE-M3 embedding (8192-token
+        # sequence limit), and can surface as an upstream 502 for partners.
+        "query": _clip_retrieval_history_content(query),
         "org_id": zitadel_org_id,  # retrieval-api expects string org_id
         "scope": "org",
         "top_k": top_k,

--- a/klai-portal/backend/tests/test_context_limit_contract.py
+++ b/klai-portal/backend/tests/test_context_limit_contract.py
@@ -1,0 +1,125 @@
+"""Cross-deployable drift guard for the retrieval conversation/query content
+character limit.
+
+The 7800-vs-8000 contract lives in three separate deployables with no shared
+import path between them:
+
+- ``klai-portal/backend/app/services/partner_chat.py``
+  (``_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS = 7800``) — clips conversation
+  history entries and the retrieval query before calling retrieval-api.
+- ``deploy/litellm/klai_kb_request_context.py``
+  (``RETRIEVE_HISTORY_MAX_CONTENT_CHARS``, env-overridable, default 7800) —
+  the LiteLLM-hook mirror of the same clipping logic for LibreChat traffic.
+- ``klai-retrieval-api/retrieval_api/models.py``
+  (``_CONVERSATION_CONTENT_MAX_CHARS = 8_000``) — the hard 422-reject limit
+  enforced server-side on every ``conversation_history`` entry.
+
+Per the repo pitfall "url-shape-multi-file-drift": any contract defined in
+more than one file will silently drift unless a mechanical guard exists. This
+test reads the two OTHER deployables' source directly (they are not Python
+packages importable from portal-api's venv — different services, different
+dependency sets) and regex-extracts their constants, anchored to the exact
+assignment lines so a rename or reshape fails this test loudly instead of
+silently passing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services.partner_chat import _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS
+
+_RETRIEVAL_API_RELATIVE_PATH = "klai-retrieval-api/retrieval_api/models.py"
+_LITELLM_HOOK_RELATIVE_PATH = "deploy/litellm/klai_kb_request_context.py"
+
+# Anchored to the exact assignment line in klai-retrieval-api/retrieval_api/models.py:
+#   _CONVERSATION_CONTENT_MAX_CHARS = 8_000
+_RETRIEVAL_API_HARD_LIMIT_RE = re.compile(
+    r"^_CONVERSATION_CONTENT_MAX_CHARS\s*=\s*([\d_]+)\s*$",
+    re.MULTILINE,
+)
+
+# Anchored to the exact os.getenv default in deploy/litellm/klai_kb_request_context.py:
+#   RETRIEVE_HISTORY_MAX_CONTENT_CHARS = min(
+#       int(os.getenv("KNOWLEDGE_RETRIEVE_HISTORY_MAX_CONTENT_CHARS", "7800")),
+_LITELLM_DEFAULT_RE = re.compile(
+    r'int\(os\.getenv\("KNOWLEDGE_RETRIEVE_HISTORY_MAX_CONTENT_CHARS",\s*"(\d+)"\)\)',
+)
+
+
+def _find_monorepo_root() -> Path | None:
+    """Walk up from this test file until both sibling deployables are found.
+
+    Returns None (rather than raising) when only a partial checkout is
+    present, so the test can skip with a clear reason instead of failing
+    for an unrelated environment reason.
+    """
+    current = Path(__file__).resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / _RETRIEVAL_API_RELATIVE_PATH).is_file() and (candidate / _LITELLM_HOOK_RELATIVE_PATH).is_file():
+            return candidate
+    return None
+
+
+def _read_int_constant(pattern: re.Pattern[str], path: Path, *, description: str) -> int:
+    text = path.read_text(encoding="utf-8")
+    match = pattern.search(text)
+    if not match:
+        pytest.fail(
+            f"Could not find {description} in {path} — the assignment line "
+            "shape changed. Update the anchored regex in "
+            "test_context_limit_contract.py alongside the source change."
+        )
+    return int(match.group(1).replace("_", ""))
+
+
+@pytest.fixture(scope="module")
+def monorepo_root() -> Path:
+    root = _find_monorepo_root()
+    if root is None:
+        pytest.skip(
+            "klai-retrieval-api and/or deploy/litellm not present in this "
+            "checkout (partial checkout) — skipping cross-deployable drift "
+            "contract test."
+        )
+    return root
+
+
+def test_portal_clip_stays_below_retrieval_api_hard_limit(monorepo_root: Path) -> None:
+    """Portal's clip threshold MUST stay strictly below retrieval-api's hard
+    422-reject limit, or every clipped query/history entry would still be
+    rejected by retrieval-api."""
+    retrieval_api_hard_limit = _read_int_constant(
+        _RETRIEVAL_API_HARD_LIMIT_RE,
+        monorepo_root / _RETRIEVAL_API_RELATIVE_PATH,
+        description="_CONVERSATION_CONTENT_MAX_CHARS",
+    )
+
+    assert _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS < retrieval_api_hard_limit, (
+        f"portal's _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS "
+        f"({_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS}) must stay strictly below "
+        f"retrieval-api's _CONVERSATION_CONTENT_MAX_CHARS "
+        f"({retrieval_api_hard_limit}), or clipped content would still 422."
+    )
+
+
+def test_litellm_default_matches_portal_constant(monorepo_root: Path) -> None:
+    """The LiteLLM-hook default (env-overridable, used for LibreChat traffic)
+    must equal portal's constant (used for partner-API traffic), so both
+    paths through retrieval-api clip at the same threshold."""
+    litellm_default = _read_int_constant(
+        _LITELLM_DEFAULT_RE,
+        monorepo_root / _LITELLM_HOOK_RELATIVE_PATH,
+        description="KNOWLEDGE_RETRIEVE_HISTORY_MAX_CONTENT_CHARS default",
+    )
+
+    assert litellm_default == _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS, (
+        f"deploy/litellm/klai_kb_request_context.py default "
+        f"({litellm_default}) has drifted from portal's "
+        f"_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS "
+        f"({_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS}) — update one to match "
+        "the other."
+    )

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -2525,6 +2525,154 @@ async def test_retrieve_context_uses_explicit_query_and_top_k(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_retrieve_context_clips_oversized_last_user_message_query(monkeypatch):
+    """An unbounded last-user-message fallback query must be clipped before
+    it reaches retrieval-api — retrieval-api has no max length on `query`,
+    and downstream it feeds coreference + BGE-M3 embedding (8192-token
+    sequence limit) verbatim. See partner-retrieval-query-clip finding."""
+    from app.services.partner_chat import _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS, retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _MockResp()
+
+    monkeypatch.setattr("app.services.partner_chat.httpx.AsyncClient", lambda timeout: _MockClient())
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "secret"
+    fake_settings.internal_secret = "fallback"
+
+    oversized_query = "q" * 130_000
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=["support"],
+        messages=[
+            {"role": "system", "content": "Draft a support reply."},
+            {"role": "user", "content": oversized_query},
+        ],
+        settings=fake_settings,
+    )
+
+    assert len(captured["body"]["query"]) <= _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_clips_oversized_explicit_retrieval_query(monkeypatch):
+    """The `knowledge.query` (retrieval_query) override must be clipped the
+    same way as the last-user-message fallback."""
+    from app.services.partner_chat import _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS, retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _MockResp()
+
+    monkeypatch.setattr("app.services.partner_chat.httpx.AsyncClient", lambda timeout: _MockClient())
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "secret"
+    fake_settings.internal_secret = "fallback"
+
+    oversized_query = "z" * 130_000
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=["support"],
+        messages=[
+            {"role": "system", "content": "Draft a support reply."},
+            {"role": "user", "content": "short generation message"},
+        ],
+        settings=fake_settings,
+        retrieval_query=oversized_query,
+    )
+
+    assert len(captured["body"]["query"]) <= _RETRIEVAL_HISTORY_CONTENT_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_retrieve_context_short_query_passes_through_unchanged(monkeypatch):
+    """Queries under the clip threshold must reach retrieval-api verbatim."""
+    from app.services.partner_chat import retrieve_context
+
+    captured: dict = {}
+
+    class _MockResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"chunks": []}
+
+    class _MockClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _MockResp()
+
+    monkeypatch.setattr("app.services.partner_chat.httpx.AsyncClient", lambda timeout: _MockClient())
+
+    fake_settings = MagicMock()
+    fake_settings.knowledge_retrieve_url = "http://retrieval-api:8040"
+    fake_settings.retrieval_api_internal_secret = "secret"
+    fake_settings.internal_secret = "fallback"
+
+    await retrieve_context(
+        org_id=42,
+        zitadel_org_id="z-1",
+        kb_slugs=["support"],
+        messages=[
+            {"role": "system", "content": "Draft a support reply."},
+            {"role": "user", "content": "What are your opening hours?"},
+        ],
+        settings=fake_settings,
+        retrieval_query="short customer question",
+    )
+
+    assert captured["body"]["query"] == "short customer question"
+
+
+@pytest.mark.asyncio
 async def test_retrieve_context_can_disable_retrieval(monkeypatch):
     """knowledge.enabled=false must not call retrieval-api."""
     from app.services.partner_chat import retrieve_context


### PR DESCRIPTION
## Summary

- Adversarial review (MEDIUM finding) on `retrieve_context` in
  `klai-portal/backend/app/services/partner_chat.py`: the retrieval `query`
  (either the `knowledge.query` override or the last-user-message fallback,
  ~line 1796) was sent to retrieval-api unclipped. `RetrieveRequest.query`
  has no max length, and downstream it goes verbatim into coreference +
  dense/sparse embedding (BGE-M3, 8192-token sequence limit) — the only real
  bound was the 128 KB request-body cap. A 130k-char query was accepted in a
  local probe. Retrieval quality on such a query is meaningless, and an
  upstream embedder failure on it would surface as a partner-facing 502.
- Fix: clip the resolved query with the **existing**
  `_clip_retrieval_history_content` helper (same one already used for
  `conversation_history` entries) before it's placed in `retrieve_body["query"]`.
  No new constant, no behavior change to the messages sent to the LLM —
  only the retrieval-api call is affected.

## Three-files drift risk + guard

The 7800-vs-8000 clip/hard-limit contract now lives in **three separate
deployables** with no shared import path between them:

| File | Constant | Role |
|---|---|---|
| `klai-portal/backend/app/services/partner_chat.py` | `_RETRIEVAL_HISTORY_CONTENT_MAX_CHARS = 7800` | clips before calling retrieval-api (partner-API traffic) |
| `deploy/litellm/klai_kb_request_context.py` | `RETRIEVE_HISTORY_MAX_CONTENT_CHARS` (env-overridable, default `7800`) | same clipping logic for LibreChat traffic |
| `klai-retrieval-api/retrieval_api/models.py` | `_CONVERSATION_CONTENT_MAX_CHARS = 8_000` | hard 422-reject limit enforced server-side |

Per the repo's `url-shape-multi-file-drift` pitfall, a contract that lives in
more than one file drifts silently unless something mechanical catches it.
Added `klai-portal/backend/tests/test_context_limit_contract.py`, which:

- imports portal's constant directly,
- regex-extracts the other two deployables' constants from their source
  files (they aren't Python packages importable from portal-api's venv —
  separate services, separate dependency sets), with regexes anchored to
  the exact assignment lines so a rename/reshape fails the test loudly
  instead of silently passing,
- asserts portal's clip threshold stays strictly below retrieval-api's hard
  limit, and that the LiteLLM-side default equals portal's constant,
- skips (with a clear reason) if the other two deployables aren't present
  in the checkout (partial checkout).

## Test plan

- [x] RED confirmed pre-fix: `test_retrieve_context_clips_oversized_last_user_message_query`
      and `test_retrieve_context_clips_oversized_explicit_retrieval_query` fail
      (`130000 <= 7800` assertion) with the fix stashed out.
- [x] GREEN post-fix: all of `tests/test_partner_chat.py` +
      `tests/test_context_limit_contract.py` pass (89 passed).
- [x] `uv run ruff check` clean on touched files.
- [x] `uv run ruff format --check` clean on touched files (repo-wide
      format-check has a pre-existing unrelated failure on
      `klai-portal/scripts/test_webhook.py`, not touched here).

## Rollback

```
git revert f20a4c3a7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)