### PR TITLE
feat(renovate): run as its own GitHub App + autonomous merge policy

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # 03:00 UTC = 05:00 Amsterdam (CEST) / 04:00 (CET). GitHub delays scheduled
     # runs by 1-3h under load, so this lands mid-morning at worst. The cadence
-    # lives HERE and nowhere else — renovate.json deliberately has no top-level
+    # lives HERE and nowhere else — renovate.json5 deliberately has no top-level
     # schedule (see the comment there for the 28-week no-op it caused).
     - cron: '0 3 * * 1'
   workflow_dispatch:
@@ -20,29 +20,35 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      # Dependency Dashboard is a GitHub issue. Without this the run logs
-      # "Could not ensure issue / integration-unauthorized" and you lose the
-      # single best view of what Renovate wants to do but has not done yet.
-      issues: write
-      # Lets Renovate read our own ghcr.io/getklai/* image tags; without it the
-      # run warns "Failed to look up docker package ghcr.io/getklai/crawl4ai".
-      packages: read
+      # Only what the token-minting step needs. Renovate itself acts as the
+      # Klai Renovate GitHub App, whose rights are granted on the app
+      # installation, not here.
+      contents: read
     steps:
+      # Renovate runs as its own GitHub App rather than with GITHUB_TOKEN, for
+      # two reasons:
+      #
+      #  1. GITHUB_TOKEN cannot open pull requests unless the repo setting
+      #     "Allow GitHub Actions to create and approve pull requests" is on —
+      #     and that same switch also lets ANY workflow self-approve a PR,
+      #     which would undercut review. The app needs no such switch.
+      #  2. Events from GITHUB_TOKEN do not start new workflow runs, so its PRs
+      #     would arrive with zero checks. Renovate never automerges without
+      #     passing checks, so automerge would simply never fire. As the app,
+      #     its PRs trigger the real service test suites, which is exactly what
+      #     automerge should be gating on.
+      - name: Mint a token for the Klai Renovate app
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
 
       - uses: renovatebot/github-action@v46.2.2
         with:
-          # NOTE: the default GITHUB_TOKEN cannot create pull requests unless
-          # the repo setting "Allow GitHub Actions to create and approve pull
-          # requests" is on — it is currently off, and turning it on also lets
-          # any workflow self-approve PRs. The clean alternative is a dedicated
-          # Renovate GitHub App token in secrets.RENOVATE_TOKEN, which also
-          # makes PRs trigger CI so automerge can gate on real tests.
-          # Renovate does not automerge without passing checks, so the failure
-          # mode here is "PRs pile up", never "unverified merge".
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
         env:
           RENOVATE_REPOSITORIES: '["GetKlai/klai"]'
           # At info level a skipped update is indistinguishable from no update

--- a/renovate.json5
+++ b/renovate.json5
@@ -38,8 +38,13 @@
   // Supported for uv.lock via the pep621 manager and for package-lock.json via
   // npm (docs.renovatebot.com/modules/manager/pep621).
   //
-  // Never automerged: a lock refresh touches the whole transitive tree, so it
-  // gets human eyes even when the per-service CI gates are green.
+  // Automerged, deliberately. A lock refresh has the widest blast radius of
+  // anything Renovate does, which argues for review — but requiring review is
+  // exactly what let the locks rot for 28 weeks in the first place, and the
+  // realistic failure mode is nobody looking, not somebody looking and
+  // catching something. Every service now gates on lint + pip-audit + its own
+  // test suite, a failed deploy opens a ci-failure issue, and the refresh
+  // lands as one squash commit that `git revert` undoes cleanly.
   // 'at any time' on purpose, and it is NOT redundant: lockFileMaintenance
   // defaults to its own 'before 4am on monday' window, which would walk
   // straight back into the bug described above — the cron fires at 03:00 UTC
@@ -48,21 +53,14 @@
   lockFileMaintenance: {
     enabled: true,
     schedule: ['at any time'],
-    automerge: false,
+    automerge: true,
     commitMessageAction: 'Refresh lock files',
   },
 
   packageRules: [
     {
-      description: 'Auto-merge patch updates',
-      matchUpdateTypes: ['patch'],
-      automerge: true,
-      automergeStrategy: 'squash',
-    },
-    {
-      description: 'Auto-merge minor dev dependency updates',
-      matchUpdateTypes: ['minor'],
-      matchDepTypes: ['devDependencies'],
+      description: 'Auto-merge patch and minor updates once CI is green',
+      matchUpdateTypes: ['patch', 'minor'],
       automerge: true,
       automergeStrategy: 'squash',
     },
@@ -70,6 +68,11 @@
       description: 'Group Docker images — require manual review',
       matchManagers: ['docker-compose', 'dockerfile'],
       groupName: 'Docker images',
+      automerge: false,
+    },
+    {
+      description: 'Major upgrades always get human eyes',
+      matchUpdateTypes: ['major'],
       automerge: false,
     },
   ],


### PR DESCRIPTION
Renovate now authenticates as the **Klai Renovate GitHub App** instead of `GITHUB_TOKEN`.

## Why the app

- `GITHUB_TOKEN` cannot open PRs unless *"Allow GitHub Actions to create and approve pull requests"* is on — and that same switch lets **any** workflow self-approve a PR. The app needs no such switch, so review integrity is untouched.
- Events from `GITHUB_TOKEN` don't start workflow runs, so its PRs arrive with **zero checks**. Renovate never automerges without passing checks, so automerge could never fire. As the app, its PRs trigger the real per-service suites — exactly what automerge should gate on.

Workflow permissions dropped to `contents: read`; everything Renovate needs is granted on the app installation.

## Merge policy

| | |
|---|---|
| patch + minor | automerge on green |
| major | human review |
| Docker images | human review (crawl4ai 0.9.x, LibreChat 0.8.7 both bit us) |
| lock file refresh | automerge |

`lockFileMaintenance` automerging is deliberate. It has the widest blast radius here, which argues for review — but *requiring review is what let the locks rot for 28 weeks*. The realistic failure mode is nobody looking, not somebody catching something. It lands as one squash commit, a failed deploy now opens a `ci-failure` issue, and `git revert` undoes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)