### PR TITLE
fix(ci): stop semgrep reading an .npmrc comment as a real setting

### DIFF
--- a/klai-portal/frontend/.npmrc
+++ b/klai-portal/frontend/.npmrc
@@ -9,7 +9,10 @@ legacy-peer-deps=true
 # When a security fix is blocked by this rule and waiting is not acceptable,
 # adopt it explicitly and say so in the commit:
 #
-#     npm install <pkg>@<version> --package-lock-only --min-release-age=0
+# The line below is documentation, not configuration -- the effective setting
+# is min-release-age=7 at the bottom of this file. Semgrep's npmrc rule scans
+# comment lines too, so it reads the example as a real "too low" setting.
+#     npm install <pkg>@<version> --package-lock-only --min-release-age=0  # nosemgrep: package_managers.npm.npm-missing-minimum-release-age.npm-missing-minimum-release-age
 #
 # That is a judgement call, not a routine step: you are choosing to trust a
 # release the cooldown has not yet vetted. Weigh the age of the release and how


### PR DESCRIPTION
`main` staat rood sinds #900.

Semgrep's `npm-missing-minimum-release-age` scant óók comment-regels. De gedocumenteerde escape hatch op regel 12 — `--min-release-age=0`, binnen een `#`-comment — werd daardoor gelezen als de effectieve configuratie.

De echte instelling, `min-release-age=7`, staat onaangeroerd op de laatste regel en stond daar al.

## Fix

Onderdrukt op die ene regel, mét rule-id en een comment waaróm. Een kale `nosemgrep` is ruis; een uitgelegde is een feit dat de volgende lezer kan controleren.

## Afgewogen alternatief

Het voorbeeld herschrijven naar de spatie-vorm (`--min-release-age 0`) onderdrukt de melding ook. Afgewezen: dat werkt alleen door toeval van de regex, breekt zodra de rule strenger wordt, en verandert stilletjes gedocumenteerde operator-instructies in een vorm die niemand gekozen heeft.

## Bewijs

Lokaal gereproduceerd met dezelfde rule-pack: 1 blocking finding vóór, 0 erna. `min-release-age=7` geverifieerd intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)