### PR TITLE
fix(portal): rollback must not read container.image (socket-proxy denies IMAGES)

### DIFF
--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -690,9 +690,15 @@ def _start_librechat_container(
     old_image_ref: str | None = None
     try:
         old = client.containers.get(container_name)
-        if rollback_on_failure and old.image is not None:
-            tags = old.image.tags
-            old_image_ref = tags[0] if tags else old.image.id
+        if rollback_on_failure:
+            # Read the image ref from the container's own inspect payload
+            # (already fetched by containers.get -> GET /containers/{id}/json).
+            # Do NOT touch `old.image`: that property lazily calls
+            # GET /images/{id}/json, which docker-socket-proxy denies by design
+            # (IMAGES is deliberately not enabled — see
+            # .claude/rules/klai/platform/docker-socket-proxy.md). Reading it
+            # raised 403 and aborted the whole fleet rollout on 2026-08-14.
+            old_image_ref = (old.attrs.get("Config") or {}).get("Image") or None
         old.remove(force=True)
     except docker.errors.NotFound:  # type: ignore[attr-defined]
         pass

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -639,7 +639,15 @@ class TestStartLibrechatContainerRollback:
         self._write_lc_files(tmp_path)
 
         old_container = MagicMock()
-        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+        old_container.attrs = {"Config": {"Image": "ghcr.io/danny-avila/librechat:v0.8.6"}}
+        # Reading .image would call GET /images/{id}/json, which
+        # docker-socket-proxy denies (403). Make any access explode so this
+        # test fails if the lazy property is reintroduced.
+        type(old_container).image = property(
+            lambda _self: (_ for _ in ()).throw(
+                AssertionError("must not touch container.image: socket-proxy denies IMAGES")
+            )
+        )
         broken_container = MagicMock()
 
         mock_client = MagicMock()
@@ -693,7 +701,15 @@ class TestStartLibrechatContainerRollback:
         self._write_lc_files(tmp_path)
 
         old_container = MagicMock()
-        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+        old_container.attrs = {"Config": {"Image": "ghcr.io/danny-avila/librechat:v0.8.6"}}
+        # Reading .image would call GET /images/{id}/json, which
+        # docker-socket-proxy denies (403). Make any access explode so this
+        # test fails if the lazy property is reintroduced.
+        type(old_container).image = property(
+            lambda _self: (_ for _ in ()).throw(
+                AssertionError("must not touch container.image: socket-proxy denies IMAGES")
+            )
+        )
         broken_container = MagicMock()
 
         mock_client = MagicMock()
@@ -738,7 +754,15 @@ class TestStartLibrechatContainerRollback:
         self._write_lc_files(tmp_path)
 
         old_container = MagicMock()
-        old_container.image.tags = ["ghcr.io/danny-avila/librechat:v0.8.6"]
+        old_container.attrs = {"Config": {"Image": "ghcr.io/danny-avila/librechat:v0.8.6"}}
+        # Reading .image would call GET /images/{id}/json, which
+        # docker-socket-proxy denies (403). Make any access explode so this
+        # test fails if the lazy property is reintroduced.
+        type(old_container).image = property(
+            lambda _self: (_ for _ in ()).throw(
+                AssertionError("must not touch container.image: socket-proxy denies IMAGES")
+            )
+        )
 
         mock_client = MagicMock()
         mock_client.containers.get.side_effect = [old_container]


### PR DESCRIPTION
Found by the first real fleet recreate: the rollback code from #881 hit a 403. The abort guard prevented any damage (42/42 tenants stayed up). Fix reads Config.Image from the container inspect payload; test now fails if .image is touched again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)