### PR TITLE
fix: gedeelde LLM rate-limiter (429-fix) + transcript-timestamp UI

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -50,6 +50,13 @@ class Settings(BaseSettings):
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""
+    # SPEC-INGEST-LLM-THROTTLE-001 — shared client-side rate limit for every
+    # klai-fast LiteLLM call (enrichment, Graphiti, taxonomy, selector-AI,
+    # labelers, RAGAS judge). See knowledge_ingest/llm_throttle.py. Default
+    # 0.6 rps = 36 rpm, under the 45 rpm klai-fast alias budget in
+    # deploy/litellm/config.yaml, leaving headroom for retries.
+    litellm_klai_fast_rps: float = 0.6
+    litellm_klai_fast_burst: float = 10.0
     enrichment_enabled: bool = True  # global kill switch
     # Seconds to wait after the last Gitea save before ingesting into the knowledge layer.
     # Prevents LLM enrichment calls on every auto-save during active editing.
@@ -81,12 +88,6 @@ class Settings(BaseSettings):
     graphiti_llm_model: str = "klai-fast"
     graphiti_max_concurrent: int = 1  # concurrent episodes; increase with paid LLM plan
     graphiti_episode_delay: float = 10.0
-    # Token bucket rate limit for LLM calls inside add_episode().
-    # Graphiti makes ~5 sequential HTTP calls per episode; this ensures they never
-    # exceed the upstream API limit regardless of LLM response time.
-    # Mistral Small is 100 RPM / 100k TPM for our production key. Keep Graphiti
-    # below that because enrichment and user-facing calls share klai-fast.
-    graphiti_llm_rps: float = 0.5
     # Portal integration for taxonomy (SPEC-KB-021)
     portal_url: str = "http://portal-api:8000"
     # Bearer token for outbound calls to portal-api internal endpoints

--- a/klai-knowledge-ingest/knowledge_ingest/content_labeler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/content_labeler.py
@@ -8,10 +8,12 @@ This is a deliberate separation of concerns (SPEC-KB-023):
 
 The blind label is the raw material for clustering in SPEC-KB-024.
 
-Rate limiting: shares the module-level _TokenBucketLimiter from taxonomy_classifier
-(same 1 req/s default) so label generation and taxonomy classification never race.
-Since labeling runs first and classification runs second, the two calls are
-naturally sequential with the shared limiter enforcing the upstream rate limit.
+Rate limiting: acquires from the process-wide shared klai-fast token bucket
+(knowledge_ingest.llm_throttle.shared_klai_fast_limiter), the same bucket
+taxonomy_classifier and every other klai-fast caller draws from, so label
+generation and taxonomy classification never combine to exceed the alias
+budget. Since labeling runs first and classification runs second, the two
+calls are naturally sequential.
 """
 
 from __future__ import annotations
@@ -23,8 +25,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
-from knowledge_ingest.graph import _RateLimitedTransport
-from knowledge_ingest.taxonomy_classifier import _get_llm_limiter
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -85,14 +86,10 @@ async def generate_content_label(
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for blind content label generation.
 
-    Uses _RateLimitedTransport with the shared taxonomy limiter (graphiti_llm_rps).
+    Acquires from the shared klai-fast token bucket before calling out.
     """
-    transport = _RateLimitedTransport(
-        wrapped=httpx.AsyncHTTPTransport(),
-        limiter=_get_llm_limiter(),
-    )
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(
-        transport=transport,
         timeout=settings.content_label_timeout,
     ) as client:
         resp = await client.post(

--- a/klai-knowledge-ingest/knowledge_ingest/contextual.py
+++ b/klai-knowledge-ingest/knowledge_ingest/contextual.py
@@ -40,6 +40,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -208,6 +209,7 @@ async def generate_document_summary(
         client_kwargs["transport"] = _transport
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(**client_kwargs) as client:
             resp = await asyncio.wait_for(
                 client.post(url, json=payload, headers=headers),

--- a/klai-knowledge-ingest/knowledge_ingest/description_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/description_generator.py
@@ -3,6 +3,7 @@ Generate short descriptions for taxonomy nodes using klai-fast.
 
 Max 200 chars, 5-second timeout, empty string fallback on error.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -12,6 +13,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -65,6 +67,7 @@ async def generate_node_description(
 
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for description generation."""
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=5.0) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ValidationError
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.context_strategies import STRATEGIES
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -169,6 +170,7 @@ async def _call_llm(prompt: str, path: str) -> dict:
         headers["Authorization"] = f"Bearer {settings.litellm_api_key}"
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=settings.enrichment_timeout) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/v1/chat/completions",
@@ -422,9 +424,7 @@ async def enrich_chunks(
             )
         enriched_text = f"{result.context_prefix}\n\n{chunk_text}"
         heading_path = (
-            heading_paths[chunk_index]
-            if heading_paths and chunk_index < len(heading_paths)
-            else ""
+            heading_paths[chunk_index] if heading_paths and chunk_index < len(heading_paths) else ""
         )
         return EnrichedChunk(
             original_text=chunk_text,

--- a/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
@@ -40,6 +40,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -214,6 +215,7 @@ async def generate_answer(
     url = f"{settings.litellm_url}/v1/chat/completions"
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with _build_http_client(float(settings.rag_eval_judge_timeout), _transport) as client:
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -34,6 +34,7 @@ import structlog
 
 import knowledge_ingest.qdrant_store as qdrant_store
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import TokenBucketLimiter, shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -42,31 +43,8 @@ logger = structlog.get_logger()
 _episode_semaphore: asyncio.Semaphore | None = None
 
 
-class _TokenBucketLimiter:
-    """Token bucket: enforces at most `rate` HTTP calls per second, no burst.
-
-    Applied to the AsyncOpenAI httpx transport so every LLM call Graphiti makes
-    internally (entity extraction, deduplication, etc.) is throttled — regardless
-    of how fast the upstream API responds.
-    """
-
-    def __init__(self, rate: float) -> None:
-        self._min_interval = 1.0 / rate
-        self._lock = asyncio.Lock()
-        self._next_allowed: float = 0.0
-
-    async def acquire(self) -> None:
-        async with self._lock:
-            loop = asyncio.get_event_loop()
-            now = loop.time()
-            wait = self._next_allowed - now
-            if wait > 0:
-                await asyncio.sleep(wait)
-            self._next_allowed = loop.time() + self._min_interval
-
-
 class _RateLimitedTransport(httpx.AsyncBaseTransport):
-    def __init__(self, wrapped: httpx.AsyncBaseTransport, limiter: _TokenBucketLimiter) -> None:
+    def __init__(self, wrapped: httpx.AsyncBaseTransport, limiter: TokenBucketLimiter) -> None:
         self._wrapped = wrapped
         self._limiter = limiter
 
@@ -185,7 +163,7 @@ def _graphiti_retry_delay(exc: Exception, attempt: int) -> tuple[str, float]:
         "503" in exc_str
         or "service unavailable" in exc_str
         or "internal_server_error" in exc_str
-        or "code\":\"3800" in exc_str
+        or 'code":"3800' in exc_str
         or "code': '3800" in exc_str
     ):
         return "provider_unavailable", 30.0 * (2**attempt)
@@ -217,9 +195,11 @@ def _get_graphiti() -> Graphiti:
         # max_retries=0: 429s surface immediately to our ingest_episode() retry loop
         # instead of being silently swallowed by the openai client for minutes.
         # Token bucket transport: throttles every HTTP call Graphiti makes internally
-        # (entity extraction, deduplication, embedding, etc.) to graphiti_llm_rps req/s.
-        # This prevents bursts that would exceed the upstream Mistral 1 req/s org limit.
-        _llm_limiter = _TokenBucketLimiter(rate=settings.graphiti_llm_rps)
+        # (entity extraction, deduplication, embedding, etc.) via the SHARED
+        # klai-fast budget (knowledge_ingest.llm_throttle), not a Graphiti-only
+        # rate. This prevents Graphiti's bursts from exceeding the upstream
+        # klai-fast alias budget in combination with every other klai-fast caller.
+        _llm_limiter = shared_klai_fast_limiter()
         openai_client = AsyncOpenAI(
             api_key=api_key,
             base_url=litellm_base_url,

--- a/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
+++ b/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
@@ -1,0 +1,96 @@
+"""Shared client-side rate limiter for every LiteLLM ``klai-fast`` call.
+
+Why this exists
+---------------
+
+The ``klai-fast`` alias in ``deploy/litellm/config.yaml`` has a 45 rpm / 45k
+tpm budget (half of mistral-small's upstream 100 rpm, shared with
+``klai-primary``). Before 2026-08-14, knowledge-ingest offered LiteLLM far
+more than that during bulk crawls: the LLM worker-lane ran 4 concurrent
+enrichment jobs firing one unthrottled chat call per chunk, while Graphiti
+paced only its OWN calls (0.5 rps ≈ 30 rpm — already most of the alias
+budget on its own). The overflow bounced as 429s: 641 ``enrichment_llm_error``
+events in two weeks, 1165 permanently-failed enrich-bulk jobs, and the
+intermedia.com source that stayed broken for 8 days.
+
+A Procrastinate queue orders the *jobs* but does not pace the *HTTP calls*
+the job bodies make. This module is that missing pacing layer: one
+process-wide token bucket that every ``klai-fast`` chat call acquires from,
+tuned under the alias budget so sustained bulk work simply runs slower
+instead of erroring.
+
+Burst capacity keeps interactive work snappy: an idle bucket lets the first
+``litellm_klai_fast_burst`` calls through immediately (a single-document
+re-sync mostly fits in the burst), and only sustained load degrades to the
+refill rate.
+
+Usage::
+
+    from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
+
+    await shared_klai_fast_limiter().acquire()
+    resp = await client.post(f"{settings.litellm_url}/v1/chat/completions", ...)
+
+``tests/test_llm_throttle.py`` contains a drift-guard that fails when a
+module POSTs to ``chat/completions`` without referencing this limiter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from knowledge_ingest.config import settings
+
+
+class TokenBucketLimiter:
+    """Async token bucket: ``rate`` sustained calls/sec with ``capacity`` burst.
+
+    ``acquire()`` returns immediately while burst tokens remain and sleeps
+    just long enough for the next token otherwise. The sleep happens while
+    holding the internal lock, so concurrent acquirers are served strictly
+    in arrival order — same serialisation behaviour as the previous
+    graph.py ``_TokenBucketLimiter``, now with a burst allowance.
+    """
+
+    def __init__(self, rate: float, capacity: float | None = None) -> None:
+        if rate <= 0:
+            raise ValueError(f"rate must be > 0, got {rate}")
+        self._rate = rate
+        self._capacity = max(1.0, capacity if capacity is not None else rate)
+        self._tokens = self._capacity
+        self._last: float | None = None
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            loop = asyncio.get_event_loop()
+            now = loop.time()
+            if self._last is not None:
+                self._tokens = min(self._capacity, self._tokens + (now - self._last) * self._rate)
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return
+            wait = (1.0 - self._tokens) / self._rate
+            self._tokens = 0.0
+            await asyncio.sleep(wait)
+            self._last = loop.time()
+
+
+_shared_limiter: TokenBucketLimiter | None = None
+
+
+def shared_klai_fast_limiter() -> TokenBucketLimiter:
+    """Process-wide limiter for ALL klai-fast LiteLLM calls (lazy singleton).
+
+    Shared across enrichment, Graphiti, taxonomy, selector-AI, labelers and
+    the RAGAS judge so their combined rate stays under the 45 rpm alias
+    budget. Default 0.6 rps = 36 rpm, leaving headroom for retries.
+    """
+    global _shared_limiter
+    if _shared_limiter is None:
+        _shared_limiter = TokenBucketLimiter(
+            rate=settings.litellm_klai_fast_rps,
+            capacity=settings.litellm_klai_fast_burst,
+        )
+    return _shared_limiter

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -71,6 +71,7 @@ import structlog
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.description_generator import generate_node_description
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 from knowledge_ingest.portal_client import TaxonomyProposal, submit_taxonomy_proposal
 from knowledge_ingest.taxonomy_classifier import TaxonomyNode
 
@@ -286,6 +287,7 @@ async def _suggest_cluster_name(
     doc_lines = "\n".join(f"- {doc.title}: {doc.content_preview[:200]}" for doc in cluster_docs)
     user_message = f"{len(cluster_docs)} documents in this cluster:\n{doc_lines}"
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",
@@ -385,6 +387,7 @@ async def _suggest_cluster_names_batched(
     user_message = "\n\n".join(cluster_lines)
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/chat/completions",
@@ -623,6 +626,7 @@ async def _consolidate_to_parents(
 
     max_tokens = 600 + 80 * n_clusters
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",
@@ -1184,6 +1188,7 @@ async def _suggest_category_name(documents: list[DocumentSummary]) -> str | None
     )
     user_message = f"Documents that don't fit existing categories:\n{doc_summaries}"
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
@@ -59,6 +59,7 @@ from knowledge_ingest.clustering import (
 )
 from knowledge_ingest.config import settings
 from knowledge_ingest.description_generator import generate_node_description
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 from knowledge_ingest.portal_client import (
     fetch_kb_metadata,
     fetch_taxonomy_nodes,
@@ -413,6 +414,7 @@ async def _group_and_assign(
         max_tokens,
     )
     t0 = time.monotonic()
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/selector_ai.py
+++ b/klai-knowledge-ingest/knowledge_ingest/selector_ai.py
@@ -17,6 +17,7 @@ import structlog
 from klai_llm_safety import SafetyPhase, SafetyRequest, SafetySurface, check_text
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -47,6 +48,7 @@ DOM Summary:
 async def _call_llm(prompt: str, log_event: str) -> str | None:
     """Shared LLM call via LiteLLM proxy. Returns stripped response or None."""
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/v1/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py
+++ b/klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py
@@ -8,9 +8,12 @@ Returns (matched_nodes, suggested_tags):
 Threshold: confidence >= 0.5, max 5 nodes, max 5 tags.
 30-second timeout; falls back to ([], []) on error without failing the ingest.
 
-Rate limiting: uses the same _TokenBucketLimiter/_RateLimitedTransport from graph.py,
-throttled to settings.graphiti_llm_rps (default 1 req/s) to avoid 429s on LiteLLM.
+Rate limiting: acquires from the process-wide shared klai-fast token bucket
+(knowledge_ingest.llm_throttle.shared_klai_fast_limiter) so this shares the
+same 45 rpm alias budget as every other klai-fast caller instead of pacing
+against its own separate rate.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -20,23 +23,14 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
-from knowledge_ingest.graph import _RateLimitedTransport, _TokenBucketLimiter
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
-
-# Module-level rate limiter shared across all classify_document calls
-_llm_limiter: _TokenBucketLimiter | None = None
-
-
-def _get_llm_limiter() -> _TokenBucketLimiter:
-    global _llm_limiter
-    if _llm_limiter is None:
-        _llm_limiter = _TokenBucketLimiter(rate=settings.graphiti_llm_rps)
-    return _llm_limiter
 
 
 class TaxonomyNode:
     """Lightweight DTO for taxonomy nodes from the portal."""
+
     __slots__ = ("description", "id", "name")
 
     def __init__(self, id: int, name: str, description: str | None = None) -> None:
@@ -53,7 +47,7 @@ _SYSTEM_PROMPT = (
     "Only include nodes with confidence >= 0.5. Maximum 5 nodes and 5 tags. "
     "Return empty nodes list if no category matches with confidence >= 0.5. "
     "Tags should be lowercase, concise keywords describing the document content."
-    '\n\nReply with ONLY a JSON object, no markdown, no explanation: '
+    "\n\nReply with ONLY a JSON object, no markdown, no explanation: "
     '{"nodes": [{"node_id": <int>, "confidence": <float 0-1>}], '
     '"tags": ["<string>"]}'
 )
@@ -133,14 +127,10 @@ async def classify_document(
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for taxonomy classification.
 
-    Uses _RateLimitedTransport to throttle calls to graphiti_llm_rps (default 1/s).
+    Acquires from the shared klai-fast token bucket before calling out.
     """
-    transport = _RateLimitedTransport(
-        wrapped=httpx.AsyncHTTPTransport(),
-        limiter=_get_llm_limiter(),
-    )
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(
-        transport=transport,
         timeout=settings.taxonomy_classification_timeout,
     ) as client:
         resp = await client.post(

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -269,6 +269,26 @@ def _mock_db_helpers(request):
                 pass
 
 
+@pytest.fixture(autouse=True)
+def _reset_shared_klai_fast_limiter():
+    """Reset the process-wide klai-fast token bucket before each test.
+
+    ``knowledge_ingest.llm_throttle.shared_klai_fast_limiter()`` is a lazy
+    singleton by design (one bucket per production process). Left
+    unreset across the test suite, its default burst capacity (10)
+    would be exhausted after the first ~10 tests that exercise a real
+    ``_call_litellm``/``_call_llm`` path, and every test after that
+    would pay the 1/0.6s pacing delay -- silently multiplying suite
+    runtime without any test asserting on it. Resetting to ``None``
+    gives each test a fresh, full-burst bucket.
+    """
+    import knowledge_ingest.llm_throttle as _llm_throttle_mod
+
+    _llm_throttle_mod._shared_limiter = None
+    yield
+    _llm_throttle_mod._shared_limiter = None
+
+
 @pytest.fixture
 def client(mock_pool):
     """Test client with auth middleware.

--- a/klai-knowledge-ingest/tests/test_llm_throttle.py
+++ b/klai-knowledge-ingest/tests/test_llm_throttle.py
@@ -1,0 +1,84 @@
+"""Tests for knowledge_ingest.llm_throttle -- shared klai-fast token bucket.
+
+See knowledge_ingest/llm_throttle.py module docstring for the incident this
+module fixes (641 enrichment_llm_error 429s in two weeks, pre-2026-08-14).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from knowledge_ingest.llm_throttle import TokenBucketLimiter, shared_klai_fast_limiter
+
+
+class TestTokenBucketLimiterBurst:
+    @pytest.mark.asyncio
+    async def test_burst_capacity_returns_near_instantly(self):
+        """Acquires within the burst capacity must not sleep meaningfully."""
+        limiter = TokenBucketLimiter(rate=100, capacity=3)
+
+        t0 = time.monotonic()
+        for _ in range(3):
+            await limiter.acquire()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.1
+
+
+class TestTokenBucketLimiterPacing:
+    @pytest.mark.asyncio
+    async def test_exhausted_burst_paces_to_rate(self):
+        """Once the single-token burst is spent, subsequent acquires pace at ``rate``."""
+        limiter = TokenBucketLimiter(rate=50, capacity=1)
+
+        t0 = time.monotonic()
+        for _ in range(5):
+            await limiter.acquire()
+        elapsed = time.monotonic() - t0
+
+        # First acquire is free (burst=1); the remaining 4 pace at 1/50s each,
+        # so the floor is 4/50 = 0.08s. Assert a slightly looser floor to
+        # absorb scheduler jitter while still catching a broken/no-op limiter.
+        assert elapsed >= 0.06
+        # Keep the test fast — must stay well under a second.
+        assert elapsed < 1.0
+
+
+class TestSharedKlaiFastLimiterSingleton:
+    def test_returns_same_instance_across_calls(self):
+        first = shared_klai_fast_limiter()
+        second = shared_klai_fast_limiter()
+
+        assert first is second
+
+
+class TestChatCompletionsThrottleDriftGuard:
+    """Fails loudly when a new klai-fast caller forgets to throttle.
+
+    Every module under ``knowledge_ingest/`` (excluding tests) that POSTs to
+    a ``chat/completions`` endpoint MUST also reference
+    ``shared_klai_fast_limiter`` -- otherwise it bypasses the shared budget
+    and can trigger 429s on LiteLLM again, exactly like the incident this
+    module was built to fix.
+    """
+
+    def test_every_chat_completions_caller_uses_shared_limiter(self):
+        package_root = Path(__file__).resolve().parent.parent / "knowledge_ingest"
+        offenders: list[str] = []
+
+        for path in sorted(package_root.rglob("*.py")):
+            relative = path.relative_to(package_root)
+            if "tests" in relative.parts:
+                continue
+            source = path.read_text(encoding="utf-8")
+            if "chat/completions" in source and "shared_klai_fast_limiter" not in source:
+                offenders.append(str(relative))
+
+        assert not offenders, (
+            "These files POST to chat/completions without acquiring from "
+            "shared_klai_fast_limiter() -- they bypass the shared klai-fast "
+            f"rate budget: {offenders}"
+        )

--- a/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
@@ -12,6 +12,7 @@ import * as m from '@/paraglide/messages'
 import { ProductGuard } from '@/components/layout/ProductGuard'
 import { apiFetch } from '@/lib/apiFetch'
 import { activeMeetingInfoKind } from './-status-copy'
+import { formatSegmentTimestamp, relativeSegmentSeconds } from './-transcript-timestamp'
 
 type TabId = 'summary' | 'transcript'
 
@@ -42,6 +43,7 @@ interface TranscriptSegment {
   end: number
   text: string
   speaker: string
+  absolute_start_time?: string | null
 }
 
 interface SummaryStructured {
@@ -74,15 +76,6 @@ interface MeetingDetail {
   ended_at: string | null
   created_at: string
   summary_json: SummaryJson | null
-}
-
-function formatTimestamp(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const mins = Math.floor((seconds % 3600) / 60)
-  const secs = Math.floor(seconds % 60)
-  if (h > 0)
-    return `${h}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
-  return `${mins}:${secs.toString().padStart(2, '0')}`
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -448,19 +441,32 @@ function MeetingDetailPage() {
             <section aria-label={m.app_meetings_transcript_title()}>
               {meeting.transcript_segments && meeting.transcript_segments.length > 0 ? (
                 <div className="space-y-2 text-sm">
-                  {meeting.transcript_segments.map((seg, i) => (
-                    <div key={i} className="flex gap-3">
-                      <span className="shrink-0 text-xs text-gray-400 tabular-nums mt-0.5 w-14">
-                        [{formatTimestamp(seg.start)}]
-                      </span>
-                      <div>
-                        <span className="font-medium text-gray-900">
-                          {seg.speaker}:{' '}
-                        </span>
-                        <span className="text-gray-900">{seg.text}</span>
-                      </div>
-                    </div>
-                  ))}
+                  {(() => {
+                    const firstSegmentStart = meeting.transcript_segments[0].start
+                    return meeting.transcript_segments.map((seg, i) => {
+                      const relSeconds = relativeSegmentSeconds(
+                        seg,
+                        meeting.started_at,
+                        firstSegmentStart,
+                      )
+                      const timestamp = formatSegmentTimestamp(relSeconds)
+                      return (
+                        <div key={i} className="flex gap-3">
+                          {timestamp && (
+                            <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-gray-400 tabular-nums">
+                              [{timestamp}]
+                            </span>
+                          )}
+                          <div className="min-w-0">
+                            <span className="font-medium text-gray-900">
+                              {seg.speaker}:{' '}
+                            </span>
+                            <span className="text-gray-900">{seg.text}</span>
+                          </div>
+                        </div>
+                      )
+                    })
+                  })()}
                 </div>
               ) : (
                 <p className="text-sm text-gray-400 whitespace-pre-wrap">

--- a/klai-portal/frontend/src/routes/app/meetings/-transcript-timestamp.ts
+++ b/klai-portal/frontend/src/routes/app/meetings/-transcript-timestamp.ts
@@ -1,0 +1,57 @@
+/** Segment shape needed to compute a display-relative timestamp. */
+export interface TranscriptSegmentLike {
+  start: number
+  absolute_start_time?: string | null
+}
+
+const MAX_DISPLAYABLE_SECONDS = 24 * 60 * 60
+
+/**
+ * Elapsed seconds for a transcript segment, relative to the meeting.
+ *
+ * Vexa's raw `start` field is relative to the underlying bot recording's
+ * own internal clock, not to this specific meeting -- when a bot session
+ * runs far longer than expected (see the "Fix Vexa lifecycle" incident),
+ * `start` can be a huge, meaningless offset.
+ *
+ * When both the segment's `absolute_start_time` (a real UTC timestamp)
+ * and the meeting's `started_at` are available, elapsed time is derived
+ * from those wall-clock values instead, sidestepping any drift in
+ * Vexa's own clock. Otherwise this falls back to the segment's own
+ * `start` minus the first segment's `start` -- still the same unit, so
+ * always self-consistent even without wall-clock data.
+ */
+export function relativeSegmentSeconds(
+  segment: TranscriptSegmentLike,
+  meetingStartedAt: string | null,
+  firstSegmentStart: number,
+): number {
+  if (meetingStartedAt && segment.absolute_start_time) {
+    const meetingStart = Date.parse(meetingStartedAt)
+    const segStart = Date.parse(segment.absolute_start_time)
+    if (Number.isFinite(meetingStart) && Number.isFinite(segStart)) {
+      return (segStart - meetingStart) / 1000
+    }
+  }
+  return segment.start - firstSegmentStart
+}
+
+/**
+ * Format elapsed seconds as `m:ss` (or `h:mm:ss` once past the hour).
+ *
+ * Returns `null` for negative or absurdly large (>= 24h) input rather
+ * than rendering a nonsensical timestamp -- a bad upstream `start`
+ * value should hide the timestamp, not display garbage.
+ */
+export function formatSegmentTimestamp(seconds: number): string | null {
+  if (!Number.isFinite(seconds) || seconds < 0 || seconds >= MAX_DISPLAYABLE_SECONDS) {
+    return null
+  }
+  const h = Math.floor(seconds / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const secs = Math.floor(seconds % 60)
+  if (h > 0) {
+    return `${h}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}

--- a/klai-portal/frontend/src/routes/app/meetings/__tests__/-transcript-timestamp.test.ts
+++ b/klai-portal/frontend/src/routes/app/meetings/__tests__/-transcript-timestamp.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatSegmentTimestamp, relativeSegmentSeconds } from '../-transcript-timestamp'
+
+describe('formatSegmentTimestamp', () => {
+  it('formats zero seconds', () => {
+    expect(formatSegmentTimestamp(0)).toBe('0:00')
+  })
+
+  it('formats sub-hour durations as m:ss', () => {
+    expect(formatSegmentTimestamp(65)).toBe('1:05')
+  })
+
+  it('formats durations past the hour as h:mm:ss', () => {
+    expect(formatSegmentTimestamp(3661)).toBe('1:01:01')
+  })
+
+  it('hides absurdly large durations (>= 24h) instead of showing garbage', () => {
+    // The 2026-08-14 production bug: a stale Vexa bot clock produced a
+    // `start` value of 496306.28s (~137.9h) for a segment mid-meeting.
+    expect(formatSegmentTimestamp(496306.28)).toBeNull()
+    expect(formatSegmentTimestamp(24 * 60 * 60)).toBeNull()
+  })
+
+  it('hides negative durations instead of showing garbage', () => {
+    expect(formatSegmentTimestamp(-5)).toBeNull()
+  })
+
+  it('hides non-finite input', () => {
+    expect(formatSegmentTimestamp(Number.NaN)).toBeNull()
+    expect(formatSegmentTimestamp(Number.POSITIVE_INFINITY)).toBeNull()
+  })
+})
+
+describe('relativeSegmentSeconds', () => {
+  it('derives elapsed time from absolute_start_time vs meeting.started_at when both are present', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 999999, absolute_start_time: '2026-08-14T10:05:30.000Z' },
+      '2026-08-14T10:00:00.000Z',
+      0,
+    )
+    expect(seconds).toBe(330)
+  })
+
+  it('falls back to start-minus-first-segment-start when absolute_start_time is missing', () => {
+    const seconds = relativeSegmentSeconds({ start: 620 }, '2026-08-14T10:00:00.000Z', 500)
+    expect(seconds).toBe(120)
+  })
+
+  it('falls back to start-minus-first-segment-start when meeting.started_at is missing', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 620, absolute_start_time: '2026-08-14T10:05:30.000Z' },
+      null,
+      500,
+    )
+    expect(seconds).toBe(120)
+  })
+
+  it('falls back when absolute_start_time is unparseable', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 620, absolute_start_time: 'not-a-date' },
+      '2026-08-14T10:00:00.000Z',
+      500,
+    )
+    expect(seconds).toBe(120)
+  })
+
+  it('reproduces the production bug scenario: stale Vexa clock produces a huge start value', () => {
+    // Without a meeting-relative anchor, a bot reused across sessions can
+    // report `start` as seconds-since-bot-boot rather than since this
+    // meeting -- e.g. 496306.28s (~137.9h) for a segment actually a few
+    // minutes into the meeting. Falling back to first-segment-start still
+    // yields a sane elapsed time because both values share the same
+    // (buggy) clock.
+    const seconds = relativeSegmentSeconds({ start: 496306.28 }, null, 496300.0)
+    expect(seconds).toBeCloseTo(6.28, 5)
+    expect(formatSegmentTimestamp(seconds)).toBe('0:06')
+  })
+})


### PR DESCRIPTION
## Wat

Twee fixes, geïmplementeerd door subagents en regel-voor-regel gereviewd:

### 1. Structurele 429-fix (knowledge-ingest)
De `klai-fast`-alias heeft 45 rpm budget; knowledge-ingest bood tijdens crawls structureel meer aan (enrichment ongethrotteld, graphiti eigen 30 rpm, taxonomy/labeler eigen limiters — drie budgetten zonder coördinatie). Nu: **één process-brede token bucket** (0,6 rps = 36 rpm sustained, burst 10 zodat een enkele re-sync snel blijft) waar álle 11 chat/completions-callsites doorheen gaan. De drie losse limiters + `graphiti_llm_rps`-setting (niet gezet in prod) zijn verwijderd. Een **drift-guard test** faalt zodra een toekomstige module naar chat/completions POST zonder de bucket.

### 2. Transcript-timestamps (portal frontend)
`[496306:28]` over de sprekernaam heen: Vexa's `segment.start` is relatief aan de bot-sessieklok (niet de meeting) en de vaste `w-14`-kolom liet lange waarden overlopen. Nu: tijd afgeleid van `absolute_start_time` − `started_at` (fallback: start − eerste-segment-start), `m:ss`/`h:mm:ss`, verborgen bij negatief of ≥24u, en `shrink-0 whitespace-nowrap` i.p.v. vaste breedte.

## Verificatie (onafhankelijk herdraaid na agent-rapportage)
- knowledge-ingest: 1228 passed (4 skipped), ruff clean op alle gewijzigde files
- frontend: 14 tests groen (incl. reproductie `496306.28` → verborgen), `tsc -b` clean, eslint clean
- Rebased op origin/main; diff = exact deze 2 commits

## Effect
Crawls worden bewust trager (36 rpm sustained) maar produceren nul 429's; user-triggered re-syncs blijven snel via de burst + eigen interactive-lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)