### PR TITLE
fix(portal): per-transaction RLS tenant context (transaction-local GUCs)

### DIFF
--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -23,7 +23,64 @@ paths:
 - Use `text()` raw SQL for inserts on RLS-protected tables where the inserting role differs from the reading role.
 - `::jsonb` casts conflict with SQLAlchemy `:param` — use `CAST(:param AS jsonb)` instead.
 
-## Pool-GUC pollution — reset at checkout AND cleanup (CRIT)
+## Pool-GUC pollution — tenant context is per-TRANSACTION (CRIT)
+
+**Current model (2026-08-13, SPEC-less structural fix).** Tenant context is a
+property of the *transaction*, not of the pooled connection. `app/core/database.py`
+registers an `after_begin` listener on `_SyncPooledTenantSession` (wired into
+`PooledTenantSession` via `sync_session_class`). At the start of EVERY
+transaction it emits one combined statement setting all four RLS GUCs
+**transaction-locally** (`set_config(..., true)`):
+
+| GUC | Source | Truthy literal |
+|---|---|---|
+| `app.current_org_id` | `session.info["tenant_org_id"]` (via `set_tenant`) | — |
+| `app.cross_org_admin` | `session.info["cross_org_admin"]` (via `cross_org_session`) | `'true'` |
+| `klai.changed_by_user_id` | `current_changed_by_user_id` contextvar (via `set_request_actor`) | — |
+| `app.is_platform_admin` | `current_is_platform_admin` contextvar (via `set_request_actor`) | `'1'` |
+
+Tenant scope lives on `session.info` (per-session, so a request session and a
+`tenant_scoped_session` / `cross_org_session` block opened inside it hold
+different scopes without contaminating each other). Actor identity lives in
+contextvars (per-task, so a background write opened inside a request attributes
+to the same admin). The statement is always emitted, even when every value is
+empty — a deterministic override also neutralises any legacy session-level GUC.
+
+Consequences:
+- portal-api writes **zero** `is_local=false` GUCs. Grep guard: the only
+  `set_config(..., false)` calls left in `app/` are the three `''` resets inside
+  `_reset_tenant_context`.
+- A post-commit statement (`db.refresh()` right after `db.commit()`) is safe on
+  whatever pooled connection it lands on — its transaction re-declares the
+  context before the first query.
+- Transaction-local GUCs vanish at COMMIT/ROLLBACK, so pool pollution is
+  structurally impossible rather than defended against.
+
+**Incident that forced this (2026-08-13).** `PATCH .../connectors/{id}` returned
+500: `sqlalchemy.exc.InvalidRequestError: Could not refresh instance
+'<PortalConnector>'` at `app/api/connectors.py:802` — `await db.refresh(connector)`
+directly after `await db.commit()`. `commit()` releases the pooled connection;
+the refresh checks one out again with no tenant guarantee. The cleanup reset in
+`_reset_tenant_context` runs inside a transaction that is rolled back at session
+close, so the reset never durably landed and pooled connections carried the last
+COMMITTED tenant GUC. A connection polluted with a foreign org made the
+freshly-updated row invisible under `org_id = GUC OR GUC IS NULL` → zero rows →
+500. Same class, earlier symptom: widget-create 500 `InsufficientPrivilegeError`
+post-commit (worked around locally in `app/api/admin_widgets.py` by loading
+before commit). An audit found 17 post-commit-query sites, 4 with cross-tenant
+READ risk; all are safe under the new invariant and were left untouched.
+
+Regression proof: `tests/test_rls_txn_context_postgres.py` (marker `postgres`,
+real PostgreSQL + real policies + non-superuser role, gated in CI by the
+`rls-policy-smoke-test` job). Unit coverage of the listener:
+`tests/test_rls_txn_context.py`.
+
+### Historical layers (still in place, now defense-in-depth)
+
+The three layers below predate the per-transaction model and remain deliberately
+active. They no longer carry the tenant contract, but they neutralise anything a
+manual `psql` session, a legacy deployment, or a future regression might leave
+on a pooled connection. Do not remove them as "dead code".
 
 PostgreSQL `set_config('app.current_org_id', ...)` persists for the lifetime
 of the pooled connection. `app/core/database.py` resets both RLS GUCs on

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -310,6 +310,27 @@ jobs:
         working-directory: klai-portal/backend
         run: psql -h localhost -U klai -d klai -v ON_ERROR_STOP=1 < alembic/versions/post_deploy_rls_rollback_to_nullif_pattern.sql
 
+      # 2026-08-13 per-transaction RLS context (incident: `db.refresh()` after
+      # `db.commit()` 500'd because the pooled connection carried another
+      # tenant's session-level GUC). These tests need a REAL PostgreSQL with
+      # REAL policies and a non-superuser role — mocks cannot express the
+      # failure. They create and drop their own throwaway role + tables, so
+      # they are independent of the smoke-test schema above and of its
+      # rollback step.
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        working-directory: klai-portal/backend
+        run: uv sync --group dev
+
+      - name: Run real-PostgreSQL RLS transaction-context tests
+        working-directory: klai-portal/backend
+        env:
+          RLS_TEST_DATABASE_URL: postgresql+asyncpg://klai:klai@localhost:5432/klai
+        run: uv run pytest -m postgres -q --tb=short
+
   zitadel-password-policy-drift:
     # Deployment gate for the fail-loud startup guard in
     # app.services.password_policy_guard. Without this, a Zitadel drift would

--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -2,13 +2,25 @@ import contextlib
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextvars import ContextVar
 
-from sqlalchemy import text
+from sqlalchemy import event, text
+from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session, SessionTransaction
 
 from app.core.config import settings
 
 # Tracks the current request's org_id so RLS context can be set once per request.
 current_org_id: ContextVar[int | None] = ContextVar("current_org_id", default=None)
+
+# Actor identity for the current asyncio task. Task-scoped (contextvar) rather
+# than session-scoped because "who is acting" is a property of the request, not
+# of a particular DB session: a request that opens a `tenant_scoped_session`
+# or `cross_org_session` block must carry the same actor into those sessions.
+#
+# Feeds `klai.changed_by_user_id`, read by `portal_users_seat_history_trg`.
+current_changed_by_user_id: ContextVar[str | None] = ContextVar("current_changed_by_user_id", default=None)
+# Feeds `app.is_platform_admin`, read by the tenant_lifecycle_events policies.
+current_is_platform_admin: ContextVar[bool] = ContextVar("current_is_platform_admin", default=False)
 
 engine = create_async_engine(
     settings.database_url,
@@ -19,25 +31,123 @@ engine = create_async_engine(
     pool_pre_ping=settings.db_pool_pre_ping,
 )
 
+# One statement, four transaction-local GUCs. `is_local=true` (the third
+# set_config argument) is the whole point: the values vanish at COMMIT/ROLLBACK
+# so a pooled connection can never carry them into the next request.
+_TENANT_CONTEXT_SQL = (
+    "SELECT set_config('app.current_org_id', :org_id, true), "
+    "set_config('app.cross_org_admin', :cross_org_admin, true), "
+    "set_config('klai.changed_by_user_id', :changed_by_user_id, true), "
+    "set_config('app.is_platform_admin', :is_platform_admin, true)"
+)
+
+
+def _tenant_context_params(session: Session | AsyncSession) -> dict[str, str]:
+    """Render the four RLS GUC values from Python-side state.
+
+    Tenant scope comes from `session.info` (per-session, so a request session
+    and a nested `cross_org_session` block cannot contaminate each other).
+    Actor identity comes from contextvars (per-task, so it flows into nested
+    session blocks opened by the same request).
+
+    Empty string is the "unset" value for every policy — they all wrap the GUC
+    in `NULLIF(..., '')`. Values are always rendered, even when everything is
+    empty: a deterministic override also neutralises any legacy session-level
+    GUC left on the pooled connection by older code or by a manual `psql`
+    session.
+
+    Note the two different truthy literals: `app.cross_org_admin` uses `'true'`
+    and `app.is_platform_admin` uses `'1'`. Both are pre-existing conventions
+    baked into deployed RLS policies — do not "normalise" them.
+    """
+    # Mocked sessions in tests do not carry a real info dict; a non-dict means
+    # no tenant scope (and avoids `.get()` returning a coroutine on AsyncMock).
+    info = session.info if isinstance(getattr(session, "info", None), dict) else {}
+    org_id = info.get("tenant_org_id")
+    return {
+        "org_id": str(org_id) if org_id is not None else "",
+        "cross_org_admin": "true" if info.get("cross_org_admin") else "",
+        "changed_by_user_id": current_changed_by_user_id.get() or "",
+        "is_platform_admin": "1" if current_is_platform_admin.get() else "",
+    }
+
+
+class _SyncPooledTenantSession(Session):
+    """Sync `Session` used underneath `PooledTenantSession`.
+
+    Exists purely so the `after_begin` listener below can be registered on a
+    class that ONLY portal-api's pooled sessions use. Registering on the stock
+    `Session` would also fire for third-party / test-fixture sessions that have
+    no tenant contract.
+    """
+
+
+@event.listens_for(_SyncPooledTenantSession, "after_begin")
+def _apply_tenant_context_on_begin(
+    session: Session,
+    transaction: SessionTransaction,
+    connection: Connection,
+) -> None:
+    """Re-apply the four RLS GUCs transaction-locally at every BEGIN.
+
+    This is the invariant that makes post-commit queries safe: `commit()`
+    releases the pooled connection, and the next statement checks one out again
+    with no tenant guarantee. Because every transaction begins by re-declaring
+    its own context, it does not matter which physical connection it lands on
+    or what the previous tenant left behind.
+
+    SQLAlchemy docs require emitting SQL through the supplied `Connection` here,
+    not through the `Session` — the session is mid-begin and re-entering it
+    would recurse.
+    """
+    if transaction.nested:
+        # SAVEPOINT: inherits the enclosing transaction's GUCs, so there is
+        # nothing to establish. PostgreSQL DOES restore SET LOCAL values on
+        # ROLLBACK TO SAVEPOINT (verified: 33 before, 22 set inside, 33 after
+        # rollback). That makes skipping correct today, and also flags a latent
+        # mismatch: if a mutator changed session.info / the actor contextvars
+        # INSIDE a nested transaction that later rolls back, PostgreSQL would
+        # restore the old GUC while the Python-side state keeps the new value.
+        # The mismatch heals at the next top-level BEGIN. No `begin_nested()`
+        # call site exists under app/ today, so this is latent, not live.
+        return
+    if connection.dialect.name != "postgresql":
+        # SQLite/in-memory rigs used by some tests have no set_config().
+        return
+    connection.execute(text(_TENANT_CONTEXT_SQL), _tenant_context_params(session))
+
+
+async def _apply_tenant_context(session: AsyncSession) -> None:
+    """Apply the four RLS GUCs to the session's ALREADY-OPEN transaction.
+
+    `after_begin` fired for that transaction before the caller mutated
+    `session.info` / the actor contextvars, so it ran with the previous state.
+    Every mutator (`set_tenant`, `set_request_actor`, `cross_org_session`) calls
+    this immediately afterwards so the current transaction picks the new context
+    up without waiting for the next BEGIN.
+    """
+    await session.execute(text(_TENANT_CONTEXT_SQL), _tenant_context_params(session))
+
 
 class PooledTenantSession(AsyncSession):
     """AsyncSession that auto-pins + resets RLS tenant context on `__aenter__`.
 
     Every `async with AsyncSessionLocal() as s:` block starts with:
-      1. a pinned pooled connection (session-level `set_config` survives awaits); and
-      2. both RLS GUCs (`app.current_org_id`, `app.cross_org_admin`) cleared.
+      1. a pinned pooled connection; and
+      2. all RLS GUCs cleared on that connection.
 
-    This is a defense-in-depth layer on top of the explicit
-    `_pin_and_reset_connection` calls in `get_db`, `tenant_scoped_session`,
-    `pin_session`, `cross_org_session`. A new helper that forgets to call the
-    explicit pin+reset would previously re-introduce the 2026-04-24 pool
-    pollution bug. With this subclass as the session base, forgetting is
-    harmless — every session-maker exit point runs pin+reset unconditionally.
+    The authoritative mechanism is `sync_session_class`: it wires in
+    `_SyncPooledTenantSession`, whose `after_begin` listener re-applies the
+    tenant context transaction-locally at the start of EVERY transaction. That
+    is what makes post-commit statements (`db.refresh()` after `db.commit()`)
+    safe regardless of which pooled connection they land on.
 
-    The explicit `_pin_and_reset_connection` calls stay in place so the
-    behaviour remains visible at the call site (and idempotent — a repeat
-    reset is three cheap no-op SQL statements).
+    The pin + checkout reset below stays as defense-in-depth: it neutralises any
+    session-level GUC that older code, a manual `psql` session, or a future
+    regression might leave on a pooled connection.
     """
+
+    sync_session_class = _SyncPooledTenantSession
 
     async def __aenter__(self) -> AsyncSession:  # type: ignore[override]
         session = await super().__aenter__()
@@ -67,10 +177,11 @@ async def _pin_and_reset_connection(session: AsyncSession) -> None:
 
     Two jobs, both at checkout time:
 
-    1. Pin the pooled connection via `session.connection()`. After this call
-       every subsequent statement on the session uses the same physical
-       connection, so PostgreSQL session-level `set_config()` values stay
-       visible across awaits.
+    1. Pin the pooled connection via `session.connection()`. Tenant context no
+       longer depends on this (it is re-applied per transaction by the
+       `after_begin` listener), but pinning keeps a session's statements on one
+       physical connection, which keeps advisory locks and `SELECT … FOR UPDATE`
+       semantics predictable across awaits.
 
     2. Clear any stale `app.current_org_id` / `app.cross_org_admin` inherited
        from a prior request. `_reset_tenant_context` already runs at cleanup,
@@ -94,6 +205,11 @@ async def _reset_tenant_context(session: AsyncSession) -> None:
 
     Called before the connection returns to the pool so the next request /
     task that picks it up starts with a clean RLS context.
+
+    Since tenant context became transaction-local (`after_begin` listener),
+    portal-api writes no session-level GUCs at all and this reset is pure
+    defense-in-depth: it neutralises anything a manual `psql` session, a legacy
+    deployment, or a future regression might leave behind. Keep it.
 
     Rolls back FIRST. If the session is in an aborted-transaction state (e.g.
     after a 42501 RLS failure from the fail-loud policy), PostgreSQL rejects
@@ -129,16 +245,10 @@ async def _reset_tenant_context(session: AsyncSession) -> None:
 async def get_db() -> AsyncGenerator[AsyncSession]:
     """Yield an async DB session with a pinned connection.
 
-    Calling session.connection() at the start pins a single pooled connection
-    for the entire session lifetime. This guarantees that set_tenant() and all
-    subsequent queries run on the SAME connection — required for PostgreSQL
-    session-level set_config() to be visible to RLS policies.
-
-    Without pinning, AsyncSession lazily checks out connections per-statement,
-    and the async event loop can hand out different connections for sequential
-    awaits. This caused set_tenant() to set app.current_org_id on connection A
-    while the next query ran on connection B (where the setting was empty),
-    making RLS block all rows.
+    Tenant context is carried by the session (`session.info`) and re-declared
+    transaction-locally at every BEGIN by the `after_begin` listener, so RLS no
+    longer depends on which pooled connection a statement lands on. Pinning via
+    `session.connection()` remains for lock/transaction predictability.
 
     The explicit `_pin_and_reset_connection` below is intentionally double work
     with `PooledTenantSession.__aenter__`. Rationale:
@@ -158,24 +268,54 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
 
 
 async def set_tenant(session: AsyncSession, org_id: int) -> None:
-    """Set PostgreSQL session-level tenant context for RLS.
+    """Bind this session's tenant scope for RLS.
 
-    Uses set_config with is_local=false so the setting survives commits within
-    the same connection checkout. get_db() resets it on cleanup.
+    The scope is stored on `session.info` — Python-side state, not a
+    connection-level GUC. From here on, EVERY transaction this session opens
+    re-declares `app.current_org_id` transaction-locally via the `after_begin`
+    listener, so the context follows the session across commits and across
+    pooled-connection checkouts. That is what makes `db.refresh()` immediately
+    after `db.commit()` safe.
 
-    The caller is responsible for ensuring the session's connection is pinned
-    (via session.connection() or a pinned dependency). Otherwise the
-    SET may land on a different pooled connection than later queries and RLS
-    will silently filter rows. Use `tenant_scoped_session()` below if you
-    don't already have a pinned session.
+    `session.info` (rather than a contextvar) is deliberate: a request session
+    and a `tenant_scoped_session` / `cross_org_session` block opened inside the
+    same asyncio task can hold different scopes without contaminating each
+    other.
 
-    Called once per request by _get_caller_org after authentication.
+    The immediate `_apply_tenant_context` call covers the transaction that is
+    already open right now — `after_begin` fired for it before this scope
+    existed.
+
+    Called once per request by `_get_caller_org` / `get_caller` after
+    authentication.
     """
-    await session.execute(
-        text("SELECT set_config('app.current_org_id', :org_id, false)"),
-        {"org_id": str(org_id)},
-    )
+    session.info["tenant_org_id"] = org_id
     current_org_id.set(org_id)
+    await _apply_tenant_context(session)
+
+
+async def set_request_actor(
+    session: AsyncSession,
+    changed_by_user_id: str | None,
+    is_platform_admin: bool,
+) -> None:
+    """Bind the acting identity for this asyncio task.
+
+    Feeds two GUCs:
+      * `klai.changed_by_user_id` — read by `portal_users_seat_history_trg` to
+        record WHO changed a seat. Empty means "no acting admin" (signup flows,
+        internal callers), which the trigger stores as NULL.
+      * `app.is_platform_admin` — unlocks the platform-admin branch of the
+        `tenant_lifecycle_events` policies.
+
+    Contextvars (not `session.info`) because identity is a property of the task:
+    a background write opened via `tenant_scoped_session` inside a request must
+    attribute to the same admin. `_reset_tenant_context` still clears the GUCs
+    on the connection as defense-in-depth.
+    """
+    current_changed_by_user_id.set(changed_by_user_id)
+    current_is_platform_admin.set(is_platform_admin)
+    await _apply_tenant_context(session)
 
 
 async def assert_portal_users_rls_ready() -> None:
@@ -408,9 +548,10 @@ async def assert_product_updates_rls_ready() -> None:
 async def tenant_scoped_session(org_id: int) -> AsyncIterator[AsyncSession]:
     """Yield an RLS-aware session for background tasks and fire-and-forget writes.
 
-    Opens a fresh AsyncSession, pins its pooled connection, sets
-    app.current_org_id via set_config(), yields for use, and resets the
-    tenant context on exit before the connection returns to the pool.
+    Opens a fresh AsyncSession, pins its pooled connection, binds the tenant
+    scope via `set_tenant` (re-applied transaction-locally at every BEGIN),
+    yields for use, and resets the connection's tenant context on exit before
+    it returns to the pool.
 
     Use this instead of `async with AsyncSessionLocal() as db` anywhere
     you need to read or write an RLS-protected table outside of a request
@@ -440,10 +581,9 @@ async def pin_session(session: AsyncSession) -> None:
     """Pin an externally-provided session's pooled connection.
 
     For code paths that accept a session as a parameter (e.g. provisioning
-    orchestrator) and need to guarantee that later set_config() calls on
-    that session remain visible. Idempotent — calling session.connection()
-    twice is safe, and re-clearing the tenant GUC is a no-op when already
-    clear.
+    orchestrator) and want a single physical connection for the duration plus a
+    clean starting RLS context. Idempotent — calling session.connection() twice
+    is safe, and re-clearing the tenant GUC is a no-op when already clear.
     """
     await _pin_and_reset_connection(session)
 
@@ -478,10 +618,20 @@ async def cross_org_session() -> AsyncIterator[AsyncSession]:
 
     Anything new you add here must have a written @MX:REASON justifying
     why tenant scoping is not possible.
+
+    Do NOT call this from a handler that already holds a session (webhook
+    handlers, FastAPI routes with `Depends(get_db)`) — it checks out a SECOND
+    pooled connection while the first is still held, so a burst of concurrent
+    requests can exhaust the pool. Use `cross_org_scope(session)` there.
     """
     async with AsyncSessionLocal() as session:
         await _pin_and_reset_connection(session)
-        await session.execute(text("SELECT set_config('app.cross_org_admin', 'true', false)"))
+        # Session-scoped flag: the `after_begin` listener re-declares
+        # `app.cross_org_admin` transaction-locally on every transaction this
+        # session opens, so the bypass survives the commits that multi-step
+        # cross-org blocks (invite_scheduler, KEK rotation) perform.
+        session.info["cross_org_admin"] = True
+        await _apply_tenant_context(session)
         try:
             yield session
         finally:
@@ -490,3 +640,31 @@ async def cross_org_session() -> AsyncIterator[AsyncSession]:
             # so the pool cannot inherit the cross-org bypass flag from a
             # session that aborted before reaching this finally.
             await _reset_tenant_context(session)
+
+
+@contextlib.asynccontextmanager
+async def cross_org_scope(session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    """Temporarily enable the cross-org RLS bypass on an EXISTING session.
+
+    Unlike `cross_org_session()` this does NOT check out a second pooled
+    connection — use it when the caller already holds a session (webhook
+    handlers, any route with `Depends(get_db)`). Opening a nested
+    `cross_org_session()` there doubles connection usage per request; a burst
+    can exhaust the pool while each outer session still holds its connection.
+
+    Safe only because tenant context is transaction-local: the flag lives in
+    `session.info` and is applied via `set_config(..., true)`, so no
+    session-level GUC can leak onto the pooled connection. The `finally`
+    clears the flag and re-applies immediately, so the bypass cannot outlive
+    the block even if the body raises.
+
+    Scope it as tightly as possible — ideally one lookup. Everything inside
+    sees ALL tenants' rows.
+    """
+    session.info["cross_org_admin"] = True
+    await _apply_tenant_context(session)
+    try:
+        yield session
+    finally:
+        session.info["cross_org_admin"] = False
+        await _apply_tenant_context(session)

--- a/klai-portal/backend/app/core/permissions.py
+++ b/klai-portal/backend/app/core/permissions.py
@@ -28,12 +28,12 @@ from dataclasses import dataclass
 import structlog
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.bearer import bearer
 from app.core.config import settings as _app_settings
-from app.core.database import get_db, set_tenant
+from app.core.database import get_db, set_request_actor, set_tenant
 from app.core.features import derive_user_products
 from app.core.plan_limits import KBLimits
 from app.core.profiles import (
@@ -288,22 +288,18 @@ async def _resolve_caller_with_options(
 
     await set_tenant(db, perms.org_id)
 
-    # SPEC-PORTAL-PRICING-PER-USER-001 Phase 2: propagate the caller's
-    # zitadel_user_id into ``klai.changed_by_user_id``. The
-    # ``portal_users_seat_history_trg`` trigger reads this GUC and stores
-    # it into ``portal_user_seat_history.changed_by`` so the audit trail
-    # carries the WHO. Empty GUC -> trigger writes NULL ("no acting
-    # admin" — correct semantics for signup flows and internal callers).
-    await db.execute(
-        text("SELECT set_config('klai.changed_by_user_id', :uid, false)"),
-        {"uid": zitadel_user_id},
-    )
-
-    # SPEC-INFRA-TENANT-DELETE-001 R6: enable platform-admin RLS on
-    # tenant_lifecycle_events when caller is in the platform org. Same value
-    # as `admin/__init__::_get_caller_org` — must remain '1' (text), not 'true'.
-    if perms.is_platform_admin:
-        await db.execute(text("SELECT set_config('app.is_platform_admin', '1', true)"))
+    # Bind the acting identity for this request task. Feeds two GUCs, both
+    # re-applied transaction-locally at every BEGIN:
+    #
+    #   * ``klai.changed_by_user_id`` (SPEC-PORTAL-PRICING-PER-USER-001 Phase 2)
+    #     — read by ``portal_users_seat_history_trg`` and stored into
+    #     ``portal_user_seat_history.changed_by`` so the audit trail carries the
+    #     WHO. Empty -> trigger writes NULL ("no acting admin", correct for
+    #     signup flows and internal callers).
+    #   * ``app.is_platform_admin`` (SPEC-INFRA-TENANT-DELETE-001 R6) — unlocks
+    #     the platform-admin branch of the tenant_lifecycle_events policies.
+    #     Same '1' (text, not 'true') value as `admin/__init__::_get_caller_org`.
+    await set_request_actor(db, zitadel_user_id, perms.is_platform_admin)
 
     structlog.contextvars.bind_contextvars(org_id=str(perms.org_id), user_id=zitadel_user_id)
     return perms

--- a/klai-portal/backend/app/services/widget_handoff.py
+++ b/klai-portal/backend/app/services/widget_handoff.py
@@ -8,7 +8,7 @@ import structlog
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import set_tenant
+from app.core.database import cross_org_scope, set_tenant
 from app.services.hubspot_custom_channel import ensure_channel_account, publish_incoming_message
 from app.services.redis_client import get_redis_pool
 
@@ -476,11 +476,16 @@ async def record_hubspot_agent_reply(db: AsyncSession, payload: dict[str, Any]) 
         return {"status": "ignored", "reason": "missing_required_fields"}
 
     # HubSpot webhooks are not tenant-authenticated requests. We must first map
-    # the globally unique HubSpot thread id to a Klai tenant, then switch back to
-    # normal tenant RLS before writing the visible agent message.
-    await db.execute(text("SELECT set_config('app.cross_org_admin', 'true', false)"))
-    try:
-        session = (
+    # the globally unique HubSpot thread id to a Klai tenant, then write the
+    # visible agent message under normal tenant RLS.
+    #
+    # The bypass is scoped to the single lookup via `cross_org_scope`, which
+    # flips a `session.info` flag applied transaction-locally. It reuses the
+    # request's own session — opening a second `cross_org_session()` here would
+    # hold TWO pooled connections per webhook, and a HubSpot burst can exhaust
+    # the pool. The `finally` clears the flag before the INSERT below runs.
+    async with cross_org_scope(db):
+        row = (
             await db.execute(
                 text(
                     """
@@ -496,9 +501,8 @@ async def record_hubspot_agent_reply(db: AsyncSession, payload: dict[str, Any]) 
                 {"provider": _PROVIDER, "thread_id": thread_id},
             )
         ).first()
-    finally:
-        await db.execute(text("SELECT set_config('app.cross_org_admin', '', false)"))
-    if session is None:
+
+    if row is None:
         logger.info(
             "hubspot_custom_channel_webhook_unmapped",
             conversations_thread_id=thread_id,
@@ -506,8 +510,8 @@ async def record_hubspot_agent_reply(db: AsyncSession, payload: dict[str, Any]) 
         )
         return {"status": "ignored", "reason": "unmapped_thread"}
 
-    session_id = int(session[0])
-    org_id = int(session[1])
+    session_id = int(row[0])
+    org_id = int(row[1])
     await set_tenant(db, org_id)
     inserted = (
         await db.execute(

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -124,8 +124,9 @@ asyncio_mode = "auto"
 pythonpath = [".", "tests"]
 markers = [
     "benchmark: constant-time regression benchmarks (run with: pytest -m benchmark)",
+    "postgres: real-PostgreSQL RLS regression tests (need RLS_TEST_DATABASE_URL)",
 ]
-addopts = "-m 'not benchmark'"
+addopts = "-m 'not benchmark and not postgres'"
 
 [tool.ruff]
 line-length = 120

--- a/klai-portal/backend/tests/test_pricing_per_user_phase2_migration.py
+++ b/klai-portal/backend/tests/test_pricing_per_user_phase2_migration.py
@@ -6,9 +6,9 @@ File-content regex checks on the Phase 2 migration that extends
 ``portal_user_seat_history.changed_by``.
 
 Also pins the matching change in ``permissions.py``: the authenticated
-caller dependency MUST issue ``set_config('klai.changed_by_user_id', ...)``
-right after ``set_tenant`` so the GUC is bound before any subsequent
-UPDATE on portal_users fires the trigger.
+caller dependency MUST bind the actor identity (via ``set_request_actor``)
+right after ``set_tenant`` so ``klai.changed_by_user_id`` is set before any
+subsequent UPDATE on portal_users fires the trigger.
 """
 
 from __future__ import annotations
@@ -108,24 +108,55 @@ class TestTriggerBodyReadsActorGuc:
 
 class TestCallerDependencyBindsActorGuc:
     """The matching code side: ``_resolve_caller_with_options`` in
-    permissions.py MUST issue ``set_config('klai.changed_by_user_id', ...)``
-    right after ``set_tenant`` so the trigger sees the actor on the next
-    portal_users UPDATE within the same request.
+    permissions.py MUST bind the actor identity right after ``set_tenant`` so
+    the trigger sees it on the next portal_users UPDATE within the same request.
+
+    The 2026-08-13 per-transaction-RLS-context change moved the raw
+    ``set_config('klai.changed_by_user_id', :uid, false)`` out of permissions.py
+    and into ``database.set_request_actor``, which writes a contextvar and
+    re-applies all four GUCs transaction-locally at every BEGIN. The guarantee
+    under test is unchanged — the actor is bound before any trigger fires — so
+    these assertions now pin the wiring rather than the literal SQL.
     """
 
-    def test_permissions_sets_changed_by_user_id_guc(self, permissions_src: str) -> None:
-        # The exact statement we expect:
-        #   await db.execute(
-        #       text("SELECT set_config('klai.changed_by_user_id', :uid, false)"),
-        #       {"uid": zitadel_user_id},
-        #   )
+    def test_permissions_binds_actor_via_set_request_actor(self, permissions_src: str) -> None:
+        # The exact call we expect:
+        #   await set_request_actor(db, zitadel_user_id, perms.is_platform_admin)
         assert re.search(
-            r"set_config\('klai\.changed_by_user_id',\s*:uid,\s*false\)",
+            r"await\s+set_request_actor\(\s*db,\s*zitadel_user_id,\s*perms\.is_platform_admin\s*\)",
             permissions_src,
         ), (
-            "permissions.py must bind klai.changed_by_user_id on the request "
-            "connection — without this the trigger writes NULL changed_by "
-            "for every admin action."
+            "permissions.py must bind the actor identity via set_request_actor "
+            "— without this the trigger writes NULL changed_by for every admin "
+            "action."
+        )
+        assert re.search(r"from app\.core\.database import .*\bset_request_actor\b", permissions_src), (
+            "set_request_actor must be imported from app.core.database"
+        )
+
+    def test_permissions_no_longer_writes_session_level_actor_guc(self, permissions_src: str) -> None:
+        """No `is_local=false` GUC writes may remain in permissions.py.
+
+        A session-level write survives on the pooled connection past the
+        request, which is the whole class of bug the transaction-local model
+        removes. See tests/test_rls_txn_context_postgres.py for the runtime
+        proof.
+        """
+        assert not re.search(r"set_config\([^)]*,\s*false\s*\)", permissions_src), (
+            "permissions.py must not write session-level (is_local=false) GUCs"
+        )
+
+    def test_set_request_actor_binds_changed_by_user_id(self, database_src: str) -> None:
+        """database.py's combined statement must still carry the actor GUC."""
+        assert re.search(
+            r"set_config\('klai\.changed_by_user_id',\s*:changed_by_user_id,\s*true\)",
+            database_src,
+        ), (
+            "database.py's transaction-local context statement must bind "
+            "klai.changed_by_user_id, or the seat-history trigger records NULL."
+        )
+        assert re.search(r"async def set_request_actor\(", database_src), (
+            "database.py must expose set_request_actor as the actor-binding entry point"
         )
 
 

--- a/klai-portal/backend/tests/test_rls_guards.py
+++ b/klai-portal/backend/tests/test_rls_guards.py
@@ -45,6 +45,10 @@ async def test_tenant_scoped_session_pins_before_set_tenant(monkeypatch):
     calls: list[str] = []
 
     class FakeSession:
+        def __init__(self):
+            # `set_tenant` writes the tenant scope here before applying it to SQL.
+            self.info: dict = {}
+
         async def connection(self):
             calls.append("pin")
 
@@ -54,8 +58,10 @@ async def test_tenant_scoped_session_pins_before_set_tenant(monkeypatch):
         async def execute(self, stmt, params=None):
             sql = str(stmt)
             if "set_config" in sql:
-                if params and params.get("org_id") == "42":
-                    calls.append("set_tenant:42")
+                # The combined transaction-local apply carries all four GUCs as
+                # bound params; the cleanup resets are single-GUC literals.
+                if params and "changed_by_user_id" in params:
+                    calls.append(f"set_tenant:{params['org_id']}")
                 elif "current_org_id" in sql:
                     calls.append("reset_current_org_id")
                 elif "cross_org_admin" in sql:
@@ -105,6 +111,9 @@ async def test_tenant_scoped_session_resets_on_exception(monkeypatch):
     calls: list[str] = []
 
     class FakeSession:
+        def __init__(self):
+            self.info: dict = {}
+
         async def connection(self):
             calls.append("pin")
 
@@ -114,7 +123,7 @@ async def test_tenant_scoped_session_resets_on_exception(monkeypatch):
         async def execute(self, stmt, params=None):
             sql = str(stmt)
             if "set_config" in sql:
-                if params and params.get("org_id") == "7":
+                if params and "changed_by_user_id" in params:
                     calls.append("set")
                 elif "current_org_id" in sql:
                     calls.append("reset_current_org_id")
@@ -177,6 +186,10 @@ async def test_cross_org_session_sets_and_resets_bypass_flag(monkeypatch):
     calls: list[str] = []
 
     class FakeSession:
+        def __init__(self):
+            # `cross_org_session` writes {"cross_org_admin": True} here, then applies.
+            self.info: dict = {}
+
         async def connection(self):
             calls.append("pin")
 
@@ -185,8 +198,12 @@ async def test_cross_org_session_sets_and_resets_bypass_flag(monkeypatch):
 
         async def execute(self, stmt, params=None):
             sql = str(stmt)
-            if "set_config" in sql and "cross_org_admin" in sql:
-                calls.append("bypass_on" if "'true'" in sql else "bypass_off")
+            if params and "changed_by_user_id" in params:
+                # Combined transaction-local apply: the bypass is on iff the
+                # bound cross_org_admin param renders as 'true'.
+                calls.append("bypass_on" if params["cross_org_admin"] == "true" else "bypass_off")
+            elif "set_config" in sql and "cross_org_admin" in sql:
+                calls.append("bypass_off")
             elif "set_config" in sql and "current_org_id" in sql:
                 calls.append("tenant_reset")
             return SimpleNamespace(rowcount=-1)
@@ -230,13 +247,16 @@ async def test_cross_org_session_clears_bypass_on_exception(monkeypatch):
     calls: list[str] = []
 
     class FakeSession:
+        def __init__(self):
+            self.info: dict = {}
+
         async def connection(self):
             calls.append("pin")
 
         async def execute(self, stmt, params=None):
             sql = str(stmt)
-            if "cross_org_admin" in sql and "'true'" in sql:
-                calls.append("bypass_on")
+            if params and "changed_by_user_id" in params:
+                calls.append("bypass_on" if params["cross_org_admin"] == "true" else "bypass_off")
             elif "cross_org_admin" in sql:
                 calls.append("bypass_off")
             return SimpleNamespace(rowcount=-1)

--- a/klai-portal/backend/tests/test_rls_txn_context.py
+++ b/klai-portal/backend/tests/test_rls_txn_context.py
@@ -1,0 +1,352 @@
+"""Unit tests for the per-transaction RLS context mechanism (2026-08-13).
+
+Incident: ``PATCH .../connectors/{id}`` 500'd with
+``InvalidRequestError: Could not refresh instance`` because ``db.refresh()``
+after ``db.commit()`` ran on a pooled connection whose session-level
+``app.current_org_id`` belonged to a different tenant.
+
+Structural fix: tenant context is a property of the TRANSACTION. The
+``after_begin`` listener on ``_SyncPooledTenantSession`` re-declares all four
+RLS GUCs transaction-locally (``is_local=true``) from Python-side state at every
+BEGIN, so no statement can ever run under a foreign tenant's context and no GUC
+can outlive its transaction.
+
+These tests invoke the listener directly (house pattern D from
+``test_rls_guards.py``) — no DB required. The real-PostgreSQL proof lives in
+``tests/test_rls_txn_context_postgres.py`` (marker: ``postgres``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core import database as db_module
+
+
+class _RecordingConnection:
+    """Minimal stand-in for the ``Connection`` handed to ``after_begin``."""
+
+    def __init__(self, dialect_name: str = "postgresql") -> None:
+        self.dialect = SimpleNamespace(name=dialect_name)
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute(self, stmt: object, params: dict[str, Any] | None = None) -> object:
+        self.calls.append((str(stmt), params or {}))
+        return SimpleNamespace(rowcount=-1)
+
+
+def _session(info: dict[str, Any] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(info=info if info is not None else {})
+
+
+def _txn(*, nested: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(nested=nested)
+
+
+@pytest.fixture(autouse=True)
+def _clean_actor_contextvars() -> Any:
+    """Actor contextvars are process-global; reset them around every test."""
+    actor_token = db_module.current_changed_by_user_id.set(None)
+    admin_token = db_module.current_is_platform_admin.set(False)
+    yield
+    db_module.current_changed_by_user_id.reset(actor_token)
+    db_module.current_is_platform_admin.reset(admin_token)
+
+
+# ---------------------------------------------------------------------------
+# after_begin listener — the core invariant
+# ---------------------------------------------------------------------------
+
+
+def test_after_begin_applies_all_four_gucs_transaction_locally() -> None:
+    """One statement, four GUCs, every one of them ``is_local=true``.
+
+    ``is_local=true`` is what makes pool pollution structurally impossible:
+    the value vanishes at COMMIT/ROLLBACK instead of sticking to the pooled
+    connection.
+    """
+    conn = _RecordingConnection()
+
+    db_module._apply_tenant_context_on_begin(_session({"tenant_org_id": 8}), _txn(), conn)  # type: ignore[arg-type]
+
+    assert len(conn.calls) == 1
+    sql, params = conn.calls[0]
+    for guc in (
+        "app.current_org_id",
+        "app.cross_org_admin",
+        "klai.changed_by_user_id",
+        "app.is_platform_admin",
+    ):
+        assert guc in sql, f"{guc} missing from the combined statement: {sql}"
+    # Four set_config calls, all is_local=true. A `false` here would re-open
+    # the 2026-08-13 incident.
+    assert sql.count("true)") == 4, sql
+    assert "false)" not in sql, sql
+    assert set(params) == {"org_id", "cross_org_admin", "changed_by_user_id", "is_platform_admin"}
+
+
+def test_after_begin_values_come_from_session_info_and_contextvars() -> None:
+    """Tenant scope from ``session.info``, actor identity from contextvars.
+
+    Note the two different truthy literals — ``'true'`` for cross_org_admin,
+    ``'1'`` for is_platform_admin. Both are baked into deployed RLS policies.
+    """
+    db_module.current_changed_by_user_id.set("zitadel-user-42")
+    db_module.current_is_platform_admin.set(True)
+    conn = _RecordingConnection()
+
+    db_module._apply_tenant_context_on_begin(
+        _session({"tenant_org_id": 8, "cross_org_admin": True}),  # type: ignore[arg-type]
+        _txn(),
+        conn,
+    )
+
+    _, params = conn.calls[0]
+    assert params == {
+        "org_id": "8",
+        "cross_org_admin": "true",
+        "changed_by_user_id": "zitadel-user-42",
+        "is_platform_admin": "1",
+    }
+
+
+def test_after_begin_empty_state_still_executes_with_blank_values() -> None:
+    """A blank apply is not a no-op — it is the override.
+
+    Rendering all four GUCs as '' on every BEGIN neutralises any legacy
+    session-level value a pooled connection might still carry. Skipping the
+    statement when state is empty would let that value leak through.
+    """
+    conn = _RecordingConnection()
+
+    db_module._apply_tenant_context_on_begin(_session(), _txn(), conn)  # type: ignore[arg-type]
+
+    assert len(conn.calls) == 1
+    _, params = conn.calls[0]
+    assert params == {
+        "org_id": "",
+        "cross_org_admin": "",
+        "changed_by_user_id": "",
+        "is_platform_admin": "",
+    }
+
+
+def test_after_begin_skips_nested_transactions() -> None:
+    """SAVEPOINTs inherit the enclosing transaction's GUCs — nothing to establish.
+
+    PostgreSQL DOES restore SET LOCAL values on ROLLBACK TO SAVEPOINT, so
+    skipping is correct: the enclosing transaction's context is intact either
+    way. (The latent caveat — a mutator changing Python-side state inside a
+    nested transaction that later rolls back — is documented on the listener;
+    no `begin_nested()` call site exists under app/ today.)
+    """
+    conn = _RecordingConnection()
+
+    db_module._apply_tenant_context_on_begin(
+        _session({"tenant_org_id": 8}),  # type: ignore[arg-type]
+        _txn(nested=True),
+        conn,
+    )
+
+    assert conn.calls == []
+
+
+def test_after_begin_skips_non_postgresql_dialects() -> None:
+    """SQLite/in-memory test rigs have no ``set_config()`` — must not break."""
+    conn = _RecordingConnection(dialect_name="sqlite")
+
+    db_module._apply_tenant_context_on_begin(_session({"tenant_org_id": 8}), _txn(), conn)  # type: ignore[arg-type]
+
+    assert conn.calls == []
+
+
+def test_listener_is_registered_on_the_pooled_sync_session_class() -> None:
+    """The listener must hang off ``_SyncPooledTenantSession``, not ``Session``.
+
+    Registering globally on ``Session`` would fire for every third-party or
+    test-fixture session in the process, which have no tenant contract.
+    """
+    from sqlalchemy import event
+    from sqlalchemy.orm import Session
+
+    assert db_module.PooledTenantSession.sync_session_class is db_module._SyncPooledTenantSession
+    assert event.contains(db_module._SyncPooledTenantSession, "after_begin", db_module._apply_tenant_context_on_begin)
+    assert not event.contains(Session, "after_begin", db_module._apply_tenant_context_on_begin)
+
+
+# ---------------------------------------------------------------------------
+# set_tenant — session-scoped tenant binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_writes_session_info_and_applies_immediately() -> None:
+    """``after_begin`` already fired for the open transaction with the OLD
+    state, so ``set_tenant`` must also apply the new context right away."""
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    await db_module.set_tenant(session, 8)
+
+    assert session.info["tenant_org_id"] == 8
+    assert db_module.current_org_id.get() == 8
+    assert session.execute.await_count == 1
+    sql, params = session.execute.await_args.args
+    assert "app.current_org_id" in str(sql)
+    assert params["org_id"] == "8"
+
+
+@pytest.mark.asyncio
+async def test_set_tenant_scope_is_per_session_not_per_task() -> None:
+    """Two sessions in the same task must be able to hold different scopes.
+
+    A request session (org 8) and a ``tenant_scoped_session(22)`` block opened
+    inside it coexist; storing the scope in a contextvar instead of
+    ``session.info`` would let the inner block silently retarget the outer one.
+    """
+    outer = MagicMock()
+    outer.info = {}
+    outer.execute = AsyncMock()
+    inner = MagicMock()
+    inner.info = {}
+    inner.execute = AsyncMock()
+
+    await db_module.set_tenant(outer, 8)
+    await db_module.set_tenant(inner, 22)
+
+    assert outer.info["tenant_org_id"] == 8
+    assert inner.info["tenant_org_id"] == 22
+
+
+# ---------------------------------------------------------------------------
+# set_request_actor — task-scoped actor binding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_request_actor_sets_both_contextvars_and_applies() -> None:
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    await db_module.set_request_actor(session, "zitadel-user-7", True)
+
+    assert db_module.current_changed_by_user_id.get() == "zitadel-user-7"
+    assert db_module.current_is_platform_admin.get() is True
+    assert session.execute.await_count == 1
+    _, params = session.execute.await_args.args
+    assert params["changed_by_user_id"] == "zitadel-user-7"
+    assert params["is_platform_admin"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_set_request_actor_clears_platform_admin_for_normal_callers() -> None:
+    """Non-platform callers must render '' — not the previous request's '1'."""
+    db_module.current_is_platform_admin.set(True)
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    await db_module.set_request_actor(session, "zitadel-user-9", False)
+
+    _, params = session.execute.await_args.args
+    assert params["is_platform_admin"] == ""
+
+
+@pytest.mark.asyncio
+async def test_set_request_actor_actor_flows_into_nested_sessions() -> None:
+    """Actor identity is task-scoped, so a session opened later in the same
+    task inherits it.
+
+    This is the pre-existing gap the change closes: seat-history ``changed_by``
+    was NULL for admin actions routed through ``tenant_scoped_session``, because
+    the actor GUC only ever landed on the request session's connection.
+    """
+    request_session = MagicMock()
+    request_session.info = {}
+    request_session.execute = AsyncMock()
+
+    await db_module.set_request_actor(request_session, "admin-1", False)
+
+    # A background/scoped session opened afterwards renders the same actor.
+    conn = _RecordingConnection()
+    db_module._apply_tenant_context_on_begin(_session({"tenant_org_id": 8}), _txn(), conn)  # type: ignore[arg-type]
+
+    _, params = conn.calls[0]
+    assert params["changed_by_user_id"] == "admin-1"
+
+
+# ---------------------------------------------------------------------------
+# cross_org_scope — bypass on an EXISTING session (no second connection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_sets_flag_and_applies_then_clears() -> None:
+    """Enter: flag True + apply. Exit: flag False + apply again.
+
+    Unlike `cross_org_session()` this must not open a session of its own —
+    webhook handlers already hold one, and a second checkout per request lets a
+    burst exhaust the pool.
+    """
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    async with db_module.cross_org_scope(session) as scoped:
+        assert scoped is session
+        assert session.info["cross_org_admin"] is True
+        # The bypass reached SQL, transaction-locally.
+        _, params = session.execute.await_args.args
+        assert params["cross_org_admin"] == "true"
+        assert session.execute.await_count == 1
+
+    assert session.info["cross_org_admin"] is False
+    assert session.execute.await_count == 2
+    _, params = session.execute.await_args.args
+    assert params["cross_org_admin"] == ""
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_clears_flag_on_exception() -> None:
+    """A raising body must not leave the bypass lit on the caller's session.
+
+    The handler keeps using that session afterwards (set_tenant + INSERT), so a
+    leaked flag would give the rest of the request cross-tenant visibility.
+    """
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        async with db_module.cross_org_scope(session):
+            raise RuntimeError("kaboom")
+
+    assert session.info["cross_org_admin"] is False
+    assert session.execute.await_count == 2
+    _, params = session.execute.await_args.args
+    assert params["cross_org_admin"] == ""
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_does_not_open_a_new_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit pool-usage guard: zero calls to the session factory."""
+    opened: list[object] = []
+    monkeypatch.setattr(
+        db_module,
+        "AsyncSessionLocal",
+        lambda *a, **kw: opened.append(1),  # type: ignore[misc,return-value]
+    )
+    session = MagicMock()
+    session.info = {}
+    session.execute = AsyncMock()
+
+    async with db_module.cross_org_scope(session):
+        pass
+
+    assert opened == [], "cross_org_scope must reuse the caller's session"

--- a/klai-portal/backend/tests/test_rls_txn_context_postgres.py
+++ b/klai-portal/backend/tests/test_rls_txn_context_postgres.py
@@ -1,0 +1,328 @@
+"""Real-PostgreSQL regression tests for the per-transaction RLS context invariant.
+
+Incident (2026-08-13): ``PATCH /api/app/knowledge-bases/{kb}/connectors/{id}``
+returned 500 with::
+
+    sqlalchemy.exc.InvalidRequestError: Could not refresh instance '<PortalConnector>'
+
+raised by ``await db.refresh(connector)`` immediately after ``await db.commit()``.
+
+Root cause: portal-api used to set the RLS GUCs *session-level*
+(``set_config(..., is_local=false)``). ``commit()`` releases the pooled
+connection; the very next statement (the refresh) implicitly checks a
+connection out again with no tenant-context guarantee. A pooled connection
+carries whatever GUC the last COMMITTED transaction on it left behind — the
+cleanup reset in ``_reset_tenant_context`` runs inside a transaction that is
+rolled back at session close, so the reset never durably lands. A connection
+polluted with a *different* org's GUC makes the freshly-updated row invisible
+under the policy ``org_id = GUC OR GUC IS NULL`` → refresh finds zero rows →
+500.
+
+Structural fix: tenant context is a property of the TRANSACTION, not the
+connection. The ``after_begin`` listener on ``_SyncPooledTenantSession`` applies
+all four RLS GUCs transaction-locally (``is_local=true``) from Python-side state
+at the start of every transaction. Pool pollution becomes structurally
+impossible (transaction-local GUCs vanish at commit/rollback) and every
+post-commit statement automatically re-establishes the correct context on
+whatever pooled connection it lands on.
+
+These tests exercise a REAL PostgreSQL with REAL RLS policies and a REAL
+non-superuser role. They are skipped unless ``RLS_TEST_DATABASE_URL`` is set.
+
+Local run::
+
+    docker run --rm -d --name rls-txn-test -e POSTGRES_PASSWORD=test \
+        -p 55439:5432 postgres:16
+    RLS_TEST_DATABASE_URL=postgresql+asyncpg://postgres:test@localhost:55439/postgres \
+        uv run pytest tests/test_rls_txn_context_postgres.py -m postgres -q
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import Integer, String, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from app.core import database as db_module
+from app.core.database import PooledTenantSession, set_tenant
+
+pytestmark = pytest.mark.postgres
+
+_TEST_ROLE = "rls_txn_test_role"
+_TEST_ROLE_PASSWORD = "rls_txn_test_pw"  # throwaway role in a disposable container
+_TENANT_TABLE = "rls_txn_test_items"
+_STRICT_TABLE = "rls_txn_test_strict_items"
+
+
+class _Base(DeclarativeBase):
+    """Local declarative base — deliberately NOT the app's Base.
+
+    The app's metadata carries every portal table; binding it here would make
+    this fixture's create/drop cycle touch tables the test does not own.
+    """
+
+
+class RlsTxnTestItem(_Base):
+    """Cat-A shaped table: permissive ``IS NULL`` branch, like ``portal_users``."""
+
+    __tablename__ = _TENANT_TABLE
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    org_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+
+
+class RlsTxnStrictItem(_Base):
+    """Cat-D shaped table: no permissive branch; cross-org needs the bypass flag."""
+
+    __tablename__ = _STRICT_TABLE
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    org_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+
+
+def _superuser_dsn() -> str:
+    dsn = os.environ.get("RLS_TEST_DATABASE_URL", "")
+    if not dsn:
+        pytest.skip("RLS_TEST_DATABASE_URL not set — real-PostgreSQL RLS tests skipped")
+    return dsn
+
+
+def _role_dsn(superuser_dsn: str) -> str:
+    """Rewrite the superuser DSN's userinfo to the non-superuser test role.
+
+    Table owners bypass RLS unless FORCE ROW LEVEL SECURITY is set; even then,
+    connecting as a dedicated non-owner role is what portal_api actually does.
+    """
+    scheme, _, rest = superuser_dsn.partition("://")
+    _, _, hostpart = rest.rpartition("@")
+    return f"{scheme}://{_TEST_ROLE}:{_TEST_ROLE_PASSWORD}@{hostpart}"
+
+
+# S608: the interpolated values are module-level constants in this file, not
+# user input — the rule cannot see that through the f-string.
+_CREATE_ROLE_SQL = f"DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{_TEST_ROLE}') THEN CREATE ROLE {_TEST_ROLE} LOGIN PASSWORD '{_TEST_ROLE_PASSWORD}'; END IF; END $$;"  # noqa: S608
+
+# Cat-A shape (portal_users): inline NULLIF with a permissive IS NULL branch.
+_TENANT_USING = (
+    "org_id = NULLIF(current_setting('app.current_org_id', true), '')::integer "
+    "OR NULLIF(current_setting('app.current_org_id', true), '') IS NULL"
+)
+_TENANT_WITH_CHECK = "org_id = NULLIF(current_setting('app.current_org_id', true), '')::integer"
+
+# Cat-D shape: calls the fail-loud helper. Mirrors production's
+# `_rls_current_org_id()` from alembic/versions/post_deploy_rls_raise_on_missing_context.sql
+# — same three branches (bypass -> NULL, missing context -> RAISE 42501, else
+# the org id) and the same STABLE plpgsql body. Renamed so it can never collide
+# with the real function in a shared CI database (Postgres has no return-type
+# overloading; a same-name/different-signature CREATE would fail).
+_STRICT_HELPER_SQL = """
+CREATE OR REPLACE FUNCTION _rls_txn_test_org_id()
+    RETURNS integer
+    LANGUAGE plpgsql
+    STABLE
+AS $$
+DECLARE
+    v_org     text := current_setting('app.current_org_id', true);
+    v_bypass  text := current_setting('app.cross_org_admin', true);
+BEGIN
+    IF v_bypass = 'true' THEN
+        RETURN NULL;
+    END IF;
+
+    IF v_org IS NULL OR v_org = '' THEN
+        RAISE EXCEPTION
+            'RLS: app.current_org_id is not set and app.cross_org_admin is not true.'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN v_org::integer;
+END;
+$$;
+"""
+# Prod omits WITH CHECK on these policies, so it defaults to the USING clause.
+_STRICT_USING = "_rls_txn_test_org_id() IS NULL OR org_id = _rls_txn_test_org_id()"
+
+
+def _schema_statements() -> list[str]:
+    stmts: list[str] = [
+        _CREATE_ROLE_SQL,
+        _STRICT_HELPER_SQL,
+        f"GRANT EXECUTE ON FUNCTION _rls_txn_test_org_id() TO {_TEST_ROLE}",
+    ]
+    policies = {
+        _TENANT_TABLE: f"USING ({_TENANT_USING}) WITH CHECK ({_TENANT_WITH_CHECK})",
+        _STRICT_TABLE: f"USING ({_STRICT_USING})",
+    }
+    for table, policy in policies.items():
+        stmts += [
+            f"DROP TABLE IF EXISTS {table} CASCADE",
+            f"CREATE TABLE {table} (id serial PRIMARY KEY, org_id integer NOT NULL, name text)",
+            f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY",
+            f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY",
+            f"CREATE POLICY tenant_isolation ON {table} {policy}",
+            f"GRANT SELECT, INSERT, UPDATE, DELETE ON {table} TO {_TEST_ROLE}",
+            f"GRANT USAGE, SELECT ON SEQUENCE {table}_id_seq TO {_TEST_ROLE}",
+        ]
+    return stmts
+
+
+@pytest_asyncio.fixture
+async def rls_sessionmaker() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Throwaway RLS-protected tables plus a session factory bound to a
+    non-superuser role, using the app's real ``PooledTenantSession`` class.
+
+    ``pool_size=1, max_overflow=0`` guarantees every session in a test reuses
+    the SAME physical connection — which is what makes pool-pollution
+    observable at all.
+    """
+    superuser_dsn = _superuser_dsn()
+    admin_engine = create_async_engine(superuser_dsn)
+
+    async with admin_engine.begin() as conn:
+        for stmt in _schema_statements():
+            await conn.execute(text(stmt))
+
+    role_engine = create_async_engine(_role_dsn(superuser_dsn), pool_size=1, max_overflow=0)
+    factory = async_sessionmaker(role_engine, class_=PooledTenantSession, expire_on_commit=False)
+
+    try:
+        yield factory
+    finally:
+        await role_engine.dispose()
+        async with admin_engine.begin() as conn:
+            for table in (_TENANT_TABLE, _STRICT_TABLE):
+                await conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+        await admin_engine.dispose()
+
+
+async def _current_org_guc(session: AsyncSession) -> str | None:
+    result = await session.execute(text("SELECT current_setting('app.current_org_id', true)"))
+    return result.scalar()
+
+
+# ---------------------------------------------------------------------------
+# Test A — the incident repro
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_commit_survives_pool_pollution(
+    rls_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """``session.refresh()`` after ``commit()`` MUST see the row it just wrote.
+
+    The pollution simulated here (``set_config(..., false)`` for a FOREIGN org)
+    is exactly what a pooled connection carried in production: a previous
+    request's session-level GUC, still committed on the physical connection.
+
+    Old behaviour: the refresh's implicitly-begun transaction inherits
+    ``app.current_org_id='22'`` from the connection, the org-8 row fails the
+    USING clause, zero rows come back, SQLAlchemy raises
+    ``InvalidRequestError: Could not refresh instance``.
+
+    New behaviour: ``after_begin`` re-applies ``app.current_org_id='8'``
+    transaction-locally at the start of the refresh's transaction, overriding
+    the session-level pollution for the duration of that transaction.
+    """
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 8)
+
+        item = RlsTxnTestItem(org_id=8, name="incident-repro")
+        session.add(item)
+        await session.commit()
+
+        # Simulate pool pollution: a foreign request's session-level GUC that
+        # survived (was committed) on this physical connection.
+        await session.execute(text("SELECT set_config('app.current_org_id', '22', false)"))
+        await session.commit()
+
+        # THE incident line — portal-api connectors.py:802 equivalent.
+        await session.refresh(item)
+
+        assert item.name == "incident-repro"
+
+        # The transaction that served the refresh must have run with the
+        # session's own tenant context, not the polluted '22'.
+        assert await _current_org_guc(session) == "8"
+
+
+# ---------------------------------------------------------------------------
+# Test B — the new code writes no durable pollution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_context_leaves_no_durable_pool_pollution(
+    rls_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """After a full set_tenant + commit + close cycle, the pooled connection
+    must carry NO session-level ``app.current_org_id``.
+
+    The assertion reads the GUC over a RAW engine connection, bypassing
+    ``PooledTenantSession`` entirely. Observing through a fresh pooled session
+    would be green by construction: its ``__aenter__`` reset clears the GUC
+    before the assertion could see it. With ``pool_size=1`` the raw checkout
+    returns the exact physical connection the tenant session just used — under
+    the OLD (session-level ``set_config``) code this read shows the committed
+    ``'8'``, which is what makes the test honest.
+    """
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 8)
+        session.add(RlsTxnTestItem(org_id=8, name="pollution-check"))
+        await session.commit()
+
+    engine = rls_sessionmaker.kw["bind"]
+    async with engine.connect() as raw:
+        leftover = (await raw.execute(text("SELECT current_setting('app.current_org_id', true)"))).scalar()
+    assert leftover in ("", None), f"pooled connection carried a stale tenant GUC: {leftover!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test C — cross-org bypass survives a commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_flag_survives_commit(
+    rls_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A cross-org session must still see all tenants' rows AFTER a commit.
+
+    ``_STRICT_TABLE`` has no permissive ``IS NULL`` branch — without the
+    ``app.cross_org_admin`` flag a session sees zero rows. That makes this a
+    real assertion rather than a vacuous one.
+
+    Pins the invariant that multi-commit cross-org blocks depend on
+    (``invite_scheduler``, platform-admin sweeps). Under the old model the
+    session-level flag happened to survive because the connection was pinned;
+    under the new model ``after_begin`` re-applies it on every transaction.
+    """
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 8)
+        session.add(RlsTxnStrictItem(org_id=8, name="org8-row"))
+        await session.commit()
+
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 22)
+        session.add(RlsTxnStrictItem(org_id=22, name="org22-row"))
+        await session.commit()
+
+    async with rls_sessionmaker() as session:
+        # Same state transition `cross_org_session()` performs.
+        session.info["cross_org_admin"] = True
+        await db_module._apply_tenant_context(session)
+
+        first = (await session.execute(select(func.count()).select_from(RlsTxnStrictItem))).scalar()
+        assert first is not None and first >= 2, f"cross-org session saw only {first} rows"
+
+        await session.commit()
+
+        second = (await session.execute(select(func.count()).select_from(RlsTxnStrictItem))).scalar()
+        assert second == first, f"cross-org visibility regressed after commit: {first} before, {second} after"

--- a/klai-portal/backend/tests/test_tenant_context_reset.py
+++ b/klai-portal/backend/tests/test_tenant_context_reset.py
@@ -456,6 +456,8 @@ async def test_cross_org_session_delegates_reset_to_shared_helper(
     fake_session.rollback = AsyncMock()
     fake_session.execute = AsyncMock(return_value=MagicMock())
     fake_session.connection = AsyncMock()
+    # `cross_org_session` records the bypass in session.info before applying it.
+    fake_session.info = {}
 
     class FakeSessionCM:
         async def __aenter__(self) -> AsyncMock:

--- a/klai-portal/backend/tests/test_widget_handoff.py
+++ b/klai-portal/backend/tests/test_widget_handoff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, patch
 
@@ -238,18 +239,64 @@ def test_build_handoff_context_text_includes_summary_and_recent_transcript() -> 
     assert "Klai: Waarmee kan ik helpen?" in text
 
 
+def _tracking_cross_org_scope(events: list[str]):
+    """Stand-in for `app.core.database.cross_org_scope`.
+
+    The real helper flips `session.info["cross_org_admin"]` and re-applies the
+    transaction-local context. It runs on the CALLER'S session — no second
+    pooled connection. This fake records enter/exit so a test can assert the
+    bypass is live during the lookup and cleared afterwards, and it asserts it
+    was handed the very session the handler was called with.
+    """
+
+    @asynccontextmanager
+    async def _cm(session):
+        session.info["cross_org_admin"] = True
+        events.append("scope_enter")
+        try:
+            yield session
+        finally:
+            session.info["cross_org_admin"] = False
+            events.append("scope_exit")
+
+    return _cm
+
+
+def _explode_if_second_session():
+    """`cross_org_session()` must NOT be reachable from the webhook path.
+
+    Opening it there would hold a second pooled connection for the duration of
+    every webhook request — a HubSpot burst then exhausts the pool.
+    """
+
+    @asynccontextmanager
+    async def _cm():
+        raise AssertionError("record_hubspot_agent_reply must not open a second pooled session")
+        yield  # pragma: no cover — unreachable, keeps this a generator
+
+    return _cm
+
+
 @pytest.mark.asyncio
 async def test_record_hubspot_agent_reply_records_and_publishes() -> None:
+    events: list[str] = []
     db = AsyncMock()
-    db.execute = AsyncMock(
-        side_effect=[
-            _Result(None),  # enable cross-org lookup
-            _Result((42, 7)),
-            _Result(None),  # disable cross-org lookup
-            _Result(None),  # set_tenant
-            _Result((99, "2026-05-27T13:05:31Z")),
-        ]
-    )
+    db.info = {}  # set_tenant / cross_org_scope record their state here
+
+    async def _execute(stmt, params=None):
+        sql = str(stmt)
+        if "widget_handoff_sessions" in sql:
+            # The bypass must be LIVE while the globally-unique thread id is
+            # mapped to a tenant — that row belongs to another org's scope.
+            events.append(f"lookup:cross_org={db.info.get('cross_org_admin')}")
+            return _Result((42, 7))
+        if "INSERT INTO widget_handoff_messages" in sql:
+            events.append(f"insert:cross_org={db.info.get('cross_org_admin')}")
+            return _Result((99, "2026-05-27T13:05:31Z"))
+        events.append("set_config")
+        return _Result(None)
+
+    db.execute = AsyncMock(side_effect=_execute)
     db.commit = AsyncMock()
     payload = {
         "message": {
@@ -262,27 +309,30 @@ async def test_record_hubspot_agent_reply_records_and_publishes() -> None:
 
     with (
         patch("app.services.widget_handoff.get_redis_pool", AsyncMock(return_value=None)),
+        patch("app.services.widget_handoff.cross_org_scope", _tracking_cross_org_scope(events)),
+        patch("app.core.database.cross_org_session", _explode_if_second_session()),
     ):
         result = await record_hubspot_agent_reply(db, payload)
 
     assert result["status"] == "recorded"
     assert result["handoff_session_id"] == 42
     assert result["id"] == 99
-    assert db.execute.await_count == 5
-    assert db.execute.await_args_list[4].args[1]["agent_name"] == "Mark Vletter"
+    # Everything runs on the ONE session the handler was given.
+    assert "lookup:cross_org=True" in events, events
+    assert "insert:cross_org=False" in events, events
+    assert events.index("scope_exit") < events.index("insert:cross_org=False"), events
+    assert db.info["cross_org_admin"] is False, "bypass must not outlive the lookup"
+    insert_call = next(c for c in db.execute.await_args_list if "INSERT INTO" in str(c.args[0]))
+    assert insert_call.args[1]["agent_name"] == "Mark Vletter"
     db.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_record_hubspot_agent_reply_ignores_unmapped_thread() -> None:
     db = AsyncMock()
-    db.execute = AsyncMock(
-        side_effect=[
-            _Result(None),  # enable cross-org lookup
-            _Result(None),
-            _Result(None),  # disable cross-org lookup
-        ]
-    )
+    events: list[str] = []
+    db.info = {}
+    db.execute = AsyncMock(return_value=_Result(None))
     db.commit = AsyncMock()
     payload = {
         "message": {
@@ -292,8 +342,16 @@ async def test_record_hubspot_agent_reply_ignores_unmapped_thread() -> None:
         }
     }
 
-    result = await record_hubspot_agent_reply(db, payload)
+    with (
+        patch("app.services.widget_handoff.cross_org_scope", _tracking_cross_org_scope(events)),
+        patch("app.core.database.cross_org_session", _explode_if_second_session()),
+    ):
+        result = await record_hubspot_agent_reply(db, payload)
 
     assert result == {"status": "ignored", "reason": "unmapped_thread"}
-    assert db.execute.await_count == 3
+    # Exactly one statement (the lookup), on the request session, inside the scope.
+    assert db.execute.await_count == 1
+    assert "widget_handoff_sessions" in str(db.execute.await_args_list[0].args[0])
+    assert events == ["scope_enter", "scope_exit"], events
+    assert db.info["cross_org_admin"] is False
     db.commit.assert_not_awaited()


### PR DESCRIPTION
## Incident

2026-08-13, voys.getklai.com: `PATCH .../connectors/{id}` → 500 `InvalidRequestError: Could not refresh instance '<PortalConnector>'` at `connectors.py:802` (`db.refresh` directly after `db.commit`). The commit itself landed. Root cause: session-level RLS GUCs + pooled-connection reuse — the refresh ran on a connection carrying another tenant's committed GUC, hiding the row. The cleanup reset never persisted because its `set_config` is reverted by the rollback at session close. Earlier same-class incident: widget-create 500 (2026-05-20), then worked around locally.

## Fix

Tenant context becomes a property of the **transaction**: an `after_begin` listener applies all four RLS GUCs transaction-locally at every BEGIN, from `session.info` (org / cross-org scope) + contextvars (actor identity). Pool pollution is structurally impossible; all 17 audited post-commit query sites (4 with cross-tenant READ risk) are safe without per-site edits. Details in the commit message and `.claude/rules/klai/projects/portal-backend.md`.

Intentional behavior changes:
1. Zero session-level GUC writes remain (checkout/cleanup resets stay as defense-in-depth).
2. `klai.changed_by_user_id` now reaches `tenant_scoped_session` blocks — fixes silent NULL seat-history attribution.
3. `app.is_platform_admin` persists across all transactions of a request.
4. `widget_handoff` cross-org lookup via new `cross_org_scope()` on the existing session (no second pooled connection).

## Evidence

- Reproduction-first: `tests/test_rls_txn_context_postgres.py` (real PostgreSQL, fail-loud Cat-D-style policy, non-superuser role, `pool_size=1`). All 3 tests FAIL on the old code (incl. verbatim repro of the production error) and PASS on the new. Runs in CI inside `rls-policy-smoke-test` (deploy-gating).
- Full suite: 3486 passed; ruff + format + pyright clean; warnings back at baseline (35).
- Independently adversarially reviewed; both ship-blocking findings (nested-session pool exhaustion, green-by-construction pollution test) fixed and re-verified.

## Rollback

`git revert <merge-sha>` — no migrations, no env vars, no policy DDL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)