### PR TITLE
fix(partner-api): fail closed on empty KB scope in knowledge chat

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -1562,15 +1562,53 @@ async def chat_completions(  # noqa: C901
     # OpenAI-compatible request shape. Top-level knowledge_base_ids remains
     # supported for existing partner clients.
     knowledge = request.knowledge
+    retrieval_enabled = knowledge.enabled if knowledge is not None else True
     requested_kb_ids = (
         knowledge.knowledge_base_ids
         if knowledge is not None and knowledge.knowledge_base_ids is not None
         else request.knowledge_base_ids
     )
+    # SPEC-PARTNER-KB-SCOPE-001: an explicit empty list is ambiguous — it must
+    # never be treated the same as "no scope requested" (which falls back to
+    # the key's configured KBs). validate_kb_access() cannot distinguish an
+    # explicit [] from a zero-access key, so reject it here before that call.
+    if retrieval_enabled and requested_kb_ids is not None and len(requested_kb_ids) == 0:
+        raise _openai_error(
+            status.HTTP_400_BAD_REQUEST,
+            "knowledge_base_ids is empty, which is ambiguous. Omit the field to use "
+            "this key's configured knowledge bases, or set knowledge.enabled=false to "
+            "skip retrieval entirely.",
+        )
     kb_ids = validate_kb_access(auth, requested_kb_ids)
+    if retrieval_enabled and not kb_ids:
+        # No requested ids fell back to the key's/widget's own KB access,
+        # which is empty. Never let this silently widen to every KB in the
+        # org — fail closed instead. Message is intentionally generic (never
+        # reveal KB existence/names).
+        raise _openai_error(
+            status.HTTP_403_FORBIDDEN,
+            "This API key has no knowledge base access configured for chat",
+            error_type="permission_error",
+        )
 
     # 5. Translate kb_ids -> kb_slugs
     kb_slugs = await _resolve_kb_slugs(kb_ids, auth.org_id, db)
+    if retrieval_enabled and kb_ids:
+        if not kb_slugs:
+            # Every authorized/requested KB id failed to resolve (e.g. a
+            # deleted KB). Fail closed rather than letting retrieve_context
+            # silently widen scope by omitting kb_slugs entirely.
+            raise _openai_error(
+                status.HTTP_403_FORBIDDEN,
+                "This API key has no knowledge base access configured for chat",
+                error_type="permission_error",
+            )
+        if len(kb_slugs) < len(kb_ids):
+            logger.warning(
+                "partner_kb_ids_unresolved",
+                org_id=auth.org_id,
+                unresolved_kb_ids=len(kb_ids) - len(kb_slugs),
+            )
 
     # 6. Retrieve context.
     # F2 (audit retrieval-coupling-2026-05-06): pass synthetic partner_user_id
@@ -1605,6 +1643,16 @@ async def chat_completions(  # noqa: C901
     page_context_enabled = await _widget_page_context_enabled(auth, db) if is_widget_chat else False
     page_context = (
         request.page_context.model_dump(exclude_none=True) if page_context_enabled and request.page_context else None
+    )
+
+    # SPEC-PARTNER-KB-SCOPE-001 invariant: when retrieval is enabled,
+    # kb_slugs must never be empty here — retrieve_context() only sends
+    # kb_slugs to retrieval-api when the list is truthy, and an empty list
+    # is silently treated as "no KB restriction" (widens to every KB the
+    # org can see). The 400/403 guards above must have already fired for
+    # every empty-scope case by this point.
+    assert not retrieval_enabled or kb_slugs, (
+        "chat_completions: retrieve_context must not be called with empty kb_slugs while retrieval is enabled"
     )
 
     try:

--- a/klai-portal/backend/tests/test_partner_chat.py
+++ b/klai-portal/backend/tests/test_partner_chat.py
@@ -197,6 +197,213 @@ async def test_kb_out_of_scope_returns_403():
     assert exc_info.value.status_code == 403
 
 
+# ---------------------------------------------------------------------------
+# SPEC-PARTNER-KB-SCOPE-001: fail-closed on empty/unresolvable KB scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_top_level_kb_ids_returns_400():
+    """Top-level knowledge_base_ids: [] is ambiguous -> 400, never widened."""
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+        knowledge_base_ids=[],
+    )
+
+    with (
+        patch("app.api.partner.retrieve_context") as mock_retrieve,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await chat_completions(
+            request=req,
+            http_request=_http_request_stub(),
+            auth=make_partner_auth(kb_access={10: "read"}),
+            db=AsyncMock(),
+        )
+    assert exc_info.value.status_code == 400
+    mock_retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_knowledge_kb_ids_returns_400():
+    """knowledge.knowledge_base_ids: [] is ambiguous -> 400, never widened."""
+    from app.api.partner import ChatCompletionsRequest, KnowledgeOptions, chat_completions
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+        knowledge=KnowledgeOptions(query="hello", knowledge_base_ids=[]),
+    )
+
+    with (
+        patch("app.api.partner.retrieve_context") as mock_retrieve,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await chat_completions(
+            request=req,
+            http_request=_http_request_stub(),
+            auth=make_partner_auth(kb_access={10: "read"}),
+            db=AsyncMock(),
+        )
+    assert exc_info.value.status_code == 400
+    mock_retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_key_with_no_kb_access_returns_403_and_skips_retrieval():
+    """A key/widget with zero configured KB access -> 403, retrieval never called.
+
+    This is the confirmed defect: previously validate_kb_access() returned []
+    for a key with no kb_access rows, retrieve_context() silently omitted
+    kb_slugs, and retrieval-api widened to every KB visible to the org.
+    """
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    with (
+        patch("app.api.partner.retrieve_context") as mock_retrieve,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await chat_completions(
+            request=req,
+            http_request=_http_request_stub(),
+            auth=make_partner_auth(kb_access={}),
+            db=AsyncMock(),
+        )
+    assert exc_info.value.status_code == 403
+    mock_retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_all_authorized_kb_ids_unresolvable_returns_403_and_skips_retrieval():
+    """Authorized KB ids that all fail to resolve to slugs (e.g. deleted KB)
+
+    -> fail closed with 403 rather than widening retrieval scope.
+    """
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=FakeResult(rows=[]))  # no KB rows resolve
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    with (
+        patch("app.api.partner.retrieve_context") as mock_retrieve,
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await chat_completions(
+            request=req,
+            http_request=_http_request_stub(),
+            auth=make_partner_auth(kb_access={10: "read"}),
+            db=db,
+        )
+    assert exc_info.value.status_code == 403
+    mock_retrieve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_partial_kb_id_resolution_proceeds_with_resolved_subset():
+    """2 authorized KB ids, 1 resolves -> proceeds with the resolved subset
+
+    and logs a partner_kb_ids_unresolved warning for the dropped id.
+    """
+    import structlog
+
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=FakeResult(rows=fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+        knowledge_base_ids=[10, 20],
+    )
+
+    litellm_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    with structlog.testing.capture_logs() as cap:
+        with (
+            patch("app.api.partner.retrieve_context", return_value=([], "prompt", [])) as mock_retrieve,
+            patch("app.api.partner.chat_completion_non_streaming", return_value=litellm_response),
+            patch("app.api.partner.asyncio"),
+        ):
+            await chat_completions(
+                request=req,
+                http_request=_http_request_stub(),
+                auth=make_partner_auth(kb_access={10: "read", 20: "read"}),
+                db=db,
+            )
+
+    call_kwargs = mock_retrieve.call_args
+    kb_slugs_arg = call_kwargs[1].get("kb_slugs") or call_kwargs[0][2]
+    assert set(kb_slugs_arg) == {"kb-alpha"}
+    assert any(entry.get("event") == "partner_kb_ids_unresolved" for entry in cap)
+
+
+@pytest.mark.asyncio
+async def test_key_with_kb_access_and_no_requested_ids_passes_slugs_to_retrieval():
+    """Regression: a key WITH kb_access and no requested ids still gets its
+
+    configured KBs passed to retrieval (non-empty kb_slugs).
+    """
+    from app.api.partner import ChatCompletionsRequest, chat_completions
+
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=FakeResult(rows=fake_kbs))
+
+    req = ChatCompletionsRequest(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="klai-primary",
+        stream=False,
+    )
+
+    litellm_response = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    with (
+        patch("app.api.partner.retrieve_context", return_value=([], "prompt", [])) as mock_retrieve,
+        patch("app.api.partner.chat_completion_non_streaming", return_value=litellm_response),
+        patch("app.api.partner.asyncio"),
+    ):
+        await chat_completions(
+            request=req,
+            http_request=_http_request_stub(),
+            auth=make_partner_auth(kb_access={10: "read"}),
+            db=db,
+        )
+
+    call_kwargs = mock_retrieve.call_args
+    kb_slugs_arg = call_kwargs[1].get("kb_slugs") or call_kwargs[0][2]
+    assert kb_slugs_arg == ["kb-alpha"]
+
+
 @pytest.mark.asyncio
 async def test_retrieval_timeout_returns_502():
     """Retrieval-api timeout -> 502 Bad Gateway."""
@@ -625,11 +832,17 @@ async def test_widget_streaming_uses_structured_citation_mode():
 
 @pytest.mark.asyncio
 async def test_widget_page_context_ignored_when_disabled():
+    """Unrelated to KB scope: exercises page-context handling only.
+
+    Needs non-empty kb_access — SPEC-PARTNER-KB-SCOPE-001 fails a zero-KB-access
+    key/widget closed with 403 before this code path is reached.
+    """
     from app.api.partner import ChatCompletionsRequest, chat_completions
 
+    fake_kbs = [FakeKB(id=10, name="KB Alpha", slug="kb-alpha", org_id=42)]
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=FakeResult(rows=[]))
-    auth = make_partner_auth(kb_access={})
+    db.execute = AsyncMock(return_value=FakeResult(rows=fake_kbs))
+    auth = make_partner_auth(kb_access={10: "read"})
     auth.key_id = "wgt_901"
 
     req = ChatCompletionsRequest(

--- a/klai-portal/backend/tests/test_partner_chat_web_search.py
+++ b/klai-portal/backend/tests/test_partner_chat_web_search.py
@@ -435,7 +435,9 @@ async def test_chat_handler_web_search_requires_partner_permission(monkeypatch):
 async def test_chat_handler_web_search_never_runs_for_widget_key(monkeypatch):
     import app.api.partner as partner
 
-    monkeypatch.setattr(partner, "_resolve_kb_slugs", AsyncMock(return_value=[]))
+    # kb_access resolves to a real slug (SPEC-PARTNER-KB-SCOPE-001 fails closed
+    # on an unresolvable KB scope) — this test is about web search, not KB scope.
+    monkeypatch.setattr(partner, "_resolve_kb_slugs", AsyncMock(return_value=["kb-1"]))
     monkeypatch.setattr(partner, "_widget_system_prompt", AsyncMock(return_value=None))
     monkeypatch.setattr(partner, "_widget_page_context_enabled", AsyncMock(return_value=False))
     monkeypatch.setattr(partner, "retrieve_context", AsyncMock(return_value=([], "sp", [])))
@@ -466,7 +468,9 @@ async def test_chat_handler_web_search_never_runs_for_widget_key(monkeypatch):
 async def test_chat_handler_web_search_allowed_for_partner_key(monkeypatch):
     import app.api.partner as partner
 
-    monkeypatch.setattr(partner, "_resolve_kb_slugs", AsyncMock(return_value=[]))
+    # kb_access resolves to a real slug (SPEC-PARTNER-KB-SCOPE-001 fails closed
+    # on an unresolvable KB scope) — this test is about web search, not KB scope.
+    monkeypatch.setattr(partner, "_resolve_kb_slugs", AsyncMock(return_value=["kb-1"]))
     monkeypatch.setattr(partner, "retrieve_context", AsyncMock(return_value=([], "sp", [])))
     search = AsyncMock(return_value=[{"title": "T", "url": "https://x.test/1", "content": "c"}])
     chat = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})


### PR DESCRIPTION
## Summary

`POST /partner/v1/chat/completions` knowledge path could silently widen a
partner key's retrieval scope to **every KB visible in the org**, bypassing
the key's per-KB authorization. Same-org only (not cross-tenant), but a real
authorization bypass confirmed by adversarial review.

### The widening scenario

1. `validate_kb_access(auth, requested_kb_ids)` returns `[]` for **both**:
   - an explicit `knowledge_base_ids: []` (or `knowledge.knowledge_base_ids: []`), and
   - a key/widget whose configured `kb_access` is empty (requested `None` falls back to "all key KBs" → `[]`).
2. `_resolve_kb_slugs` silently drops IDs that no longer resolve (e.g. a deleted KB) — can also yield `[]` from a non-empty authorized list.
3. `retrieve_context` only serializes `kb_slugs` into the retrieval request when the list is truthy. When `kb_slugs == []`, retrieval-api's scope filter applies **no KB restriction** — retrieval widens to every KB the org can see.

### Fix — three fail-closed guards in `chat_completions`, gated on retrieval being enabled

1. **Explicit empty list is ambiguous** — `knowledge_base_ids: []` (top-level or nested under `knowledge`) → `400`. Message tells the caller to either omit the field (use the key's configured KBs) or set `knowledge.enabled: false` to skip retrieval.
2. **Zero authorized KBs** — if `validate_kb_access` returns `[]` (key/widget has no KB access configured) → `403 permission_error`, generic message (no KB existence/name disclosure).
3. **Stale mappings** — after `_resolve_kb_slugs`: if the authorized ID list was non-empty but **zero** slugs resolved → same `403` (fail closed). If *some* resolve, proceeds with the resolved subset and logs a `partner_kb_ids_unresolved` structlog warning (org_id + count dropped).

A defensive `assert` at the `retrieve_context` call site pins the invariant: when retrieval is enabled, `kb_slugs` must never be empty by that point.

### Production evidence (no legitimate traffic affected)

All 9 real partner keys have ≥1 `partner_api_key_kb_access` row. All widgets except one getklai widget named "test" (0 rows) have ≥1 `widget_kb_access` row. Fail-closed here breaks no legitimate production traffic — only closes the bypass.

### Rollback

```
git revert 3e65e8bdea5f7ee92bd6947479e8a504586fe1d0
```

## Test plan

- [x] RED: 5 new tests fail against pre-fix code (`uv run pytest tests/test_partner_chat.py -k "explicit_empty or no_kb_access or unresolvable or partial_kb_id"` → 5 failed)
- [x] GREEN: all 6 new tests pass post-fix, including the regression test that a key WITH kb_access still gets its KBs passed to retrieval
- [x] `uv run pytest tests/test_partner_openai_compat.py tests/test_partner_chat.py` → 152 passed
- [x] Full backend suite: `uv run pytest -q` → 3438 passed, 3 deselected
- [x] `uv run ruff check .` and `uv run ruff format --check .` → clean
- [x] Two pre-existing tests updated to use non-empty/resolvable `kb_access` fixtures where the KB scope was incidental to what they test (page-context handling, web-search gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)