### PR TITLE
fix(portal): cross_org_scope state restore + no error masking (review round 2)

### DIFF
--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -101,7 +101,11 @@ GUCs visible. Three mechanical guards replace it:
 3. Grafana alert `rls-ctx-001-tenant-context-failure`
    (`deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml`) fires
    on any portal-api log line matching `"Could not refresh instance"`,
-   `"InsufficientPrivilegeError"` or `"42501"` in a 10m window. Baseline is zero.
+   `"InsufficientPrivilegeError"` or `"42501"` in a 10m window. Baseline is
+   zero, but the signatures are indicative, not proof — 42501 also covers
+   unrelated permission failures (missing GRANT, role misconfig) and a refresh
+   failure can be a genuine concurrent delete. Classify before concluding;
+   detection latency is ~5-6 min (`for: 5m`).
 
 `assert_portal_users_rls_ready()` stays in the `main.py` lifespan: the auth
 lookup still runs before `set_tenant`, with an empty `app.current_org_id`, so the

--- a/deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml
@@ -92,20 +92,26 @@ groups:
           service_group: portal-api
         annotations:
           summary: |
-            portal-api statements running without correct RLS tenant context.
+            portal-api log lines matching an RLS tenant-context failure signature.
           description: |
             One or more portal-api log lines in the last 10 minutes matched a
-            tenant-context failure signature. Baseline is zero — any fire means
-            a statement executed with missing or foreign tenant context.
+            tenant-context failure signature. Baseline is zero, so any fire
+            deserves a look — but the signatures are INDICATIVE, not proof:
+            classify before concluding. Detection latency is ~5-6 minutes
+            (for: 5m on a 1m evaluation interval), and monitoring failures are
+            silent by design (noDataState/execErrState both OK, the house
+            pattern for LogsQL rules).
 
-            What each signature means:
+            What each signature means, and its non-tenant-context causes:
               - "Could not refresh instance": a post-commit re-SELECT returned
                 zero rows. The 2026-08-13 incident signature (db.refresh() right
-                after db.commit() on PATCH .../connectors/{id}).
-              - "InsufficientPrivilegeError" / "42501": the fail-loud Cat-D
-                helper `_rls_current_org_id()` raised because
-                app.current_org_id was unset and app.cross_org_admin was not
-                true.
+                after db.commit() on PATCH .../connectors/{id}) — but a genuine
+                concurrent DELETE of the refreshed row produces the same line.
+              - "InsufficientPrivilegeError" / "42501": raised by the fail-loud
+                Cat-D helper `_rls_current_org_id()` when app.current_org_id is
+                unset and app.cross_org_admin is not true — but ANY PostgreSQL
+                permission failure (missing GRANT after a migration, role
+                misconfiguration) carries the same class/SQLSTATE.
 
             Investigation:
               1. Find the request chain:

--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -582,18 +582,35 @@ async def cross_org_scope(session: AsyncSession) -> AsyncIterator[AsyncSession]:
 
     Safe only because tenant context is transaction-local: the flag lives in
     `session.info` and is applied via `set_config(..., true)`, so no
-    session-level GUC can leak onto the pooled connection. The `finally`
-    clears the flag and re-applies immediately, so the bypass cannot outlive
-    the block even if the body raises.
+    session-level GUC can leak onto the pooled connection. On exit the
+    PREVIOUS flag value is restored (not hardcoded off), so the scope nests
+    correctly and a session that was already cross-org stays cross-org.
+
+    When the body raises, the Python-side flag is restored and the SQL
+    re-apply is BEST-EFFORT: after a database error the transaction is
+    aborted, and any statement there (including the re-apply) raises 25P02
+    InFailedSQLTransaction — letting that propagate would MASK the original
+    error. The suppress hides nothing real: Python-side state is restored
+    either way, the aborted transaction cannot execute any further query, and
+    the next `after_begin` re-declares the restored context. For non-database
+    exceptions the transaction is healthy, so the re-apply succeeds and the
+    bypass ends immediately.
 
     Scope it as tightly as possible — ideally one lookup. Everything inside
     sees ALL tenants' rows.
     """
     _reject_savepoint_mutation(session, "cross_org_scope")
+    info = session.info if isinstance(getattr(session, "info", None), dict) else {}
+    previous = bool(info.get("cross_org_admin"))
     session.info["cross_org_admin"] = True
     await _apply_tenant_context(session)
     try:
         yield session
-    finally:
-        session.info["cross_org_admin"] = False
+    except BaseException:
+        session.info["cross_org_admin"] = previous
+        with contextlib.suppress(Exception):
+            await _apply_tenant_context(session)
+        raise
+    else:
+        session.info["cross_org_admin"] = previous
         await _apply_tenant_context(session)

--- a/klai-portal/backend/tests/test_rls_txn_context.py
+++ b/klai-portal/backend/tests/test_rls_txn_context.py
@@ -332,6 +332,63 @@ async def test_cross_org_scope_clears_flag_on_exception() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cross_org_scope_restores_preexisting_bypass() -> None:
+    """A session that was ALREADY cross-org must stay cross-org after the scope.
+
+    Hardcoding the flag off on exit would silently disable an enclosing
+    cross-org context (adversarial-review round 2, finding 2). Exit restores
+    the previous value instead.
+    """
+    session = _mock_session()
+    session.info["cross_org_admin"] = True
+
+    async with db_module.cross_org_scope(session):
+        assert session.info["cross_org_admin"] is True
+
+    assert session.info["cross_org_admin"] is True
+    _, params = session.execute.await_args.args
+    assert params["cross_org_admin"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_nested_inner_exit_keeps_outer_scope() -> None:
+    """An inner scope's exit must not turn off the outer scope's bypass."""
+    session = _mock_session()
+
+    async with db_module.cross_org_scope(session):
+        async with db_module.cross_org_scope(session):
+            assert session.info["cross_org_admin"] is True
+        # Inner exit: outer scope is still active.
+        assert session.info["cross_org_admin"] is True
+
+    assert session.info["cross_org_admin"] is False
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_db_error_is_not_masked_by_the_exit_reapply() -> None:
+    """A database error in the body must surface AS ITSELF.
+
+    After a DB error the transaction is aborted; the exit re-apply then raises
+    25P02 InFailedSQLTransaction. Letting that propagate would replace the
+    diagnostic error (adversarial-review round 2, finding 1). The re-apply is
+    best-effort on the exception path: its failure is suppressed, the flag is
+    restored Python-side, and the next after_begin re-declares the context.
+    """
+    session = _mock_session()
+    original = RuntimeError("relation does not exist")
+    aborted = RuntimeError("current transaction is aborted")
+    # Call 1 = entry apply (ok); call 2 = exit re-apply (aborted transaction).
+    session.execute = AsyncMock(side_effect=[None, aborted])
+
+    with pytest.raises(RuntimeError, match="relation does not exist"):
+        async with db_module.cross_org_scope(session):
+            raise original
+
+    assert session.info["cross_org_admin"] is False
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_cross_org_scope_does_not_open_a_new_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """Explicit pool-usage guard: zero calls to the session factory."""
     opened: list[object] = []

--- a/klai-portal/backend/tests/test_rls_txn_context_postgres.py
+++ b/klai-portal/backend/tests/test_rls_txn_context_postgres.py
@@ -45,6 +45,7 @@ from collections.abc import AsyncIterator
 import pytest
 import pytest_asyncio
 from sqlalchemy import Integer, String, func, select, text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -372,3 +373,42 @@ async def test_sequential_tenant_sessions_reuse_one_connection_without_leaking(
         # The reads above ran post-commit — i.e. in a transaction that began
         # after the pooled connection was released and re-acquired.
         assert await _current_org_guc(session) == "22"
+
+
+# ---------------------------------------------------------------------------
+# Test E — cross_org_scope on an aborted transaction surfaces the ORIGINAL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_db_error_surfaces_original_error(
+    rls_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A database error inside `cross_org_scope` must surface as itself.
+
+    The failing statement aborts the transaction; a naive exit re-apply would
+    then raise 25P02 InFailedSQLTransaction and MASK the diagnostic error
+    (adversarial-review round 2, finding 1). The exit re-apply is best-effort
+    on the exception path, so the original UndefinedTable error propagates.
+    Afterwards the session must be fully usable again under its own tenant.
+    """
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 8)
+        session.add(RlsTxnTestItem(org_id=8, name="scope-error-probe"))
+        await session.commit()
+
+        with pytest.raises(ProgrammingError) as excinfo:
+            async with db_module.cross_org_scope(session):
+                await session.execute(text("SELECT 1 FROM rls_txn_no_such_table"))
+
+        message = str(excinfo.value)
+        assert "rls_txn_no_such_table" in message, f"original error was masked: {message}"
+        assert "current transaction is aborted" not in message, f"25P02 masked the real error: {message}"
+        assert session.info["cross_org_admin"] is False
+
+        # The session recovers: rollback, then the next transaction runs under
+        # the restored org-8 scope (after_begin re-declares it).
+        await session.rollback()
+        count = (await session.execute(select(func.count()).select_from(RlsTxnTestItem))).scalar()
+        assert count == 1
+        assert await _current_org_guc(session) == "8"


### PR DESCRIPTION
Follow-ups from adversarial-review round 2 (verdict: accept; all findings LOW).

1. **cross_org_scope restores the previous bypass value** instead of hardcoding it off — nesting-safe, and a session that was already cross-org stays cross-org after the scope.
2. **The exit re-apply never masks the body error**: after a DB error the transaction is aborted and a naive re-apply raises 25P02 `InFailedSQLTransaction`, replacing the diagnostic error. The re-apply is now best-effort on the exception path (Python-side state is restored either way; the next `after_begin` re-declares the context).
3. **Alert annotations made honest**: signatures are indicative, not proof (42501 also covers unrelated permission failures; refresh failure can be a genuine concurrent delete); detection latency ~5-6 min; monitoring failures silent by design.

Evidence: 3 new unit tests + 1 new real-PostgreSQL test (DB error inside the scope surfaces as the original `UndefinedTable` error, session recovers under its own tenant). Suite 3491 passed; postgres 5 passed; ruff + format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)