### PR TITLE
fix(portal): fleet regenerate fails loud + per-tenant rollback (review F3)

### DIFF
--- a/.github/workflows/deploy-librechat-config.yml
+++ b/.github/workflows/deploy-librechat-config.yml
@@ -75,16 +75,31 @@ jobs:
             # Python's httpx (already installed) instead of curl because the python:slim
             # base image does not ship curl. The INTERNAL_SECRET env var is already set
             # inside the container from .env.
+            #
+            # Finding 3D (adversarial review 2026-08-13): a bare "HTTP 200 = success"
+            # check is not enough -- the endpoint can report per-tenant failures in its
+            # errors array on a 200 (restart-only mode keeps that contract on purpose,
+            # see finding 3E). The script below is belt and braces: it fails on any
+            # non-200 status AND, independently, fails whenever the errors array is
+            # non-empty regardless of status code. `set -e` is active for this whole
+            # script (line 39), so a non-zero exit from the exec'd python process aborts
+            # the step and surfaces every printed line (including the errors list) in
+            # the step output.
             echo "Triggering tenant config regeneration via portal-api..."
-            set +e
-            RESPONSE=$(docker compose -f /opt/klai/docker-compose.yml exec -T \
+            docker compose -f /opt/klai/docker-compose.yml exec -T \
               -e RECREATE_CONTAINERS="$RECREATE_CONTAINERS" \
               portal-api python -c '
-            import os, sys, httpx
+            import json
+            import os
+            import sys
+
+            import httpx
+
             secret = os.environ["INTERNAL_SECRET"]
             url = "http://localhost:8010/internal/librechat/regenerate"
             if os.environ.get("RECREATE_CONTAINERS") == "true":
                 url += "?recreate_containers=true"
+
             try:
                 r = httpx.post(
                     url,
@@ -94,25 +109,35 @@ jobs:
                     },
                     timeout=600.0,
                 )
-                print(r.status_code)
-                print(r.text)
             except Exception as exc:
-                print("ERROR")
-                print(f"Request failed: {exc}", file=sys.stderr)
+                print(f"ERROR: request to {url} failed: {exc}", file=sys.stderr)
                 sys.exit(1)
-            ')
-            EXIT=$?
-            set -e
 
-            HTTP_CODE=$(echo "$RESPONSE" | head -n1)
-            BODY=$(echo "$RESPONSE" | tail -n +2)
+            print(f"HTTP {r.status_code}")
+            try:
+                body = r.json()
+            except (json.JSONDecodeError, ValueError):
+                print(r.text)
+                print("ERROR: response body was not valid JSON", file=sys.stderr)
+                sys.exit(1)
 
-            if [ "$EXIT" = "0" ] && [ "$HTTP_CODE" = "200" ]; then
-              echo "Tenant configs regenerated successfully"
-              echo "$BODY"
-            else
-              echo "ERROR: Regeneration failed (exit=$EXIT, http=$HTTP_CODE)"
-              echo "$BODY"
-              # Fail the workflow — without regeneration the YAML change is not live.
-              exit 1
-            fi
+            updated = body.get("tenants_updated") or []
+            skipped = body.get("tenants_skipped") or []
+            errors = body.get("errors") or []
+            print(f"tenants_updated ({len(updated)}): {updated}")
+            print(f"tenants_skipped ({len(skipped)}): {skipped}")
+            if errors:
+                print(f"errors ({len(errors)}):")
+                for e in errors:
+                    print(f"  - {e}")
+
+            if r.status_code != 200:
+                print(f"ERROR: regenerate endpoint returned HTTP {r.status_code}", file=sys.stderr)
+                sys.exit(1)
+            if errors:
+                # Belt and braces: some paths can report errors on a 200.
+                print("ERROR: regenerate endpoint reported a non-empty errors array on HTTP 200", file=sys.stderr)
+                sys.exit(1)
+
+            print("Tenant configs regenerated successfully")
+            '

--- a/deploy/librechat/tests/global_rollout_config.test.cjs
+++ b/deploy/librechat/tests/global_rollout_config.test.cjs
@@ -30,4 +30,19 @@ assert.match(workflow, /timeout=600\.0/);
 assert.match(drift, /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-ghcr\.io\/danny-avila\/librechat:v0\.8\.7\}"/);
 assert.match(portalConfig, /librechat_image: str = "ghcr\.io\/danny-avila\/librechat:v0\.8\.7"/);
 
+// Finding 3D (adversarial review 2026-08-13): the deploy step must not treat
+// a bare HTTP 200 as success. It must parse the JSON body and fail the job
+// if the errors array is non-empty, even on a 200 -- belt and braces on top
+// of the non-200 status check. Pin both halves of that contract so a future
+// edit can't silently drop the errors-array check and go back to trusting
+// the status code alone.
+assert.match(workflow, /r\.status_code != 200/);
+assert.match(workflow, /errors = body\.get\("errors"\) or \[\]/);
+assert.match(workflow, /if errors:\s*\n\s*# Belt and braces/);
+assert.match(workflow, /sys\.exit\(1\)/);
+// The old bare bash-side "$HTTP_CODE" = "200" check must be gone -- that was
+// exactly the class of check that let a 200-with-errors response go green.
+assert.doesNotMatch(workflow, /HTTP_CODE.*=.*"200"/);
+
 console.log('OK: global LibreChat rollout config enables OCR/artifacts and keeps risky capabilities disabled.');
+console.log('OK: LibreChat regenerate deploy step fails loud on non-200 and on a non-empty errors array.');

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1494,41 +1494,24 @@ async def mailing_send(
 class RegenerateResponse(BaseModel):
     tenants_updated: list[str]
     errors: list[str]
+    tenants_skipped: list[str] = []
 
 
-@router.post("/librechat/regenerate", response_model=RegenerateResponse)
-async def regenerate_librechat_configs(
-    request: Request,
-    db: AsyncSession = Depends(get_db),
-) -> RegenerateResponse:
-    """Regenerate per-tenant librechat.yaml from the base template for all active tenants.
+def _regenerate_tenant_yaml_configs(
+    tenants: list[PortalOrg],
+    base_yaml_path: Path,
+) -> tuple[list[str], list[str], list[str]]:
+    """Step 1 of the fleet regenerate: write librechat.yaml for every tenant.
 
-    Called by CI after syncing a new base librechat.yaml to the server.
-    For each tenant: re-runs _generate_librechat_yaml with the tenant's MCP servers,
-    writes the result, flushes Redis, and restarts or recreates the container.
+    Non-destructive (file writes only) -- always attempts every tenant and
+    accumulates errors, regardless of ``recreate_containers``. Returns
+    ``(updated, slugs_to_restart, errors)``.
     """
-    await _require_internal_token(request)
-
-    import docker
-
     from app.services.provisioning.generators import _generate_librechat_yaml
 
-    base_yaml_path = Path(settings.librechat_container_data_path) / "librechat.yaml"
-    if not base_yaml_path.exists():
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Base config not found at {base_yaml_path}",
-        )
-
-    result = await db.execute(select(PortalOrg).where(PortalOrg.provisioning_status == "ready"))
-    tenants = result.scalars().all()
-
     updated: list[str] = []
-    errors: list[str] = []
-    loop = asyncio.get_running_loop()
-
-    # Step 1: Regenerate all tenant configs from the updated base template
     slugs_to_restart: list[str] = []
+    errors: list[str] = []
     for org in tenants:
         slug = org.slug
         if not slug:
@@ -1544,11 +1527,118 @@ async def regenerate_librechat_configs(
         except Exception as exc:
             errors.append(f"{slug}: {exc}")
             logger.warning("Config regeneration failed for %s: %s", slug, exc, exc_info=True)
+    return updated, slugs_to_restart, errors
+
+
+def _apply_librechat_container_step(
+    orgs_to_apply: list[PortalOrg],
+    recreate_containers: bool,
+) -> tuple[list[str], list[str]]:
+    """Step 3 of the fleet regenerate: restart or recreate each tenant's container.
+
+    Default remains restart-only for existing callers. CI passes
+    ``recreate_containers=true`` for LibreChat image upgrades, because
+    restart does not change a container's image.
+
+    Finding 3 (adversarial review 2026-08-13): recreate mode force-removes
+    the running container before the replacement boots (see
+    ``_start_librechat_container``). Replaying that against the whole fleet
+    after the FIRST tenant already proved the shared image/config is broken
+    would strand every remaining tenant with no container at all. So
+    recreate mode ABORTS at the first recreate-or-health-gate failure;
+    remaining tenants are reported as skipped, never attempted. Restart-only
+    mode is non-destructive and keeps the pre-existing per-tenant isolation
+    (continue on error, report every tenant).
+    """
+    import docker
+
+    client = None if recreate_containers else docker.from_env()
+    apply_errors: list[str] = []
+    apply_skipped: list[str] = []
+    for idx, org in enumerate(orgs_to_apply):
+        slug = org.slug
+        if not slug:
+            continue
+        container_name = validate_slug_for_provisioning(slug, domain=settings.domain).librechat_container
+        try:
+            if recreate_containers:
+                from app.services.provisioning.infrastructure import _start_librechat_container
+
+                env_file_host_path = f"{settings.librechat_host_data_path}/{slug}/.env"
+                _start_librechat_container(
+                    slug,
+                    env_file_host_path,
+                    org.mcp_servers or None,
+                    rollback_on_failure=True,
+                )
+                logger.info("Recreated container %s", container_name)
+            else:
+                assert client is not None
+                ctr = client.containers.get(container_name)
+                ctr.restart(timeout=10)
+                logger.info("Restarted container %s", container_name)
+        except Exception as exc:
+            apply_errors.append(f"{slug}: {exc}")
+            logger.warning("LibreChat container apply failed for %s: %s", container_name, exc, exc_info=True)
+            if recreate_containers:
+                remaining = [o.slug for o in orgs_to_apply[idx + 1 :] if o.slug]
+                apply_skipped.extend(remaining)
+                break
+    return apply_errors, apply_skipped
+
+
+@router.post("/librechat/regenerate", response_model=RegenerateResponse)
+async def regenerate_librechat_configs(
+    request: Request,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> RegenerateResponse:
+    """Regenerate per-tenant librechat.yaml from the base template for all active tenants.
+
+    Called by CI after syncing a new base librechat.yaml to the server.
+    For each tenant: re-runs _generate_librechat_yaml with the tenant's MCP servers,
+    writes the result, flushes Redis, and restarts or recreates the container.
+
+    Fail-loud contract (adversarial review 2026-08-13, finding 3):
+    - ``recreate_containers=true`` is destructive (the running container is
+      force-removed before the replacement boots). The fleet loop therefore
+      ABORTS at the first tenant whose recreate-and-health-check fails instead
+      of replaying a broken shared config/image against the rest of the
+      fleet; remaining tenants are reported in ``tenants_skipped``, and the
+      response status is 500 whenever any error occurred in this mode, so CI
+      cannot go green while the fleet is actually broken.
+    - The default restart-only path is non-destructive and keeps its
+      pre-existing per-tenant isolation (continue on error, report, 200)
+      EXCEPT when every tenant fails config regeneration itself, which is
+      always a fail-loud 500 regardless of ``recreate_containers``.
+    """
+    await _require_internal_token(request)
+
+    base_yaml_path = Path(settings.librechat_container_data_path) / "librechat.yaml"
+    if not base_yaml_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Base config not found at {base_yaml_path}",
+        )
+
+    result = await db.execute(select(PortalOrg).where(PortalOrg.provisioning_status == "ready"))
+    tenants = result.scalars().all()
+
+    loop = asyncio.get_running_loop()
+    skipped: list[str] = []
+
+    # Step 1: Regenerate all tenant configs from the updated base template.
+    updated, slugs_to_restart, errors = _regenerate_tenant_yaml_configs(tenants, base_yaml_path)
 
     if not slugs_to_restart:
         # Cross-tenant operation — no resolvable org_id. Use 0 per REQ-2.6.
         await _audit_internal_call(request, org_id=0)
-        return RegenerateResponse(tenants_updated=updated, errors=errors)
+        if tenants and errors:
+            # Finding 3E: every tenant failed config regeneration (e.g. a
+            # broken base template) -- fail loud instead of a green 200 that
+            # hides a systemic break from CI.
+            response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        return RegenerateResponse(tenants_updated=updated, errors=errors, tenants_skipped=skipped)
 
     # Step 2: Targeted invalidation of the LibreChat config cache via protocol
     # (NOT docker exec -- SEC-021 docker-socket-proxy denies /exec/*/start).
@@ -1599,40 +1689,23 @@ async def regenerate_librechat_configs(
     recreate_containers = request.query_params.get("recreate_containers") == "true"
 
     # Step 3: Restart or recreate all tenant containers via docker-socket-proxy.
-    # Default remains restart-only for existing callers. CI passes
-    # recreate_containers=true for LibreChat image upgrades, because restart
-    # does not change a container's image.
-    def _restart_or_recreate_all(orgs_to_apply: list[PortalOrg]) -> list[str]:
-        client = None if recreate_containers else docker.from_env()
-        apply_errors: list[str] = []
-        for org in orgs_to_apply:
-            slug = org.slug
-            if not slug:
-                continue
-            container_name = validate_slug_for_provisioning(slug, domain=settings.domain).librechat_container
-            try:
-                if recreate_containers:
-                    from app.services.provisioning.infrastructure import _start_librechat_container
-
-                    env_file_host_path = f"{settings.librechat_host_data_path}/{slug}/.env"
-                    _start_librechat_container(slug, env_file_host_path, org.mcp_servers or None)
-                    logger.info("Recreated container %s", container_name)
-                else:
-                    assert client is not None
-                    ctr = client.containers.get(container_name)
-                    ctr.restart(timeout=10)
-                    logger.info("Restarted container %s", container_name)
-            except Exception as exc:
-                apply_errors.append(f"{slug}: {exc}")
-                logger.warning("LibreChat container apply failed for %s: %s", container_name, exc, exc_info=True)
-        return apply_errors
-
+    # See _apply_librechat_container_step for the abort-on-first-failure
+    # contract in recreate mode (finding 3, adversarial review 2026-08-13).
     orgs_to_apply = [org for org in tenants if org.slug in set(slugs_to_restart)]
-    restart_errors = await loop.run_in_executor(None, _restart_or_recreate_all, orgs_to_apply)
+    restart_errors, restart_skipped = await loop.run_in_executor(
+        None, _apply_librechat_container_step, orgs_to_apply, recreate_containers
+    )
     errors.extend(restart_errors)
+    skipped.extend(restart_skipped)
 
     await _audit_internal_call(request, org_id=0)
-    return RegenerateResponse(tenants_updated=updated, errors=errors)
+
+    if recreate_containers and errors:
+        # Finding 3C: recreate mode is destructive -- any error in this mode
+        # must fail loud so CI cannot go green while the fleet crashloops.
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+
+    return RegenerateResponse(tenants_updated=updated, errors=errors, tenants_skipped=skipped)
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1628,7 +1628,7 @@ async def regenerate_librechat_configs(
     skipped: list[str] = []
 
     # Step 1: Regenerate all tenant configs from the updated base template.
-    updated, slugs_to_restart, errors = _regenerate_tenant_yaml_configs(tenants, base_yaml_path)
+    updated, slugs_to_restart, errors = _regenerate_tenant_yaml_configs(list(tenants), base_yaml_path)
 
     if not slugs_to_restart:
         # Cross-tenant operation — no resolvable org_id. Use 0 per REQ-2.6.

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -690,7 +690,7 @@ def _start_librechat_container(
     old_image_ref: str | None = None
     try:
         old = client.containers.get(container_name)
-        if rollback_on_failure:
+        if rollback_on_failure and old.image is not None:
             tags = old.image.tags
             old_image_ref = tags[0] if tags else old.image.id
         old.remove(force=True)

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -494,24 +494,22 @@ def _reload_caddy() -> None:
     caddy.restart(timeout=10)
 
 
-def _start_librechat_container(
+def _create_and_start_librechat_container(
+    client,
+    container_name: str,
     slug: str,
     env_file_host_path: str,
-    mcp_servers: dict | None = None,
+    mcp_servers: dict | None,
+    image: str,
 ) -> None:
-    """Start the LibreChat Docker container for a tenant (synchronous, run in executor)."""
-    _assert_safe_slug(slug)  # REQ-18 (Finding C-3)
-    names = validate_slug_for_provisioning(slug, domain=settings.domain)
-    client = docker.from_env()
-    container_name = names.librechat_container
+    """Create, network-attach, boot and health-gate a tenant's LibreChat container.
 
-    # Remove stale container if it exists (e.g. failed previous provisioning)
-    try:
-        old = client.containers.get(container_name)
-        old.remove(force=True)
-    except docker.errors.NotFound:  # type: ignore[attr-defined]
-        pass
-
+    Pure "create a working container" logic, factored out of
+    `_start_librechat_container` so the rollback path in that function can
+    replay it with a different (previous-known-good) `image`. Raises on any
+    failure, including a failed OpenID readiness gate -- callers decide what
+    to do about a failure (roll back, let it propagate, etc).
+    """
     librechat_host_base = settings.librechat_host_data_path
 
     # Generate per-tenant librechat.yaml by merging base config with tenant MCP servers
@@ -579,7 +577,7 @@ def _start_librechat_container(
     #   all networks pre-attached avoids the disruption entirely.
     #   (2026-05-22 onboarding/chat incident.)
     container = client.containers.create(  # type: ignore[call-overload]  # nosemgrep: docker-arbitrary-container-run
-        image=settings.librechat_image,
+        image=image,
         name=container_name,
         restart_policy={"Name": "unless-stopped"},  # type: ignore[arg-type]
         labels=container_labels,
@@ -603,3 +601,119 @@ def _start_librechat_container(
 
     container.start()
     _wait_for_librechat_openid_ready(client, container_name)
+
+
+def _restore_librechat_container(
+    client,
+    container_name: str,
+    slug: str,
+    env_file_host_path: str,
+    mcp_servers: dict | None,
+    old_image_ref: str,
+) -> None:
+    """Best-effort restore of a tenant's LibreChat container to its previous image.
+
+    Called only after a recreate attempt has already failed its
+    create/boot/readiness gate (see `_start_librechat_container`,
+    `rollback_on_failure=True`). Never raises: a failed restore must not mask
+    the original failure that triggered it -- the caller re-raises that
+    original exception regardless of what happens here. The outcome is
+    logged either way so an operator can see whether the tenant was left
+    running the old image or with no container at all.
+    """
+    logger.warning(
+        "librechat_container_restore_attempt",
+        slug=slug,
+        container=container_name,
+        old_image=old_image_ref,
+    )
+    try:
+        # Remove whatever half-booted container the failed attempt left behind.
+        try:
+            broken = client.containers.get(container_name)
+            broken.remove(force=True)
+        except docker.errors.NotFound:  # type: ignore[attr-defined]
+            pass
+
+        _create_and_start_librechat_container(
+            client,
+            container_name,
+            slug,
+            env_file_host_path,
+            mcp_servers,
+            image=old_image_ref,
+        )
+    except Exception as restore_exc:
+        logger.exception(
+            "librechat_container_restore_failed",
+            slug=slug,
+            container=container_name,
+            old_image=old_image_ref,
+            error=str(restore_exc),
+        )
+        return
+
+    logger.info(
+        "librechat_container_restore_succeeded",
+        slug=slug,
+        container=container_name,
+        old_image=old_image_ref,
+    )
+
+
+def _start_librechat_container(
+    slug: str,
+    env_file_host_path: str,
+    mcp_servers: dict | None = None,
+    *,
+    rollback_on_failure: bool = False,
+) -> None:
+    """Start the LibreChat Docker container for a tenant (synchronous, run in executor).
+
+    `rollback_on_failure` (finding 3A, adversarial review 2026-08-13): when
+    set, the currently-running container's image is recorded BEFORE it is
+    force-removed. If the replacement container then fails to create, boot,
+    or pass its OpenID readiness gate, a best-effort attempt is made to
+    restore the tenant on the previous image so it isn't left with nothing.
+    The restore outcome is logged; the original failure always propagates,
+    restore or no restore. Defaults to off so the initial-provisioning path
+    (no prior container to roll back to) and the MCP-config-apply recreate
+    path keep their existing behaviour unchanged.
+    """
+    _assert_safe_slug(slug)  # REQ-18 (Finding C-3)
+    names = validate_slug_for_provisioning(slug, domain=settings.domain)
+    client = docker.from_env()
+    container_name = names.librechat_container
+
+    # Remove stale container if it exists (e.g. failed previous provisioning).
+    # Record its image first so a failed replacement can be rolled back.
+    old_image_ref: str | None = None
+    try:
+        old = client.containers.get(container_name)
+        if rollback_on_failure:
+            tags = old.image.tags
+            old_image_ref = tags[0] if tags else old.image.id
+        old.remove(force=True)
+    except docker.errors.NotFound:  # type: ignore[attr-defined]
+        pass
+
+    try:
+        _create_and_start_librechat_container(
+            client,
+            container_name,
+            slug,
+            env_file_host_path,
+            mcp_servers,
+            image=settings.librechat_image,
+        )
+    except Exception:
+        if rollback_on_failure and old_image_ref:
+            _restore_librechat_container(
+                client,
+                container_name,
+                slug,
+                env_file_host_path,
+                mcp_servers,
+                old_image_ref,
+            )
+        raise

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -610,6 +610,164 @@ class TestCharacterizeStartLibrechatContainer:
                 assert labels["klai.tenant_slug"] == tenant_slug
 
 
+class TestStartLibrechatContainerRollback:
+    """Finding 3A (adversarial review 2026-08-13): ``rollback_on_failure``
+    records the running container's image before it is force-removed, and
+    attempts a best-effort restore to that image if the replacement fails to
+    create/boot/pass its OpenID readiness gate. Used only by the fleet
+    regenerate endpoint's recreate path; other callers (initial provisioning,
+    MCP-config-apply) default the flag off and keep their pre-existing
+    behaviour.
+    """
+
+    def _write_lc_files(self, tmp_path: Path, slug: str = "acme") -> None:
+        (tmp_path / "librechat.yaml").write_text("version: 1.0\n")
+        tenant_dir = tmp_path / slug
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        (tenant_dir / ".env").write_text("MONGO_URI=mongodb://example\nALLOW_IFRAME=true\nJWT_SECRET=keep-me\n")
+        patch_dir = tmp_path / "patches"
+        patch_dir.mkdir(exist_ok=True)
+        for name in ("format.cjs", "share.js", "stream.cjs", "search.cjs", "createStreamServices.ts"):
+            (patch_dir / name).write_text("// patch\n")
+        (tmp_path / "klai-entrypoint.sh").write_text('#!/bin/sh\nexec docker-entrypoint.sh "$@"\n')
+
+    def test_health_gate_failure_triggers_rollback_to_old_image(self, tmp_path):
+        """The replacement fails its readiness gate; the restore recreates
+        with the OLD image tag captured before removal, and succeeds."""
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        old_container = MagicMock()
+        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+        broken_container = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.containers.get.side_effect = [old_container, broken_container]
+        mock_client.containers.create.return_value = MagicMock()
+
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+            patch(
+                "app.services.provisioning.infrastructure._wait_for_librechat_openid_ready",
+                side_effect=[RuntimeError("boot failed"), None],
+            ) as mock_ready,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.7"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+
+            # The original failure still propagates -- rollback is best
+            # effort, it never swallows the error that triggered it.
+            with pytest.raises(RuntimeError, match=r"^boot failed$"):
+                _start_librechat_container(
+                    "acme",
+                    "/opt/klai/librechat-data/acme/.env",
+                    rollback_on_failure=True,
+                )
+
+        # Old container recorded + force-removed; the broken replacement is
+        # also force-removed before the rollback recreate attempt.
+        old_container.remove.assert_called_once_with(force=True)
+        broken_container.remove.assert_called_once_with(force=True)
+
+        # create() called twice: once with the new image (failed), once with
+        # the recorded old image (the rollback).
+        assert mock_client.containers.create.call_count == 2
+        first_image = mock_client.containers.create.call_args_list[0].kwargs["image"]
+        second_image = mock_client.containers.create.call_args_list[1].kwargs["image"]
+        assert first_image == "ghcr.io/danny-avila/librechat:v0.8.7"
+        assert second_image == "ghcr.io/danny-avila/librechat:v0.8.6"
+        assert mock_ready.call_count == 2
+
+    def test_rollback_failure_does_not_mask_original_error(self, tmp_path):
+        """Both the initial recreate AND the rollback attempt fail. The
+        exception that propagates out of _start_librechat_container is the
+        ORIGINAL failure, not the rollback's own failure -- and the restore
+        failure is logged, not silently dropped."""
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        old_container = MagicMock()
+        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+        broken_container = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.containers.get.side_effect = [old_container, broken_container]
+        mock_client.containers.create.return_value = MagicMock()
+
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+            patch(
+                "app.services.provisioning.infrastructure._wait_for_librechat_openid_ready",
+                side_effect=[RuntimeError("boot failed"), RuntimeError("rollback also failed")],
+            ),
+            patch("app.services.provisioning.infrastructure.logger") as mock_logger,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.7"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+
+            with pytest.raises(RuntimeError, match=r"^boot failed$"):
+                _start_librechat_container(
+                    "acme",
+                    "/opt/klai/librechat-data/acme/.env",
+                    rollback_on_failure=True,
+                )
+
+        assert mock_client.containers.create.call_count == 2
+        error_calls = [
+            call
+            for call in mock_logger.exception.call_args_list
+            if call.args and call.args[0] == "librechat_container_restore_failed"
+        ]
+        assert error_calls, mock_logger.exception.call_args_list
+
+    def test_no_rollback_when_flag_is_off(self, tmp_path):
+        """Default callers (initial provisioning, MCP-config-apply) keep the
+        pre-existing behaviour: no old-image capture, no restore attempt."""
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+
+        old_container = MagicMock()
+        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+
+        mock_client = MagicMock()
+        mock_client.containers.get.side_effect = [old_container]
+        mock_client.containers.create.return_value = MagicMock()
+
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+            patch(
+                "app.services.provisioning.infrastructure._wait_for_librechat_openid_ready",
+                side_effect=RuntimeError("boot failed"),
+            ),
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.7"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+
+            with pytest.raises(RuntimeError, match="boot failed"):
+                _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        # No rollback attempt -- create() called exactly once (the failed
+        # attempt), and containers.get() only the one time to find/remove
+        # the pre-existing container.
+        assert mock_client.containers.create.call_count == 1
+        assert mock_client.containers.get.call_count == 1
+
+
 class TestCharacterizeLibrechatOpenidReadiness:
     """Characterization tests for the post-start OpenID readiness gate."""
 

--- a/klai-portal/backend/tests/test_librechat_regenerate.py
+++ b/klai-portal/backend/tests/test_librechat_regenerate.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import docker.errors
 import pytest
+from fastapi import Response
 from redis.exceptions import RedisError
 
 
@@ -113,10 +114,23 @@ async def _regenerate_setup(
     redis_client: MagicMock,
     docker_client: MagicMock,
     base_config_exists: bool = True,
-) -> AsyncIterator[MagicMock]:
-    """Patches every external dep of regenerate_librechat_configs."""
+    generate_yaml: MagicMock | None = None,
+) -> AsyncIterator[tuple[MagicMock, Response]]:
+    """Patches every external dep of regenerate_librechat_configs.
+
+    Yields ``(request, response)`` -- ``response`` is a real ``fastapi.Response``
+    so tests can assert on ``response.status_code`` exactly as FastAPI would
+    set it for a real HTTP call (see finding 3C: fail-loud status on recreate
+    errors).
+
+    ``generate_yaml`` lets a test override config-regeneration (Step 1) per
+    tenant -- e.g. to simulate one tenant's regen failing -- by passing a
+    ``MagicMock(side_effect=...)`` keyed on the ``mcp_servers`` argument.
+    """
     request = MagicMock()
     request.state = MagicMock()
+    request.query_params = {}
+    response = Response()
 
     path_exists = MagicMock(return_value=base_config_exists)
 
@@ -128,12 +142,12 @@ async def _regenerate_setup(
         patch("app.api.internal.Path.write_text", MagicMock(return_value=None)),
         patch(
             "app.services.provisioning.generators._generate_librechat_yaml",
-            MagicMock(return_value="version: 1.3.8\n"),
+            generate_yaml or MagicMock(return_value="version: 1.3.8\n"),
         ),
         patch("app.api.internal.aioredis.Redis", MagicMock(return_value=redis_client)),
         patch("docker.from_env", MagicMock(return_value=docker_client)),
     ):
-        yield request
+        yield request, response
 
 
 # ---------------------------------------------------------------------------
@@ -154,8 +168,8 @@ class TestRegenerateUsesScanUnlink:
         )
         docker_client = _docker_client()
 
-        async with _regenerate_setup(orgs, redis_client, docker_client) as request:
-            resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         # SCAN with the configured pattern (default "configs:*").
         redis_client.scan_iter.assert_called_once()
@@ -203,8 +217,8 @@ class TestTargetedInvalidationLeavesUnrelatedKeys:
         )
         docker_client = _docker_client()
 
-        async with _regenerate_setup(orgs, redis_client, docker_client) as request:
-            resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         # Two configs:* keys unlinked, nothing else.
         unlinked_keys = [k for batch in redis_client._unlinked_calls for k in batch]
@@ -233,8 +247,8 @@ class TestRedisFailureSurfaceAndContinue:
         )
         docker_client = _docker_client()
 
-        async with _regenerate_setup(orgs, redis_client, docker_client) as request:
-            resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         # AC-2.4: errors list contains the cache-invalidation prefix.
         assert any(e.startswith("redis-cache-invalidation:") for e in resp.errors), resp.errors
@@ -265,13 +279,19 @@ class TestRestartIsolation:
             restart_raises={"librechat-voys": docker.errors.APIError("500 boom")},
         )
 
-        async with _regenerate_setup(orgs, redis_client, docker_client) as request:
-            resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         assert sorted(resp.tenants_updated) == ["acme", "getklai", "voys"]
         assert any(e.startswith("voys:") for e in resp.errors), resp.errors
         assert docker_client.containers.get.call_count == 3
         redis_client.flushall.assert_not_called()
+        # Finding 3E: restart-only mode keeps its pre-existing semantics --
+        # a per-tenant restart failure is reported but does NOT flip the
+        # endpoint to 500 (that fail-loud behaviour is reserved for the
+        # destructive recreate_containers=true path).
+        assert response.status_code == 200
+        assert resp.tenants_skipped == []
 
 
 class TestRecreateMode:
@@ -284,19 +304,21 @@ class TestRecreateMode:
         redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
         docker_client = _docker_client()
 
-        async with _regenerate_setup(orgs, redis_client, docker_client) as request:
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
             request.query_params = {"recreate_containers": "true"}
             with patch(
                 "app.services.provisioning.infrastructure._start_librechat_container",
                 MagicMock(return_value=None),
             ) as start_librechat:
-                resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+                resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         assert sorted(resp.tenants_updated) == ["getklai", "voys"]
         assert resp.errors == []
+        assert resp.tenants_skipped == []
+        assert response.status_code == 200
         assert start_librechat.call_count == 2
-        start_librechat.assert_any_call("getklai", "/opt/klai/librechat/getklai/.env", None)
-        start_librechat.assert_any_call("voys", "/opt/klai/librechat/voys/.env", None)
+        start_librechat.assert_any_call("getklai", "/opt/klai/librechat/getklai/.env", None, rollback_on_failure=True)
+        start_librechat.assert_any_call("voys", "/opt/klai/librechat/voys/.env", None, rollback_on_failure=True)
         docker_client.containers.get.assert_not_called()
         redis_client.flushall.assert_not_called()
 
@@ -310,11 +332,126 @@ class TestEmptyTenantList:
         redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
         docker_client = _docker_client()
 
-        async with _regenerate_setup([], redis_client, docker_client) as request:
-            resp = await internal_mod.regenerate_librechat_configs(request=request, db=db)
+        async with _regenerate_setup([], redis_client, docker_client) as (request, response):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
 
         redis_client.scan_iter.assert_not_called()
         redis_client.unlink.assert_not_called()
         redis_client.flushall.assert_not_called()
         docker_client.containers.get.assert_not_called()
         assert resp.tenants_updated == []
+        assert resp.tenants_skipped == []
+        # No tenants at all is not a failure -- must not be conflated with
+        # "every tenant failed config regeneration" (finding 3E).
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 (adversarial review 2026-08-13): recreate mode must abort the
+# fleet loop at the first failure instead of replaying a broken shared
+# image/config against every remaining tenant, and must fail loud (500)
+# instead of a green 200 that hides a crashlooping fleet from CI.
+# ---------------------------------------------------------------------------
+
+
+class TestRecreateModeAbortsOnFirstFailure:
+    @pytest.mark.asyncio
+    async def test_first_tenant_failure_aborts_loop_and_skips_the_rest(self):
+        """AC (finding 3B/3C): first recreate-or-health-gate failure stops the
+        loop. Later tenants are reported as skipped, never attempted. The
+        failing tenant's error is first in ``errors`` (config regen and cache
+        invalidation both succeed here, so nothing precedes it). Response is
+        500.
+        """
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1), _org("voys", 2), _org("acme", 3)]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            request.query_params = {"recreate_containers": "true"}
+            with patch(
+                "app.services.provisioning.infrastructure._start_librechat_container",
+                MagicMock(side_effect=RuntimeError("boot failed for getklai")),
+            ) as start_librechat:
+                resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        # Only the first tenant was attempted -- the loop aborted before
+        # touching voys or acme.
+        assert start_librechat.call_count == 1
+        start_librechat.assert_called_once_with(
+            "getklai", "/opt/klai/librechat/getklai/.env", None, rollback_on_failure=True
+        )
+
+        assert resp.errors, resp.errors
+        assert resp.errors[0].startswith("getklai:"), resp.errors
+        assert sorted(resp.tenants_skipped) == ["acme", "voys"]
+        # getklai still regenerated its config (Step 1 succeeded); the
+        # failure was in the destructive recreate step.
+        assert sorted(resp.tenants_updated) == ["acme", "getklai", "voys"]
+        assert response.status_code == 500
+
+
+class TestConfigOnlyRegenerationSemantics:
+    """Finding 3E: the non-recreate (config-only) path keeps its pre-existing
+    accumulate-and-report semantics, EXCEPT when every tenant fails config
+    regeneration -- that is always a fail-loud 500 regardless of
+    ``recreate_containers``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_partial_config_regen_failure_stays_200(self):
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1, mcp_servers=["ok"]), _org("voys", 2, mcp_servers=["boom"])]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+
+        def _generate(_base_path, mcp_servers):
+            if mcp_servers == ["boom"]:
+                raise RuntimeError("bad mcp config")
+            return "version: 1.3.8\n"
+
+        generate_yaml = MagicMock(side_effect=_generate)
+
+        async with _regenerate_setup(orgs, redis_client, docker_client, generate_yaml=generate_yaml) as (
+            request,
+            response,
+        ):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        assert resp.tenants_updated == ["getklai"]
+        assert any(e.startswith("voys:") for e in resp.errors), resp.errors
+        assert resp.tenants_skipped == []
+        # Unchanged pre-existing semantics: partial failure still reports 200.
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_total_config_regen_failure_is_500(self):
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1, mcp_servers=["boom"]), _org("voys", 2, mcp_servers=["boom"])]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+
+        generate_yaml = MagicMock(side_effect=RuntimeError("base template is broken"))
+
+        async with _regenerate_setup(orgs, redis_client, docker_client, generate_yaml=generate_yaml) as (
+            request,
+            response,
+        ):
+            resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        assert resp.tenants_updated == []
+        assert len(resp.errors) == 2
+        assert resp.tenants_skipped == []
+        # Finding 3E exception: every tenant failed config regen -- fail loud
+        # even though recreate_containers was never requested.
+        assert response.status_code == 500
+        # Cache invalidation / restart never ran -- there was nothing to apply.
+        redis_client.scan_iter.assert_not_called()
+        docker_client.containers.get.assert_not_called()


### PR DESCRIPTION
Adversarial review finding 3: the all-tenant recreate reported HTTP 200 with failures accumulated, destroyed the old container before the replacement proved healthy, and CI treated any 200 as success. Now: old-image capture + best-effort restore on health-gate failure, abort-on-first-failure with tenants_skipped, HTTP 500 on any recreate error, and the workflow parses the errors array. Full backend suite green (3494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)