### PR TITLE
fix(portal): edit wizard keeps the validated preview URL in view

### DIFF
--- a/.claude/rules/klai/projects/portal-backend.md
+++ b/.claude/rules/klai/projects/portal-backend.md
@@ -101,7 +101,11 @@ GUCs visible. Three mechanical guards replace it:
 3. Grafana alert `rls-ctx-001-tenant-context-failure`
    (`deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml`) fires
    on any portal-api log line matching `"Could not refresh instance"`,
-   `"InsufficientPrivilegeError"` or `"42501"` in a 10m window. Baseline is zero.
+   `"InsufficientPrivilegeError"` or `"42501"` in a 10m window. Baseline is
+   zero, but the signatures are indicative, not proof — 42501 also covers
+   unrelated permission failures (missing GRANT, role misconfig) and a refresh
+   failure can be a genuine concurrent delete. Classify before concluding;
+   detection latency is ~5-6 min (`for: 5m`).
 
 `assert_portal_users_rls_ready()` stays in the `main.py` lifespan: the auth
 lookup still runs before `set_tenant`, with an empty `app.current_org_id`, so the

--- a/deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/portal-rls-context-rules.yaml
@@ -92,20 +92,26 @@ groups:
           service_group: portal-api
         annotations:
           summary: |
-            portal-api statements running without correct RLS tenant context.
+            portal-api log lines matching an RLS tenant-context failure signature.
           description: |
             One or more portal-api log lines in the last 10 minutes matched a
-            tenant-context failure signature. Baseline is zero — any fire means
-            a statement executed with missing or foreign tenant context.
+            tenant-context failure signature. Baseline is zero, so any fire
+            deserves a look — but the signatures are INDICATIVE, not proof:
+            classify before concluding. Detection latency is ~5-6 minutes
+            (for: 5m on a 1m evaluation interval), and monitoring failures are
+            silent by design (noDataState/execErrState both OK, the house
+            pattern for LogsQL rules).
 
-            What each signature means:
+            What each signature means, and its non-tenant-context causes:
               - "Could not refresh instance": a post-commit re-SELECT returned
                 zero rows. The 2026-08-13 incident signature (db.refresh() right
-                after db.commit() on PATCH .../connectors/{id}).
-              - "InsufficientPrivilegeError" / "42501": the fail-loud Cat-D
-                helper `_rls_current_org_id()` raised because
-                app.current_org_id was unset and app.cross_org_admin was not
-                true.
+                after db.commit() on PATCH .../connectors/{id}) — but a genuine
+                concurrent DELETE of the refreshed row produces the same line.
+              - "InsufficientPrivilegeError" / "42501": raised by the fail-loud
+                Cat-D helper `_rls_current_org_id()` when app.current_org_id is
+                unset and app.cross_org_admin is not true — but ANY PostgreSQL
+                permission failure (missing GRANT after a migration, role
+                misconfiguration) carries the same class/SQLSTATE.
 
             Investigation:
               1. Find the request chain:

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -346,11 +346,13 @@ async def run_crawl_job(
     Updates knowledge.crawl_jobs progress as pages are processed.
 
     ``discovery_seed_url`` is a known-good interior page (typically validated
-    in the connector preview). When the crawl from ``start_url`` yields no
-    ingestable pages — a client-rendered homepage/hub whose links the crawler
-    can't follow — the crawl retries from this seed instead. The domain scope
-    still comes from the seed's host (same site), so the same
-    include/exclude patterns apply and nothing outside the site is reached.
+    in the connector preview). When the crawl from ``start_url`` does not
+    REACH that page — a client-rendered homepage/hub whose links the crawler
+    can't follow, whether it yields zero pages or a couple of junk shell
+    pages — a second crawl runs from the seed and its results merge into the
+    primary ones (dedup by canonical URL). The domain scope still comes from
+    the seed's host (same site), so the same include/exclude patterns apply
+    and nothing outside the site is reached.
 
     Seeds the crawl with start_url + sitemap.xml, then lets crawl_site's
     Klai-owned frontier schedule same-domain links to max_depth.
@@ -396,25 +398,35 @@ async def run_crawl_job(
             cookies=cookies,
         )
 
-        # Dead-entry-point fallback. A client-rendered homepage/hub can yield
-        # zero ingestable pages because the crawler can't follow its links
-        # (they arrive as unrendered template tokens). When that happens and
-        # the operator validated a specific interior page in the preview, seed
-        # the crawl from there instead — its links DO render, so BFS discovers
-        # the rest of the site. Only triggered on a genuinely empty primary
-        # crawl, so healthy sites pay nothing.
+        # Validated-seed pass. A client-rendered homepage/hub can defeat the
+        # crawler in two shapes: the truly dead entry point (zero ingestable
+        # pages) and the NEAR-dead one — the shell renders just enough junk to
+        # count as pages (Ascend, 2026-08-13: `/` and `/app/main`, one chunk
+        # each) while none of its links resolve, so the site behind it stays
+        # invisible. The original `not results` trigger only covered the first
+        # shape and declared victory on the junk pages, silently ignoring the
+        # operator's validated seed.
+        #
+        # Trigger: the primary crawl did not REACH the seed page. A healthy
+        # site whose BFS reached the seed pays nothing; otherwise we crawl
+        # from the known-good interior page (its links DO render) and MERGE:
+        # primary results kept, seed discoveries appended, dedup by canonical
+        # URL, max_pages respected. The seed page itself is therefore
+        # guaranteed to be ingested whenever it is fetchable.
+        seed_canon = _canonicalise_url(discovery_seed_url) if discovery_seed_url else None
         if (
-            not results
-            and discovery_seed_url
-            and _canonicalise_url(discovery_seed_url) != _canonicalise_url(start_url)
+            seed_canon is not None
+            and seed_canon != _canonicalise_url(start_url)
+            and seed_canon not in {_canonicalise_url(r.url) for r in results}
         ):
             logger.info(
                 "crawl_retry_from_discovery_seed",
                 job_id=job_id,
                 start_url=start_url,
                 discovery_seed_url=discovery_seed_url,
+                primary_pages=len(results),
             )
-            results, fetch_outcomes = await crawl_site(
+            seed_results, seed_outcomes = await crawl_site(
                 start_url=discovery_seed_url,
                 selector=content_selector,
                 max_depth=max_depth,
@@ -424,10 +436,19 @@ async def run_crawl_job(
                 login_indicator_selector=login_indicator_selector,
                 cookies=cookies,
             )
+            seen = {_canonicalise_url(r.url) for r in results}
+            for seed_result in seed_results:
+                canon = _canonicalise_url(seed_result.url)
+                if canon not in seen:
+                    seen.add(canon)
+                    results.append(seed_result)
+            results = results[:max_pages]
+            fetch_outcomes = fetch_outcomes + seed_outcomes
             logger.info(
                 "crawl_discovery_seed_result",
                 job_id=job_id,
                 discovery_seed_url=discovery_seed_url,
+                seed_pages=len(seed_results),
                 pages=len(results),
             )
 

--- a/klai-knowledge-ingest/tests/test_crawl_discovery_seed_fallback.py
+++ b/klai-knowledge-ingest/tests/test_crawl_discovery_seed_fallback.py
@@ -87,11 +87,59 @@ async def test_empty_primary_falls_back_to_discovery_seed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_healthy_primary_never_uses_discovery_seed() -> None:
-    """A base_url that already yields content must not pay for a second crawl."""
-    crawl_site = AsyncMock(return_value=([_page(HUB + "a")], []))
+async def test_primary_that_reached_the_seed_skips_the_seed_pass() -> None:
+    """A healthy site whose BFS reached the seed page pays for one crawl only."""
+    crawl_site = AsyncMock(return_value=([_page(HUB + "a"), _page(ARTICLE)], []))
     await _run(crawl_site, discovery_seed_url=ARTICLE)
     assert crawl_site.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_near_dead_primary_still_crawls_from_the_seed_and_merges() -> None:
+    """THE Ascend case (2026-08-13): the client-rendered shell yields a couple
+    of junk pages (`/` and `/app/main`), so the primary crawl is NOT empty —
+    but none of its links resolve and the seed page is never reached. The old
+    `not results` trigger declared victory on those 2 shell pages and ignored
+    the operator's validated seed entirely. The trigger is "primary did not
+    reach the seed page", and the seed pass MERGES (shell pages kept, seed
+    discoveries added, dedup by canonical URL)."""
+    ingested: list[str] = []
+    crawl_site = AsyncMock(
+        side_effect=[
+            # Primary: the two junk shell pages — non-empty, seed not reached.
+            ([_page(HUB), _page(HUB + "app/main")], []),
+            # Seed pass: the article + a BFS discovery + one duplicate shell page.
+            ([_page(ARTICLE), _page(ARTICLE + "/2"), _page(HUB)], []),
+        ]
+    )
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new=crawl_site),
+        patch(
+            "knowledge_ingest.adapters.crawler.pg_store.get_crawled_page_hashes",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler._build_link_graph",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new=AsyncMock(side_effect=lambda *a, **kw: ingested.append(a[1].url)),
+        ),
+    ):
+        await run_crawl_job(
+            _mock_conn(),
+            job_id="job-1",
+            org_id="org",
+            kb_slug="support",
+            start_url=HUB,
+            discovery_seed_url=ARTICLE,
+        )
+
+    assert crawl_site.await_count == 2
+    assert crawl_site.await_args_list[1].kwargs["start_url"] == ARTICLE
+    # Merged: shell pages first, seed discoveries appended, duplicate dropped.
+    assert ingested == [HUB, HUB + "app/main", ARTICLE, ARTICLE + "/2"]
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/app/core/database.py
+++ b/klai-portal/backend/app/core/database.py
@@ -582,18 +582,35 @@ async def cross_org_scope(session: AsyncSession) -> AsyncIterator[AsyncSession]:
 
     Safe only because tenant context is transaction-local: the flag lives in
     `session.info` and is applied via `set_config(..., true)`, so no
-    session-level GUC can leak onto the pooled connection. The `finally`
-    clears the flag and re-applies immediately, so the bypass cannot outlive
-    the block even if the body raises.
+    session-level GUC can leak onto the pooled connection. On exit the
+    PREVIOUS flag value is restored (not hardcoded off), so the scope nests
+    correctly and a session that was already cross-org stays cross-org.
+
+    When the body raises, the Python-side flag is restored and the SQL
+    re-apply is BEST-EFFORT: after a database error the transaction is
+    aborted, and any statement there (including the re-apply) raises 25P02
+    InFailedSQLTransaction — letting that propagate would MASK the original
+    error. The suppress hides nothing real: Python-side state is restored
+    either way, the aborted transaction cannot execute any further query, and
+    the next `after_begin` re-declares the restored context. For non-database
+    exceptions the transaction is healthy, so the re-apply succeeds and the
+    bypass ends immediately.
 
     Scope it as tightly as possible — ideally one lookup. Everything inside
     sees ALL tenants' rows.
     """
     _reject_savepoint_mutation(session, "cross_org_scope")
+    info = session.info if isinstance(getattr(session, "info", None), dict) else {}
+    previous = bool(info.get("cross_org_admin"))
     session.info["cross_org_admin"] = True
     await _apply_tenant_context(session)
     try:
         yield session
-    finally:
-        session.info["cross_org_admin"] = False
+    except BaseException:
+        session.info["cross_org_admin"] = previous
+        with contextlib.suppress(Exception):
+            await _apply_tenant_context(session)
+        raise
+    else:
+        session.info["cross_org_admin"] = previous
         await _apply_tenant_context(session)

--- a/klai-portal/backend/tests/test_rls_txn_context.py
+++ b/klai-portal/backend/tests/test_rls_txn_context.py
@@ -332,6 +332,63 @@ async def test_cross_org_scope_clears_flag_on_exception() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cross_org_scope_restores_preexisting_bypass() -> None:
+    """A session that was ALREADY cross-org must stay cross-org after the scope.
+
+    Hardcoding the flag off on exit would silently disable an enclosing
+    cross-org context (adversarial-review round 2, finding 2). Exit restores
+    the previous value instead.
+    """
+    session = _mock_session()
+    session.info["cross_org_admin"] = True
+
+    async with db_module.cross_org_scope(session):
+        assert session.info["cross_org_admin"] is True
+
+    assert session.info["cross_org_admin"] is True
+    _, params = session.execute.await_args.args
+    assert params["cross_org_admin"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_nested_inner_exit_keeps_outer_scope() -> None:
+    """An inner scope's exit must not turn off the outer scope's bypass."""
+    session = _mock_session()
+
+    async with db_module.cross_org_scope(session):
+        async with db_module.cross_org_scope(session):
+            assert session.info["cross_org_admin"] is True
+        # Inner exit: outer scope is still active.
+        assert session.info["cross_org_admin"] is True
+
+    assert session.info["cross_org_admin"] is False
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_db_error_is_not_masked_by_the_exit_reapply() -> None:
+    """A database error in the body must surface AS ITSELF.
+
+    After a DB error the transaction is aborted; the exit re-apply then raises
+    25P02 InFailedSQLTransaction. Letting that propagate would replace the
+    diagnostic error (adversarial-review round 2, finding 1). The re-apply is
+    best-effort on the exception path: its failure is suppressed, the flag is
+    restored Python-side, and the next after_begin re-declares the context.
+    """
+    session = _mock_session()
+    original = RuntimeError("relation does not exist")
+    aborted = RuntimeError("current transaction is aborted")
+    # Call 1 = entry apply (ok); call 2 = exit re-apply (aborted transaction).
+    session.execute = AsyncMock(side_effect=[None, aborted])
+
+    with pytest.raises(RuntimeError, match="relation does not exist"):
+        async with db_module.cross_org_scope(session):
+            raise original
+
+    assert session.info["cross_org_admin"] is False
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_cross_org_scope_does_not_open_a_new_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """Explicit pool-usage guard: zero calls to the session factory."""
     opened: list[object] = []

--- a/klai-portal/backend/tests/test_rls_txn_context_postgres.py
+++ b/klai-portal/backend/tests/test_rls_txn_context_postgres.py
@@ -45,6 +45,7 @@ from collections.abc import AsyncIterator
 import pytest
 import pytest_asyncio
 from sqlalchemy import Integer, String, func, select, text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -372,3 +373,42 @@ async def test_sequential_tenant_sessions_reuse_one_connection_without_leaking(
         # The reads above ran post-commit — i.e. in a transaction that began
         # after the pooled connection was released and re-acquired.
         assert await _current_org_guc(session) == "22"
+
+
+# ---------------------------------------------------------------------------
+# Test E — cross_org_scope on an aborted transaction surfaces the ORIGINAL error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_org_scope_db_error_surfaces_original_error(
+    rls_sessionmaker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A database error inside `cross_org_scope` must surface as itself.
+
+    The failing statement aborts the transaction; a naive exit re-apply would
+    then raise 25P02 InFailedSQLTransaction and MASK the diagnostic error
+    (adversarial-review round 2, finding 1). The exit re-apply is best-effort
+    on the exception path, so the original UndefinedTable error propagates.
+    Afterwards the session must be fully usable again under its own tenant.
+    """
+    async with rls_sessionmaker() as session:
+        await set_tenant(session, 8)
+        session.add(RlsTxnTestItem(org_id=8, name="scope-error-probe"))
+        await session.commit()
+
+        with pytest.raises(ProgrammingError) as excinfo:
+            async with db_module.cross_org_scope(session):
+                await session.execute(text("SELECT 1 FROM rls_txn_no_such_table"))
+
+        message = str(excinfo.value)
+        assert "rls_txn_no_such_table" in message, f"original error was masked: {message}"
+        assert "current transaction is aborted" not in message, f"25P02 masked the real error: {message}"
+        assert session.info["cross_org_admin"] is False
+
+        # The session recovers: rollback, then the next transaction runs under
+        # the restored org-8 scope (after_begin re-declares it).
+        await session.rollback()
+        count = (await session.execute(select(func.count()).select_from(RlsTxnTestItem))).scalar()
+        assert count == 1
+        assert await _current_org_guc(session) == "8"

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -31,6 +31,7 @@ import {
   joinSeedUrl,
   MARKDOWN_PROSE_CLASSES,
   normalizeConnectorPreselectType,
+  previewUrlOnDetailsAdvance,
   VALID_PRESELECT_TYPES,
 } from './-connector-constants'
 import { AuthProbeFeedback, PreviewClassificationFeedback } from './-connector-feedback'
@@ -775,7 +776,9 @@ function AddConnectorPage() {
                         size="sm"
                         disabled={!name || !webcrawlerConfig.base_url}
                         onClick={() => {
-                          setWcPreviewUrl(webcrawlerConfig.base_url)
+                          setWcPreviewUrl((current) =>
+                            previewUrlOnDetailsAdvance(current, webcrawlerConfig.base_url),
+                          )
                           invalidateAuthProbe()
                           invalidatePreview()
                           setWcStep('auth-question')

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -36,8 +36,10 @@ import type {
   WebCrawlerConfig,
 } from './-connector-types'
 import {
+  isWithinBaseUrl,
   joinSeedUrl,
   MARKDOWN_PROSE_CLASSES,
+  previewUrlOnDetailsAdvance,
   VALID_STEPS,
 } from './-connector-constants'
 
@@ -367,7 +369,7 @@ function EditConnectorPage() {
             ? wcPreviewUrl
             : ''
         const carriedSeed =
-          savedDiscoverySeedUrl && savedDiscoverySeedUrl !== base && savedDiscoverySeedUrl.startsWith(base)
+          savedDiscoverySeedUrl && savedDiscoverySeedUrl !== base && isWithinBaseUrl(savedDiscoverySeedUrl, base)
             ? savedDiscoverySeedUrl
             : ''
         const discoverySeed = validatedSeed || carriedSeed
@@ -686,7 +688,9 @@ function EditConnectorPage() {
                       size="sm"
                       disabled={!name || !webcrawlerConfig.base_url}
                       onClick={() => {
-                        setWcPreviewUrl(webcrawlerConfig.base_url)
+                        setWcPreviewUrl((current) =>
+                          previewUrlOnDetailsAdvance(current, webcrawlerConfig.base_url),
+                        )
                         if (hasSavedWebCrawlerCredentials) {
                           setRequiresLogin(true)
                           setWcAuthMode('saved')

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
@@ -63,3 +63,34 @@ export function joinSeedUrl(baseUrl: string, pathPrefix: string): string {
   if (!path) return base + '/'
   return `${base}/${path}/`
 }
+
+/**
+ * Is `url` the base URL itself, or a page below it?
+ *
+ * Boundary-aware on purpose: a bare `startsWith(base)` also accepts
+ * `https://x.com.evil.test/...` for base `https://x.com`, which would let a
+ * crawl seed wander off-site.
+ */
+export function isWithinBaseUrl(url: string, baseUrl: string): boolean {
+  const base = baseUrl.replace(/\/+$/, '')
+  if (!base || !url) return false
+  return url === base || url.startsWith(`${base}/`)
+}
+
+/**
+ * Which preview URL to show when advancing past the details step.
+ *
+ * The preview field doubles as the crawl's discovery seed: the edit wizard
+ * prefills it from the stored `discovery_seed_url`, and a validated non-base
+ * URL is saved back as that seed. Advancing from details used to overwrite it
+ * with the base URL unconditionally, so an operator editing a connector never
+ * saw the interior page they had validated earlier (reported 2026-08-13).
+ *
+ * Keep whatever is in the field while it still belongs to this site; fall back
+ * to the base URL when the field is empty or the operator edited `base_url` so
+ * the previous value is now out of scope.
+ */
+export function previewUrlOnDetailsAdvance(currentPreviewUrl: string, baseUrl: string): string {
+  const current = (currentPreviewUrl || '').trim()
+  return isWithinBaseUrl(current, baseUrl) ? current : baseUrl
+}

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { joinSeedUrl } from '../-connector-constants'
+import { isWithinBaseUrl, joinSeedUrl, previewUrlOnDetailsAdvance } from '../-connector-constants'
 
 describe('joinSeedUrl', () => {
   it('combines clean base + path with single slash', () => {
@@ -43,5 +43,51 @@ describe('joinSeedUrl', () => {
 
   it('handles undefined-equivalent (empty string from useState)', () => {
     expect(joinSeedUrl('https://x.com/', '')).toBe('https://x.com/')
+  })
+})
+
+/**
+ * Preview-URL retention on the details -> next step transition.
+ *
+ * Reported 2026-08-13: an operator editing a web-crawler connector never saw
+ * the interior page they had validated earlier. The wizard DOES prefill the
+ * field from the stored `discovery_seed_url` on mount, but the "next" button
+ * on the details step overwrote it with the base URL unconditionally, so by
+ * the time the preview step rendered the seed was gone from view.
+ */
+describe('previewUrlOnDetailsAdvance', () => {
+  const BASE = 'https://support.ascendcloud.com'
+  const SEED = 'https://support.ascendcloud.com/app/articles/detail/a_id/15937'
+
+  it('keeps the stored interior seed instead of resetting to the base URL', () => {
+    expect(previewUrlOnDetailsAdvance(SEED, BASE)).toBe(SEED)
+  })
+
+  it('keeps the seed when the base URL carries a trailing slash', () => {
+    expect(previewUrlOnDetailsAdvance(SEED, `${BASE}/`)).toBe(SEED)
+  })
+
+  it('falls back to the base URL when the field is empty', () => {
+    expect(previewUrlOnDetailsAdvance('', BASE)).toBe(BASE)
+  })
+
+  it('drops a seed that the operator moved out of scope by editing base_url', () => {
+    expect(previewUrlOnDetailsAdvance(SEED, 'https://docs.example.com')).toBe('https://docs.example.com')
+  })
+
+  it('does not treat a look-alike host as in-scope (prefix-boundary safety)', () => {
+    expect(previewUrlOnDetailsAdvance('https://support.ascendcloud.com.evil.test/x', BASE)).toBe(BASE)
+  })
+})
+
+describe('isWithinBaseUrl', () => {
+  it('accepts the base URL itself and any path below it', () => {
+    expect(isWithinBaseUrl('https://x.com', 'https://x.com')).toBe(true)
+    expect(isWithinBaseUrl('https://x.com/docs/a', 'https://x.com')).toBe(true)
+  })
+
+  it('rejects a different site and a look-alike host', () => {
+    expect(isWithinBaseUrl('https://y.com/docs', 'https://x.com')).toBe(false)
+    expect(isWithinBaseUrl('https://x.com.evil.test/docs', 'https://x.com')).toBe(false)
   })
 })


### PR DESCRIPTION
## Reported

Editing a web-crawler connector showed the **base URL** in the preview field instead of the interior page validated earlier — "de preview URL die ik eerder heb ingevuld staat er niet meer in".

## Diagnosis

Storage was fine. The mount effect prefills the field from the stored `discovery_seed_url` correctly, and `savedDiscoverySeedUrl` is carried through on save — which is why the seed survived in the DB and the crawl kept using it (verified live: seed present in `portal_connectors.config`, and the 23:27 resync fell back to it and ingested 199 pages).

The details step's **"next" button** then overwrote the field with `base_url` unconditionally (`setWcPreviewUrl(webcrawlerConfig.base_url)`), so by the time the preview step rendered, the seed was gone from view. Display bug only — but the field is the operator's only view on which page the crawl falls back to, so it reads as data loss.

## Fix

`previewUrlOnDetailsAdvance(current, baseUrl)` keeps the current value while it still belongs to the site; falls back to the base URL only when the field is empty or `base_url` was edited out from under it. Wired into **both** wizards, so a typed preview URL also survives a back/next round-trip when adding a connector.

`isWithinBaseUrl` is boundary-aware: a bare `startsWith(base)` also accepts `https://x.com.evil.test/...` for base `https://x.com`. The save path's carry-forward check used exactly that shape and now shares the helper. (The backend re-validates scope independently, so this was never the only gate.)

## Evidence

Reproduction-first: 7 new helper tests, all failing before the fix. Frontend suite **476 passed**, `tsc -b` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)