### PR TITLE
feat(crawl): crawl4ai 0.9-compatible client — DOM prep via wait_for

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -39,23 +39,57 @@ FetchOutcome = dict[str, Any]
 # JS scripts — single source of truth for content filtering
 # ---------------------------------------------------------------------------
 
-# Injected BEFORE wait_for: strip nav chrome so the word-count condition fires
-# only when article content is present.  Uses semantic selectors only — never
-# class/id substring selectors (see pitfalls/backend.md).
-JS_REMOVE_CHROME = """
-[
-  'nav', 'header', 'footer', 'aside',
-  '[role="navigation"]', '[role="banner"]', '[role="contentinfo"]', '[role="complementary"]',
-  '[role="search"]',
-].forEach(sel => document.querySelectorAll(sel).forEach(el => el.remove()));
-"""
+# crawl4ai >= 0.9 rejects ``js_code`` / ``js_code_before_wait`` on every
+# network request (the untrusted-config boundary that fixes CVE-2026-57572),
+# with no trusted-caller escape hatch. ``wait_for`` JS remains allowlisted,
+# so the one-time DOM preparation that used to live in those fields now runs
+# inside the wait_for predicate: the first poll mutates the DOM (guarded by a
+# dataset marker so repeated polling never re-runs it), later polls evaluate
+# readiness after a 300ms settle — preserving the old js_code sleep that let
+# expanded toggles render. If upstream ever locks down wait_for JS too, the
+# fallback is computing these steps server-side from the returned HTML.
 
-# Injected AFTER wait_for: open collapsed toggles (Notion / <details>).
-JS_EXPAND_TOGGLES = """
-document.querySelectorAll('details:not([open])').forEach(d => d.setAttribute('open', ''));
-document.querySelectorAll('.notion-toggle__summary, [data-block-type="toggle"] > *:first-child').forEach(s => s.click());
-await new Promise(r => setTimeout(r, 300));
-"""
+# Strip nav chrome so the word-count condition fires only when article
+# content is present. Semantic selectors only — never class/id substring
+# selectors (see pitfalls/backend.md).
+JS_PREP_REMOVE_CHROME = (
+    "['nav','header','footer','aside',"
+    "'[role=\"navigation\"]','[role=\"banner\"]','[role=\"contentinfo\"]',"
+    "'[role=\"complementary\"]','[role=\"search\"]'"
+    "].forEach(sel => document.querySelectorAll(sel).forEach(el => el.remove()));"
+)
+
+# Open collapsed toggles (Notion / <details>) so lazy content renders.
+JS_PREP_EXPAND_TOGGLES = (
+    "document.querySelectorAll('details:not([open])')"
+    ".forEach(d => d.setAttribute('open', ''));"
+    "document.querySelectorAll('.notion-toggle__summary, "
+    '[data-block-type="toggle"] > *:first-child\')'
+    ".forEach(s => s.click());"
+)
+
+
+def build_wait_for(
+    *,
+    strip_chrome: bool,
+    ready_condition: str,
+) -> str:
+    """Compose the crawl4ai ``wait_for`` predicate with one-time DOM prep.
+
+    ``ready_condition`` is a JS boolean expression evaluated on every poll
+    after the prep + 300ms settle. The prep block runs exactly once per page
+    (``data-klai-prep-ts`` marker on <html>).
+    """
+    prep = (JS_PREP_REMOVE_CHROME if strip_chrome else "") + JS_PREP_EXPAND_TOGGLES
+    return (
+        "js:() => {"
+        " const d = document.documentElement.dataset;"
+        " if (!d.klaiPrepTs) { " + prep + " d.klaiPrepTs = String(Date.now()); return false; }"
+        " if (Date.now() - Number(d.klaiPrepTs) < 300) return false;"
+        " return " + ready_condition + ";"
+        " }"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Result dataclass
@@ -189,23 +223,23 @@ def build_crawl_config(
         },
     }
 
-    base_wait = "js:() => document.body.innerText.trim().split(/\\s+/).length > 50"
+    ready_condition = "(document.body.innerText.trim().split(/\\s+/).length > 50)"
     if login_indicator_selector:
         # Escape quotes/backslashes to prevent JS injection from a stored selector.
         selector_escaped = login_indicator_selector.replace("\\", "\\\\").replace("'", "\\'")
         # Negate: page is only "ready" when base condition is met AND the
         # login indicator is NOT present. When the indicator IS present the
         # wait_for times out and crawl4ai returns success=False.
-        base_wait = (
-            "js:() => (document.body.innerText.trim().split(/\\s+/).length > 50) "
-            f"&& !document.querySelector('{selector_escaped}')"
-        )
+        ready_condition += f" && !document.querySelector('{selector_escaped}')"
 
     params: dict[str, Any] = {
         "cache_mode": "bypass",
         "word_count_threshold": 10,
-        "wait_for": base_wait,
-        "js_code": JS_EXPAND_TOGGLES,
+        # Chrome stripping runs inside wait_for's one-time prep (0.9's
+        # untrusted-config boundary forbids js_code_before_wait), and only in
+        # the no-selector pipeline — with a selector the caller vouches for
+        # the content scope, matching the old trusted-pipeline behaviour.
+        "wait_for": build_wait_for(strip_chrome=selector is None, ready_condition=ready_condition),
         "remove_consent_popups": True,
         "remove_overlay_elements": True,
         "page_timeout": 30000,
@@ -223,7 +257,7 @@ def build_crawl_config(
         params["target_elements"] = [selector]
         params["excluded_tags"] = []
     else:
-        params["js_code_before_wait"] = JS_REMOVE_CHROME
+        # Chrome stripping itself lives in wait_for's prep (see build_wait_for).
         params["excluded_tags"] = ["nav", "footer", "header", "aside", "script", "style"]
 
     return params
@@ -1040,8 +1074,8 @@ def _relax_seed_crawl_config(crawler_config: dict[str, Any]) -> dict[str, Any]:
     relaxed = copy.deepcopy(crawler_config)
     # Some personal/portfolio sites put real content in <header>. If strict
     # chrome stripping leaves no visible text, retry the seed before treating
-    # the page as anti-bot.
-    relaxed.pop("js_code_before_wait", None)
+    # the page as anti-bot. Chrome stripping lives inside wait_for's prep, so
+    # dropping wait_for drops the stripping with it.
     relaxed.pop("wait_for", None)
     if relaxed.get("excluded_tags"):
         relaxed["excluded_tags"] = ["script", "style"]
@@ -1998,9 +2032,20 @@ async def crawl_dom_summary(url: str) -> list[dict] | None:
 })();
 """
 
+    # 0.9's untrusted-config boundary forbids js_code, so the summary
+    # injection rides in the wait_for predicate: wait for load-complete,
+    # inject the <pre> once, and report ready when it exists (matching the
+    # old js_code-after-load timing).
+    inject_wait = (
+        "js:() => {"
+        " if (document.readyState !== 'complete') return false;"
+        " if (!document.getElementById('__klai_dom_summary__')) { " + dom_js + " return false; }"
+        " return true;"
+        " }"
+    )
     config: dict[str, Any] = {
         "cache_mode": "bypass",
-        "js_code": dom_js,
+        "wait_for": inject_wait,
         "css_selector": "#__klai_dom_summary__",
         "word_count_threshold": 0,
         "page_timeout": 30000,

--- a/klai-knowledge-ingest/tests/test_build_crawl_config.py
+++ b/klai-knowledge-ingest/tests/test_build_crawl_config.py
@@ -12,6 +12,11 @@ and the contract surfaces in CI before live debugging is needed.
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+
+import pytest
+
 from knowledge_ingest.crawl4ai_client import build_crawl_config
 
 
@@ -19,8 +24,7 @@ def test_selector_goes_to_target_elements_not_css_selector() -> None:
     cfg = build_crawl_config(selector="main")
 
     assert cfg.get("target_elements") == ["main"], (
-        "selector must be delivered as target_elements so BFS link discovery "
-        "sees the full DOM"
+        "selector must be delivered as target_elements so BFS link discovery sees the full DOM"
     )
     assert "css_selector" not in cfg, (
         "css_selector shrinks raw HTML before BFS walks the DOM — forbidden "
@@ -46,7 +50,10 @@ def test_no_selector_enables_chrome_stripping() -> None:
         "script",
         "style",
     ]
-    assert "js_code_before_wait" in cfg
+    # Chrome stripping moved into wait_for's one-time prep (crawl4ai >= 0.9
+    # forbids js_code_before_wait on network requests).
+    assert "js_code_before_wait" not in cfg
+    assert "el.remove()" in cfg["wait_for"]
 
 
 def test_selector_with_complex_css_is_passed_as_list() -> None:
@@ -56,3 +63,23 @@ def test_selector_with_complex_css_is_passed_as_list() -> None:
 
     assert cfg["target_elements"] == [".tab-structure article"]
     assert isinstance(cfg["target_elements"], list)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+@pytest.mark.parametrize("selector", [None, "article.main"])
+def test_wait_for_predicate_is_valid_javascript(selector) -> None:
+    """The wait_for prep predicate must stay parseable JS — crawl4ai evaluates
+    it in the page context, and a syntax error silently degrades every crawl."""
+    cfg = build_crawl_config(selector=selector, login_indicator_selector=".login-wall")
+    js = cfg["wait_for"]
+    assert js.startswith("js:")
+    node = shutil.which("node")
+    assert node is not None
+    proc = subprocess.run(  # noqa: S603 — fixed argv, test-only syntax check
+        [node, "--check", "/dev/stdin"],
+        input=f"const f = {js[3:]};",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/klai-knowledge-ingest/tests/test_build_crawl_config.py
+++ b/klai-knowledge-ingest/tests/test_build_crawl_config.py
@@ -12,8 +12,10 @@ and the contract surfaces in CI before live debugging is needed.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import tempfile
 
 import pytest
 
@@ -75,11 +77,18 @@ def test_wait_for_predicate_is_valid_javascript(selector) -> None:
     assert js.startswith("js:")
     node = shutil.which("node")
     assert node is not None
-    proc = subprocess.run(  # noqa: S603 — fixed argv, test-only syntax check
-        [node, "--check", "/dev/stdin"],
-        input=f"const f = {js[3:]};",
-        capture_output=True,
-        text=True,
-        timeout=15,
-    )
-    assert proc.returncode == 0, proc.stderr
+    # A real temp file, not /dev/stdin — node --check on a stdin pipe fails
+    # with ENOENT on Linux CI runners (it reopens /proc/<pid>/fd/pipe:[...]).
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+        fh.write(f"const f = {js[3:]};")
+        path = fh.name
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed argv, test-only syntax check
+            [node, "--check", path],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert proc.returncode == 0, proc.stderr
+    finally:
+        os.unlink(path)

--- a/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
+++ b/klai-knowledge-ingest/tests/test_crawl4ai_filter_chain.py
@@ -83,9 +83,11 @@ async def test_fetch_seed_retries_relaxed_config_after_minimal_content_antibot(
 
     assert result.success is True
     assert len(calls) == 2
-    assert "js_code_before_wait" in calls[0]
+    # Chrome stripping lives inside wait_for's prep on >= 0.9-compatible
+    # configs; the relaxed retry drops wait_for (and the stripping with it).
+    assert "js_code_before_wait" not in calls[0]
     assert "wait_for" in calls[0]
-    assert "js_code_before_wait" not in calls[1]
+    assert "el.remove()" in calls[0]["wait_for"]
     assert "wait_for" not in calls[1]
     assert calls[1]["excluded_tags"] == ["script", "style"]
 
@@ -135,8 +137,8 @@ async def test_crawl_page_retries_relaxed_config_when_strict_result_is_thin(
 
     assert result.word_count >= 100
     assert len(calls) == 2
-    assert "js_code_before_wait" in calls[0]
-    assert "js_code_before_wait" not in calls[1]
+    assert "el.remove()" in calls[0]["wait_for"]
+    assert "wait_for" not in calls[1]
     assert calls[1]["excluded_tags"] == ["script", "style"]
 
 
@@ -169,7 +171,7 @@ async def test_crawl_site_recovers_thin_bulk_pages_with_relaxed_retry(
     ) -> dict[str, Any]:
         params = payload["crawler_config"]["params"]
         bulk_configs.append(params)
-        relaxed = "js_code_before_wait" not in params
+        relaxed = "wait_for" not in params
         return {
             "results": [
                 {
@@ -194,8 +196,8 @@ async def test_crawl_site_recovers_thin_bulk_pages_with_relaxed_retry(
     assert work.word_count >= 100  # recovered, not the 1-word strict result
     # Strict bulk fetch + one relaxed retry over the thin page.
     assert len(bulk_configs) == 2
-    assert "js_code_before_wait" in bulk_configs[0]
-    assert "js_code_before_wait" not in bulk_configs[1]
+    assert "el.remove()" in bulk_configs[0]["wait_for"]
+    assert "wait_for" not in bulk_configs[1]
 
 
 @pytest.mark.asyncio
@@ -226,7 +228,7 @@ async def test_crawl_site_discovers_links_from_recovered_bulk_pages(
         urls = payload["urls"]
         submitted_batches.append(urls)
         params = payload["crawler_config"]["params"]
-        relaxed = "js_code_before_wait" not in params
+        relaxed = "wait_for" not in params
 
         if urls == ["https://portfolio.example/work"] and not relaxed:
             return {

--- a/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
+++ b/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
@@ -31,7 +31,9 @@ class TestBuildCrawlConfigWithLoginIndicator:
 
     def test_no_login_indicator_uses_base_wait(self) -> None:
         cfg = build_crawl_config(selector=None)
-        assert "querySelector" not in cfg["wait_for"]
+        # No negation clause: the wait_for prep block uses querySelectorAll,
+        # but the login-indicator pattern (!document.querySelector) is absent.
+        assert "!document.querySelector(" not in cfg["wait_for"]
 
     def test_login_indicator_negates_wait_for(self) -> None:
         cfg = build_crawl_config(selector=None, login_indicator_selector="#login-form")


### PR DESCRIPTION
Unblocks the crawl4ai 0.9.2 security bump (2 critical CVEs). Same output on both server versions (byte-equal word counts, verified in prod network). Pin flip follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)