### PR TITLE
fix(kb): page-source sync — 429 backoff, interactive lane, honest status UI

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/0008_artifacts_index_status_changed_at.py
+++ b/klai-knowledge-ingest/alembic/versions/0008_artifacts_index_status_changed_at.py
@@ -1,0 +1,38 @@
+"""Add index_status_changed_at column to knowledge.artifacts
+
+Tracks WHEN index_status last transitioned (epoch seconds). Consumed by the
+portal sources list so the frontend "Bezig sinds Xm / Hangt al Xm" badge can
+measure from the (re)sync start instead of the artifact creation date — a
+re-synced 8-day-old artifact previously showed "Hangt al 11384m" immediately.
+
+NULL means "never transitioned since this column landed"; readers fall back
+to created_at.
+
+Revision ID: b7c2d9e4f1a3
+Revises: f3a8e1b2d9c4
+Create Date: 2026-08-14 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c2d9e4f1a3"
+down_revision: str = "f3a8e1b2d9c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE knowledge.artifacts
+        ADD COLUMN IF NOT EXISTS index_status_changed_at BIGINT
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE knowledge.artifacts DROP COLUMN IF EXISTS index_status_changed_at")

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -292,8 +292,19 @@ def _register_tasks(procrastinate_app: Any) -> None:
     """Register task functions on the given App instance."""
     import procrastinate
 
+    # Backoff rationale: enrichment failures in production are dominated by
+    # LiteLLM 429s during bulk crawls. Immediate retries (the previous
+    # default: wait=0) burn every attempt inside the same rate-limit window
+    # — the intermedia.com artifact failed 3x in 20 seconds and went
+    # permanent-failed. exponential_wait waits
+    # ``exponential_wait ** (attempts + 1)`` seconds between attempts, so
+    # retries land after the rate-limit window has moved on.
+
     @procrastinate_app.task(
-        queue=queues.ENRICH_INTERACTIVE, retry=procrastinate.RetryStrategy(max_attempts=2)
+        queue=queues.ENRICH_INTERACTIVE,
+        # Waits 3s, 9s, 27s — user is watching, keep worst-case added latency
+        # under a minute while still escaping a per-minute rate-limit window.
+        retry=procrastinate.RetryStrategy(max_attempts=4, exponential_wait=3),
     )
     async def enrich_document_interactive(artifact_id: str) -> None:
         """Enrich chunks for a single-doc upload (high priority).
@@ -304,7 +315,10 @@ def _register_tasks(procrastinate_app: Any) -> None:
         await _load_and_enrich(artifact_id)
 
     @procrastinate_app.task(
-        queue=queues.ENRICH_BULK, retry=procrastinate.RetryStrategy(max_attempts=2)
+        queue=queues.ENRICH_BULK,
+        # Waits 4s, 16s, 64s, 256s (~5.7 min total) — nobody is watching bulk
+        # jobs, so ride out the whole 429 burst a concurrent crawl produces.
+        retry=procrastinate.RetryStrategy(max_attempts=5, exponential_wait=4),
     )
     async def enrich_document_bulk(artifact_id: str) -> None:
         """Enrich chunks for crawl/import jobs (lower priority).
@@ -318,7 +332,10 @@ def _register_tasks(procrastinate_app: Any) -> None:
     procrastinate_app.enrich_document_bulk = enrich_document_bulk  # type: ignore[attr-defined]
 
     @procrastinate_app.task(
-        queue=queues.GRAPHITI_BULK, retry=procrastinate.RetryStrategy(max_attempts=3)
+        queue=queues.GRAPHITI_BULK,
+        # Waits 4s, 16s — graphiti already has a token bucket in graph.py, but
+        # LiteLLM 429s still surface here during crawl bursts.
+        retry=procrastinate.RetryStrategy(max_attempts=3, exponential_wait=4),
     )
     async def ingest_graphiti_episode(
         artifact_id: str,

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -1574,14 +1574,16 @@ async def list_kb_sources(
             a.content_type AS content_type,
             a.created_at AS created_at,
             COUNT(pc.id) AS chunks_count,
-            a.index_status AS index_status
+            a.index_status AS index_status,
+            a.index_status_changed_at AS index_status_changed_at
         FROM knowledge.artifacts a
         LEFT JOIN knowledge.parent_chunks pc ON pc.artifact_id = a.id
         WHERE a.org_id = $1
           AND a.kb_slug = $2
           AND a.belief_time_end = $3
           AND (a.extra IS NULL OR a.extra::jsonb->>'source_connector_id' IS NULL)
-        GROUP BY a.id, a.path, a.extra, a.content_type, a.created_at, a.index_status
+        GROUP BY a.id, a.path, a.extra, a.content_type, a.created_at, a.index_status,
+                 a.index_status_changed_at
         ORDER BY a.created_at DESC
         """,
         org_id,
@@ -1598,6 +1600,11 @@ async def list_kb_sources(
             "created_at": int(row["created_at"]),
             "chunks_count": int(row["chunks_count"] or 0),
             "index_status": row["index_status"],
+            "index_status_changed_at": (
+                int(row["index_status_changed_at"])
+                if row["index_status_changed_at"] is not None
+                else None
+            ),
         }
         for row in upload_rows
     ]
@@ -1773,6 +1780,7 @@ async def set_artifact_index_status(
             """
             UPDATE knowledge.artifacts
             SET index_status = $1,
+                index_status_changed_at = $5,
                 belief_time_end = $2
             WHERE id = $3::uuid
               AND org_id = $4
@@ -1783,6 +1791,7 @@ async def set_artifact_index_status(
             _SENTINEL,
             artifact_id,
             org_id,
+            int(time.time()),
         )
     if row is None:
         return None
@@ -1799,7 +1808,8 @@ async def set_artifact_ingest_status(
     row = await conn.fetchrow(
         """
         UPDATE knowledge.artifacts
-        SET index_status = $1
+        SET index_status = $1,
+            index_status_changed_at = $4
         WHERE id = $2::uuid
           AND org_id = $3
         RETURNING id::text AS artifact_id, path
@@ -1807,6 +1817,7 @@ async def set_artifact_ingest_status(
         status,
         artifact_id,
         org_id,
+        int(time.time()),
     )
     if row is None:
         return None
@@ -1845,7 +1856,8 @@ async def mark_stale_pending_artifacts_failed(
             FOR UPDATE SKIP LOCKED
         )
         UPDATE knowledge.artifacts a
-        SET index_status = 'failed'
+        SET index_status = 'failed',
+            index_status_changed_at = extract(epoch from now())::bigint
         FROM stale
         WHERE a.id = stale.id
         RETURNING

--- a/klai-knowledge-ingest/knowledge_ingest/queues.py
+++ b/klai-knowledge-ingest/knowledge_ingest/queues.py
@@ -91,8 +91,17 @@ IO_QUEUES: list[str] = [
 ]
 """Latency-sensitive I/O work — HTTP, file ops, DB. No LLM calls."""
 
-LLM_QUEUES: list[str] = [
+INTERACTIVE_QUEUES: list[str] = [
     ENRICH_INTERACTIVE,
+]
+"""User-triggered LLM work (re-sync button). Own lane so a bulk-crawl
+backlog of hundreds of enrich-bulk/graphiti-bulk jobs cannot starve a
+single user-requested reindex for hours — procrastinate fetches oldest
+todo across a worker's queue set with no per-queue fairness, so sharing
+a lane with bulk queues made "drains first" a lie in practice
+(intermedia.com incident, 2026-08-14)."""
+
+LLM_QUEUES: list[str] = [
     ENRICH_BULK,
     GRAPHITI_BULK,
     RAG_EVAL,
@@ -101,6 +110,6 @@ LLM_QUEUES: list[str] = [
 ]
 """Throughput-bound LLM work — bounded by upstream rate limit."""
 
-ALL_QUEUES: list[str] = IO_QUEUES + LLM_QUEUES
-"""Union of both lanes. Tests pin that every declared constant is in exactly
+ALL_QUEUES: list[str] = IO_QUEUES + INTERACTIVE_QUEUES + LLM_QUEUES
+"""Union of all lanes. Tests pin that every declared constant is in exactly
 one lane and that ALL_QUEUES contains every constant."""

--- a/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
@@ -65,6 +65,7 @@ class UploadSummary(BaseModel):
     created_at: int
     chunks_count: int = 0
     index_status: str = "synced"
+    index_status_changed_at: int | None = None
 
 
 class KBSourcesResponse(BaseModel):
@@ -258,10 +259,24 @@ async def reindex_upload(
     if updated is None:
         raise HTTPException(status_code=404, detail="artifact not found")
 
+    from procrastinate.exceptions import AlreadyEnqueued
+
     proc_app = enrichment_tasks.get_app()
-    await proc_app.enrich_document_interactive.configure(
-        queueing_lock=f"reindex:{verified_org_id}:{artifact_id}",
-    ).defer_async(artifact_id=artifact_id)
+    try:
+        await proc_app.enrich_document_interactive.configure(
+            queueing_lock=f"reindex:{verified_org_id}:{artifact_id}",
+        ).defer_async(artifact_id=artifact_id)
+    except AlreadyEnqueued:
+        # A reindex for this artifact is already queued (user double-clicked
+        # the sync button, or the queue is still draining). The queued job
+        # will pick up the current PG state, so "accepted" is the truthful
+        # answer — previously this raised an unhandled 500.
+        logger.info(
+            "reindex_already_enqueued",
+            artifact_id=artifact_id,
+            org_id=verified_org_id,
+        )
+        return ReindexResponse(artifact_id=artifact_id, index_status="pending")
 
     logger.info(
         "reindex_enqueued",

--- a/klai-knowledge-ingest/knowledge_ingest/worker.py
+++ b/klai-knowledge-ingest/knowledge_ingest/worker.py
@@ -82,6 +82,11 @@ class WorkerLifecycle:
     # leaving slots idle.
     IO_CONCURRENCY: int = 8
     LLM_CONCURRENCY: int = 4
+    # Interactive lane: user-triggered re-syncs are rare (single documents,
+    # button clicks) but latency-critical. 2 slots is enough parallelism for
+    # concurrent users while keeping extra LLM pressure negligible next to
+    # the bulk lane's 4 slots.
+    INTERACTIVE_CONCURRENCY: int = 2
 
     def __init__(self, *, postgres_dsn: str) -> None:
         self.postgres_dsn = postgres_dsn
@@ -93,6 +98,7 @@ class WorkerLifecycle:
         # its natural throughput — procrastinate has no per-queue fairness
         # within a single worker.
         self._io_worker_task: asyncio.Task | None = None
+        self._interactive_worker_task: asyncio.Task | None = None
         self._llm_worker_task: asyncio.Task | None = None
         self._stack = AsyncExitStack()
 
@@ -138,7 +144,7 @@ class WorkerLifecycle:
         # design) would still let a backlog of LLM jobs starve I/O work
         # because procrastinate fetches the oldest todo across the worker's
         # queue set, regardless of queue identity.
-        from knowledge_ingest.queues import IO_QUEUES, LLM_QUEUES
+        from knowledge_ingest.queues import INTERACTIVE_QUEUES, IO_QUEUES, LLM_QUEUES
 
         self._io_worker_task = asyncio.create_task(
             self.proc_app.run_worker_async(
@@ -147,6 +153,14 @@ class WorkerLifecycle:
                 install_signal_handlers=False,
             ),
             name="procrastinate-worker-io",
+        )
+        self._interactive_worker_task = asyncio.create_task(
+            self.proc_app.run_worker_async(
+                queues=INTERACTIVE_QUEUES,
+                concurrency=self.INTERACTIVE_CONCURRENCY,
+                install_signal_handlers=False,
+            ),
+            name="procrastinate-worker-interactive",
         )
         self._llm_worker_task = asyncio.create_task(
             self.proc_app.run_worker_async(
@@ -160,6 +174,8 @@ class WorkerLifecycle:
             "procrastinate_workers_started",
             io_queues=IO_QUEUES,
             io_concurrency=self.IO_CONCURRENCY,
+            interactive_queues=INTERACTIVE_QUEUES,
+            interactive_concurrency=self.INTERACTIVE_CONCURRENCY,
             llm_queues=LLM_QUEUES,
             llm_concurrency=self.LLM_CONCURRENCY,
         )
@@ -167,7 +183,11 @@ class WorkerLifecycle:
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         # Cancel both lane workers in parallel and wait for them to exit.
-        worker_tasks = [t for t in (self._io_worker_task, self._llm_worker_task) if t is not None]
+        worker_tasks = [
+            t
+            for t in (self._io_worker_task, self._interactive_worker_task, self._llm_worker_task)
+            if t is not None
+        ]
         if worker_tasks:
             logger.info("procrastinate_workers_stopping", count=len(worker_tasks))
             for t in worker_tasks:

--- a/klai-knowledge-ingest/tests/test_enrichment_retry_config.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_retry_config.py
@@ -1,0 +1,79 @@
+"""Retry-strategy configuration for the enrichment tasks.
+
+Regression for the intermedia.com incident (2026-08-14): enrichment failures
+are dominated by LiteLLM 429s during bulk crawls, and the previous
+``RetryStrategy(max_attempts=2)`` (implicit wait=0) burned every attempt
+inside the same rate-limit window — the artifact failed 3x within 20 seconds
+and went permanent-failed. These tests pin the exponential backoff so a
+future "simplification" cannot silently reintroduce instant retries.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from knowledge_ingest import enrichment_tasks, queues
+
+
+class _RecordingRetryStrategy:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeApp:
+    """Records @app.task(...) registrations without running anything."""
+
+    def __init__(self) -> None:
+        self.task_kwargs: list[dict] = []
+
+    def task(self, **kwargs):
+        self.task_kwargs.append(kwargs)
+
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+@pytest.fixture
+def registered_tasks(monkeypatch) -> dict[str, dict]:
+    """Register tasks against a fake app; return {queue_name: retry_kwargs}."""
+    monkeypatch.setattr(sys.modules["procrastinate"], "RetryStrategy", _RecordingRetryStrategy)
+    app = _FakeApp()
+    enrichment_tasks._register_tasks(app)
+    by_queue: dict[str, dict] = {}
+    for kwargs in app.task_kwargs:
+        retry = kwargs.get("retry")
+        if isinstance(retry, _RecordingRetryStrategy):
+            by_queue[kwargs["queue"]] = retry.kwargs
+    return by_queue
+
+
+def test_interactive_enrichment_backs_off_exponentially(registered_tasks):
+    retry = registered_tasks[queues.ENRICH_INTERACTIVE]
+    assert retry["max_attempts"] == 4
+    assert retry["exponential_wait"] == 3  # waits 3s, 9s, 27s
+
+
+def test_bulk_enrichment_backs_off_exponentially(registered_tasks):
+    retry = registered_tasks[queues.ENRICH_BULK]
+    assert retry["max_attempts"] == 5
+    assert retry["exponential_wait"] == 4  # waits 4s, 16s, 64s, 256s
+
+
+def test_graphiti_backs_off_exponentially(registered_tasks):
+    retry = registered_tasks[queues.GRAPHITI_BULK]
+    assert retry["max_attempts"] == 3
+    assert retry["exponential_wait"] == 4  # waits 4s, 16s
+
+
+def test_no_enrichment_task_retries_instantly(registered_tasks):
+    """Every LLM-calling task must have SOME backoff — wait-free retries are
+    exactly the 429 failure mode this configuration exists to prevent."""
+    for queue_name in (queues.ENRICH_INTERACTIVE, queues.ENRICH_BULK, queues.GRAPHITI_BULK):
+        retry = registered_tasks[queue_name]
+        assert (
+            retry.get("wait", 0) or retry.get("linear_wait", 0) or retry.get("exponential_wait", 0)
+        ), f"task on {queue_name} retries with zero wait"

--- a/klai-knowledge-ingest/tests/test_kb_sources.py
+++ b/klai-knowledge-ingest/tests/test_kb_sources.py
@@ -140,6 +140,7 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
                     "created_at": 1700000000,
                     "chunks_count": 7,
                     "index_status": "synced",
+                    "index_status_changed_at": 1700000100,
                 },
             ],
         ]
@@ -160,6 +161,7 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
             "created_at": 1700000000,
             "chunks_count": 7,
             "index_status": "synced",
+            "index_status_changed_at": 1700000100,
         },
     ]
     # Two distinct queries: connectors then uploads

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -471,6 +471,7 @@ async def test_mark_stale_pending_artifacts_failed_requires_no_runnable_job():
     assert "pj.args->>'artifact_id' = a.id::text" in sql
     assert "FOR UPDATE SKIP LOCKED" in sql
     assert "SET index_status = 'failed'" in sql
+    assert "index_status_changed_at = extract(epoch from now())::bigint" in sql
     assert conn.fetch.call_args[0][1:] == (
         1700001800,
         _SENTINEL,
@@ -492,8 +493,12 @@ async def test_set_artifact_ingest_status_updates_any_artifact():
     assert result == {"artifact_id": "art-1", "path": "doc.md"}
     sql = conn.fetchrow.call_args[0][0]
     assert "SET index_status = $1" in sql
+    assert "index_status_changed_at = $4" in sql
     assert "source_connector_id" not in sql
-    assert conn.fetchrow.call_args[0][1:] == ("synced", "art-1", "org1")
+    args = conn.fetchrow.call_args[0][1:]
+    assert args[:3] == ("synced", "art-1", "org1")
+    # 4th arg is the transition timestamp (epoch seconds).
+    assert isinstance(args[3], int)
 
 
 # -- list_personal_artifacts --------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_queues_constants.py
+++ b/klai-knowledge-ingest/tests/test_queues_constants.py
@@ -68,34 +68,51 @@ def test_all_queue_values_use_kebab_case():
 # --- SPEC-WORKER-LANES-001 invariants ---------------------------------------
 
 
-def test_io_and_llm_lanes_partition_all_queues():
-    """Every queue MUST belong to exactly one lane (I/O xor LLM).
+def test_lanes_partition_all_queues():
+    """Every queue MUST belong to exactly one lane (I/O xor interactive xor LLM).
 
-    A queue that escapes both lanes silently disables itself: no worker
-    subscribes to it. A queue that lands in both lanes is double-handled
+    A queue that escapes all lanes silently disables itself: no worker
+    subscribes to it. A queue that lands in two lanes is double-handled
     by competing worker processes and the lane SLAs collapse. Both are
     silent failures — pin the partition mechanically.
     """
     io = set(queues.IO_QUEUES)
+    interactive = set(queues.INTERACTIVE_QUEUES)
     llm = set(queues.LLM_QUEUES)
     all_q = set(queues.ALL_QUEUES)
 
-    assert io & llm == set(), f"queue belongs to both lanes: {io & llm}"
-    assert io | llm == all_q, (
+    assert io & llm == set(), f"queue belongs to both I/O and LLM lanes: {io & llm}"
+    assert io & interactive == set(), f"queue in both I/O and interactive: {io & interactive}"
+    assert interactive & llm == set(), f"queue in both interactive and LLM: {interactive & llm}"
+    assert io | interactive | llm == all_q, (
         f"lanes do not cover ALL_QUEUES.\n"
-        f"  in ALL_QUEUES but not in any lane: {all_q - (io | llm)}\n"
-        f"  in lanes but not in ALL_QUEUES: {(io | llm) - all_q}"
+        f"  in ALL_QUEUES but not in any lane: {all_q - (io | interactive | llm)}\n"
+        f"  in lanes but not in ALL_QUEUES: {(io | interactive | llm) - all_q}"
     )
 
 
-def test_all_queues_is_io_plus_llm_in_order():
-    """``ALL_QUEUES = IO_QUEUES + LLM_QUEUES`` (and order matters: I/O
-    first reflects the 'latency-first' priority of the architecture).
+def test_all_queues_is_lanes_concatenated_in_order():
+    """``ALL_QUEUES = IO_QUEUES + INTERACTIVE_QUEUES + LLM_QUEUES`` (order
+    matters: latency-sensitive lanes first reflects the architecture).
 
     Order matters because ``test_all_queues_contains_every_string_constant``
     + downstream tests rely on the union being deterministic.
     """
-    assert queues.ALL_QUEUES == queues.IO_QUEUES + queues.LLM_QUEUES
+    assert queues.ALL_QUEUES == queues.IO_QUEUES + queues.INTERACTIVE_QUEUES + queues.LLM_QUEUES
+
+
+def test_enrich_interactive_has_its_own_lane():
+    """User-triggered re-syncs must not share a lane with bulk work.
+
+    Procrastinate fetches the oldest todo across a worker's whole queue
+    set — with ENRICH_INTERACTIVE inside the LLM lane, a bulk crawl's
+    backlog of hundreds of enrich-bulk/graphiti-bulk jobs made a single
+    user-requested reindex wait for hours (intermedia.com incident,
+    2026-08-14).
+    """
+    assert queues.INTERACTIVE_QUEUES == [queues.ENRICH_INTERACTIVE]
+    assert queues.ENRICH_INTERACTIVE not in queues.LLM_QUEUES
+    assert queues.ENRICH_INTERACTIVE not in queues.IO_QUEUES
 
 
 def test_crawl_jobs_lives_in_io_lane():

--- a/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
+++ b/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
@@ -174,6 +174,53 @@ class TestReindexHappyPath:
         status_arg = conn.fetchrow.await_args_list[1].args[1]
         assert status_arg == "pending"
 
+    def test_double_click_returns_202_when_reindex_already_enqueued(self) -> None:
+        """Regression: a second sync click while the first reindex job was
+        still queued raised procrastinate's AlreadyEnqueued unhandled → 500.
+        The queued job will pick up current PG state, so 202 is truthful.
+        """
+        from procrastinate.exceptions import AlreadyEnqueued
+
+        conn = _make_mock_conn()
+        conn.fetchrow = AsyncMock(
+            side_effect=[
+                {
+                    "id": _ARTIFACT,
+                    "kb_slug": _KB,
+                    "path": _PATH,
+                    "belief_time_end": 253402300800,
+                },
+                {"artifact_id": _ARTIFACT, "path": _PATH},
+            ]
+        )
+
+        mock_job = MagicMock()
+        mock_job.configure = MagicMock(return_value=mock_job)
+        mock_job.defer_async = AsyncMock(side_effect=AlreadyEnqueued("locked"))
+        mock_proc_app = MagicMock()
+        mock_proc_app.enrich_document_interactive = mock_job
+
+        with (
+            patch(
+                "knowledge_ingest.routes.kb_sources.assert_caller_identity_tenant_only",
+                AsyncMock(return_value=_ORG),
+            ),
+            patch(
+                "knowledge_ingest.enrichment_tasks.get_app",
+                return_value=mock_proc_app,
+            ),
+        ):
+            with _client_with_conn(conn) as client:
+                resp = client.post(
+                    f"/knowledge/v1/artifacts/{_ARTIFACT}/reindex",
+                    params={"org_id": _ORG},
+                )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["artifact_id"] == _ARTIFACT
+        assert body["index_status"] == "pending"
+
     def test_reactivates_expired_upload_artifact(self) -> None:
         conn = _make_mock_conn()
         conn.fetchrow = AsyncMock(
@@ -397,6 +444,7 @@ class TestListKbSourcesIndexStatus:
             "created_at": 1751328000,
             "chunks_count": 5,
             "index_status": "pending",
+            "index_status_changed_at": 1751330000,
         }
         # list_kb_sources makes two fetch calls: connectors then uploads.
         # Make the first call return [] (no connectors), second return the upload.
@@ -426,3 +474,4 @@ class TestListKbSourcesIndexStatus:
         uploads = resp.json()["uploads"]
         assert len(uploads) == 1
         assert uploads[0]["index_status"] == "pending"
+        assert uploads[0]["index_status_changed_at"] == 1751330000

--- a/klai-knowledge-ingest/tests/test_worker_lifecycle.py
+++ b/klai-knowledge-ingest/tests/test_worker_lifecycle.py
@@ -93,8 +93,9 @@ def stub_procrastinate(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_lifecycle_starts_two_workers(stub_procrastinate):
-    """SPEC-WORKER-LANES-001 REQ-1: I/O and LLM workers start in parallel."""
+async def test_lifecycle_starts_three_workers(stub_procrastinate):
+    """SPEC-WORKER-LANES-001 REQ-1 + interactive lane: I/O, interactive and
+    LLM workers start in parallel."""
     from knowledge_ingest.worker import WorkerLifecycle
 
     async with WorkerLifecycle.start(postgres_dsn="postgresql+asyncpg://u:p@h:5432/d"):
@@ -104,7 +105,7 @@ async def test_lifecycle_starts_two_workers(stub_procrastinate):
         await asyncio.sleep(0)
 
     calls = stub_procrastinate["run_worker_calls"]
-    assert len(calls) == 2, f"expected 2 worker calls (I/O + LLM), got {len(calls)}"
+    assert len(calls) == 3, f"expected 3 worker calls (I/O + interactive + LLM), got {len(calls)}"
 
 
 @pytest.mark.asyncio
@@ -122,6 +123,7 @@ async def test_io_worker_subscribed_to_io_queues_only(stub_procrastinate):
     # The IO call's queues must not include any LLM queue.
     io_call = next(c for c in calls if tuple(c["queues"]) == tuple(queues.IO_QUEUES))
     assert set(io_call["queues"]).isdisjoint(queues.LLM_QUEUES)
+    assert set(io_call["queues"]).isdisjoint(queues.INTERACTIVE_QUEUES)
 
 
 @pytest.mark.asyncio
@@ -138,6 +140,29 @@ async def test_llm_worker_subscribed_to_llm_queues_only(stub_procrastinate):
     assert tuple(queues.LLM_QUEUES) in queue_sets
     llm_call = next(c for c in calls if tuple(c["queues"]) == tuple(queues.LLM_QUEUES))
     assert set(llm_call["queues"]).isdisjoint(queues.IO_QUEUES)
+    assert set(llm_call["queues"]).isdisjoint(queues.INTERACTIVE_QUEUES)
+
+
+@pytest.mark.asyncio
+async def test_interactive_worker_subscribed_to_interactive_queue_only(stub_procrastinate):
+    """Interactive lane: user-triggered re-syncs must not share a worker with
+    bulk queues, or a crawl backlog starves them (intermedia.com incident,
+    2026-08-14: a re-sync sat behind ~550 bulk jobs)."""
+    from knowledge_ingest.worker import WorkerLifecycle
+
+    async with WorkerLifecycle.start(postgres_dsn="postgresql+asyncpg://u:p@h:5432/d"):
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    calls = stub_procrastinate["run_worker_calls"]
+    queue_sets = [tuple(c["queues"]) for c in calls]
+    assert tuple(queues.INTERACTIVE_QUEUES) in queue_sets
+    interactive_call = next(
+        c for c in calls if tuple(c["queues"]) == tuple(queues.INTERACTIVE_QUEUES)
+    )
+    assert set(interactive_call["queues"]).isdisjoint(queues.IO_QUEUES)
+    assert set(interactive_call["queues"]).isdisjoint(queues.LLM_QUEUES)
+    assert interactive_call["concurrency"] == WorkerLifecycle.INTERACTIVE_CONCURRENCY
 
 
 @pytest.mark.asyncio
@@ -185,4 +210,4 @@ async def test_zombie_recovery_failure_does_not_block_workers(stub_procrastinate
         await asyncio.sleep(0)
 
     # Workers still started despite the recovery failure.
-    assert len(stub_procrastinate["run_worker_calls"]) == 2
+    assert len(stub_procrastinate["run_worker_calls"]) == 3

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1264,6 +1264,17 @@ async def list_kb_sources(
         active_upload_paths.add(path)
         created_at_unix = upload.get("created_at")
         created_at_dt = datetime.fromtimestamp(int(created_at_unix), tz=dt.UTC) if created_at_unix is not None else None
+        # index_status_changed_at marks the start of the LAST (re)index
+        # attempt. Surfacing it as last_sync_at lets the frontend's
+        # "Bezig sinds Xm / Hangt al Xm" badge measure from the re-sync
+        # click instead of the artifact creation date (which showed
+        # "Hangt al 11384m" immediately after re-syncing an 8-day-old
+        # source). NULL for rows that never transitioned since the column
+        # landed — frontend falls back to created_at.
+        status_changed_unix = upload.get("index_status_changed_at")
+        status_changed_dt = (
+            datetime.fromtimestamp(int(status_changed_unix), tz=dt.UTC) if status_changed_unix is not None else None
+        )
         sources.append(
             SourceOut(
                 kind="upload",
@@ -1276,6 +1287,7 @@ async def list_kb_sources(
                 chunks_count=int(upload.get("chunks_count") or 0),
                 status=None,
                 created_at=created_at_dt,
+                last_sync_at=status_changed_dt,
                 index_status=str(upload.get("index_status") or "synced"),
             )
         )

--- a/klai-portal/backend/tests/test_app_knowledge_sources_list.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_list.py
@@ -184,6 +184,7 @@ async def test_list_kb_sources_merges_connectors_and_uploads() -> None:
                 "content_type": "pdf",
                 "created_at": 1700000000,
                 "chunks_count": 7,
+                "index_status_changed_at": 1700005000,
             },
         ],
     }
@@ -228,6 +229,9 @@ async def test_list_kb_sources_merges_connectors_and_uploads() -> None:
     assert by_id["art-1"].source_url is None
     assert by_id["art-1"].chunks_count == 7
     assert by_id["art-1"].created_at is not None
+    # index_status_changed_at (epoch) surfaces as last_sync_at so the frontend
+    # measures "Bezig sinds Xm" from the (re)sync start, not artifact creation.
+    assert by_id["art-1"].last_sync_at == datetime.fromtimestamp(1700005000, tz=UTC)
 
 
 @pytest.mark.asyncio

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -748,6 +748,7 @@
   "kb_status_stuck": "Stuck for {minutes}m",
   "kb_status_stuck_tooltip": "This source has been processing for over 10 minutes. Click the refresh icon to retry, or delete and re-add the source.",
   "kb_status_probleem": "Issue",
+  "kb_status_failed_tooltip": "Processing this source failed. Click the refresh icon to retry.",
   "kb_status_leeg": "Not synced",
   "knowledge_page_meta_items": "{count} items",
   "knowledge_page_meta_items_personal": "{count} items remembered",
@@ -2111,8 +2112,7 @@
   "admin_widgets_page_context_help": "Sends the URL, title, and a short visible page excerpt. The AI only uses this when the question is clearly about the current page.",
   "admin_widgets_position_left": "Bottom left",
   "admin_widgets_position_right": "Bottom right",
-  "admin_widgets_subtitle": "An agent answers your visitors' questions from your knowledge bases, and always cites the source. You decide which knowledge, instruction, and styling it uses."
-  ,
+  "admin_widgets_subtitle": "An agent answers your visitors' questions from your knowledge bases, and always cites the source. You decide which knowledge, instruction, and styling it uses.",
   "admin_widgets_activity_hourly_title": "Load profile - conversations per hour",
   "admin_widgets_activity_top_questions_title": "Most asked questions",
   "admin_widgets_activity_no_questions": "No questions yet.",
@@ -2300,8 +2300,7 @@
   "platform_role": "Role",
   "platform_first_name": "First name",
   "platform_last_name": "Last name",
-  "platform_send_invite": "Send invitation"
-  ,
+  "platform_send_invite": "Send invitation",
   "platform_status_portal_api": "Portal API",
   "platform_status_portal_api_description": "Live check through /api/health, refreshed every 30s.",
   "platform_checking": "Checking...",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -748,6 +748,7 @@
   "kb_status_stuck": "Hangt al {minutes}m",
   "kb_status_stuck_tooltip": "Deze bron is al meer dan 10 minuten aan het verwerken. Klik op het refresh-icoon hiernaast om het opnieuw te proberen, of verwijder en voeg de bron opnieuw toe.",
   "kb_status_probleem": "Probleem",
+  "kb_status_failed_tooltip": "De verwerking van deze bron is mislukt. Klik op het refresh-icoon hiernaast om het opnieuw te proberen.",
   "kb_status_leeg": "Niet gesynct",
   "knowledge_page_meta_items": "{count} items",
   "knowledge_page_meta_items_personal": "{count} items onthouden",
@@ -2111,8 +2112,7 @@
   "admin_widgets_page_context_help": "Stuurt URL, titel en een korte zichtbare pagina-excerpt mee. De AI gebruikt dit alleen wanneer de vraag duidelijk over de huidige pagina gaat.",
   "admin_widgets_position_left": "Linksonder",
   "admin_widgets_position_right": "Rechtsonder",
-  "admin_widgets_subtitle": "Een agent beantwoordt vragen van je bezoekers op basis van jouw kennisbanken, en verwijst altijd naar de bron. Jij bepaalt welke kennis, instructie en vormgeving hij gebruikt."
-  ,
+  "admin_widgets_subtitle": "Een agent beantwoordt vragen van je bezoekers op basis van jouw kennisbanken, en verwijst altijd naar de bron. Jij bepaalt welke kennis, instructie en vormgeving hij gebruikt.",
   "admin_widgets_activity_hourly_title": "Druktespiegel - gesprekken per uur",
   "admin_widgets_activity_top_questions_title": "Meest gestelde vragen",
   "admin_widgets_activity_no_questions": "Nog geen vragen.",
@@ -2300,8 +2300,7 @@
   "platform_role": "Rol",
   "platform_first_name": "Voornaam",
   "platform_last_name": "Achternaam",
-  "platform_send_invite": "Uitnodiging versturen"
-  ,
+  "platform_send_invite": "Uitnodiging versturen",
   "platform_status_portal_api": "Portal API",
   "platform_status_portal_api_description": "Live check via /api/health, ververst elke 30s.",
   "platform_checking": "Controleren...",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -92,6 +92,18 @@ export function StatusBadge({ source }: { source: Source }) {
     )
   }
 
+  // Failed uploads (index_status === 'failed') previously fell through to the
+  // neutral "Leeg" badge, so a permanently failed source looked merely
+  // un-synced — the intermedia.com failure went unnoticed for 8 days. Show
+  // the same destructive treatment connectors get, with a retry hint.
+  if (source.kind === 'upload' && (source.index_status ?? '').toLowerCase() === 'failed') {
+    return (
+      <Badge variant="destructive" title={m.kb_status_failed_tooltip()}>
+        {m.kb_status_probleem()}
+      </Badge>
+    )
+  }
+
   // Stale-indicator for sources stuck in 'pending'. last_sync_at is the
   // best signal of "when did this attempt start" — falls back to created_at
   // for sources that have never completed a sync yet (the common case for

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-helpers.test.ts
@@ -8,6 +8,7 @@ vi.mock('@/paraglide/messages', () => ({
   kb_status_bezig_elapsed: ({ minutes }: { minutes: string }) => `${minutes}m`,
   kb_status_klaar: () => 'Klaar',
   kb_status_leeg: () => 'Leeg',
+  kb_status_failed_tooltip: () => 'Verwerking mislukt',
 }))
 
 import { mapSourceStatus, shouldPollSource } from '../-sources-helpers'
@@ -54,5 +55,25 @@ describe('sources helpers', () => {
 
   it('does not poll terminal sources', () => {
     expect(shouldPollSource(uploadSource({ index_status: 'synced', chunks_count: 4 }))).toBe(false)
+  })
+
+  it('resumes polling when an old source is re-synced (last_sync_at fresh, created_at stale)', () => {
+    // Regression: a re-synced 8-day-old artifact measured elapsed time from
+    // created_at, so it showed "Hangt al 11384m" immediately and polling
+    // never resumed. The backend now sets last_sync_at to the reindex start.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-14T09:20:00Z'))
+
+    const resynced = uploadSource({
+      created_at: '2026-08-06T11:30:00Z',
+      last_sync_at: '2026-08-14T09:13:00Z',
+    })
+
+    expect(mapSourceStatus(resynced)).toBe('pending')
+    expect(shouldPollSource(resynced)).toBe(true)
+  })
+
+  it('maps failed uploads to not_synced', () => {
+    expect(mapSourceStatus(uploadSource({ index_status: 'failed' }))).toBe('not_synced')
   })
 })

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-status-badge.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-status-badge.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/paraglide/messages', () => ({
+  kb_status_probleem: () => 'Probleem',
+  kb_status_stuck_tooltip: () => 'Hangt vast',
+  kb_status_stuck: ({ minutes }: { minutes: string }) => `Hangt al ${minutes}m`,
+  kb_status_bezig: () => 'Bezig',
+  kb_status_bezig_elapsed: ({ minutes }: { minutes: string }) => `${minutes}m`,
+  kb_status_klaar: () => 'Klaar',
+  kb_status_leeg: () => 'Leeg',
+  kb_status_failed_tooltip: () => 'Verwerking mislukt — probeer opnieuw',
+}))
+
+import { StatusBadge } from '../-sources-helpers'
+import type { Source } from '../-sources-types'
+
+function uploadSource(overrides: Partial<Source> = {}): Source {
+  return {
+    kind: 'upload',
+    id: 'art-1',
+    name: 'https://www.example.com/',
+    type_label: 'Websitepagina',
+    connector_type: null,
+    items_count: 1,
+    chunks_count: 0,
+    status: null,
+    last_sync_at: null,
+    created_at: null,
+    index_status: 'synced',
+    ...overrides,
+  }
+}
+
+describe('StatusBadge', () => {
+  it('shows a destructive Probleem badge for failed uploads instead of neutral Leeg', () => {
+    // Regression: index_status='failed' uploads rendered the neutral "Leeg"
+    // badge, so a permanently failed source went unnoticed for 8 days.
+    render(<StatusBadge source={uploadSource({ index_status: 'failed' })} />)
+
+    const badge = screen.getByText('Probleem')
+    expect(badge).toBeTruthy()
+    expect(badge.getAttribute('title')).toBe('Verwerking mislukt — probeer opnieuw')
+    expect(screen.queryByText('Leeg')).toBeNull()
+  })
+
+  it('still shows Klaar for synced uploads', () => {
+    render(<StatusBadge source={uploadSource({ index_status: 'synced', chunks_count: 3 })} />)
+    expect(screen.getByText('Klaar')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Wat

Vier gestapelde fixes uit het intermedia.com stuck-source incident (Ascend KB, 6–14 aug):

1. **429-backoff (knowledge-ingest)** — enrichment-retries hadden geen wait: LiteLLM 429s tijdens bulk-crawls verbrandden alle attempts binnen 20s → bron permanent failed. Nu exponentiële backoff (interactive 3/9/27s, bulk 4/16/64/256s, graphiti 4/16s). 641 `enrichment_llm_error` events in 2 weken, geclusterd tijdens crawls.
2. **Interactive lane (knowledge-ingest)** — `enrich-interactive` deelde de LLM-lane FIFO met `enrich-bulk`/`graphiti-bulk`; een user-re-sync wachtte achter ~550 crawl-jobs (uren). Nu een eigen worker (concurrency 2).
3. **Eerlijke elapsed-tijd (ingest → portal → frontend)** — nieuwe kolom `artifacts.index_status_changed_at` (migratie 0008, auto-applied door entrypoint) registreert de laatste statusovergang; portal geeft hem door als `last_sync_at`, waardoor de 'Bezig sinds Xm / Hangt al Xm'-badge vanaf de re-sync-klik meet i.p.v. de artifact-aanmaakdatum ('Hangt al 11384m' na 7 min echt wachten) en polling weer aanslaat na re-sync.
4. **Failed-badge (frontend)** — een mislukte upload toonde de neutrale 'Leeg'-badge, waardoor de failure 8 dagen onopgemerkt bleef. Nu een destructive 'Probleem'-badge met retry-hint.

Plus: dubbelklik op sync gaf een onafgehandelde `AlreadyEnqueued` → 500; nu 202.

## Verificatie

- knowledge-ingest: volledige suite 1224 passed (4 skipped), `alembic heads` = 1 (b7c2d9e4f1a3), ruff check+format clean op gewijzigde files
- portal-backend: `tests/test_app_knowledge_sources_list.py` 16 passed, ruff clean
- frontend: sources-tests 38 passed + nieuwe StatusBadge-tests, `tsc -b` clean, eslint clean
- Migratie is pure DDL (`ADD COLUMN ... BIGINT`, nullable) — metadata-only, RLS-veilig

## Rollback

`git revert <merge-sha>` — migratie 0008 kan blijven staan (nullable kolom, geen reader vereist hem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)