### PR TITLE
fix(librechat): split-marker citation framing + review findings 8/9

### DIFF
--- a/deploy/librechat/getklai/patches/format.cjs
+++ b/deploy/librechat/getklai/patches/format.cjs
@@ -30,6 +30,12 @@ const formatMediaMessage = ({ message, endpoint, mediaParts }) => {
 	return result;
 };
 const isRecord = (value) => value != null && typeof value === "object";
+const _klaiWarned = /* @__PURE__ */ new Set();
+const warnOnce = (message) => {
+	if (_klaiWarned.has(message)) return;
+	_klaiWarned.add(message);
+	console.warn(`[klai-patch] ${message}`);
+};
 function withMessageRole(message, role) {
 	const roleMessage = message;
 	if (roleMessage.role === role) return roleMessage;
@@ -914,6 +920,10 @@ function ensureThinkingBlockInMessages(messages, _provider, config, runStartInde
 	let lastHumanIndex = -1;
 	for (let k = messages.length - 1; k >= 0; k--) {
 		const m = messages[k];
+		if (!isRecord(m)) {
+			warnOnce("format.ensureThinkingBlockInMessages skipped non-record entry");
+			continue;
+		}
 		if (m instanceof _langchain_core_messages.HumanMessage || "role" in m && m.role === "user") {
 			lastHumanIndex = k;
 			break;
@@ -924,6 +934,12 @@ function ensureThinkingBlockInMessages(messages, _provider, config, runStartInde
 	let i = lastHumanIndex + 1;
 	while (i < messages.length) {
 		const msg = messages[i];
+		if (!isRecord(msg)) {
+			warnOnce("format.ensureThinkingBlockInMessages skipped non-record entry");
+			result.push(msg);
+			i++;
+			continue;
+		}
 		if (!(msg instanceof _langchain_core_messages.AIMessage || msg instanceof _langchain_core_messages.AIMessageChunk || "role" in msg && msg.role === "assistant")) {
 			result.push(msg);
 			i++;

--- a/deploy/librechat/getklai/patches/stream.cjs
+++ b/deploy/librechat/getklai/patches/stream.cjs
@@ -515,6 +515,12 @@ function getChunkSources(chunk) {
 	return void 0;
 }
 const KLAI_SOURCES_MARKER_RE = /<!--\s*klai_sources=([A-Za-z0-9_-]+={0,2})\s*-->/g;
+const _klaiStreamWarned = /* @__PURE__ */ new Set();
+function klaiWarnOnce(message) {
+	if (_klaiStreamWarned.has(message)) return;
+	_klaiStreamWarned.add(message);
+	console.warn(`[klai-patch] ${message}`);
+}
 function decodeKlaiSourcesMarker(encoded) {
 	try {
 		const padded = encoded + "=".repeat((4 - encoded.length % 4) % 4);
@@ -522,9 +528,44 @@ function decodeKlaiSourcesMarker(encoded) {
 		const parsed = JSON.parse(json);
 		return Array.isArray(parsed) ? parsed : void 0;
 	} catch (_error) {
-		console.warn("[klai-patch] stream.decodeKlaiSourcesMarker decode failed");
+		klaiWarnOnce("stream.decodeKlaiSourcesMarker decode failed");
 		return void 0;
 	}
+}
+const KLAI_MARKER_HEAD = "<!-- klai_sources=";
+const KLAI_FRAMER_MAX_TAIL = 8192;
+function isPotentialPartialKlaiMarker(tail) {
+	if (tail.length > KLAI_FRAMER_MAX_TAIL) return false;
+	if (tail.length < KLAI_MARKER_HEAD.length) return KLAI_MARKER_HEAD.startsWith(tail);
+	if (!tail.startsWith(KLAI_MARKER_HEAD)) return false;
+	return /^[A-Za-z0-9_-]*={0,2}(?: ?-{0,2})?$/.test(tail.slice(KLAI_MARKER_HEAD.length));
+}
+function findPartialKlaiMarkerStart(text) {
+	if (typeof text !== "string" || text === "") return -1;
+	const idx = text.lastIndexOf("<");
+	if (idx === -1) return -1;
+	return isPotentialPartialKlaiMarker(text.slice(idx)) ? idx : -1;
+}
+function createKlaiSourcesFramer() {
+	let buffer = "";
+	return { push(fragment) {
+		const combined = buffer + (typeof fragment === "string" ? fragment : "");
+		buffer = "";
+		const extracted = extractKlaiSourcesFromText(combined);
+		let out = extracted.text;
+		const splitIdx = findPartialKlaiMarkerStart(out);
+		if (splitIdx !== -1) {
+			const tail = out.slice(splitIdx);
+			if (tail.length <= KLAI_FRAMER_MAX_TAIL) {
+				buffer = tail;
+				out = out.slice(0, splitIdx);
+			} else klaiWarnOnce("stream.klai_sources framer overflow — tail flushed as text");
+		}
+		return {
+			text: out,
+			sources: extracted.sources
+		};
+	} };
 }
 function extractKlaiSourcesFromText(text) {
 	let sources;
@@ -737,7 +778,8 @@ hasToolCallChunks: ${hasToolCallChunks}
 		if (typeof content === "string" && runStep.type === "tool_calls") return;
 		else if (hasToolCallChunks && (chunk.tool_call_chunks?.some((tc) => tc.args === content) ?? false)) return;
 		else if (typeof content === "string") {
-			const extracted = extractKlaiSourcesFromText(content);
+			agentContext._klaiSourcesFramer ?? (agentContext._klaiSourcesFramer = createKlaiSourcesFramer());
+			const extracted = agentContext._klaiSourcesFramer.push(content);
 			const textContent = extracted.text;
 			const sources = getChunkSources(chunk) ?? extracted.sources;
 			if (agentContext.currentTokenType === "text") await graph.dispatchMessageDelta(stepId, { content: [{
@@ -831,10 +873,20 @@ function createContentAggregator() {
 		}
 		if (partType.startsWith("text") && "text" in contentPart && typeof contentPart.text === "string") {
 			const currentContent = contentParts[index];
-			const extracted = extractKlaiSourcesFromText(contentPart.text);
+			// A klai_sources marker can be split across delta fragments. Any
+			// leaked partial-marker prefix sits at the END of the accumulated
+			// text (it matched nothing, so it passed through) — re-extract on
+			// the seam of accumulated tail + new fragment instead of the new
+			// fragment alone. Stateless: the "buffer" IS the accumulated text,
+			// so a stream ending mid-marker keeps its characters as plain text.
+			const accumulated = currentContent.text || "";
+			const seamIdx = findPartialKlaiMarkerStart(accumulated);
+			const head = seamIdx === -1 ? accumulated : accumulated.slice(0, seamIdx);
+			const carry = seamIdx === -1 ? "" : accumulated.slice(seamIdx);
+			const extracted = extractKlaiSourcesFromText(carry + contentPart.text);
 			const update = {
 				type: "text",
-				text: (currentContent.text || "") + extracted.text
+				text: head + extracted.text
 			};
 			if (contentPart.tool_call_ids) update.tool_call_ids = contentPart.tool_call_ids;
 			const incomingSources = contentPart.sources ?? extracted.sources;
@@ -945,7 +997,7 @@ function createContentAggregator() {
 				return;
 			}
 			const messageDeltaContent = Array.isArray(messageDelta.delta.content) ? messageDelta.delta.content : [messageDelta.delta.content];
-			if (messageDeltaContent.length > 1) console.warn("[klai-patch] stream.delta-array guard saw multi-part delta");
+			if (messageDeltaContent.length > 1) klaiWarnOnce("stream.delta-array guard saw multi-part delta (message)");
 			for (const contentPart of messageDeltaContent) {
 				if (contentPart != null) updateContent(runStep.index, contentPart);
 			}
@@ -961,7 +1013,7 @@ function createContentAggregator() {
 				return;
 			}
 			const reasoningDeltaContent = Array.isArray(reasoningDelta.delta.content) ? reasoningDelta.delta.content : [reasoningDelta.delta.content];
-			if (reasoningDeltaContent.length > 1) console.warn("[klai-patch] stream.delta-array guard saw multi-part delta");
+			if (reasoningDeltaContent.length > 1) klaiWarnOnce("stream.delta-array guard saw multi-part delta (reasoning)");
 			for (const contentPart of reasoningDeltaContent) {
 				if (contentPart != null) updateContent(runStep.index, contentPart);
 			}
@@ -1014,6 +1066,8 @@ function createContentAggregator() {
 exports.ChatModelStreamHandler = ChatModelStreamHandler;
 exports.createContentAggregator = createContentAggregator;
 exports.extractKlaiSourcesFromText = extractKlaiSourcesFromText;
+exports.createKlaiSourcesFramer = createKlaiSourcesFramer;
+exports.findPartialKlaiMarkerStart = findPartialKlaiMarkerStart;
 exports.getChunkContent = getChunkContent;
 exports.getChunkSources = getChunkSources;
 

--- a/deploy/librechat/patches/format.cjs
+++ b/deploy/librechat/patches/format.cjs
@@ -30,6 +30,12 @@ const formatMediaMessage = ({ message, endpoint, mediaParts }) => {
 	return result;
 };
 const isRecord = (value) => value != null && typeof value === "object";
+const _klaiWarned = /* @__PURE__ */ new Set();
+const warnOnce = (message) => {
+	if (_klaiWarned.has(message)) return;
+	_klaiWarned.add(message);
+	console.warn(`[klai-patch] ${message}`);
+};
 function withMessageRole(message, role) {
 	const roleMessage = message;
 	if (roleMessage.role === role) return roleMessage;
@@ -914,6 +920,10 @@ function ensureThinkingBlockInMessages(messages, _provider, config, runStartInde
 	let lastHumanIndex = -1;
 	for (let k = messages.length - 1; k >= 0; k--) {
 		const m = messages[k];
+		if (!isRecord(m)) {
+			warnOnce("format.ensureThinkingBlockInMessages skipped non-record entry");
+			continue;
+		}
 		if (m instanceof _langchain_core_messages.HumanMessage || "role" in m && m.role === "user") {
 			lastHumanIndex = k;
 			break;
@@ -924,6 +934,12 @@ function ensureThinkingBlockInMessages(messages, _provider, config, runStartInde
 	let i = lastHumanIndex + 1;
 	while (i < messages.length) {
 		const msg = messages[i];
+		if (!isRecord(msg)) {
+			warnOnce("format.ensureThinkingBlockInMessages skipped non-record entry");
+			result.push(msg);
+			i++;
+			continue;
+		}
 		if (!(msg instanceof _langchain_core_messages.AIMessage || msg instanceof _langchain_core_messages.AIMessageChunk || "role" in msg && msg.role === "assistant")) {
 			result.push(msg);
 			i++;

--- a/deploy/librechat/patches/stream.cjs
+++ b/deploy/librechat/patches/stream.cjs
@@ -515,6 +515,12 @@ function getChunkSources(chunk) {
 	return void 0;
 }
 const KLAI_SOURCES_MARKER_RE = /<!--\s*klai_sources=([A-Za-z0-9_-]+={0,2})\s*-->/g;
+const _klaiStreamWarned = /* @__PURE__ */ new Set();
+function klaiWarnOnce(message) {
+	if (_klaiStreamWarned.has(message)) return;
+	_klaiStreamWarned.add(message);
+	console.warn(`[klai-patch] ${message}`);
+}
 function decodeKlaiSourcesMarker(encoded) {
 	try {
 		const padded = encoded + "=".repeat((4 - encoded.length % 4) % 4);
@@ -522,9 +528,44 @@ function decodeKlaiSourcesMarker(encoded) {
 		const parsed = JSON.parse(json);
 		return Array.isArray(parsed) ? parsed : void 0;
 	} catch (_error) {
-		console.warn("[klai-patch] stream.decodeKlaiSourcesMarker decode failed");
+		klaiWarnOnce("stream.decodeKlaiSourcesMarker decode failed");
 		return void 0;
 	}
+}
+const KLAI_MARKER_HEAD = "<!-- klai_sources=";
+const KLAI_FRAMER_MAX_TAIL = 8192;
+function isPotentialPartialKlaiMarker(tail) {
+	if (tail.length > KLAI_FRAMER_MAX_TAIL) return false;
+	if (tail.length < KLAI_MARKER_HEAD.length) return KLAI_MARKER_HEAD.startsWith(tail);
+	if (!tail.startsWith(KLAI_MARKER_HEAD)) return false;
+	return /^[A-Za-z0-9_-]*={0,2}(?: ?-{0,2})?$/.test(tail.slice(KLAI_MARKER_HEAD.length));
+}
+function findPartialKlaiMarkerStart(text) {
+	if (typeof text !== "string" || text === "") return -1;
+	const idx = text.lastIndexOf("<");
+	if (idx === -1) return -1;
+	return isPotentialPartialKlaiMarker(text.slice(idx)) ? idx : -1;
+}
+function createKlaiSourcesFramer() {
+	let buffer = "";
+	return { push(fragment) {
+		const combined = buffer + (typeof fragment === "string" ? fragment : "");
+		buffer = "";
+		const extracted = extractKlaiSourcesFromText(combined);
+		let out = extracted.text;
+		const splitIdx = findPartialKlaiMarkerStart(out);
+		if (splitIdx !== -1) {
+			const tail = out.slice(splitIdx);
+			if (tail.length <= KLAI_FRAMER_MAX_TAIL) {
+				buffer = tail;
+				out = out.slice(0, splitIdx);
+			} else klaiWarnOnce("stream.klai_sources framer overflow — tail flushed as text");
+		}
+		return {
+			text: out,
+			sources: extracted.sources
+		};
+	} };
 }
 function extractKlaiSourcesFromText(text) {
 	let sources;
@@ -737,7 +778,8 @@ hasToolCallChunks: ${hasToolCallChunks}
 		if (typeof content === "string" && runStep.type === "tool_calls") return;
 		else if (hasToolCallChunks && (chunk.tool_call_chunks?.some((tc) => tc.args === content) ?? false)) return;
 		else if (typeof content === "string") {
-			const extracted = extractKlaiSourcesFromText(content);
+			agentContext._klaiSourcesFramer ?? (agentContext._klaiSourcesFramer = createKlaiSourcesFramer());
+			const extracted = agentContext._klaiSourcesFramer.push(content);
 			const textContent = extracted.text;
 			const sources = getChunkSources(chunk) ?? extracted.sources;
 			if (agentContext.currentTokenType === "text") await graph.dispatchMessageDelta(stepId, { content: [{
@@ -831,10 +873,20 @@ function createContentAggregator() {
 		}
 		if (partType.startsWith("text") && "text" in contentPart && typeof contentPart.text === "string") {
 			const currentContent = contentParts[index];
-			const extracted = extractKlaiSourcesFromText(contentPart.text);
+			// A klai_sources marker can be split across delta fragments. Any
+			// leaked partial-marker prefix sits at the END of the accumulated
+			// text (it matched nothing, so it passed through) — re-extract on
+			// the seam of accumulated tail + new fragment instead of the new
+			// fragment alone. Stateless: the "buffer" IS the accumulated text,
+			// so a stream ending mid-marker keeps its characters as plain text.
+			const accumulated = currentContent.text || "";
+			const seamIdx = findPartialKlaiMarkerStart(accumulated);
+			const head = seamIdx === -1 ? accumulated : accumulated.slice(0, seamIdx);
+			const carry = seamIdx === -1 ? "" : accumulated.slice(seamIdx);
+			const extracted = extractKlaiSourcesFromText(carry + contentPart.text);
 			const update = {
 				type: "text",
-				text: (currentContent.text || "") + extracted.text
+				text: head + extracted.text
 			};
 			if (contentPart.tool_call_ids) update.tool_call_ids = contentPart.tool_call_ids;
 			const incomingSources = contentPart.sources ?? extracted.sources;
@@ -945,7 +997,7 @@ function createContentAggregator() {
 				return;
 			}
 			const messageDeltaContent = Array.isArray(messageDelta.delta.content) ? messageDelta.delta.content : [messageDelta.delta.content];
-			if (messageDeltaContent.length > 1) console.warn("[klai-patch] stream.delta-array guard saw multi-part delta");
+			if (messageDeltaContent.length > 1) klaiWarnOnce("stream.delta-array guard saw multi-part delta (message)");
 			for (const contentPart of messageDeltaContent) {
 				if (contentPart != null) updateContent(runStep.index, contentPart);
 			}
@@ -961,7 +1013,7 @@ function createContentAggregator() {
 				return;
 			}
 			const reasoningDeltaContent = Array.isArray(reasoningDelta.delta.content) ? reasoningDelta.delta.content : [reasoningDelta.delta.content];
-			if (reasoningDeltaContent.length > 1) console.warn("[klai-patch] stream.delta-array guard saw multi-part delta");
+			if (reasoningDeltaContent.length > 1) klaiWarnOnce("stream.delta-array guard saw multi-part delta (reasoning)");
 			for (const contentPart of reasoningDeltaContent) {
 				if (contentPart != null) updateContent(runStep.index, contentPart);
 			}
@@ -1014,6 +1066,8 @@ function createContentAggregator() {
 exports.ChatModelStreamHandler = ChatModelStreamHandler;
 exports.createContentAggregator = createContentAggregator;
 exports.extractKlaiSourcesFromText = extractKlaiSourcesFromText;
+exports.createKlaiSourcesFramer = createKlaiSourcesFramer;
+exports.findPartialKlaiMarkerStart = findPartialKlaiMarkerStart;
 exports.getChunkContent = getChunkContent;
 exports.getChunkSources = getChunkSources;
 

--- a/deploy/librechat/tests/format_guard.test.cjs
+++ b/deploy/librechat/tests/format_guard.test.cjs
@@ -136,4 +136,30 @@ const guarded = ensureThinkingBlockInMessages(
 );
 assert.ok(Array.isArray(guarded));
 
+// Adversarial review 2026-08-13, finding 8: sparse entries AFTER the last
+// user message used to throw ("role" in undefined) because both scans lacked
+// the record guard. Cover before / between / after positions explicitly.
+const sparseAfter = ensureThinkingBlockInMessages(
+  [{ role: 'user', content: 'vraag' }, undefined, { role: 'assistant', content: 'antwoord' }],
+  'openai',
+);
+assert.ok(Array.isArray(sparseAfter));
+
+const sparseBetween = ensureThinkingBlockInMessages(
+  [
+    { role: 'user', content: 'vraag' },
+    { role: 'assistant', content: 'a1' },
+    null,
+    { role: 'assistant', content: 'a2' },
+  ],
+  'openai',
+);
+assert.ok(Array.isArray(sparseBetween));
+
+const sparseEverywhere = ensureThinkingBlockInMessages(
+  [undefined, { role: 'user', content: 'vraag' }, null, { role: 'assistant', content: 'a' }, undefined],
+  'openai',
+);
+assert.ok(Array.isArray(sparseEverywhere));
+
 console.log('OK: LibreChat format guards tolerate sparse message arrays.');

--- a/deploy/librechat/tests/stream_sources.test.cjs
+++ b/deploy/librechat/tests/stream_sources.test.cjs
@@ -221,3 +221,112 @@ assert.equal(toolAggregator.contentParts[1].type, 'tool_call');
 assert.equal(toolAggregator.contentParts[2].text, 'Final answer after tool.');
 
 console.log('OK: LibreChat stream aggregator preserves Klai source metadata.');
+
+// ---------------------------------------------------------------------------
+// Split-marker framing (adversarial review 2026-08-13, finding 1): a
+// klai_sources marker divided across stream chunks must neither leak marker
+// text into the answer nor lose the sources.
+// ---------------------------------------------------------------------------
+const { createKlaiSourcesFramer, findPartialKlaiMarkerStart } = sandbox.exports;
+assert.equal(typeof createKlaiSourcesFramer, 'function');
+assert.equal(typeof findPartialKlaiMarkerStart, 'function');
+
+const fullMarker = `<!-- klai_sources=${marker} -->`;
+const splitBody = `Antwoord. ${fullMarker} En verder.`;
+
+function runAggregator(fragments) {
+  const agg = createContentAggregator();
+  agg.aggregateContent({
+    event: 'on_run_step',
+    data: { id: 'step-split', index: 0, stepDetails: { type: 'message_creation' } },
+  });
+  for (const fragment of fragments) {
+    agg.aggregateContent({
+      event: 'on_message_delta',
+      data: { id: 'step-split', delta: { content: { type: 'text', text: fragment } } },
+    });
+  }
+  return agg.contentParts[0];
+}
+
+// Exhaustive two-fragment sweep: split the message at EVERY position.
+for (let cut = 1; cut < splitBody.length; cut++) {
+  const part = runAggregator([splitBody.slice(0, cut), splitBody.slice(cut)]);
+  assert.equal(
+    part.text,
+    'Antwoord.  En verder.',
+    `aggregated text leaked marker content at cut=${cut}: ${JSON.stringify(part.text)}`,
+  );
+  assert.equal(
+    JSON.stringify(part.sources),
+    JSON.stringify(sources),
+    `sources lost at cut=${cut}`,
+  );
+}
+
+// Three-way split through the base64 body.
+{
+  const a = splitBody.slice(0, 30);
+  const b = splitBody.slice(30, 60);
+  const c = splitBody.slice(60);
+  const part = runAggregator([a, b, c]);
+  assert.equal(part.text, 'Antwoord.  En verder.');
+  assert.equal(JSON.stringify(part.sources), JSON.stringify(sources));
+}
+
+// A stream that ENDS mid-marker must keep the characters as plain text —
+// never swallow user content (the aggregator is the persisted message).
+{
+  const truncated = `Antwoord. ${fullMarker.slice(0, 40)}`;
+  const part = runAggregator(['Antwoord. ', fullMarker.slice(0, 40)]);
+  assert.equal(part.text, truncated, 'truncated marker tail must remain as text');
+  assert.equal(part.sources, undefined);
+}
+
+// A '<' that is NOT a marker prefix must pass through immediately.
+{
+  const part = runAggregator(['a < b en <div> blijven ', 'gewoon staan.']);
+  assert.equal(part.text, 'a < b en <div> blijven gewoon staan.');
+}
+
+// Two interleaved aggregators must not cross-contaminate.
+{
+  const aggA = createContentAggregator();
+  const aggB = createContentAggregator();
+  for (const agg of [aggA, aggB]) {
+    agg.aggregateContent({
+      event: 'on_run_step',
+      data: { id: 's', index: 0, stepDetails: { type: 'message_creation' } },
+    });
+  }
+  aggA.aggregateContent({ event: 'on_message_delta', data: { id: 's', delta: { content: { type: 'text', text: `A. ${fullMarker.slice(0, 25)}` } } } });
+  aggB.aggregateContent({ event: 'on_message_delta', data: { id: 's', delta: { content: { type: 'text', text: 'B zonder marker. ' } } } });
+  aggA.aggregateContent({ event: 'on_message_delta', data: { id: 's', delta: { content: { type: 'text', text: `${fullMarker.slice(25)} klaar.` } } } });
+  aggB.aggregateContent({ event: 'on_message_delta', data: { id: 's', delta: { content: { type: 'text', text: 'B einde.' } } } });
+  assert.equal(aggA.contentParts[0].text, 'A.  klaar.');
+  assert.equal(JSON.stringify(aggA.contentParts[0].sources), JSON.stringify(sources));
+  assert.equal(aggB.contentParts[0].text, 'B zonder marker. B einde.');
+  assert.equal(aggB.contentParts[0].sources, undefined);
+}
+
+// The per-run framer (live-dispatch path): exhaustive sweep as well.
+for (let cut = 1; cut < splitBody.length; cut++) {
+  const framer = createKlaiSourcesFramer();
+  const first = framer.push(splitBody.slice(0, cut));
+  const second = framer.push(splitBody.slice(cut));
+  const emitted = first.text + second.text;
+  const seen = first.sources ?? second.sources;
+  assert.equal(emitted, 'Antwoord.  En verder.', `framer leaked at cut=${cut}: ${JSON.stringify(emitted)}`);
+  assert.equal(JSON.stringify(seen), JSON.stringify(sources), `framer lost sources at cut=${cut}`);
+}
+
+// Framer overflow: a never-closing marker-lookalike longer than the cap is
+// flushed as plain text instead of buffering forever.
+{
+  const framer = createKlaiSourcesFramer();
+  const hugeTail = `<!-- klai_sources=${'A'.repeat(9000)}`;
+  const out = framer.push(`tekst ${hugeTail}`);
+  assert.ok(out.text.includes(hugeTail), 'oversized tail must flush as text');
+}
+
+console.log('OK: klai_sources markers survive arbitrary stream-chunk splits without leaking or losing sources.');


### PR DESCRIPTION
Fixes findings 1 (HIGH, reproduced), 8 and 9 from the adversarial review. Exhaustive split-position tests on both stream paths. See commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)