### PR TITLE
fix(deploy): make the bind-mount prune hazard impossible to ship silently

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -2080,6 +2080,39 @@ If steps 1 and 3 cannot land in the same change, keep a placeholder file at
 the path until every container has been recreated. A placeholder is cheap;
 an empty auto-created directory is an outage.
 
+**Prevention (mechanical, two layers, both fail loud):**
+
+1. **The delete is blocked at the sync.**
+   `deploy/scripts/assert-safe-to-prune.sh <repo-src-dir> <host-dst-dir>` runs
+   immediately before the `rsync --delete` in
+   `.github/workflows/deploy-librechat-config.yml`. It fires only when a file
+   is BOTH about to be deleted AND still bind-mounted by a running container,
+   so an ordinary sync never trips it. Verified against live prod: replaying
+   PR #895's tree blocks and names all 41 containers holding the file, while
+   the current tree exits 0. Own test suite (7 cases, Docker-free via
+   `KLAI_MOUNT_PAIRS_FILE`) runs in the same workflow.
+
+2. **The broken state can no longer be started or restarted.**
+   `assert_shared_librechat_mount_sources_intact()` in
+   `klai-portal/backend/app/services/provisioning/infrastructure.py` requires
+   every fleet-shared bind source to be an actual **file**. Called from both
+   the create path (`_start_librechat_container`) and, crucially, before the
+   restart loop in the regenerate endpoint — the incident's containers were
+   *restarted*, so a create-only guard would have missed it entirely.
+   Restarting a healthy container against a deleted source is strictly worse
+   than doing nothing, so the endpoint refuses fleet-wide and returns 500 in
+   BOTH restart-only and recreate mode.
+
+Note the trap that made the pre-existing guard useless: it used
+`Path.exists()`, which is **True** for the auto-created empty directory. Only
+`is_file()` distinguishes "the file is there" from "Docker put a directory
+where the file used to be".
+
+**The structural fix** is to stop bind-mounting patches at all and bake them
+into an image — SPEC-LIBRECHAT-PATCH-MODEL-001. That removes this class along
+with the two sibling bind-mount pitfalls below. Until it lands, the two guards
+above are the containment.
+
 **Generalisation.** Any resource resolved at container-start time and owned by
 a *different* deploy pipeline than the container definition has this hazard:
 bind-mount sources, named-volume contents, secret files, config files pulled

--- a/.github/workflows/deploy-librechat-config.yml
+++ b/.github/workflows/deploy-librechat-config.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Validate LibreChat patches
         run: sh deploy/librechat/check-patch-drift.sh
 
+      - name: Validate the prune guard itself
+        run: sh deploy/scripts/tests/assert-safe-to-prune.test.sh
+
       - name: Sync base config and patches to core-01
         uses: appleboy/ssh-action@v1
         with:
@@ -43,14 +46,27 @@ jobs:
             git clone --depth=1 --filter=blob:none --sparse \
               https://github.com/GetKlai/klai.git klai-librechat-sync
             cd klai-librechat-sync
-            git sparse-checkout set --skip-checks deploy/librechat
+            git sparse-checkout set --skip-checks deploy/librechat deploy/scripts
 
             # Sync base config (template for all tenants)
             cp deploy/librechat/librechat.yaml /opt/klai/librechat/librechat.yaml
             cp deploy/librechat/mcp_catalog.yaml /opt/klai/librechat/mcp_catalog.yaml
             cp deploy/librechat/klai-entrypoint.sh /opt/klai/librechat/klai-entrypoint.sh
 
-            # Sync mounted LibreChat patches (format.cjs, stream.cjs, etc.)
+            # Sync mounted LibreChat patches (format.cjs, stream.cjs, etc.).
+            #
+            # --delete is the dangerous half: removing a patch file the repo no
+            # longer ships breaks nothing today, but Docker re-resolves bind
+            # mounts at container START and silently substitutes an empty
+            # DIRECTORY for the missing source. On 2026-08-14 that took down 36
+            # of 42 tenants (exit 127) on their next restart.
+            #
+            # The guard refuses the prune while any running container still
+            # mounts a file that is about to disappear. Retire a patch by
+            # removing its mount from the container definitions and recreating
+            # them FIRST; the delete is then safe and the guard stays quiet.
+            sh deploy/scripts/assert-safe-to-prune.sh \
+              deploy/librechat/patches /opt/klai/librechat/patches
             rsync -a --delete deploy/librechat/patches/ /opt/klai/librechat/patches/
 
             rm -rf /tmp/klai-librechat-sync

--- a/deploy/scripts/assert-safe-to-prune.sh
+++ b/deploy/scripts/assert-safe-to-prune.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Refuse to delete a file that a running container still bind-mounts.
+#
+# Incident 2026-08-14. A config sync ran `rsync --delete` over
+# /opt/klai/librechat/patches/ and removed a patch file that 42 tenant
+# containers still declared as a mount. Nothing broke at that moment: a
+# running container's mounts are already resolved. The damage landed on the
+# NEXT start -- Docker re-resolves the bind mount, finds no source, and
+# silently creates an empty DIRECTORY there. LibreChat then booted against a
+# directory where it expected a file and 36 of 42 tenants exited 127.
+#
+# A bind mount has two ends and they must be retired in this order:
+#   1. remove the mount from the container definitions and recreate them
+#   2. verify no running container declares the path any more
+#   3. only then delete the host file
+#
+# This guard enforces step 3 by blocking the delete while step 1 is undone.
+# It fires only when a file is BOTH about to be deleted AND still mounted, so
+# it has no false positives on an ordinary sync.
+#
+# usage: assert-safe-to-prune.sh <repo-src-dir> <host-dst-dir>
+#
+# KLAI_MOUNT_PAIRS_FILE overrides Docker introspection with a file of
+# "container-name<TAB>mount-source" lines. Used by the test suite so the guard
+# is verifiable without a Docker daemon.
+
+set -eu
+
+if [ $# -ne 2 ]; then
+    echo "usage: $0 <repo-src-dir> <host-dst-dir>" >&2
+    exit 2
+fi
+
+src_dir="$1"
+dst_dir="$2"
+
+# Nothing on the host yet means nothing can be pruned.
+[ -d "$dst_dir" ] || exit 0
+
+if [ -n "${KLAI_MOUNT_PAIRS_FILE:-}" ]; then
+    mount_pairs=$(cat "$KLAI_MOUNT_PAIRS_FILE")
+elif running_ids=$(docker ps -q) && [ -n "$running_ids" ]; then
+    # .Name carries a leading slash; the awk below strips it.
+    mount_pairs=$(
+        echo "$running_ids" | xargs docker inspect \
+            --format '{{$name := .Name}}{{range .Mounts}}{{$name}}{{"\t"}}{{.Source}}{{"\n"}}{{end}}'
+    )
+else
+    mount_pairs=""
+fi
+
+blocked=""
+for host_path in "$dst_dir"/*; do
+    # Literal glob when the directory is empty.
+    [ -e "$host_path" ] || continue
+
+    base_name=$(basename "$host_path")
+    # Present in the incoming tree: survives the sync, not our problem.
+    [ -e "$src_dir/$base_name" ] && continue
+
+    users=$(
+        printf '%s\n' "$mount_pairs" \
+            | awk -F'\t' -v target="$host_path" '$2 == target { print substr($1, 2) }' \
+            | sort -u \
+            | tr '\n' ' '
+    )
+    [ -n "$users" ] || continue
+
+    blocked="${blocked}  ${host_path}
+      still mounted by: ${users}
+"
+done
+
+if [ -n "$blocked" ]; then
+    cat >&2 <<EOF
+REFUSING TO PRUNE.
+
+These files are about to be deleted from
+  ${dst_dir}
+while running containers still bind-mount them:
+
+${blocked}
+Deleting them now breaks nothing today. It arms an outage for the next
+container start: Docker replaces the missing source with an empty directory
+and the container dies against it (2026-08-14: 36 of 42 tenants, exit 127).
+
+Fix the order instead:
+  1. remove the mount from the container definitions, then recreate them
+  2. confirm nothing declares the path any more:
+       for n in \$(docker ps --format '{{.Names}}'); do
+         docker inspect "\$n" --format '{{range .Mounts}}{{.Source}} {{end}}' \\
+           | grep -q '<file>' && echo "\$n"
+       done
+  3. re-run this deploy
+
+If the two steps cannot land together, keep a placeholder file at the path
+until every container has been recreated. A placeholder is cheap; an
+auto-created empty directory is an outage.
+EOF
+    exit 1
+fi

--- a/deploy/scripts/tests/assert-safe-to-prune.test.sh
+++ b/deploy/scripts/tests/assert-safe-to-prune.test.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# Tests for assert-safe-to-prune.sh. No Docker daemon needed: the guard reads
+# container mounts from KLAI_MOUNT_PAIRS_FILE when it is set.
+#
+# Run: sh deploy/scripts/tests/assert-safe-to-prune.test.sh
+
+set -eu
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+guard="$script_dir/assert-safe-to-prune.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+check() {
+    label="$1"
+    expected="$2"
+    actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  ok   $label"
+    else
+        echo "  FAIL $label (expected exit $expected, got $actual)"
+        failures=$((failures + 1))
+    fi
+}
+
+new_case() {
+    case_dir="$work/$1"
+    rm -rf "$case_dir"
+    mkdir -p "$case_dir/src" "$case_dir/dst"
+}
+
+run_guard() {
+    set +e
+    KLAI_MOUNT_PAIRS_FILE="$case_dir/mounts.tsv" \
+        sh "$guard" "$case_dir/src" "$case_dir/dst" >"$case_dir/out" 2>&1
+    rc=$?
+    set -e
+}
+
+echo "assert-safe-to-prune.sh"
+
+# 1. A file that disappears from the repo AND is still mounted: block.
+new_case blocked
+printf 'keep\n' >"$case_dir/src/keep.cjs"
+printf 'keep\n' >"$case_dir/dst/keep.cjs"
+printf 'gone\n' >"$case_dir/dst/gone.cjs"
+printf '/librechat-acme\t%s\n' "$case_dir/dst/gone.cjs" >"$case_dir/mounts.tsv"
+run_guard
+check "blocks a still-mounted file that the repo no longer has" 1 "$rc"
+grep -q 'librechat-acme' "$case_dir/out" || {
+    echo "  FAIL blocked case does not name the container"
+    failures=$((failures + 1))
+}
+grep -q 'gone.cjs' "$case_dir/out" || {
+    echo "  FAIL blocked case does not name the file"
+    failures=$((failures + 1))
+}
+
+# 2. Same deletion, but nothing mounts it any more: allow. This is the
+#    supported way to retire a patch -- recreate the containers first.
+new_case unmounted
+printf 'keep\n' >"$case_dir/src/keep.cjs"
+printf 'keep\n' >"$case_dir/dst/keep.cjs"
+printf 'gone\n' >"$case_dir/dst/gone.cjs"
+: >"$case_dir/mounts.tsv"
+run_guard
+check "allows deleting a file no container mounts" 0 "$rc"
+
+# 3. A mounted file that the repo still ships: allow. The guard must not fire
+#    on every ordinary sync -- that is what makes it survivable.
+new_case mounted_but_kept
+printf 'keep\n' >"$case_dir/src/keep.cjs"
+printf 'keep\n' >"$case_dir/dst/keep.cjs"
+printf '/librechat-acme\t%s\n' "$case_dir/dst/keep.cjs" >"$case_dir/mounts.tsv"
+run_guard
+check "allows a mounted file that survives the sync" 0 "$rc"
+
+# 4. Empty host dir: nothing to prune.
+new_case empty_dst
+printf 'keep\n' >"$case_dir/src/keep.cjs"
+: >"$case_dir/mounts.tsv"
+run_guard
+check "allows an empty host directory" 0 "$rc"
+
+# 5. Host dir absent entirely (first-ever deploy).
+new_case missing_dst
+printf 'keep\n' >"$case_dir/src/keep.cjs"
+rmdir "$case_dir/dst"
+: >"$case_dir/mounts.tsv"
+run_guard
+check "allows a host directory that does not exist yet" 0 "$rc"
+
+# 6. Several blocked files are reported together, not one per run.
+new_case multiple
+printf 'a\n' >"$case_dir/dst/a.cjs"
+printf 'b\n' >"$case_dir/dst/b.cjs"
+{
+    printf '/librechat-acme\t%s\n' "$case_dir/dst/a.cjs"
+    printf '/librechat-voys\t%s\n' "$case_dir/dst/b.cjs"
+} >"$case_dir/mounts.tsv"
+run_guard
+check "blocks on multiple still-mounted files" 1 "$rc"
+grep -q 'a.cjs' "$case_dir/out" && grep -q 'b.cjs' "$case_dir/out" || {
+    echo "  FAIL multiple case does not list both files"
+    failures=$((failures + 1))
+}
+
+# 7. A path prefix must not count as a match (dst/gone.cjs.bak != dst/gone.cjs).
+new_case prefix_not_a_match
+printf 'gone\n' >"$case_dir/dst/gone.cjs"
+printf '/librechat-acme\t%s.bak\n' "$case_dir/dst/gone.cjs" >"$case_dir/mounts.tsv"
+run_guard
+check "does not treat a longer path as a match" 0 "$rc"
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures check(s) failed"
+    exit 1
+fi
+echo "all checks passed"

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -51,6 +51,7 @@ from app.services.entitlements import get_effective_products
 from app.services.events import emit_event
 from app.services.gap_rescorer import schedule_rescore
 from app.services.partner_rate_limit import check_rate_limit
+from app.services.provisioning.infrastructure import assert_shared_librechat_mount_sources_intact
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
 from app.services.retrieval_log import find_correlated_log
@@ -1765,6 +1766,29 @@ async def regenerate_librechat_configs(
     # See _apply_librechat_container_step for the abort-on-first-failure
     # contract in recreate mode (finding 3, adversarial review 2026-08-13).
     orgs_to_apply = [org for org in tenants if org.slug in set(slugs_to_restart)]
+
+    # Fleet-wide preflight: every tenant mounts the SAME patch files, so one
+    # broken shared source means no container can be safely started -- and,
+    # more importantly, none can be safely *restarted* either: a restart
+    # re-resolves the bind mount and would destroy a currently-working process
+    # (incident 2026-08-14). Fail loud in both modes and touch nothing.
+    compose_managed_skipped: list[str] = []
+    try:
+        assert_shared_librechat_mount_sources_intact()
+    except RuntimeError as exc:
+        logger.exception("Shared LibreChat mount preflight failed; no tenant touched")
+        errors.append(f"shared-mount-preflight: {exc}")
+        skipped.extend([org.slug for org in orgs_to_apply if org.slug])
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        await _audit_internal_call(request, org_id=0)
+        return RegenerateResponse(
+            tenants_updated=updated,
+            errors=errors,
+            tenants_skipped=skipped,
+            env_keys_added=env_keys_added,
+            compose_managed_skipped=compose_managed_skipped,
+        )
+
     restart_errors, restart_skipped, compose_managed_skipped = await loop.run_in_executor(
         None, _apply_librechat_container_step, orgs_to_apply, recreate_containers
     )

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -48,6 +48,54 @@ _LIBRECHAT_PATCH_MOUNTS = {
     "patches/search.cjs": "/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs",
 }
 
+
+def assert_shared_librechat_mount_sources_intact() -> None:
+    """Refuse to start or restart a tenant when a fleet-shared bind source is broken.
+
+    Docker resolves a bind mount at container *start*, not at create. When the
+    host source no longer exists it does NOT fail -- it silently creates an
+    empty DIRECTORY there. LibreChat then boots against a directory where it
+    expects a file and exits 127.
+
+    That is what happened on 2026-08-14: a config sync ran
+    ``rsync --delete`` over ``/opt/klai/librechat/patches/`` while 42 tenant
+    containers still declared one of the removed files as a mount. Nothing
+    broke until the next start; then 36 of 42 tenants went down at once.
+
+    ``Path.exists()`` is True for the auto-created directory, so the guard that
+    used it waved the broken state straight through. ``is_file()`` is the check
+    that actually distinguishes them.
+
+    Called on BOTH paths that can arm the failure:
+
+    * create -- ``_start_librechat_container`` before handing mounts to Docker;
+    * restart -- ``_apply_librechat_container_step``, where restarting a
+      *healthy* container against a broken source is strictly worse than doing
+      nothing, because it destroys a working process.
+
+    Raises RuntimeError naming every broken source and its shape (missing vs
+    directory), so one run tells an operator the whole story.
+    """
+    base = Path(settings.librechat_container_data_path)
+    expected = [*_LIBRECHAT_PATCH_MOUNTS, "klai-entrypoint.sh"]
+
+    broken: list[str] = []
+    for rel_path in expected:
+        source = base / rel_path
+        if source.is_file():
+            continue
+        shape = "directory (Docker auto-created it — the file was deleted)" if source.is_dir() else "missing"
+        broken.append(f"{source} [{shape}]")
+
+    if broken:
+        raise RuntimeError(
+            "LibreChat shared mount sources are not usable: "
+            + "; ".join(broken)
+            + ". Restore them on the host before starting or restarting any tenant "
+            "(a directory here means a file was deleted while containers still mounted it)."
+        )
+
+
 _LIBRECHAT_OPENID_READY_BOOT_ATTEMPTS = 3
 _LIBRECHAT_OPENID_READY_BOOT_TIMEOUT_SECONDS = 45
 _LIBRECHAT_OPENID_PROBE_INTERVAL_SECONDS = 2
@@ -528,21 +576,16 @@ def _create_and_start_librechat_container(
         f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},
         f"{librechat_host_base}/{slug}/images": {"bind": "/app/client/public/images", "mode": "rw"},
     }
+    # Every fleet-shared bind source must be an actual FILE before we hand the
+    # mount list to Docker -- see assert_shared_librechat_mount_sources_intact.
+    assert_shared_librechat_mount_sources_intact()
+
     for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
-        patch_container_path = Path(settings.librechat_container_data_path) / source_rel_path
-        if not patch_container_path.exists():
-            raise RuntimeError(f"LibreChat patch file missing: {patch_container_path}")
         volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
 
     # Klai entrypoint wrapper that forces light theme on every tenant (LibreChat
     # has no server-side theme config — see deploy/librechat/klai-entrypoint.sh).
     # Mounted read-only; the container `entrypoint` below runs it before boot.
-    # Fail-loud if missing: a missing bind source would make Docker create an
-    # empty directory at /klai-entrypoint.sh and the container would crash on
-    # start. The file is synced to the host by deploy-compose.yml.
-    entrypoint_container_path = Path(settings.librechat_container_data_path) / "klai-entrypoint.sh"
-    if not entrypoint_container_path.exists():
-        raise RuntimeError(f"LibreChat entrypoint wrapper missing: {entrypoint_container_path}")
     volumes[f"{librechat_host_base}/klai-entrypoint.sh"] = {
         "bind": "/klai-entrypoint.sh",
         "mode": "ro",

--- a/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
+++ b/klai-portal/backend/tests/services/provisioning/test_infrastructure.py
@@ -827,3 +827,128 @@ class TestCharacterizeLibrechatOpenidReadiness:
 
         assert mock_client.containers.get.call_count == 2
         assert mock_client.containers.get.return_value.restart.call_count == 2
+
+
+class TestPatchMountSourcesMustBeFiles:
+    """A bind-mount source that is a DIRECTORY is the shape of the outage.
+
+    Incident 2026-08-14: the config sync deleted a patch file from the host
+    while 42 containers still declared it as a bind mount. Docker resolves a
+    bind mount at container *start*; a missing source is silently replaced by
+    an empty directory. LibreChat then booted against a directory where it
+    expected a file and 36 of 42 tenants exited 127.
+
+    The pre-existing guard used ``Path.exists()``, which is True for that
+    auto-created directory -- it waved the broken state straight through.
+    Only ``is_file()`` distinguishes them.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mock_openid_ready(self):
+        with patch("app.services.provisioning.infrastructure._wait_for_librechat_openid_ready") as mock:
+            yield mock
+
+    def _write_lc_files(self, tmp_path: Path, slug: str = "acme") -> None:
+        (tmp_path / "librechat.yaml").write_text("version: 1.0\n")
+        tenant_dir = tmp_path / slug
+        tenant_dir.mkdir(parents=True, exist_ok=True)
+        (tenant_dir / ".env").write_text("MONGO_URI=mongodb://example\n")
+        patch_dir = tmp_path / "patches"
+        patch_dir.mkdir(exist_ok=True)
+        for name in ("format.cjs", "share.js", "stream.cjs", "search.cjs"):
+            (patch_dir / name).write_text("// patch\n")
+        (tmp_path / "klai-entrypoint.sh").write_text('#!/bin/sh\nexec docker-entrypoint.sh "$@"\n')
+
+    def test_create_refuses_when_a_patch_source_is_a_directory(self, tmp_path):
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+        # Reproduce exactly what Docker leaves behind after the source is gone.
+        stream = tmp_path / "patches" / "stream.cjs"
+        stream.unlink()
+        stream.mkdir()
+
+        mock_client = MagicMock()
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.7"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            with pytest.raises(RuntimeError, match=r"stream\.cjs"):
+                _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        mock_client.containers.create.assert_not_called()
+
+    def test_create_refuses_when_the_entrypoint_wrapper_is_a_directory(self, tmp_path):
+        from app.services.provisioning import _start_librechat_container
+
+        self._write_lc_files(tmp_path)
+        wrapper = tmp_path / "klai-entrypoint.sh"
+        wrapper.unlink()
+        wrapper.mkdir()
+
+        mock_client = MagicMock()
+        with (
+            patch("app.services.provisioning.infrastructure.docker") as mock_docker,
+            patch("app.services.provisioning.infrastructure.settings") as mock_settings,
+        ):
+            mock_settings.librechat_host_data_path = "/opt/klai/librechat-data"
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            mock_settings.librechat_image = "ghcr.io/danny-avila/librechat:v0.8.7"
+            mock_docker.from_env.return_value = mock_client
+            mock_docker.errors.NotFound = type("NotFound", (Exception,), {})
+            mock_client.containers.get.side_effect = mock_docker.errors.NotFound("not found")
+
+            with pytest.raises(RuntimeError, match=r"klai-entrypoint\.sh"):
+                _start_librechat_container("acme", "/opt/klai/librechat-data/acme/.env")
+
+        mock_client.containers.create.assert_not_called()
+
+
+class TestAssertSharedLibrechatMountSourcesIntact:
+    """The fleet-shared preflight used by BOTH the create and restart paths."""
+
+    def _write_shared(self, tmp_path: Path) -> None:
+        patch_dir = tmp_path / "patches"
+        patch_dir.mkdir(exist_ok=True)
+        for name in ("format.cjs", "share.js", "stream.cjs", "search.cjs"):
+            (patch_dir / name).write_text("// patch\n")
+        (tmp_path / "klai-entrypoint.sh").write_text("#!/bin/sh\n")
+
+    def test_passes_when_every_shared_source_is_a_file(self, tmp_path):
+        from app.services.provisioning.infrastructure import assert_shared_librechat_mount_sources_intact
+
+        self._write_shared(tmp_path)
+        with patch("app.services.provisioning.infrastructure.settings") as mock_settings:
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            assert_shared_librechat_mount_sources_intact()
+
+    def test_names_every_broken_source_and_its_shape(self, tmp_path):
+        from app.services.provisioning.infrastructure import assert_shared_librechat_mount_sources_intact
+
+        self._write_shared(tmp_path)
+        (tmp_path / "patches" / "format.cjs").unlink()
+        stream = tmp_path / "patches" / "stream.cjs"
+        stream.unlink()
+        stream.mkdir()
+
+        with patch("app.services.provisioning.infrastructure.settings") as mock_settings:
+            mock_settings.librechat_container_data_path = str(tmp_path)
+            with pytest.raises(RuntimeError) as exc:
+                assert_shared_librechat_mount_sources_intact()
+
+        message = str(exc.value)
+        # Both broken sources reported in one go -- an operator should not have
+        # to re-run to discover the second one.
+        assert "format.cjs" in message
+        assert "stream.cjs" in message
+        assert "missing" in message
+        assert "directory" in message
+        # The intact ones are not noise in the error.
+        assert "share.js" not in message

--- a/klai-portal/backend/tests/test_librechat_regenerate.py
+++ b/klai-portal/backend/tests/test_librechat_regenerate.py
@@ -177,6 +177,12 @@ async def _regenerate_setup(
         ),
         patch("app.api.internal.aioredis.Redis", MagicMock(return_value=redis_client)),
         patch("docker.from_env", MagicMock(return_value=docker_client)),
+        # Shared bind sources are intact unless a test says otherwise; the
+        # failure path has its own coverage in TestSharedMountPreflight.
+        patch(
+            "app.api.internal.assert_shared_librechat_mount_sources_intact",
+            MagicMock(return_value=None),
+        ),
     ):
         yield request, response
 
@@ -673,3 +679,72 @@ class TestEnvReconciliationWiring:
         )
         assert any("voys" in e for e in resp.errors), resp.errors
         assert response.status_code == 500
+
+
+class TestSharedMountPreflight:
+    """A broken fleet-shared bind source blocks the whole apply step.
+
+    Incident 2026-08-14: the containers that went down were RESTARTED, not
+    recreated -- so the create-path guard never ran. Restarting a healthy
+    container against a deleted mount source destroys a working process, so
+    the only correct move is to refuse and say why.
+
+    This is fleet-wide, not per-tenant: every tenant mounts the same patch
+    files. It therefore fails loud (500) in BOTH modes, unlike a per-tenant
+    restart failure which restart-only mode reports at 200 by design.
+    """
+
+    @staticmethod
+    def _broken_preflight():
+        return patch(
+            "app.api.internal.assert_shared_librechat_mount_sources_intact",
+            MagicMock(
+                side_effect=RuntimeError(
+                    "LibreChat shared mount sources are not usable: /librechat/patches/stream.cjs [directory ...]"
+                )
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_restart_only_refuses_and_fails_loud(self):
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1), _org("voys", 2)]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            with self._broken_preflight():
+                resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        # No healthy container was touched.
+        docker_client.containers.get.assert_not_called()
+        # Loud, with the offending path in the message.
+        assert response.status_code == 500
+        assert any("stream.cjs" in e for e in resp.errors)
+        assert sorted(resp.tenants_skipped) == ["getklai", "voys"]
+
+    @pytest.mark.asyncio
+    async def test_recreate_refuses_before_removing_anything(self):
+        from app.api import internal as internal_mod
+
+        orgs = [_org("getklai", 1), _org("voys", 2)]
+        db = _db_returning_orgs(orgs)
+        redis_client = _redis_mock(keys_for_pattern={"configs:*": ["configs:librechat-config"]})
+        docker_client = _docker_client()
+
+        async with _regenerate_setup(orgs, redis_client, docker_client) as (request, response):
+            request.query_params = {"recreate_containers": "true"}
+            with self._broken_preflight():
+                with patch(
+                    "app.services.provisioning.infrastructure._start_librechat_container",
+                    MagicMock(return_value=None),
+                ) as start_librechat:
+                    resp = await internal_mod.regenerate_librechat_configs(request=request, response=response, db=db)
+
+        # Recreate force-removes before it creates. Nothing may be removed when
+        # we already know the replacement cannot boot.
+        start_librechat.assert_not_called()
+        assert response.status_code == 500
+        assert sorted(resp.tenants_skipped) == ["getklai", "voys"]


### PR DESCRIPTION
Sluit beide stille helften van de storing van gisteren (36 van de 42 tenants, exit 127). Elke laag faalt luid, op de plek waar de feiten daadwerkelijk beschikbaar zijn.

## Laag 1 — de verwijdering wordt bij de sync geblokkeerd

`deploy/scripts/assert-safe-to-prune.sh` weigert een `rsync --delete` die een bestand zou weghalen dat een draaiende container nog bind-mount. Hij gaat alleen af als een bestand **zowel** verwijderd gaat worden **als** nog gemount is — een normale sync raakt hem dus nooit.

Aangesloten in `deploy-librechat-config.yml`, direct vóór de rsync. Eigen testsuite van 7 gevallen die geen Docker-daemon nodig heeft (`KLAI_MOUNT_PAIRS_FILE` injecteert de mount-tabel), die in dezelfde workflow draait.

**Geverifieerd tegen live productie:** met de tree van PR #895 blokkeert hij en noemt hij alle 41 containers die `stream.cjs` vasthouden; met de huidige tree exit 0.

## Laag 2 — de kapotte staat kan niet meer gestart óf herstart worden

`assert_shared_librechat_mount_sources_intact()` eist dat elke fleet-gedeelde bind-bron een echt **bestand** is, en draait op beide paden die de storing kunnen scherpstellen.

Het restart-pad is degene die ertoe deed: de containers die omvielen werden *herstart*, niet hercreëerd — de bestaande create-only check draaide dus nooit. Een gezonde container herstarten tegen een verwijderde bron sloopt een werkend proces, dus de regenerate-endpoint weigert nu fleet-breed en geeft 500 in **beide** modi. Een kapotte gedeelde mount is geen per-tenant hikje.

## Waarom dit zo lang onzichtbaar bleef

De bestaande check gebruikte `Path.exists()` — en dat is **True** voor de lege directory die Docker automatisch aanmaakt. Alleen `is_file()` onderscheidt "het bestand staat er" van "Docker heeft een map gezet waar het bestand stond".

## Wat dit niet is

Geen vervanging van SPEC-LIBRECHAT-PATCH-MODEL-001. Bak de patches in het image en de hele klasse verdwijnt — inclusief de twee zusterpitfalls. Dit is de indamming tot dat landt, en blijft daarna nuttig.

## Tests

3519 passed backend-breed · 7/7 shell-guard cases · ruff + pyright schoon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)