### PR TITLE
fix(portal): never let provisioning take over a compose-managed container

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -2044,6 +2044,100 @@ Recovery was clean fix-forward (no prod impact): PR #794 added the merge
 migration, PR #795 stripped its unused imports, deploy went green,
 `alembic current` on the container = `0aac04f1bccc (head) (mergepoint)`.
 
+## remove-the-mount-before-you-delete-the-file (CRIT)
+
+Deleting a bind-mount's host source while running containers still declare
+that mount is a **delayed** outage: nothing breaks now, everything breaks on
+the next container start. Docker resolves a bind-mount source at *start*
+time; if the path is gone it silently creates an empty **directory** there.
+A container that expected a file then starts against a directory and dies.
+
+Incident 2026-08-14 (PR #895, SPEC-STREAM-CLEANUP-001). The PR removed the
+now-inert `createStreamServices.ts` patch from the repo. The config-sync step
+runs `rsync -a --delete deploy/librechat/patches/ /opt/klai/librechat/patches/`,
+so the host file disappeared immediately — while all 42 tenant containers
+still declared `- ./librechat/patches/createStreamServices.ts:...`. The
+running containers were unaffected (their mounts were already resolved). The
+restart that followed was not: Docker created a directory at that path and
+**36 of 42 tenants exited with code 127**. The 6 survivors were the ones that
+happened not to restart. Recovery: `rmdir` the directory, write a placeholder
+file, `docker start` the 36.
+
+**The ordering rule.** A bind-mount has two ends and they must be retired in
+this order, never the reverse:
+
+1. Remove the mount from every **container definition** and recreate the
+   containers (they now no longer reference the path at all).
+2. Verify zero containers still declare it:
+   ```bash
+   for n in $(docker ps --filter name=<prefix> --format '{{.Names}}'); do
+     docker inspect "$n" --format '{{range .Mounts}}{{.Source}} {{end}}' | grep -q <file> && echo "$n"
+   done
+   ```
+3. Only then delete the host file / let the sync's `--delete` remove it.
+
+If steps 1 and 3 cannot land in the same change, keep a placeholder file at
+the path until every container has been recreated. A placeholder is cheap;
+an empty auto-created directory is an outage.
+
+**Generalisation.** Any resource resolved at container-start time and owned by
+a *different* deploy pipeline than the container definition has this hazard:
+bind-mount sources, named-volume contents, secret files, config files pulled
+by an entrypoint. Whenever the "who deletes it" pipeline runs before the
+"who stops referencing it" pipeline, you have a delayed outage armed and
+waiting for the next restart.
+
+**Related:** `bind-mount-without-sync-workflow` (the file never arrives) and
+`bind-mount-content-vs-python-module-cache` (the file arrives but is not
+re-read) are the other two failure modes of the same bind-mount contract.
+
+## one-container-one-owner (HIGH)
+
+A container declared in `deploy/docker-compose.yml` is owned by compose. A
+container created by portal-api provisioning is owned by portal-api. When both
+claim the same name, the second one to run wins the container and silently
+breaks the first one's pipeline — permanently, and for every service it
+deploys, not just the contested one.
+
+Incident 2026-08-14, discovered while cleaning up the incident above. A
+fleet-wide `POST /internal/librechat/regenerate?recreate_containers=true`
+force-removed and recreated `librechat-getklai` — the canary that is declared
+as a compose service. The replacement kept the name and worked fine, but lost
+`com.docker.compose.project`. Every subsequent `docker compose up` then died
+with:
+
+```
+Conflict. The container name "/librechat-getklai" is already in use by container "db6119ef946d…"
+```
+
+That failure is in the `sync-compose` step, which runs BEFORE the per-service
+work — so a single contested container turned the deploy-compose gate red for
+the entire stack. It had been green the previous evening; the takeover was the
+only change.
+
+**Detection** — a container that should be compose-managed but is not:
+
+```bash
+docker inspect <name> --format '{{json .Config.Labels}}' | grep -c com.docker.compose.project
+```
+
+**Prevention (mechanical).** `_apply_librechat_container_step` in
+`klai-portal/backend/app/api/internal.py` now probes `Config.Labels` before
+recreating and **restarts** a compose-managed container instead of replacing
+it. Config regeneration still lands (LibreChat re-reads its yaml on boot); the
+image rollout is left to deploy-compose, which owns it. The tenant is reported
+in the response's `compose_managed_skipped` field and printed by the workflow,
+so an image rollout can never silently miss it. Regression tests:
+`TestComposeManagedOwnership` in `tests/test_librechat_regenerate.py`.
+
+Read labels via `Config.Labels` on the inspect payload — never
+`container.image`, which lazily calls `GET /images/{id}/json` and is denied by
+docker-socket-proxy (see `platform/docker-socket-proxy.md`).
+
+**Prevention (human).** Before adding a container to a second management path,
+decide which single pipeline owns it and remove the other declaration. "Both,
+they're equivalent" is how this class starts.
+
 ## docker-cp-not-a-deploy-mechanism (HIGH)
 
 `docker cp` from a developer laptop into a running production container

--- a/.github/workflows/deploy-librechat-config.yml
+++ b/.github/workflows/deploy-librechat-config.yml
@@ -124,8 +124,18 @@ jobs:
             updated = body.get("tenants_updated") or []
             skipped = body.get("tenants_skipped") or []
             errors = body.get("errors") or []
+            compose_managed = body.get("compose_managed_skipped") or []
             print(f"tenants_updated ({len(updated)}): {updated}")
             print(f"tenants_skipped ({len(skipped)}): {skipped}")
+            if compose_managed:
+                # Incident 2026-08-14: portal-api must not take over a container
+                # that docker compose owns, so these were restarted, not
+                # recreated. A restart does NOT change the image -- an image
+                # rollout for these tenants lands via deploy-compose instead.
+                print(
+                    f"compose_managed_skipped ({len(compose_managed)}): {compose_managed} "
+                    "-- restarted, NOT recreated; image rollout belongs to deploy-compose"
+                )
             if errors:
                 print(f"errors ({len(errors)}):")
                 for e in errors:

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -22,7 +22,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import redis.asyncio as aioredis
 import structlog
@@ -1500,6 +1500,11 @@ class RegenerateResponse(BaseModel):
     # keys missing (already reconciled / freshly provisioned) or failed
     # entirely (see ``errors``). Never contains an empty list.
     env_keys_added: dict[str, list[str]] = {}
+    # Tenants whose container is compose-managed and was therefore restarted
+    # instead of recreated (see _apply_librechat_container_step). Only ever
+    # non-empty in recreate mode. An image rollout does NOT reach these
+    # tenants -- deploy-compose owns that.
+    compose_managed_skipped: list[str] = []
 
 
 def _regenerate_tenant_yaml_configs(
@@ -1557,10 +1562,22 @@ def _regenerate_tenant_yaml_configs(
     return updated, slugs_to_restart, errors, env_keys_added
 
 
+def _is_compose_managed(container: Any) -> bool:
+    """True when this container is owned by docker compose, not by portal-api.
+
+    Reads ``Config.Labels`` off the already-fetched inspect payload -- that is
+    ``GET /containers/{id}/json``, which docker-socket-proxy allows
+    (CONTAINERS=1). Never touch ``container.image``: that property lazily calls
+    ``GET /images/{id}/json``, which the proxy denies by design.
+    """
+    labels = (container.attrs or {}).get("Config", {}).get("Labels") or {}
+    return "com.docker.compose.project" in labels
+
+
 def _apply_librechat_container_step(
     orgs_to_apply: list[PortalOrg],
     recreate_containers: bool,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str]]:
     """Step 3 of the fleet regenerate: restart or recreate each tenant's container.
 
     Default remains restart-only for existing callers. CI passes
@@ -1576,19 +1593,38 @@ def _apply_librechat_container_step(
     remaining tenants are reported as skipped, never attempted. Restart-only
     mode is non-destructive and keeps the pre-existing per-tenant isolation
     (continue on error, report every tenant).
+
+    Incident 2026-08-14: recreate mode used to force-remove a container even
+    when docker compose owned it (``librechat-getklai``, the canary declared in
+    deploy/docker-compose.yml). The replacement kept the name but lost the
+    compose labels, so every later ``docker compose up`` died on a name
+    conflict and the deploy-compose gate stayed red for ALL services. One
+    container has exactly one owner: compose-managed containers are restarted
+    here (config still applies) and their image rollout belongs to
+    deploy-compose.
     """
     import docker
+    import docker.errors
 
-    client = None if recreate_containers else docker.from_env()
+    client = docker.from_env()
     apply_errors: list[str] = []
     apply_skipped: list[str] = []
+    compose_managed: list[str] = []
     for idx, org in enumerate(orgs_to_apply):
         slug = org.slug
         if not slug:
             continue
         container_name = validate_slug_for_provisioning(slug, domain=settings.domain).librechat_container
         try:
-            if recreate_containers:
+            try:
+                ctr = client.containers.get(container_name)
+            except docker.errors.NotFound:
+                # Recreate mode is allowed to create a container that is not
+                # there yet; restart-only mode must still surface the absence.
+                if not recreate_containers:
+                    raise
+                ctr = None
+            if recreate_containers and (ctr is None or not _is_compose_managed(ctr)):
                 from app.services.provisioning.infrastructure import _start_librechat_container
 
                 env_file_host_path = f"{settings.librechat_host_data_path}/{slug}/.env"
@@ -1600,10 +1636,17 @@ def _apply_librechat_container_step(
                 )
                 logger.info("Recreated container %s", container_name)
             else:
-                assert client is not None
-                ctr = client.containers.get(container_name)
+                assert ctr is not None
                 ctr.restart(timeout=10)
-                logger.info("Restarted container %s", container_name)
+                if recreate_containers:
+                    compose_managed.append(slug)
+                    logger.warning(
+                        "Container %s is compose-managed: restarted instead of recreated. "
+                        "An image rollout does NOT reach this tenant -- run deploy-compose.",
+                        container_name,
+                    )
+                else:
+                    logger.info("Restarted container %s", container_name)
         except Exception as exc:
             apply_errors.append(f"{slug}: {exc}")
             logger.warning("LibreChat container apply failed for %s: %s", container_name, exc, exc_info=True)
@@ -1611,7 +1654,7 @@ def _apply_librechat_container_step(
                 remaining = [o.slug for o in orgs_to_apply[idx + 1 :] if o.slug]
                 apply_skipped.extend(remaining)
                 break
-    return apply_errors, apply_skipped
+    return apply_errors, apply_skipped, compose_managed
 
 
 @router.post("/librechat/regenerate", response_model=RegenerateResponse)
@@ -1722,7 +1765,7 @@ async def regenerate_librechat_configs(
     # See _apply_librechat_container_step for the abort-on-first-failure
     # contract in recreate mode (finding 3, adversarial review 2026-08-13).
     orgs_to_apply = [org for org in tenants if org.slug in set(slugs_to_restart)]
-    restart_errors, restart_skipped = await loop.run_in_executor(
+    restart_errors, restart_skipped, compose_managed_skipped = await loop.run_in_executor(
         None, _apply_librechat_container_step, orgs_to_apply, recreate_containers
     )
     errors.extend(restart_errors)
@@ -1736,7 +1779,11 @@ async def regenerate_librechat_configs(
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
 
     return RegenerateResponse(
-        tenants_updated=updated, errors=errors, tenants_skipped=skipped, env_keys_added=env_keys_added
+        tenants_updated=updated,
+        errors=errors,
+        tenants_skipped=skipped,
+        env_keys_added=env_keys_added,
+        compose_managed_skipped=compose_managed_skipped,
     )
 
 

--- a/klai-portal/backend/tests/test_librechat_regenerate.py
+++ b/klai-portal/backend/tests/test_librechat_regenerate.py
@@ -90,17 +90,39 @@ def _redis_mock(
     return client
 
 
-def _docker_client(restart_raises: dict[str, Exception] | None = None) -> MagicMock:
+def _docker_client(
+    restart_raises: dict[str, Exception] | None = None,
+    compose_managed: set[str] | None = None,
+) -> MagicMock:
+    """Fake docker client.
+
+    ``compose_managed`` names the containers that carry the
+    ``com.docker.compose.project`` label, i.e. the ones portal-api must NOT
+    take over on recreate.
+    """
     raises = restart_raises or {}
+    compose = compose_managed or set()
+
     client = MagicMock()
+    # Cache per name so tests can assert on a container AFTER the handler ran
+    # without a fresh ``containers.get`` call polluting ``call_args_list``.
+    made: dict[str, MagicMock] = {}
+    client._containers = made
 
     def _get(name: str) -> MagicMock:
+        if name in made:
+            return made[name]
         ctr = MagicMock()
         if name in raises:
             ctr.restart = MagicMock(side_effect=raises[name])
         else:
             ctr.restart = MagicMock(return_value=None)
+        labels = {"klai.managed_by": "portal-api-provisioning"}
+        if name in compose:
+            labels = {"com.docker.compose.project": "klai-core", "com.docker.compose.service": name}
+        ctr.attrs = {"Config": {"Labels": labels}}
         ctr._name = name
+        made[name] = ctr
         return ctr
 
     client.containers = MagicMock()
@@ -328,8 +350,87 @@ class TestRecreateMode:
         assert start_librechat.call_count == 2
         start_librechat.assert_any_call("getklai", "/opt/klai/librechat/getklai/.env", None, rollback_on_failure=True)
         start_librechat.assert_any_call("voys", "/opt/klai/librechat/voys/.env", None, rollback_on_failure=True)
-        docker_client.containers.get.assert_not_called()
+        # Recreate mode probes each container's labels first so it can leave
+        # compose-managed containers alone (see TestComposeManagedOwnership).
+        assert docker_client.containers.get.call_count == 2
         redis_client.flushall.assert_not_called()
+
+
+class TestComposeManagedOwnership:
+    """A container declared in deploy/docker-compose.yml has ONE owner: compose.
+
+    Incident 2026-08-14: a fleet-wide ``recreate_containers=true`` replaced the
+    compose-managed canary ``librechat-getklai`` with a provisioning-managed
+    container of the same name. The container itself kept working, but every
+    later ``docker compose up`` failed with ``Conflict. The container name
+    "/librechat-getklai" is already in use``, permanently breaking the
+    deploy-compose gate for ALL services.
+
+    Contract: recreate mode restarts a compose-managed container (so config
+    changes still land) and never force-removes it. The image rollout for
+    those containers belongs to deploy-compose.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recreate_mode_does_not_take_over_compose_managed_container(self):
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1), _org("voys", 2)]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client(compose_managed={"librechat-getklai"})
+
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            request.query_params = {"recreate_containers": "true"}
+            with patch(
+                "app.services.provisioning.infrastructure._start_librechat_container",
+                MagicMock(return_value=None),
+            ) as start_librechat:
+                resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        # The compose-managed canary was never force-removed/recreated.
+        assert start_librechat.call_count == 1
+        start_librechat.assert_called_once_with("voys", "/opt/klai/librechat/voys/.env", None, rollback_on_failure=True)
+        # ... it was restarted instead, so the regenerated config still applies.
+        assert docker_client._containers["librechat-getklai"].restart.called
+        assert not docker_client._containers["librechat-voys"].restart.called
+
+        # Visible in the response, not silently degraded: an operator running an
+        # image rollout must see that this tenant did NOT get a new image.
+        assert resp.compose_managed_skipped == ["getklai"]
+        assert sorted(resp.tenants_updated) == ["getklai", "voys"]
+        assert resp.errors == []
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_recreate_still_creates_a_container_that_does_not_exist_yet(self):
+        """The ownership probe must not break create-from-nothing.
+
+        Recreate mode is the path that repairs a tenant whose container was
+        removed. Probing labels first means a ``NotFound`` now happens BEFORE
+        the create -- it must not be mistaken for a failure and abort the fleet.
+        """
+        from app.api import internal as internal_mod
+
+        orgs = [_org("gone", 1), _org("voys", 2)]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+        docker_client.containers.get = MagicMock(side_effect=docker.errors.NotFound("no such container"))
+
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            request.query_params = {"recreate_containers": "true"}
+            with patch(
+                "app.services.provisioning.infrastructure._start_librechat_container",
+                MagicMock(return_value=None),
+            ) as start_librechat:
+                resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        assert start_librechat.call_count == 2
+        assert resp.errors == []
+        assert resp.tenants_skipped == []
+        assert resp.compose_managed_skipped == []
+        assert response.status_code == 200
 
 
 class TestEmptyTenantList:


### PR DESCRIPTION
## Wat er misging

Een fleet-wide `POST /internal/librechat/regenerate?recreate_containers=true` verving `librechat-getklai` — de canary die als compose-service in `deploy/docker-compose.yml` staat. De nieuwe container hield de naam maar verloor `com.docker.compose.project`. Vanaf dat moment stierf elke `docker compose up` op:

```
Conflict. The container name "/librechat-getklai" is already in use by container "db6119ef946d…"
```

Die stap zit in `sync-compose`, vóór al het per-service werk — dus één betwiste container zette de deploy-compose gate rood voor de hele stack. De avond ervoor was hij nog groen; de overname was de enige wijziging.

## De fix

Recreate leest eerst `Config.Labels`. Is de container compose-managed, dan volgt een **restart** in plaats van een vervanging:

- config-regeneratie landt gewoon (LibreChat leest z'n yaml opnieuw bij boot)
- de image-rollout blijft bij deploy-compose, die deze containers bezit
- de tenant komt terug in `RegenerateResponse.compose_managed_skipped` en wordt door de workflow geprint, zodat een image-rollout hem nooit stil kan overslaan

Labels komen van de inspect-payload, nooit via `container.image` — die roept lui `GET /images/{id}/json` aan, wat docker-socket-proxy bewust weigert.

## Regressie die ik onderweg introduceerde en afving

De label-probe zet `containers.get()` vóór het create-pad. Daardoor zou recreate een **ontbrekende** container niet meer aanmaken. `NotFound` wordt nu alleen in recreate-modus getolereerd, met een eigen test.

## Pitfalls vastgelegd

- **remove-the-mount-before-you-delete-the-file (CRIT)** — het verwijderen van een bind-mount-bron terwijl containers hem nog declareren nam vandaag 36 van de 42 tenants mee bij hun volgende start (exit 127), via een automatisch aangemaakte lege directory.
- **one-container-one-owner (HIGH)** — de overname-klasse hierboven.

## Tests

`TestComposeManagedOwnership` (2 nieuw), 14 passed in `tests/test_librechat_regenerate.py`. Ruff + pyright schoon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)