### PR TITLE
fix(knowledge-ingest): renamed source page supersedes instead of duplicating

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -376,31 +376,59 @@ async def get_personal_artifact(
 
 
 async def soft_delete_artifact(
-    conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
-) -> list[str]:
-    """Set belief_time_end = now for all active artifacts matching this path.
+    conn: asyncpg.Connection,
+    org_id: str,
+    kb_slug: str,
+    path: str,
+    source_connector_id: str | None = None,
+    source_ref: str | None = None,
+) -> list[tuple[str, str]]:
+    """Set belief_time_end = now for all active artifacts this ingest replaces.
 
-    Returns the ids of the rows that were closed, so the caller can link
-    them to their replacement via :func:`set_superseded_by`. Id-based
+    Matching is by path OR, for connector-sourced documents, by the stable
+    provider identity ``(source_connector_id, source_ref)``. Path alone is
+    not sufficient: it mirrors a user-editable title, so renaming a source
+    page produced a second active artifact under the new title while the
+    old one stayed live in PG and Qdrant (Voys ``support`` KB, 2026-08-14 —
+    "App troubleshoot & transfers" vs "App troubleshooting"). Callers with
+    no connector identity (personal KB, manual upload) keep path-only
+    semantics.
+
+    Returns ``(id, path)`` for every row that was closed. The id lets the
+    caller link it to its replacement via :func:`set_superseded_by`; id-based
     linking avoids the epoch-second collision risk of matching closed rows
-    back by timestamp (adversarial review 2026-06-11).
+    back by timestamp (adversarial review 2026-06-11). The path is needed
+    because :func:`qdrant_store.upsert_chunks` only clears points for the
+    path being written — a row closed under a DIFFERENT (old) path leaves
+    its chunks behind, still carrying an open-ended ``valid_until``, and
+    therefore still retrievable.
     """
     now = int(time.time())
     rows = await conn.fetch(
         """
         UPDATE knowledge.artifacts
         SET belief_time_end = $1
-        WHERE org_id = $2 AND kb_slug = $3 AND path = $4
+        WHERE org_id = $2 AND kb_slug = $3
           AND belief_time_end = $5
-        RETURNING id
+          AND (
+            path = $4
+            OR (
+              $6::text IS NOT NULL AND $7::text IS NOT NULL
+              AND extra->>'source_connector_id' = $6
+              AND extra->>'source_ref' = $7
+            )
+          )
+        RETURNING id, path
         """,
         now,
         org_id,
         kb_slug,
         path,
         _SENTINEL,
+        source_connector_id,
+        source_ref,
     )
-    return [str(row["id"]) for row in rows]
+    return [(str(row["id"]), str(row["path"])) for row in rows]
 
 
 async def set_superseded_by(

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -569,9 +569,15 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # (adversarial review 2026-06-11). create_artifact's internal transaction
     # nests as a SAVEPOINT, keeping its UniqueViolation recovery intact.
     async with conn.transaction():
-        superseded_ids = await pg_store.soft_delete_artifact(
-            conn, req.org_id, req.kb_slug, req.path
+        closed_rows = await pg_store.soft_delete_artifact(
+            conn,
+            req.org_id,
+            req.kb_slug,
+            req.path,
+            source_connector_id=req.source_connector_id,
+            source_ref=req.source_ref,
         )
+        superseded_ids = [row_id for row_id, _ in closed_rows]
         artifact_id = await pg_store.create_artifact(
             conn,
             org_id=req.org_id,
@@ -591,6 +597,22 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             derived_from=kf["derived_from"],
         )
         await pg_store.set_superseded_by(conn, superseded_ids, artifact_id)
+
+    # A source page that was RENAMED closes a row stored under its OLD path.
+    # upsert_chunks below only clears points for req.path, so without this the
+    # old title's chunks stay in Qdrant with an open-ended ``valid_until`` and
+    # keep answering queries with pre-rename content (Voys support, 2026-08-14).
+    for _, stale_path in closed_rows:
+        if stale_path != req.path:
+            await qdrant_store.delete_document(req.org_id, req.kb_slug, stale_path)
+            logger.info(
+                "stale_renamed_path_chunks_deleted",
+                org_id=req.org_id,
+                kb_slug=req.kb_slug,
+                stale_path=stale_path,
+                new_path=req.path,
+                source_ref=req.source_ref,
+            )
 
     # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2: record image-key
     # bookkeeping so per-connector cleanup can compute orphan keys via

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -96,7 +96,7 @@ async def test_proceeds_when_content_changed():
         patch(
             "knowledge_ingest.pg_store.soft_delete_artifact",
             new_callable=AsyncMock,
-            return_value=["closed-artifact-id"],
+            return_value=[("closed-artifact-id", "docs/page.md")],
         ) as mock_soft_delete,
         patch(
             "knowledge_ingest.pg_store.create_artifact",
@@ -156,7 +156,16 @@ async def test_proceeds_when_content_changed():
         result = await ingest_document(conn, req)
 
     assert result["status"] == "ok"
-    mock_soft_delete.assert_awaited_once_with(conn, req.org_id, req.kb_slug, req.path)
+    # Connector identity is None for this plain docs request, so the close
+    # step falls back to path-only matching (see soft_delete_artifact).
+    mock_soft_delete.assert_awaited_once_with(
+        conn,
+        req.org_id,
+        req.kb_slug,
+        req.path,
+        source_connector_id=None,
+        source_ref=None,
+    )
     mock_create.assert_awaited_once()
     mock_set_superseded_by.assert_awaited_once_with(
         conn,

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -292,11 +292,18 @@ async def test_list_recent_artifact_keys_covers_created_and_closed_rows():
 @pytest.mark.asyncio
 async def test_soft_delete_updates_belief_time_end_and_returns_closed_ids():
     conn = _make_conn()
-    conn.fetch = AsyncMock(return_value=[{"id": "closed-id-1"}, {"id": "closed-id-2"}])
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"id": "closed-id-1", "path": "note.md"},
+            {"id": "closed-id-2", "path": "old-title.md"},
+        ]
+    )
     with patch("knowledge_ingest.pg_store.time.time", return_value=1_700_000_000):
         result = await pg_store.soft_delete_artifact(conn, "org123", "personal", "note.md")
 
-    assert result == ["closed-id-1", "closed-id-2"]
+    # (id, path) pairs: the path lets the caller clear Qdrant points that were
+    # written under a previous title.
+    assert result == [("closed-id-1", "note.md"), ("closed-id-2", "old-title.md")]
     conn.fetch.assert_called_once()
     call_args = conn.fetch.call_args[0]
     assert "UPDATE knowledge.artifacts" in call_args[0]

--- a/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
+++ b/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
@@ -1,0 +1,188 @@
+"""A renamed connector page must supersede its previous artifact, not duplicate it.
+
+Contract: for connector-sourced documents the stable identity is
+``(source_connector_id, source_ref)`` -- the provider's own document id --
+NOT ``path``, which mirrors a user-editable title.
+
+Production incident (Voys ``support`` KB, 2026-08-14): a manual Notion
+recall re-ingested 95 pages. Pages whose title was unchanged superseded
+their May row correctly; pages that had been RENAMED in Notion did not
+match on ``path``, so the May artifact stayed active alongside the August
+one. Four pages ended up with two active artifacts and two live Qdrant
+chunk sets each, e.g. ``App troubleshoot & transfers`` (May content) next
+to ``App troubleshooting`` (August content). Retrieval could cite the
+three-month-old copy as current.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import pg_store
+from knowledge_ingest.models import IngestRequest
+
+_SENTINEL = 253402300800
+
+_CONNECTOR_ID = "939b7851-c675-4dad-996f-b1cbce2d81ae"
+_SOURCE_REF = "53d643e8-0a98-4c1b-95f0-03b9c018109c"
+_OLD_PATH = "App troubleshoot & transfers"
+_NEW_PATH = "App troubleshooting"
+
+
+def _make_procrastinate_app() -> MagicMock:
+    """Procrastinate stub whose ``configure_task(...).defer_async(...)`` is awaitable."""
+    app = MagicMock()
+    app.configure_task.return_value.defer_async = AsyncMock(return_value=None)
+    app.ingest_graphiti_episode.configure.return_value.defer_async = AsyncMock(return_value=None)
+    return app
+
+
+def _make_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+
+    @asynccontextmanager
+    async def _tx():
+        yield None
+
+    conn.transaction = MagicMock(side_effect=_tx)
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_closes_previous_artifact_of_same_source_ref():
+    """The close query must match on source identity, not only on path."""
+    conn = _make_conn()
+
+    await pg_store.soft_delete_artifact(
+        conn,
+        "org1",
+        "support",
+        _NEW_PATH,
+        source_connector_id=_CONNECTOR_ID,
+        source_ref=_SOURCE_REF,
+    )
+
+    sql = conn.fetch.call_args[0][0]
+    values = conn.fetch.call_args[0][1:]
+
+    assert "source_ref" in sql, "close query ignores source_ref -- renames orphan the old row"
+    assert "source_connector_id" in sql, "source_ref must be scoped to its connector"
+    assert _CONNECTOR_ID in values
+    assert _SOURCE_REF in values
+    # The path branch must survive for manual uploads / non-connector docs.
+    assert _NEW_PATH in values
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_without_source_ref_is_unchanged():
+    """Non-connector callers (personal KB, manual upload) keep path-only semantics."""
+    conn = _make_conn()
+
+    await pg_store.soft_delete_artifact(conn, "org1", "personal", "note.md")
+
+    values = conn.fetch.call_args[0][1:]
+    assert "note.md" in values
+    assert _SENTINEL in values
+
+
+@pytest.mark.asyncio
+async def test_ingest_forwards_connector_identity_when_page_is_renamed():
+    """ingest_document must hand the connector identity to the close step."""
+    req = IngestRequest(
+        org_id="org1",
+        kb_slug="support",
+        path=_NEW_PATH,
+        content="# App troubleshooting\n" + ("body content " * 40),
+        source_type="notion",
+        content_type="kb_article",
+        source_connector_id=_CONNECTOR_ID,
+        source_ref=_SOURCE_REF,
+    )
+    conn = _make_conn()
+
+    with (
+        patch(
+            "knowledge_ingest.connector_state.connector_is_active",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "knowledge_ingest.enrichment_tasks.get_app",
+            return_value=_make_procrastinate_app(),
+        ),
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.soft_delete_artifact",
+            new_callable=AsyncMock,
+            return_value=[("may-artifact-id", _OLD_PATH)],
+        ) as mock_soft_delete,
+        patch(
+            "knowledge_ingest.qdrant_store.delete_document", new_callable=AsyncMock
+        ) as mock_delete_doc,
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="august-artifact-id",
+        ),
+        patch(
+            "knowledge_ingest.pg_store.set_superseded_by", new_callable=AsyncMock
+        ) as mock_set_superseded,
+        patch("knowledge_ingest.pg_store.update_artifact_extra", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.pg_store.set_artifact_ingest_status",
+            new_callable=AsyncMock,
+            return_value={"artifact_id": "august-artifact-id", "path": req.path},
+        ),
+        patch(
+            "knowledge_ingest.pg_store.insert_parent_chunks",
+            new_callable=AsyncMock,
+            return_value=[1],
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ),
+        patch("knowledge_ingest.qdrant_store.upsert_chunks", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
+        mock_settings.chunk_size = 1500
+        mock_settings.chunk_overlap = 200
+        mock_settings.enrichment_enabled = False
+
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        result = await ingest_document(conn, req)
+
+    assert result["status"] == "ok"
+    kwargs = mock_soft_delete.await_args.kwargs
+    assert kwargs.get("source_connector_id") == _CONNECTOR_ID, (
+        "ingest did not pass the connector id -- the renamed page's old row stays active"
+    )
+    assert kwargs.get("source_ref") == _SOURCE_REF
+    # The row closed under the OLD title must be linked to the new artifact.
+    mock_set_superseded.assert_awaited_once_with(conn, ["may-artifact-id"], "august-artifact-id")
+    # ...and its chunks must leave Qdrant, or the pre-rename content stays
+    # retrievable under an open-ended valid_until.
+    mock_delete_doc.assert_awaited_once_with("org1", "support", _OLD_PATH)


### PR DESCRIPTION
## Probleem

Een connector-document wordt geïdentificeerd door zijn provider-id (`source_ref`), niet door `path` — `path` is de door gebruikers bewerkbare titel. `soft_delete_artifact` matchte alleen op `path`, dus bij het hernoemen van een Notion-pagina werd er niets afgesloten:

- de oude artifact-rij bleef actief naast de nieuwe;
- `qdrant_store.upsert_chunks` ruimt punten per `path` op, dus de chunks onder de oude titel bleven staan mét een open-einde `valid_until`.

Beide kopieën waren dus vindbaar en de chat kon inhoud van vóór de hernoeming als actueel citeren.

## Gevonden op productie

Voys `support` KB, na een handmatige Notion-recall op 2026-08-14. 138 pagina's gevonden, 95 opnieuw gesynct, 0 fouten. Vier pagina's hielden twee actieve artifacts én twee live chunksets over:

| `source_ref` | mei (verouderd, nog actief) | augustus (nieuw) |
|---|---|---|
| `53d643e8…` | App troubleshoot & transfers — 3 chunks | App troubleshooting — 3 chunks |
| `27d40e6d…` | Offerte aanmelders met 1 gebruikers nabellen — 11 chunks | Offerte aanmelders met 1 gebruiker nabellen — 11 chunks |
| `32d40e6d…` | Nieuwe versie (maart 2026) | Nieuwe versie (juni 2026) |
| `46064fc4…` | Onboarding en support kosten | Support kosten & betaalde onboarding |

Beide kanten stonden op `valid_until = 253402300800` (de open-einde sentinel), dus de temporele filter in `retrieval-api/services/search.py:82` filterde de oude versie niet weg.

## Wijziging

- `soft_delete_artifact` matcht nu op `path` **OF** `(source_connector_id, source_ref)`.
- De functie geeft `(id, path)` terug, zodat `ingest_document` de Qdrant-punten van het oude pad kan opruimen. Zonder die tweede stap bleef alleen Postgres netjes en bleef de retrieval-laag vervuild.
- Callers zonder connector-identiteit (persoonlijke KB, handmatige upload, `kb_sources`) houden exact het oude gedrag.

## Veiligheidscheck

Op productie geverifieerd dat geen enkele `source_ref` legitiem naar meer dan één actief pad wijst — de verbrede match kan dus geen losstaande documenten samenvoegen. De dubbelingen die in andere KB's leken te staan (`klai-help`, `oracle`) bleken al afgesloten rijen die retrieval niet raken.

## Tests

Reproductie-eerst: drie nieuwe tests faalden op precies dit gedrag, daarna groen. Volledige suite: **1215 passed, 4 skipped**. Twee bestaande tests zijn bijgewerkt op de nieuwe return-vorm.

## Nog te doen na deploy

De vier bestaande dubbelingen verdwijnen niet vanzelf — die pagina's worden pas hersynct als ze in Notion bewerkt worden. Na deze deploy een geforceerde re-sync draaien (cursor resetten) laat de fix ze zelf opruimen, zowel in Postgres als in Qdrant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)