### PR TITLE
test(knowledge-ingest): stub embedder in guard tests to stop 75s CI sleeps

### DIFF
--- a/klai-knowledge-ingest/tests/test_ingest_endpoints_identity_assertion.py
+++ b/klai-knowledge-ingest/tests/test_ingest_endpoints_identity_assertion.py
@@ -30,6 +30,22 @@ from fastapi import HTTPException, status
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _stub_embedder(monkeypatch):
+    """Keep the real TEI client out of these identity-assertion tests.
+
+    They assert who may call the endpoint, not embedding quality. Without
+    the stub the happy-path case reaches ``embedder.embed``, TEI is
+    unreachable in CI, and the 5-attempt jitter backoff (30s cap) sleeps
+    ~75s before the assertion is ever evaluated.
+    """
+
+    async def _fake_embed(texts: list[str]) -> list[list[float]]:
+        return [[0.0] * 8 for _ in texts]
+
+    monkeypatch.setattr("knowledge_ingest.embedder.embed", _fake_embed)
+
+
 @pytest.fixture()
 def _identity_ok(monkeypatch):
     """Patch assert_caller_identity to succeed, return the claimed org_id."""

--- a/klai-knowledge-ingest/tests/test_ingest_personal_kb_owner_binding.py
+++ b/klai-knowledge-ingest/tests/test_ingest_personal_kb_owner_binding.py
@@ -26,6 +26,23 @@ import pytest
 _CALLER = {"X-Caller-Service": "portal-api"}
 
 
+@pytest.fixture(autouse=True)
+def _stub_embedder(monkeypatch):
+    """Keep the real TEI client out of these guard tests.
+
+    These cases assert the personal-KB owner guard, not embedding. Without
+    the stub the request reaches ``embedder.embed``, TEI is unreachable in
+    CI, and the 5-attempt jitter backoff (30s cap) sleeps ~75s per test
+    before the assertion is ever evaluated — three tests here were the
+    slowest in the whole suite for that reason alone.
+    """
+
+    async def _fake_embed(texts: list[str]) -> list[list[float]]:
+        return [[0.0] * 8 for _ in texts]
+
+    monkeypatch.setattr("knowledge_ingest.embedder.embed", _fake_embed)
+
+
 @pytest.fixture()
 def _identity_ok(monkeypatch):
     """Identity assertion passes through with the claimed org_id / user_id."""


### PR DESCRIPTION
## Probleem

Vier tests bereikten de echte embedder terwijl ze iets heel anders asserten (de personal-KB owner guard, en identity assertion). TEI is onbereikbaar in CI, dus elke test brandde het volledige retry-budget op — 5 pogingen met jitter-backoff tot 30s — voordat de assertie überhaupt werd geëvalueerd.

```
75.07s test_ingest_personal_kb_owner_binding.py::test_user_a_writing_to_own_personal_kb_passes_guard
75.01s test_ingest_endpoints_identity_assertion.py::test_valid_claim_passes_identity_check
75.01s test_ingest_personal_kb_owner_binding.py::test_plain_personal_slug_without_dash_unaffected
75.01s test_ingest_personal_kb_owner_binding.py::test_org_kb_write_unaffected_by_guard
```

Die 75,01 seconden is geen rekenwerk maar een timeout.

## Waarom het erger was dan 300 seconden

Een xdist-worker die op een slaapstand van 75s staat, kan geen ander werk oppakken. Daardoor zetten deze vier tests de ondergrens voor de wall-clock van de héle run. De CI-runner heeft 4 cores, dus `-n auto` geeft precies 4 workers — genoeg om ze alle vier tegelijk vast te zetten.

**Volledige suite lokaal: 231s → 41s.** Alle 1215 tests blijven groen.

Dit zit op het kritieke pad van elke productie-deploy: de `tests`-job is de deploy-gate voor deze service en kostte 41m48s van een pipeline van 45 minuten (build + deploy samen zijn nog geen 4 minuten).

## Aanpak

De stub staat per bestand, niet als autouse-fixture in `conftest.py`. Tests die de retry-logica van de embedder juist wél moeten uitoefenen (`test_batch_splitting_embedder.py`) houden dus de echte client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)