### PR TITLE
fix(deploy): guard the canary's patch dir against the same prune hazard

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -2108,6 +2108,24 @@ Note the trap that made the pre-existing guard useless: it used
 `is_file()` distinguishes "the file is there" from "Docker put a directory
 where the file used to be".
 
+**Scope: only FILE mounts are exposed.** `rsync --delete` inside a directory
+that is itself the mount source never removes that directory, so Docker has
+nothing to auto-create and the hazard does not exist. The distinction is the
+whole audit:
+
+| `--delete` target | Mounted as | Verdict |
+|---|---|---|
+| `/opt/klai/librechat/patches/` (deploy-librechat-config) | 4 individual **files**, 41 tenants | **Guarded** — this is the incident |
+| `/opt/klai/librechat/getklai/patches/` (deploy-compose) | 4 individual **files**, canary | **Guarded** — same hazard, twin path |
+| `/opt/klai/litellm/klai_citations/` (deploy-compose + litellm-hook) | the **directory** | Safe from this class. A deleted module still breaks litellm, but loudly (ImportError at boot), not silently |
+| `/opt/klai/portal-dist/` → `/srv/portal` (portal-frontend) | the **directory** | Safe — replacing bundle files inside a mounted dir is the normal flow |
+| `/opt/klai/litellm/klai_service_auth.py` (`rm -f`, litellm-hook) | not mounted any more | Safe — this is the correct retire-order: mount removed first, file second |
+
+Audited 2026-08-14 across every `--delete` / `rm /opt` in `.github/workflows/`.
+When you add a new server-side deletion, place it in this table before merging:
+if the target contains an individual-file bind source, wire
+`assert-safe-to-prune.sh` in front of it.
+
 **The structural fix** is to stop bind-mounting patches at all and bake them
 into an image — SPEC-LIBRECHAT-PATCH-MODEL-001. That removes this class along
 with the two sibling bind-mount pitfalls below. Until it lands, the two guards

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -103,6 +103,15 @@ jobs:
             test -x /opt/klai/scripts/backup.sh
 
             mkdir -p /opt/klai/librechat/getklai/patches
+            # Twin of the fleet patches dir synced by deploy-librechat-config.yml,
+            # and exposed to the same hazard: librechat-getklai bind-mounts these
+            # four files INDIVIDUALLY (see the compose service), so --delete on a
+            # retired patch arms an empty-directory outage for its next start.
+            # PR #895 did delete a file here; the canary only escaped because
+            # this workflow failed earlier on an unrelated container-name
+            # conflict. Guard it the same way.
+            sh deploy/scripts/assert-safe-to-prune.sh \
+              deploy/librechat/getklai/patches /opt/klai/librechat/getklai/patches
             rsync -a --delete deploy/librechat/getklai/patches/ /opt/klai/librechat/getklai/patches/
             getklai_config_status=$(python3 deploy/librechat/getklai/apply-canary-config.py /opt/klai/librechat/getklai/librechat.yaml)
             echo "getklai LibreChat config patch: $getklai_config_status"


### PR DESCRIPTION
Audit van élke server-side verwijdering in `.github/workflows/`. Er bleef exact één ongedekte instantie van de hazard van gisteren over — en dat is de tweeling van degene die omviel.

`deploy-compose.yml` doet `rsync --delete` op `deploy/librechat/getklai/patches/`, en `librechat-getklai` mount die vier bestanden **individueel**.

PR #895 verwijderde daar óók een bestand. De canary ontsnapte alleen doordat deploy-compose eerder stukliep op het ongerelateerde naamconflict — de rsync draaide nooit. Twee bugs die elkaar opheffen is geen veiligheidseigenschap.

Dezelfde guard, vóór die rsync.

**Geverifieerd tegen live productie:** een teruggetrokken patch blokkeert en noemt `librechat-getklai` (exit 1); de huidige tree exit 0.

## De andere vier zijn veilig door vorm, niet door geluk

| `--delete` doel | Gemount als | Oordeel |
|---|---|---|
| `librechat/patches/` | 4 losse **bestanden**, 41 tenants | Guarded (de storing) |
| `librechat/getklai/patches/` | 4 losse **bestanden**, canary | Guarded (deze PR) |
| `litellm/klai_citations/` | de **map** | Veilig voor deze klasse — een verwijderde module breekt litellm wél, maar luid (ImportError bij boot) |
| `portal-dist/` → `/srv/portal` | de **map** | Veilig — bundles vervangen binnen een gemounte map is de normale flow |
| `litellm/klai_service_auth.py` | niet meer gemount | Veilig — dit ís de juiste volgorde: mount eerst weg, bestand daarna |

`rsync --delete` binnenin een map die zélf de mount-bron is, verwijdert die map nooit — Docker heeft dus niets om automatisch aan te maken. Dat onderscheid is de hele audit, en staat nu in de pitfall zodat een volgende verwijdering te classificeren is zonder het werk over te doen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)