### PR TITLE
fix(librechat): remove the env-var bypass from the provenance check

### DIFF
--- a/deploy/scripts/generate-librechat-build-manifest.mjs
+++ b/deploy/scripts/generate-librechat-build-manifest.mjs
@@ -15,61 +15,88 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
-import {
-  PATCHED_FILES,
-} from './lib/librechat-patched-files.mjs';
+import { PATCHED_FILES } from './lib/librechat-patched-files.mjs';
 import {
   extractFromImage,
   sha256File,
 } from './lib/librechat-image-extract.mjs';
 
-function arg(name, required = true) {
-  const idx = process.argv.indexOf(`--${name}`);
-  if (idx === -1 || idx === process.argv.length - 1) {
-    if (!required) return undefined;
-    console.error(`FATAL: missing required --${name}`);
-    process.exit(2);
-  }
-  return process.argv[idx + 1];
+/**
+ * @param {object} options
+ * @param {string} options.image
+ * @param {string} options.upstreamTag
+ * @param {string} options.agentsRef
+ * @param {string} options.patchRevision
+ * @param {string} options.patchesDir
+ * @param {typeof extractFromImage} [options.extract]
+ * @returns {object} the manifest
+ */
+export function generateManifest({
+  image,
+  upstreamTag,
+  agentsRef,
+  patchRevision,
+  patchesDir,
+  extract = extractFromImage,
+}) {
+  const { files } = extract(image, PATCHED_FILES);
+
+  const artifacts = PATCHED_FILES.map((entry) => {
+    const patchPath = path.join(patchesDir, entry.patch);
+    if (!fs.existsSync(patchPath)) {
+      throw new Error(`diff not found: ${patchPath}`);
+    }
+    return {
+      key: entry.key,
+      lane: entry.lane,
+      container_path: entry.containerPath,
+      patch: entry.patch,
+      patch_sha256: sha256File(patchPath),
+      artifact_sha256: sha256File(files.get(entry.key)),
+    };
+  });
+
+  return {
+    spec: 'SPEC-LIBRECHAT-PATCH-MODEL-001',
+    schema_version: 1,
+    upstream_librechat_tag: upstreamTag,
+    // Resolved from the upstream image, never pinned independently -- see the
+    // workflow's resolve step and the 2026-08-13 version-skew incident.
+    agents_ref: agentsRef,
+    klai_patch_revision: patchRevision,
+    artifacts,
+  };
 }
 
-const image = arg('image');
-const upstreamTag = arg('upstream-tag');
-const agentsRef = arg('agents-ref');
-const patchRevision = arg('patch-revision');
-const patchesDir = arg('patches-dir');
-const out = arg('out');
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
-const { files } = extractFromImage(image, PATCHED_FILES);
+if (invokedDirectly) {
+  const arg = (name) => {
+    const idx = process.argv.indexOf(`--${name}`);
+    if (idx === -1 || idx === process.argv.length - 1) {
+      console.error(`FATAL: missing required --${name}`);
+      process.exit(2);
+    }
+    return process.argv[idx + 1];
+  };
 
-const artifacts = PATCHED_FILES.map((entry) => {
-  const hostPath = files.get(entry.key);
-  const patchPath = path.join(patchesDir, entry.patch);
-  if (!fs.existsSync(patchPath)) {
-    console.error(`FATAL: diff not found: ${patchPath}`);
+  const out = arg('out');
+  try {
+    const manifest = generateManifest({
+      image: arg('image'),
+      upstreamTag: arg('upstream-tag'),
+      agentsRef: arg('agents-ref'),
+      patchRevision: arg('patch-revision'),
+      patchesDir: arg('patches-dir'),
+    });
+    fs.writeFileSync(out, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(`Wrote ${out} (${manifest.artifacts.length} artifacts)`);
+  } catch (error) {
+    console.error(`FATAL: ${error.message}`);
     process.exit(1);
   }
-  return {
-    key: entry.key,
-    lane: entry.lane,
-    container_path: entry.containerPath,
-    patch: entry.patch,
-    patch_sha256: sha256File(patchPath),
-    artifact_sha256: sha256File(hostPath),
-  };
-});
-
-const manifest = {
-  spec: 'SPEC-LIBRECHAT-PATCH-MODEL-001',
-  schema_version: 1,
-  upstream_librechat_tag: upstreamTag,
-  // Resolved from the upstream image, never pinned independently -- see the
-  // workflow's resolve step and the 2026-08-13 version-skew incident.
-  agents_ref: agentsRef,
-  klai_patch_revision: patchRevision,
-  artifacts,
-};
-
-fs.writeFileSync(out, `${JSON.stringify(manifest, null, 2)}\n`);
-console.log(`Wrote ${out} (${artifacts.length} artifacts)`);
+}

--- a/deploy/scripts/lib/librechat-image-extract.mjs
+++ b/deploy/scripts/lib/librechat-image-extract.mjs
@@ -13,10 +13,14 @@ import path from 'node:path';
  * image that is deliberately not deployable yet (Phase 2 pushes a tag nothing
  * points at).
  *
- * Set KLAI_LIBRECHAT_EXTRACT_DIR to a directory of `<key>` files to bypass
- * Docker entirely. That is what lets the manifest generate/verify logic be
- * tested without a daemon and without a 10-minute image build — the same
- * injection trick assert-safe-to-prune.sh uses for its mount table.
+ * There is deliberately NO environment-variable escape hatch here. An earlier
+ * revision honoured KLAI_LIBRECHAT_EXTRACT_DIR so the provenance logic could be
+ * tested without a daemon — which meant a stray env var could redirect the
+ * deploy-time check away from the image and let it "verify" nothing at all.
+ * That is the fail-open class this repo already has pitfalls about, in the one
+ * place whose entire job is to be trustworthy. Tests inject a replacement
+ * extractor as a function argument instead (see verifyManifest/generateManifest);
+ * production code has no bypass to leave switched on by accident.
  *
  * @param {string} image
  * @param {Array<{key: string, containerPath: string}>} entries
@@ -24,22 +28,6 @@ import path from 'node:path';
  * @returns {{dir: string, files: Map<string, string>}} key -> host path
  */
 export function extractFromImage(image, entries, outDir) {
-  const injected = process.env.KLAI_LIBRECHAT_EXTRACT_DIR;
-  if (injected) {
-    const files = new Map();
-    for (const entry of entries) {
-      const hostPath = path.join(injected, entry.key);
-      if (!fs.existsSync(hostPath)) {
-        throw new Error(
-          `KLAI_LIBRECHAT_EXTRACT_DIR is set but ${hostPath} is missing ` +
-            `(needed for ${entry.containerPath})`
-        );
-      }
-      files.set(entry.key, hostPath);
-    }
-    return { dir: injected, files };
-  }
-
   const dir = outDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'klai-lc-'));
   fs.mkdirSync(dir, { recursive: true });
 

--- a/deploy/scripts/tests/librechat-build-manifest.test.mjs
+++ b/deploy/scripts/tests/librechat-build-manifest.test.mjs
@@ -1,10 +1,12 @@
 /**
- * Tests for the build-manifest generate/verify pair (REQ-5 / REQ-6 seed),
- * without a Docker daemon: KLAI_LIBRECHAT_EXTRACT_DIR stands in for the image.
+ * Tests for the build-manifest generate/verify pair (REQ-5 / REQ-6 seed).
  *
- * The point of the manifest is to catch an image whose contents do not match
- * what CI says it built. So the test that matters is the negative one: change
- * a byte in an "image" file and verification must fail.
+ * The fake image is injected as a function argument. It used to be an env var
+ * (KLAI_LIBRECHAT_EXTRACT_DIR) read inside the extractor, which meant the same
+ * switch that made these tests convenient could disable the deploy-time
+ * provenance check in production. A guard whose whole job is to be trustworthy
+ * must not ship its own off switch — see the "no environment escape hatch"
+ * test at the bottom.
  *
  * Run: node --test deploy/scripts/tests/librechat-build-manifest.test.mjs
  */
@@ -17,11 +19,14 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { PATCHED_FILES } from '../lib/librechat-patched-files.mjs';
+import { generateManifest } from '../generate-librechat-build-manifest.mjs';
+import { verifyManifest } from '../verify-librechat-build-manifest.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const scriptsDir = path.resolve(here, '..');
-const librechatDir = path.resolve(here, '../../librechat');
+const repoRoot = path.resolve(here, '../../..');
+const patchesDir = path.join(repoRoot, 'deploy/librechat/patches-source');
 
+/** A directory of files standing in for the contents of a built image. */
 function fakeImage() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'klai-fake-image-'));
   for (const entry of PATCHED_FILES) {
@@ -30,87 +35,109 @@ function fakeImage() {
   return dir;
 }
 
-function generate(imageDir, outPath) {
-  execFileSync(
-    process.execPath,
-    [
-      path.join(scriptsDir, 'generate-librechat-build-manifest.mjs'),
-      '--image', 'fake:tag',
-      '--upstream-tag', 'v0.8.7',
-      '--agents-ref', 'v3.2.46',
-      '--patch-revision', '1',
-      '--patches-dir', path.join(librechatDir, 'patches-source'),
-      '--out', outPath,
-    ],
-    { env: { ...process.env, KLAI_LIBRECHAT_EXTRACT_DIR: imageDir }, stdio: 'pipe' }
-  );
+/** Stand-in extractor: reads the fake image dir instead of calling Docker. */
+function extractorFor(dir) {
+  return (_image, entries) => {
+    const files = new Map();
+    for (const entry of entries) {
+      const hostPath = path.join(dir, entry.key);
+      if (!fs.existsSync(hostPath)) {
+        throw new Error(`fake image is missing ${entry.key}`);
+      }
+      files.set(entry.key, hostPath);
+    }
+    return { dir, files };
+  };
 }
 
-function verify(imageDir) {
-  return execFileSync(
-    process.execPath,
-    [path.join(scriptsDir, 'verify-librechat-build-manifest.mjs'), '--image', 'fake:tag'],
-    { env: { ...process.env, KLAI_LIBRECHAT_EXTRACT_DIR: imageDir }, stdio: 'pipe', encoding: 'utf8' }
+function generateInto(dir) {
+  const manifest = generateManifest({
+    image: 'fake:tag',
+    upstreamTag: 'v0.8.7',
+    agentsRef: 'v3.2.46',
+    patchRevision: '1',
+    patchesDir,
+    extract: extractorFor(dir),
+  });
+  fs.writeFileSync(
+    path.join(dir, 'build-manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`
   );
+  return manifest;
 }
 
 test('manifest records every patched artifact with both hashes', () => {
-  const imageDir = fakeImage();
-  const out = path.join(imageDir, 'manifest.json');
-  generate(imageDir, out);
+  const dir = fakeImage();
+  const manifest = generateInto(dir);
 
-  const manifest = JSON.parse(fs.readFileSync(out, 'utf8'));
   assert.equal(manifest.artifacts.length, PATCHED_FILES.length);
   assert.equal(manifest.upstream_librechat_tag, 'v0.8.7');
   assert.equal(manifest.agents_ref, 'v3.2.46');
   for (const artifact of manifest.artifacts) {
-    // Both the diff that produced it AND the result it produced. patch-manifest.txt
-    // only ever had the upstream-original hash, which is why a stale patch was
-    // invisible to it.
+    // Both the diff that produced it AND the result it produced.
+    // patch-manifest.txt only ever had the upstream-original hash, which is
+    // why a stale patch was invisible to it.
     assert.match(artifact.patch_sha256, /^[0-9a-f]{64}$/, artifact.key);
     assert.match(artifact.artifact_sha256, /^[0-9a-f]{64}$/, artifact.key);
   }
 });
 
 test('verification passes when the image matches its manifest', () => {
-  const imageDir = fakeImage();
-  generate(imageDir, path.join(imageDir, 'build-manifest.json'));
-  const output = verify(imageDir);
-  assert.match(output, /^OK: /m);
+  const dir = fakeImage();
+  generateInto(dir);
+  const summary = verifyManifest({ image: 'fake:tag', extract: extractorFor(dir) });
+  assert.match(summary, /^OK: /);
 });
 
 test('verification FAILS when an artifact changed after the manifest was written', () => {
-  const imageDir = fakeImage();
-  generate(imageDir, path.join(imageDir, 'build-manifest.json'));
+  const dir = fakeImage();
+  generateInto(dir);
 
   // Exactly the drift this check exists for: the image no longer contains what
   // CI recorded. One byte is enough.
-  fs.appendFileSync(path.join(imageDir, 'stream.cjs'), '// tampered\n');
+  fs.appendFileSync(path.join(dir, 'stream.cjs'), '// tampered\n');
 
   assert.throws(
-    () => verify(imageDir),
-    (error) => {
-      const output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
-      assert.match(output, /stream\.cjs/);
-      assert.match(output, /manifest says/);
-      return true;
-    }
+    () => verifyManifest({ image: 'fake:tag', extract: extractorFor(dir) }),
+    /stream\.cjs: manifest says/
   );
 });
 
 test('verification FAILS on the placeholder manifest from build pass 1', () => {
-  const imageDir = fakeImage();
+  const dir = fakeImage();
   fs.writeFileSync(
-    path.join(imageDir, 'build-manifest.json'),
+    path.join(dir, 'build-manifest.json'),
     JSON.stringify({ placeholder: true })
   );
 
   assert.throws(
-    () => verify(imageDir),
-    (error) => {
-      const output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
-      assert.match(output, /placeholder manifest/);
-      return true;
-    }
+    () => verifyManifest({ image: 'fake:tag', extract: extractorFor(dir) }),
+    /placeholder manifest/
+  );
+});
+
+test('the CLI has no environment escape hatch that skips the image', () => {
+  // Regression guard. An earlier revision honoured KLAI_LIBRECHAT_EXTRACT_DIR
+  // inside extractFromImage, so setting it in a deploy environment made the
+  // provenance check "pass" while inspecting local files instead of the image
+  // about to roll out -- fail-open in the one place that must fail closed.
+  const dir = fakeImage();
+  generateInto(dir);
+
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        [
+          path.join(here, '..', 'verify-librechat-build-manifest.mjs'),
+          '--image',
+          'this-image-does-not-exist:nope',
+        ],
+        {
+          env: { ...process.env, KLAI_LIBRECHAT_EXTRACT_DIR: dir },
+          stdio: 'pipe',
+        }
+      ),
+    'verification succeeded against a non-existent image — an env var redirected it away from the image'
   );
 });

--- a/deploy/scripts/verify-librechat-build-manifest.mjs
+++ b/deploy/scripts/verify-librechat-build-manifest.mjs
@@ -10,9 +10,15 @@
  * Phase 2 runs this against the freshly built tag before it is pushed. Phase 3
  * extends the same check to deploy time, against the tag about to roll out.
  *
+ * The extractor is a parameter, not an env var. Tests pass a fake one; there is
+ * no switch that can be left on in a deploy environment and turn this check
+ * into a no-op.
+ *
  * usage: verify-librechat-build-manifest.mjs --image <ref>
  */
 import fs from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 import {
   MANIFEST_CONTAINER_PATH,
@@ -23,60 +29,82 @@ import {
   sha256File,
 } from './lib/librechat-image-extract.mjs';
 
-const idx = process.argv.indexOf('--image');
-if (idx === -1 || idx === process.argv.length - 1) {
-  console.error('FATAL: missing required --image');
-  process.exit(2);
-}
-const image = process.argv[idx + 1];
+/**
+ * @param {object} options
+ * @param {string} options.image
+ * @param {typeof extractFromImage} [options.extract]
+ * @returns {string} success summary
+ * @throws {Error} with every mismatch listed
+ */
+export function verifyManifest({ image, extract = extractFromImage }) {
+  const entries = [
+    ...PATCHED_FILES,
+    { key: 'build-manifest.json', containerPath: MANIFEST_CONTAINER_PATH },
+  ];
 
-const entries = [
-  ...PATCHED_FILES,
-  { key: 'build-manifest.json', containerPath: MANIFEST_CONTAINER_PATH },
-];
+  const { files } = extract(image, entries);
 
-const { files } = extractFromImage(image, entries);
-
-const manifestPath = files.get('build-manifest.json');
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-
-if (manifest.placeholder) {
-  console.error(
-    'FATAL: the image carries the placeholder manifest — pass 2 of the build did not run.'
+  const manifest = JSON.parse(
+    fs.readFileSync(files.get('build-manifest.json'), 'utf8')
   );
-  process.exit(1);
-}
 
-const byKey = new Map(manifest.artifacts.map((a) => [a.key, a]));
-const failures = [];
-
-for (const entry of PATCHED_FILES) {
-  const recorded = byKey.get(entry.key);
-  if (!recorded) {
-    failures.push(`${entry.key}: patched by the Dockerfile but absent from the manifest`);
-    continue;
-  }
-  const actual = sha256File(files.get(entry.key));
-  if (actual !== recorded.artifact_sha256) {
-    failures.push(
-      `${entry.key}: manifest says ${recorded.artifact_sha256}, image has ${actual}`
+  if (manifest.placeholder) {
+    throw new Error(
+      'the image carries the placeholder manifest — pass 2 of the build did not run.'
     );
   }
+
+  const byKey = new Map(manifest.artifacts.map((a) => [a.key, a]));
+  const failures = [];
+
+  for (const entry of PATCHED_FILES) {
+    const recorded = byKey.get(entry.key);
+    if (!recorded) {
+      failures.push(
+        `${entry.key}: patched by the Dockerfile but absent from the manifest`
+      );
+      continue;
+    }
+    const actual = sha256File(files.get(entry.key));
+    if (actual !== recorded.artifact_sha256) {
+      failures.push(
+        `${entry.key}: manifest says ${recorded.artifact_sha256}, image has ${actual}`
+      );
+    }
+  }
+
+  for (const recorded of manifest.artifacts) {
+    if (!PATCHED_FILES.some((e) => e.key === recorded.key)) {
+      failures.push(`${recorded.key}: in the manifest but not in PATCHED_FILES`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `manifest does not describe ${image}:\n` +
+        failures.map((f) => `  - ${f}`).join('\n')
+    );
+  }
+
+  return (
+    `OK: ${image} matches its baked manifest (${manifest.artifacts.length} artifacts, ` +
+    `upstream ${manifest.upstream_librechat_tag}, agents ${manifest.agents_ref}).`
+  );
 }
 
-for (const recorded of manifest.artifacts) {
-  if (!PATCHED_FILES.some((e) => e.key === recorded.key)) {
-    failures.push(`${recorded.key}: in the manifest but not in PATCHED_FILES`);
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  const idx = process.argv.indexOf('--image');
+  if (idx === -1 || idx === process.argv.length - 1) {
+    console.error('FATAL: missing required --image');
+    process.exit(2);
+  }
+  try {
+    console.log(verifyManifest({ image: process.argv[idx + 1] }));
+  } catch (error) {
+    console.error(`FATAL: ${error.message}`);
+    process.exit(1);
   }
 }
-
-if (failures.length > 0) {
-  console.error(`FATAL: manifest does not describe ${image}:`);
-  for (const failure of failures) console.error(`  - ${failure}`);
-  process.exit(1);
-}
-
-console.log(
-  `OK: ${image} matches its baked manifest (${manifest.artifacts.length} artifacts, ` +
-    `upstream ${manifest.upstream_librechat_tag}, agents ${manifest.agents_ref}).`
-);


### PR DESCRIPTION
Zelf gevonden in het werk van #908, vóór fase 3.

Ik voegde `KLAI_LIBRECHAT_EXTRACT_DIR` toe zodat de manifest-logica zonder Docker-daemon te testen was. Die werd gelezen ín `extractFromImage` — en dus stuurt diezelfde schakelaar ook `verify-librechat-build-manifest.mjs`, de check die in fase 3 een **deploy-time gate** wordt. Staat die var in een deploy-omgeving, dan leest de verificatie lokale bestanden en meldt OK zonder ooit naar de uitrollende image te kijken.

**Aangetoond vóór de fix:** met de var gezet gaf verificatie van `this-image-does-not-exist:nope` exit 0.

Dat is de fail-open-klasse waar deze repo al pitfalls over heeft, ingebouwd in juist het onderdeel dat betrouwbaar hoort te zijn. Een guard mag z'n eigen uitknop niet meeleveren.

## Fix

De extractor is nu een functieparameter met de Docker-implementatie als default; tests injecteren een nep-versie. Productiecode heeft geen bypass meer die per ongeluk aan kan blijven staan. Beide scripts exporteren hun logica en draaien de CLI alleen bij directe aanroep, zodat de tests het échte codepad raken in plaats van een subprocess met een geprepareerde omgeving.

Behouden als regressie-guard: een test die de CLI mét de oude env-var tegen een niet-bestaande image draait en eist dat hij faalt.

9 tests groen (was 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)