### PR TITLE
feat(partner-api): route chat by field values instead of presence

### DIFF
--- a/docs/runbooks/partner-chat-threading.md
+++ b/docs/runbooks/partner-chat-threading.md
@@ -92,11 +92,20 @@ the passthrough. A one-hour call transcript usually does not fit — pattern
 
 ## Routing reminder
 
-The API picks its mode by which fields are **present**, not their values.
-For passthrough requests (structured output, tool calling, prompt-grounded
-tasks): omit `web_search`, `web_search_query`, `page_context` and
-`knowledge_base_ids` entirely; `knowledge: {"enabled": false}` is allowed.
-Any of those fields present — even `web_search: false` — routes the request
-to the knowledge path, where `response_format`, `tools`, `tool_choice`,
-`parallel_tool_calls` and `prompt_cache_key` are rejected with a 400
-(fail-loud) instead of being silently ignored.
+The API picks its mode by field **values**, not presence (breaking change,
+approved by product owner 2026-08-13). Sending
+`web_search: false`, `web_search_query: null`, `page_context: null`, or
+`knowledge: null` now routes to the general passthrough path just like
+omitting the field entirely; `knowledge: {"enabled": false}` also stays a
+passthrough. Only a "yes" value opts into the knowledge path:
+`web_search: true`, a non-empty `web_search_query`, a non-null
+`page_context` object, a `knowledge` object without `enabled: false`, or a
+present `knowledge_base_ids` (including an **explicit empty list**, `[]`,
+which is intentionally still a trigger — it is rejected with a 400
+"ambiguous" error instead of silently falling back to passthrough; omit the
+field entirely to use the key's configured knowledge bases).
+
+Fields that only make sense in the knowledge path (`response_format`,
+`tools`, `tool_choice`, `parallel_tool_calls`, `prompt_cache_key`) are
+rejected with a 400 (fail-loud) when combined with a value that routes to
+the knowledge path, instead of being silently ignored.

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -90,13 +90,6 @@ _OPENAI_COMPATIBLE_MODEL_ALIASES = {
     "gpt-4.1": "klai-primary",
 }
 _OPENAI_COMPATIBLE_ACCEPTED_MODELS = _OPENAI_COMPATIBLE_MODELS | set(_OPENAI_COMPATIBLE_MODEL_ALIASES)
-_KNOWLEDGE_CHAT_TRIGGER_FIELDS = {
-    "knowledge",
-    "knowledge_base_ids",
-    "page_context",
-    "web_search",
-    "web_search_query",
-}
 # General-passthrough-only fields: ChatCompletionsRequest (the knowledge-path
 # Pydantic model) silently drops unknown fields, so a partner sending these
 # alongside a knowledge field would get HTTP 200 with their schema/tools
@@ -736,10 +729,46 @@ def _openai_error(status_code: int, message: str, error_type: str = "invalid_req
 
 
 def _uses_knowledge_chat(body: dict[str, Any]) -> bool:
+    """Route to the knowledge (RAG) path iff a trigger field's VALUE means "yes".
+
+    Presence alone is no longer enough (breaking change, approved 2026-08-13
+    — see docs/runbooks/partner-chat-threading.md "Routing reminder"):
+
+    - ``knowledge``: present and not ``None``, unless it is a dict with
+      ``enabled`` exactly ``False``. A non-dict non-null value still
+      triggers so it fails loudly in the knowledge path's Pydantic
+      validation instead of being silently dropped by the passthrough
+      allowlist.
+    - ``knowledge_base_ids``: present and not ``None``. An explicit empty
+      list ``[]`` remains a trigger so the knowledge path's "ambiguous
+      empty list" 400 guard (SPEC-PARTNER-KB-SCOPE-001) keeps firing
+      instead of silently falling through to passthrough.
+    - ``page_context``: present and not ``None``. A non-dict non-null
+      value still triggers so it fails loudly downstream.
+    - ``web_search``: truthy.
+    - ``web_search_query``: a non-empty string, or any other non-null
+      value (non-string non-null values still trigger so knowledge-path
+      validation rejects them loudly).
+    """
     knowledge = body.get("knowledge")
-    if "knowledge" in body and not (isinstance(knowledge, dict) and knowledge.get("enabled") is False):
+    if "knowledge" in body and knowledge is not None:
+        if not (isinstance(knowledge, dict) and knowledge.get("enabled") is False):
+            return True
+
+    if "knowledge_base_ids" in body and body["knowledge_base_ids"] is not None:
         return True
-    return any(field in body for field in _KNOWLEDGE_CHAT_TRIGGER_FIELDS - {"knowledge"})
+
+    if "page_context" in body and body["page_context"] is not None:
+        return True
+
+    if body.get("web_search"):
+        return True
+
+    web_search_query = body.get("web_search_query")
+    if web_search_query is not None and web_search_query != "":
+        return True
+
+    return False
 
 
 def _openai_compatible_enabled(auth: PartnerAuthContext) -> bool:

--- a/klai-portal/backend/tests/test_partner_openai_compat.py
+++ b/klai-portal/backend/tests/test_partner_openai_compat.py
@@ -1418,3 +1418,247 @@ async def test_knowledge_chat_still_rejects_klai_large():
         )
 
     assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Value-based routing for general_chat keys (breaking change, approved
+# 2026-08-13): _uses_knowledge_chat now routes on field VALUES, not
+# presence. See docs/runbooks/partner-chat-threading.md "Routing reminder".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        # -- knowledge --------------------------------------------------
+        ({}, False),
+        ({"knowledge": None}, False),
+        ({"knowledge": {"enabled": False}}, False),
+        ({"knowledge": {"enabled": True}}, True),
+        ({"knowledge": {}}, True),  # no "enabled" key -> not explicitly False -> trigger
+        ({"knowledge": "not-a-dict"}, True),  # fails loudly downstream, not silently dropped
+        # -- knowledge_base_ids ------------------------------------------
+        ({"knowledge_base_ids": None}, False),
+        ({"knowledge_base_ids": []}, True),  # explicit [] stays a trigger (SPEC-PARTNER-KB-SCOPE-001)
+        ({"knowledge_base_ids": [1]}, True),
+        # -- page_context --------------------------------------------------
+        ({"page_context": None}, False),
+        ({"page_context": {"url": "https://example.com"}}, True),
+        ({"page_context": "not-a-dict"}, True),  # fails loudly downstream
+        # -- web_search ------------------------------------------------
+        ({"web_search": False}, False),
+        ({"web_search": None}, False),
+        ({"web_search": True}, True),
+        # -- web_search_query --------------------------------------------
+        ({"web_search_query": None}, False),
+        ({"web_search_query": ""}, False),
+        ({"web_search_query": "latest news"}, True),
+        ({"web_search_query": 123}, True),  # non-string non-null still fails loudly downstream
+    ],
+)
+def test_uses_knowledge_chat_routes_on_field_values(body, expected):
+    from app.api.partner import _uses_knowledge_chat
+
+    assert _uses_knowledge_chat(body) is expected
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_web_search_false_routes_to_passthrough(monkeypatch):
+    """web_search: false PRESENT no longer routes to the knowledge path."""
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Return JSON"}],
+                "response_format": {"type": "json_object"},
+                "web_search": False,
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+    sent = forwarded.await_args.args[0]
+    assert sent["response_format"] == {"type": "json_object"}
+    assert "web_search" not in sent
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_web_search_query_null_routes_to_passthrough(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "web_search_query": None,
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_page_context_null_routes_to_passthrough(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "page_context": None,
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_knowledge_null_routes_to_passthrough(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "knowledge": None,
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_knowledge_base_ids_null_routes_to_passthrough(monkeypatch):
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "knowledge_base_ids": None,
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_knowledge_base_ids_populated_routes_to_knowledge_path(monkeypatch):
+    import app.api.partner as partner
+
+    knowledge_flow = AsyncMock(return_value={"choices": [{"message": {"content": "rag"}}]})
+    monkeypatch.setattr(partner, "chat_completions", knowledge_flow)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "klai-primary",
+                "messages": [{"role": "user", "content": "Answer from KB"}],
+                "stream": False,
+                "knowledge_base_ids": [1],
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "rag"}}]}
+    knowledge_flow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_knowledge_base_ids_empty_list_still_routes_to_knowledge_path_and_400s():
+    """Explicit [] must NOT be silently dropped by the passthrough allowlist.
+
+    It stays a knowledge-chat trigger so the existing "ambiguous empty list"
+    400 guard (SPEC-PARTNER-KB-SCOPE-001, in chat_completions) keeps firing
+    end-to-end through canonical_chat_completions.
+    """
+    import app.api.partner as partner
+
+    with pytest.raises(HTTPException) as exc:
+        await partner.canonical_chat_completions(
+            http_request=_request(
+                {
+                    "model": "klai-primary",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": False,
+                    "knowledge_base_ids": [],
+                }
+            ),
+            auth=_auth({"chat": True, "general_chat": True}),
+            db=AsyncMock(),
+        )
+
+    assert exc.value.status_code == 400
+    assert "ambiguous" in exc.value.detail["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_canonical_chat_web_search_false_with_response_format_forwards_it(monkeypatch):
+    """Integration-style: general_chat key sending web_search: false +
+    response_format routes to passthrough and forwards response_format."""
+    import app.api.partner as partner
+
+    forwarded = AsyncMock(return_value={"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(partner, "openai_chat_completion_non_streaming", forwarded)
+
+    result = await partner.canonical_chat_completions(
+        http_request=_request(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "Return JSON"}],
+                "web_search": False,
+                "response_format": {"type": "json_object"},
+                "stream": False,
+            }
+        ),
+        auth=_auth({"chat": True, "general_chat": True}),
+        db=AsyncMock(),
+    )
+
+    assert result == {"choices": [{"message": {"content": "ok"}}]}
+    sent = forwarded.await_args.args[0]
+    assert sent["model"] == "klai-fast"
+    assert sent["response_format"] == {"type": "json_object"}
+    assert "web_search" not in sent


### PR DESCRIPTION
## Summary

`POST /partner/v1/chat/completions` routes `general_chat`-permission keys
between the general passthrough and the knowledge (RAG) path via
`_uses_knowledge_chat`. It previously routed by field **presence** — sending
a field at all triggered the knowledge path, even when its value meant "no".
This PR switches routing to field **values**, approved by the product owner
on 2026-08-13 as a breaking change.

Only `general_chat` keys are affected. Other partner keys already route to
the knowledge path unconditionally (`canonical_chat_completions`, unchanged).

## Old vs new semantics

| Field | Old (presence-based) | New (value-based) |
|---|---|---|
| `knowledge` absent | passthrough | passthrough (unchanged) |
| `knowledge: null` | **knowledge path** | passthrough |
| `knowledge: {"enabled": false}` | passthrough | passthrough (unchanged) |
| `knowledge: {"enabled": true}` / any other dict | knowledge path | knowledge path (unchanged) |
| `knowledge: "not-a-dict"` | knowledge path | knowledge path (unchanged — fails loudly via 422) |
| `knowledge_base_ids` absent | passthrough | passthrough (unchanged) |
| `knowledge_base_ids: null` | **knowledge path** | passthrough |
| `knowledge_base_ids: []` | knowledge path | **knowledge path (unchanged — see exception below)** |
| `knowledge_base_ids: [1]` | knowledge path | knowledge path (unchanged) |
| `page_context` absent | passthrough | passthrough (unchanged) |
| `page_context: null` | **knowledge path** | passthrough |
| `page_context: {...}` | knowledge path | knowledge path (unchanged) |
| `web_search` absent | passthrough | passthrough (unchanged) |
| `web_search: false` | **knowledge path** | passthrough |
| `web_search: true` | knowledge path | knowledge path (unchanged) |
| `web_search_query` absent | passthrough | passthrough (unchanged) |
| `web_search_query: null` | **knowledge path** | passthrough |
| `web_search_query: ""` | **knowledge path** | passthrough |
| `web_search_query: "x"` | knowledge path | knowledge path (unchanged) |

Rows in **bold** are the behavior change: requests that used to be forced
onto the knowledge path (and would reject passthrough-only fields like
`response_format`/`tools` with a 400) now go through the general
passthrough as intended.

## The explicit-`[]` exception

`knowledge_base_ids: []` is the one case that deliberately does **not**
follow "null/absent semantics apply to everything". An explicit empty list
stays a knowledge-path trigger so the existing SPEC-PARTNER-KB-SCOPE-001
"ambiguous empty list" 400 guard in `chat_completions` keeps firing. If `[]`
became a passthrough-trigger instead, it would be silently dropped by the
passthrough's field allowlist — reintroducing the exact silent-contract-loss
failure class SPEC-PARTNER-KB-SCOPE-001 was built to prevent. `null` (or
omitting the field) is the correct way to opt out of KB scoping; `[]` stays
an explicit, loud error.

## Breaking change

Approved by product owner 2026-08-13. Any `general_chat` partner
integration that was relying on `web_search: false` / `web_search_query:
null` / `page_context: null` / `knowledge: null` to force the knowledge
path (and implicitly reject `response_format`/`tools`/etc.) will now get
the general passthrough instead. No such reliance was found in this repo's
own test suite — no existing test asserted the old presence-based behavior
for these four fields (verified via `git diff` against `origin/main`: only
new test lines were added, zero existing assertions were changed or
removed).

## Rollback

```
git revert <merge-commit-sha>
```

## Test plan

- [x] RED: added table-driven `_uses_knowledge_chat` tests plus
      end-to-end `canonical_chat_completions` tests for all 5 trigger
      fields (13 failed against old implementation, confirming they
      exercised the changed behavior)
- [x] GREEN: `uv run pytest tests/test_partner_openai_compat.py
      tests/test_partner_chat.py -q` → 182 passed
- [x] `uv run pytest tests/ -k partner -q` → 330 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run ruff format --check .` → 669 files already formatted
- [x] Docs updated: `docs/runbooks/partner-chat-threading.md` "Routing
      reminder" section rewritten for value-based semantics.
      `docs/architecture/conversation-state.md` grepped for
      `web_search`/presence-based routing wording — no matches, no
      update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
