### PR TITLE
fix(renovate): lockFileMaintenance had the same schedule trap + debug switch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,13 @@ on:
     # schedule (see the comment there for the 28-week no-op it caused).
     - cron: '0 3 * * 1'
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Renovate log level (debug explains WHY an update was skipped)'
+        type: choice
+        options: [info, debug]
+        default: info
+        required: false
 
 jobs:
   renovate:
@@ -38,3 +45,6 @@ jobs:
           token: ${{ github.token }}
         env:
           RENOVATE_REPOSITORIES: '["GetKlai/klai"]'
+          # At info level a skipped update is indistinguishable from no update
+          # at all — the 28-week no-op looked exactly like "nothing to do".
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -40,9 +40,14 @@
   //
   // Never automerged: a lock refresh touches the whole transitive tree, so it
   // gets human eyes even when the per-service CI gates are green.
+  // 'at any time' on purpose, and it is NOT redundant: lockFileMaintenance
+  // defaults to its own 'before 4am on monday' window, which would walk
+  // straight back into the bug described above — the cron fires at 03:00 UTC
+  // (05:00 Amsterdam) and GitHub's 1-3h delay pushes the actual run past 04:00.
+  // The workflow cron stays the only scheduler.
   lockFileMaintenance: {
     enabled: true,
-    schedule: ['before 6am on monday'],
+    schedule: ['at any time'],
     automerge: false,
     commitMessageAction: 'Refresh lock files',
   },


### PR DESCRIPTION
Two follow-ups to f006cafe5.

**`lockFileMaintenance` kept its own `before 6am on monday` window** — the very bug that PR fixed, one level down. The cron fires at 03:00 UTC (05:00 Amsterdam) and GitHub delays scheduled runs by 1–3h, so the actual run lands after 06:00 and the sub-schedule skips. Leaving it unset would be *worse*: it defaults to `before 4am on monday`. Now `at any time`, so the workflow cron stays the only scheduler.

**Added a `logLevel` input.** The 28-week no-op was invisible precisely because info-level output cannot distinguish "skipped this update" from "no update exists" — both look like `Repository finished`. Now: `gh workflow run renovate.yml -f logLevel=debug`.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)