### PR TITLE
fix(librechat): act on the phase 2 adversarial review — 6 findings

### DIFF
--- a/.github/workflows/librechat-image-build.yml
+++ b/.github/workflows/librechat-image-build.yml
@@ -71,9 +71,14 @@ jobs:
           set -euo pipefail
           tag="${{ inputs.librechat_tag || env.DEFAULT_LIBRECHAT_TAG }}"
           rev="${{ inputs.patch_revision || env.DEFAULT_PATCH_REVISION }}"
+          # The tag carries the commit that produced it. Without that, every
+          # push rebuilt and OVERWROTE the same v0.8.7-klai.1 -- which really
+          # happened: #908 pushed sha256:518c181f…, #913 replaced it with
+          # sha256:42fa8a92… (adversarial review 2026-08-14, finding 1). A tag
+          # that can move is not something a canary can be rolled back to.
           echo "librechat_tag=$tag" >> "$GITHUB_OUTPUT"
           echo "patch_revision=$rev" >> "$GITHUB_OUTPUT"
-          echo "image=ghcr.io/getklai/librechat:${tag}-klai.${rev}" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/getklai/librechat:${tag}-klai.${rev}-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/login-action@v4
         with:
@@ -140,14 +145,19 @@ jobs:
             --build-arg KLAI_PATCH_REVISION='${{ steps.params.outputs.patch_revision }}' \
             -f Dockerfile.klai -t '${{ steps.params.outputs.image }}' .
 
-      # The manifest is only worth something if it describes THIS image. Prove
-      # it before the tag is allowed anywhere near a registry.
+      # The manifest is only worth something if it describes THIS image, built
+      # from THESE diffs, against the upstream we asked for. Checking only that
+      # the image agrees with its own manifest is self-attesting.
       - name: Verify the baked manifest matches the built image (REQ-6 seed)
         working-directory: deploy/librechat
         run: |
           set -euo pipefail
           node ../scripts/verify-librechat-build-manifest.mjs \
-            --image '${{ steps.params.outputs.image }}'
+            --image '${{ steps.params.outputs.image }}' \
+            --expect-upstream-tag '${{ steps.params.outputs.librechat_tag }}' \
+            --expect-agents-ref '${{ steps.agents.outputs.ref }}' \
+            --expect-patch-revision '${{ steps.params.outputs.patch_revision }}' \
+            --patches-dir patches-source
 
       # The patched artifacts must still satisfy the behaviour tests that guard
       # each surface. Running them against the CI-built image (not against the
@@ -167,11 +177,48 @@ jobs:
           node --test deploy/librechat/tests/format_guard.test.cjs
           node --test deploy/librechat/tests/stream_sources.test.cjs
           node --test deploy/librechat/tests/share_sanitizer.test.cjs
+          # search.cjs and index.cjs have no suite of their own above -- the
+          # step used to copy search.cjs without ever loading it and skip
+          # index.cjs entirely, so "behaviour tests against the built image"
+          # covered 3 of 5 artifacts (finding 3). This suite closes that.
+          KLAI_BUILT_ARTIFACTS_DIR=/tmp/built-patches \
+            node --test deploy/librechat/tests/built_artifacts.test.cjs
           git checkout -- deploy/librechat/patches/
+
+      # A tag that can be overwritten cannot be rolled back to. Refuse to
+      # replace an existing tag with different content rather than silently
+      # moving it (finding 1).
+      - name: Refuse to overwrite an existing tag
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          image='${{ steps.params.outputs.image }}'
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "::error::$image already exists in the registry."
+            echo "::error::Tags are immutable here. Bump patch_revision instead of moving a tag a canary may be pinned to."
+            exit 1
+          fi
+          echo "$image is free."
 
       - name: Push
         if: github.event_name != 'pull_request'
-        run: docker push '${{ steps.params.outputs.image }}'
+        id: push
+        run: |
+          set -euo pipefail
+          image='${{ steps.params.outputs.image }}'
+          docker push "$image"
+          digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$image")
+          echo "Pushed $image"
+          echo "Pin by DIGEST, never by tag: $digest"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Klai LibreChat image"
+            echo ""
+            echo "- tag: \`$image\`"
+            echo "- digest: \`$digest\`"
+            echo ""
+            echo "Phase 3 must pin the digest."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/deploy/librechat/Dockerfile.klai
+++ b/deploy/librechat/Dockerfile.klai
@@ -29,7 +29,11 @@ ARG AGENTS_REF
 RUN test -n "$AGENTS_REF" || (echo "FATAL: AGENTS_REF build-arg is required" >&2; exit 1)
 RUN apk add --no-cache git
 WORKDIR /build
-RUN git clone --quiet --branch "${AGENTS_REF}" --depth 1 \
+# NOT --depth 1: a shallow clone carries no base blobs, so `git apply --3way`
+# silently degrades to plain context application and the 3-way protection this
+# Dockerfile claims does not exist (adversarial review 2026-08-14, finding 5).
+# --filter=blob:none keeps full history cheap and fetches base blobs on demand.
+RUN git clone --quiet --filter=blob:none --branch "${AGENTS_REF}" \
       https://github.com/danny-avila/agents.git agents
 WORKDIR /build/agents
 
@@ -41,11 +45,18 @@ COPY patches-source/format.ts.patch patches-source/stream.ts.patch \
 RUN set -eu; \
     for p in /patches/format.ts.patch /patches/stream.ts.patch /patches/search.ts.patch; do \
       echo "==> git apply --3way $p"; \
-      git apply --3way --verbose "$p" || { \
+      out=$(git apply --3way --verbose "$p" 2>&1) || { \
+        echo "$out" >&2; \
         echo "FATAL: $p did not apply to agents@${AGENTS_REF}." >&2; \
         echo "Re-diff it against that tag's source before retrying — do NOT force it." >&2; \
         exit 1; \
       }; \
+      echo "$out"; \
+      case "$out" in *"lacks the necessary blob"*|*"Falling back to direct application"*) \
+        echo "FATAL: no 3-way merge for $p; git fell back to plain context application." >&2; \
+        echo "That is weaker than what this build claims. Fix the clone filter." >&2; \
+        exit 1;; \
+      esac; \
     done
 
 # REQ-3: upstream's own toolchain, and verify it still exists before invoking
@@ -61,7 +72,7 @@ FROM node:24-alpine AS librechat-build
 ARG LIBRECHAT_TAG
 RUN apk add --no-cache git
 WORKDIR /build
-RUN git clone --quiet --branch "${LIBRECHAT_TAG}" --depth 1 \
+RUN git clone --quiet --filter=blob:none --branch "${LIBRECHAT_TAG}" \
       https://github.com/danny-avila/LibreChat.git librechat
 WORKDIR /build/librechat
 
@@ -71,11 +82,18 @@ COPY patches-source/share.js.patch \
 RUN set -eu; \
     for p in /patches/share.js.patch /patches/createStreamServices.ts.patch; do \
       echo "==> git apply --3way $p"; \
-      git apply --3way --verbose "$p" || { \
+      out=$(git apply --3way --verbose "$p" 2>&1) || { \
+        echo "$out" >&2; \
         echo "FATAL: $p did not apply to LibreChat@${LIBRECHAT_TAG}." >&2; \
         echo "Re-diff it against that tag's source before retrying — do NOT force it." >&2; \
         exit 1; \
       }; \
+      echo "$out"; \
+      case "$out" in *"lacks the necessary blob"*|*"Falling back to direct application"*) \
+        echo "FATAL: no 3-way merge for $p; git fell back to plain context application." >&2; \
+        echo "That is weaker than what this build claims. Fix the clone filter." >&2; \
+        exit 1;; \
+      esac; \
     done
 
 # share.js needs no build step. packages/api does, and it peer-depends on

--- a/deploy/librechat/patches-source/stream.ts.patch
+++ b/deploy/librechat/patches-source/stream.ts.patch
@@ -1,13 +1,43 @@
 diff --git a/src/stream.ts b/src/stream.ts
-index 940dd9b..19e50d7 100644
+index 6913f43..19e50d7 100644
 --- a/src/stream.ts
 +++ b/src/stream.ts
-@@ -72,8 +72,21 @@ function getChunkSources(chunk?: any): unknown[] | undefined {
-   return undefined;
- }
+@@ -40,6 +40,177 @@ import { safeDispatchCustomEvent } from '@/utils/events';
+ import { isGoogleLike } from '@/utils/llm';
+ import { getMessageId } from '@/messages';
  
--const KLAI_SOURCES_MARKER_RE =
--  /<!--\s*klai_sources=([A-Za-z0-9_-]+={0,2})\s*-->/g;
++/* ------------------------------------------------------------------------
++ * Klai patch — KB source propagation through the stream (SPEC-KB citations).
++ *
++ * Retrieval attaches source references to a turn, but the model's text stream
++ * carries them as an inline `<!-- klai_sources=<base64url> -->` marker. Two
++ * things have to happen here:
++ *
++ *   1. Strip the marker before the text reaches the user, and surface the
++ *      decoded sources as structured `sources` on the content part.
++ *   2. Survive the marker being SPLIT across stream fragments. A naive
++ *      per-fragment regex leaks half a marker into the visible answer.
++ *
++ * The live-dispatch path uses a stateful framer (it sees each fragment once);
++ * the aggregator re-extracts on the seam of accumulated-tail + new fragment,
++ * which is stateless on purpose so a stream that ends mid-marker keeps those
++ * characters as plain text rather than swallowing them.
++ * ---------------------------------------------------------------------- */
++
++/** Sources can arrive on the chunk itself rather than inline; providers differ. */
++function getChunkSources(chunk?: any): unknown[] | undefined {
++  const candidates = [
++    chunk?.sources,
++    chunk?.additional_kwargs?.sources,
++    chunk?.response_metadata?.sources,
++    chunk?.additional_kwargs?.delta?.sources,
++  ];
++  for (const candidate of candidates) {
++    if (Array.isArray(candidate) && candidate.length > 0) return candidate;
++  }
++  return undefined;
++}
++
 +/* The marker grammar, in pieces, so complete-matching and partial (split)
 +   detection are DERIVED from the same definition instead of hand-written twice.
 +   They disagreed before: the complete regex accepted any whitespace, the
@@ -23,16 +53,29 @@ index 940dd9b..19e50d7 100644
 +  `${KLAI_MARKER_OPEN}\\s*${KLAI_MARKER_KEY}(${KLAI_MARKER_PAYLOAD})\\s*${KLAI_MARKER_CLOSE}`,
 +  'g'
 +);
- 
- const _klaiStreamWarned = new Set<string>();
- function klaiWarnOnce(message: string): void {
-@@ -97,18 +110,39 @@ function decodeKlaiSourcesMarker(encoded: string): unknown[] | undefined {
-   }
- }
- 
--const KLAI_MARKER_HEAD = '<!-- klai_sources=';
--/** Cap on how much text may be held back waiting for a marker to complete. */
--const KLAI_FRAMER_MAX_TAIL = 8192;
++
++const _klaiStreamWarned = new Set<string>();
++function klaiWarnOnce(message: string): void {
++  if (_klaiStreamWarned.has(message)) return;
++  _klaiStreamWarned.add(message);
++  console.warn(`[klai-patch] ${message}`);
++}
++
++function decodeKlaiSourcesMarker(encoded: string): unknown[] | undefined {
++  try {
++    const padded = encoded + '='.repeat((4 - (encoded.length % 4)) % 4);
++    const json = Buffer.from(
++      padded.replace(/-/g, '+').replace(/_/g, '/'),
++      'base64'
++    ).toString('utf8');
++    const parsed = JSON.parse(json);
++    return Array.isArray(parsed) ? parsed : undefined;
++  } catch (_error) {
++    klaiWarnOnce('stream.decodeKlaiSourcesMarker decode failed');
++    return undefined;
++  }
++}
++
 +/**
 + * Protocol contract: the longest a marker may be. It bounds how much text the
 + * framer will hold back waiting for a marker to complete, so a producer that
@@ -42,20 +85,13 @@ index 940dd9b..19e50d7 100644
 + * legitimately large marker split past the cap leaked in full.
 + */
 +const KLAI_MARKER_MAX_LENGTH = 65536;
- 
++
 +/**
 + * True when `tail` could still grow into a marker the complete grammar matches.
 + * Walks the same pieces as KLAI_SOURCES_MARKER_RE, in order, so the two cannot
 + * drift apart.
 + */
- function isPotentialPartialKlaiMarker(tail: string): boolean {
--  if (tail.length > KLAI_FRAMER_MAX_TAIL) return false;
--  if (tail.length < KLAI_MARKER_HEAD.length) {
--    return KLAI_MARKER_HEAD.startsWith(tail);
--  }
--  if (!tail.startsWith(KLAI_MARKER_HEAD)) return false;
--  return /^[A-Za-z0-9_-]*={0,2}(?: ?-{0,2})?$/.test(
--    tail.slice(KLAI_MARKER_HEAD.length)
++function isPotentialPartialKlaiMarker(tail: string): boolean {
 +  if (tail.length > KLAI_MARKER_MAX_LENGTH) return false;
 +
 +  // Still typing the opening "<!--".
@@ -73,34 +109,209 @@ index 940dd9b..19e50d7 100644
 +  // Payload, then optional whitespace, then a partial "-->".
 +  return new RegExp(`^[A-Za-z0-9_-]*={0,2}\\s*-{0,2}$`).test(
 +    rest.slice(KLAI_MARKER_KEY.length)
-   );
- }
- 
-@@ -151,7 +185,7 @@ function createKlaiSourcesFramer(): {
-       const splitIdx = findPartialKlaiMarkerStart(out);
-       if (splitIdx !== -1) {
-         const tail = out.slice(splitIdx);
--        if (tail.length <= KLAI_FRAMER_MAX_TAIL) {
++  );
++}
++
++/** Index where a possibly-incomplete marker starts, or -1. */
++function findPartialKlaiMarkerStart(text: string): number {
++  if (typeof text !== 'string' || text === '') return -1;
++  const idx = text.lastIndexOf('<');
++  if (idx === -1) return -1;
++  return isPotentialPartialKlaiMarker(text.slice(idx)) ? idx : -1;
++}
++
++function extractKlaiSourcesFromText(text: string): {
++  text: string;
++  sources?: unknown[];
++} {
++  let sources: unknown[] | undefined;
++  const cleanText = text.replace(
++    KLAI_SOURCES_MARKER_RE,
++    (_match, encoded: string) => {
++      const decoded = decodeKlaiSourcesMarker(encoded);
++      if (decoded && decoded.length > 0) sources = decoded;
++      return '';
++    }
++  );
++  return { text: cleanText, sources };
++}
++
++/** Stateful framer for the live-dispatch path: holds back a partial marker. */
++function createKlaiSourcesFramer(): {
++  push(fragment: string): { text: string; sources?: unknown[] };
++} {
++  let buffer = '';
++  return {
++    push(fragment: string) {
++      const combined =
++        buffer + (typeof fragment === 'string' ? fragment : '');
++      buffer = '';
++      const extracted = extractKlaiSourcesFromText(combined);
++      let out = extracted.text;
++      const splitIdx = findPartialKlaiMarkerStart(out);
++      if (splitIdx !== -1) {
++        const tail = out.slice(splitIdx);
 +        if (tail.length <= KLAI_MARKER_MAX_LENGTH) {
-           buffer = tail;
-           out = out.slice(0, splitIdx);
-         } else {
-@@ -1966,9 +2000,16 @@ export function createContentAggregator(): t.ContentAggregatorResult {
++          buffer = tail;
++          out = out.slice(0, splitIdx);
++        } else {
++          klaiWarnOnce(
++            'stream.klai_sources framer overflow — tail flushed as text'
++          );
++        }
++      }
++      return { text: out, sources: extracted.sources };
++    },
++  };
++}
++
++/** Where the per-run framer is parked. Local cast keeps the patch to one file. */
++type KlaiFramerHost = {
++  _klaiSourcesFramer?: ReturnType<typeof createKlaiSourcesFramer>;
++};
++
++export {
++  extractKlaiSourcesFromText,
++  createKlaiSourcesFramer,
++  findPartialKlaiMarkerStart,
++  getChunkSources,
++};
++
+ const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
+   LOCAL_CODING_BUNDLE_NAMES
+ );
+@@ -1564,6 +1735,14 @@ hasToolCallChunks: ${hasToolCallChunks}
+     ) {
+       return;
+     } else if (typeof content === 'string') {
++      /* Klai patch: strip the inline klai_sources marker before this text is
++         dispatched to the client, and attach the decoded sources. The framer
++         is per-agentContext because a marker can span fragments. */
++      const framerHost = agentContext as unknown as KlaiFramerHost;
++      framerHost._klaiSourcesFramer ??= createKlaiSourcesFramer();
++      const extracted = framerHost._klaiSourcesFramer.push(content);
++      const textContent = extracted.text;
++      const sources = getChunkSources(chunk) ?? extracted.sources;
+       if (agentContext.currentTokenType === ContentTypes.TEXT) {
+         await graph.dispatchMessageDelta(
+           stepId,
+@@ -1571,14 +1750,15 @@ hasToolCallChunks: ${hasToolCallChunks}
+             content: [
+               {
+                 type: ContentTypes.TEXT,
+-                text: content,
++                text: textContent,
++                ...(sources ? { sources } : {}),
+               },
+             ],
+           },
+           metadata
+         );
+       } else if (agentContext.currentTokenType === 'think_and_text') {
+-        const { text, thinking } = parseThinkingContent(content);
++        const { text, thinking } = parseThinkingContent(textContent);
+         if (thinking) {
+           await graph.dispatchReasoningDelta(
+             stepId,
+@@ -1617,6 +1797,7 @@ hasToolCallChunks: ${hasToolCallChunks}
+                 {
+                   type: ContentTypes.TEXT,
+                   text: text,
++                  ...(sources ? { sources } : {}),
+                 },
+               ],
+             },
+@@ -1800,14 +1981,46 @@ export function createContentAggregator(): t.ContentAggregatorResult {
+     ) {
+       // TODO: update this!!
+       const currentContent = contentParts[index] as t.MessageDeltaUpdate;
++      /* Klai patch: a klai_sources marker can be split across delta fragments.
++         Any leaked partial-marker prefix sits at the END of the accumulated
++         text (it matched nothing, so it passed through) -- re-extract on the
++         seam of accumulated tail + new fragment instead of the new fragment
++         alone. Stateless on purpose: the "buffer" IS the accumulated text, so
++         a stream ending mid-marker keeps its characters as plain text. */
++      const accumulated = currentContent.text || '';
++      const seamIdx = findPartialKlaiMarkerStart(accumulated);
++      const head = seamIdx === -1 ? accumulated : accumulated.slice(0, seamIdx);
++      const carry = seamIdx === -1 ? '' : accumulated.slice(seamIdx);
++      const extracted = extractKlaiSourcesFromText(carry + contentPart.text);
+       const update: t.MessageDeltaUpdate = {
+         type: ContentTypes.TEXT,
+-        text: (currentContent.text || '') + contentPart.text,
++        text: head + extracted.text,
+       };
+ 
        if (contentPart.tool_call_ids) {
          update.tool_call_ids = contentPart.tool_call_ids;
        }
--      /* Newly-seen sources win; otherwise keep what we already accumulated. */
 +      /* Newly-seen sources win; otherwise keep what we already accumulated.
 +         `??` is wrong here: an empty array is not nullish, so a delta carrying
 +         `sources: []` alongside a valid inline marker would suppress the
 +         marker's sources entirely (adversarial review 2026-08-14, finding 4).
 +         Only a NON-EMPTY list counts as "the producer said something". */
 +      const partSources = (contentPart as { sources?: unknown[] }).sources;
-       const incomingSources =
--        (contentPart as { sources?: unknown[] }).sources ?? extracted.sources;
++      const incomingSources =
 +        Array.isArray(partSources) && partSources.length > 0
 +          ? partSources
 +          : extracted.sources;
-       if (Array.isArray(incomingSources) && incomingSources.length > 0) {
-         (update as { sources?: unknown[] }).sources = incomingSources;
-       } else if (
++      if (Array.isArray(incomingSources) && incomingSources.length > 0) {
++        (update as { sources?: unknown[] }).sources = incomingSources;
++      } else if (
++        Array.isArray((currentContent as { sources?: unknown[] }).sources) &&
++        ((currentContent as { sources?: unknown[] }).sources as unknown[])
++          .length > 0
++      ) {
++        (update as { sources?: unknown[] }).sources = (
++          currentContent as { sources?: unknown[] }
++        ).sources;
++      }
+       contentParts[index] = update;
+     } else if (
+       partType.startsWith(ContentTypes.THINK) &&
+@@ -2041,9 +2254,20 @@ export function createContentAggregator(): t.ContentAggregatorResult {
+         return;
+       }
+ 
+-      const contentPart = getFirstContentPart(messageDelta.delta.content);
+-      if (contentPart != null) {
+-        updateContent(runStep.index, contentPart);
++      /* Klai patch: upstream only ever reads content[0]. A provider that emits
++         a multi-part delta silently loses everything after the first part --
++         including a content part carrying klai_sources. Iterate all of them
++         and warn once so the frequency is queryable. */
++      const messageDeltaContent = Array.isArray(messageDelta.delta.content)
++        ? messageDelta.delta.content
++        : [messageDelta.delta.content];
++      if (messageDeltaContent.length > 1) {
++        klaiWarnOnce('stream.delta-array guard saw multi-part delta (message)');
++      }
++      for (const contentPart of messageDeltaContent) {
++        if (contentPart != null) {
++          updateContent(runStep.index, contentPart);
++        }
+       }
+     } else if (
+       event === GraphEvents.ON_AGENT_UPDATE &&
+@@ -2062,9 +2286,18 @@ export function createContentAggregator(): t.ContentAggregatorResult {
+         return;
+       }
+ 
+-      const contentPart = getFirstContentPart(reasoningDelta.delta.content);
+-      if (contentPart != null) {
+-        updateContent(runStep.index, contentPart);
++      const reasoningDeltaContent = Array.isArray(reasoningDelta.delta.content)
++        ? reasoningDelta.delta.content
++        : [reasoningDelta.delta.content];
++      if (reasoningDeltaContent.length > 1) {
++        klaiWarnOnce(
++          'stream.delta-array guard saw multi-part delta (reasoning)'
++        );
++      }
++      for (const contentPart of reasoningDeltaContent) {
++        if (contentPart != null) {
++          updateContent(runStep.index, contentPart);
++        }
+       }
+     } else if (event === GraphEvents.ON_RUN_STEP_DELTA) {
+       const runStepDelta = data as t.RunStepDeltaEvent;

--- a/deploy/librechat/patches-source/stream.ts.patch
+++ b/deploy/librechat/patches-source/stream.ts.patch
@@ -1,276 +1,106 @@
 diff --git a/src/stream.ts b/src/stream.ts
-index 6913f43..940dd9b 100644
+index 940dd9b..19e50d7 100644
 --- a/src/stream.ts
 +++ b/src/stream.ts
-@@ -40,6 +40,143 @@ import { safeDispatchCustomEvent } from '@/utils/events';
- import { isGoogleLike } from '@/utils/llm';
- import { getMessageId } from '@/messages';
+@@ -72,8 +72,21 @@ function getChunkSources(chunk?: any): unknown[] | undefined {
+   return undefined;
+ }
  
-+/* ------------------------------------------------------------------------
-+ * Klai patch — KB source propagation through the stream (SPEC-KB citations).
-+ *
-+ * Retrieval attaches source references to a turn, but the model's text stream
-+ * carries them as an inline `<!-- klai_sources=<base64url> -->` marker. Two
-+ * things have to happen here:
-+ *
-+ *   1. Strip the marker before the text reaches the user, and surface the
-+ *      decoded sources as structured `sources` on the content part.
-+ *   2. Survive the marker being SPLIT across stream fragments. A naive
-+ *      per-fragment regex leaks half a marker into the visible answer.
-+ *
-+ * The live-dispatch path uses a stateful framer (it sees each fragment once);
-+ * the aggregator re-extracts on the seam of accumulated-tail + new fragment,
-+ * which is stateless on purpose so a stream that ends mid-marker keeps those
-+ * characters as plain text rather than swallowing them.
-+ * ---------------------------------------------------------------------- */
+-const KLAI_SOURCES_MARKER_RE =
+-  /<!--\s*klai_sources=([A-Za-z0-9_-]+={0,2})\s*-->/g;
++/* The marker grammar, in pieces, so complete-matching and partial (split)
++   detection are DERIVED from the same definition instead of hand-written twice.
++   They disagreed before: the complete regex accepted any whitespace, the
++   partial detector hardcoded exactly one space, so a whitespace-variant marker
++   split at the wrong byte leaked into visible text (adversarial review
++   2026-08-14, finding 6). */
++const KLAI_MARKER_OPEN = '<!--';
++const KLAI_MARKER_KEY = 'klai_sources=';
++const KLAI_MARKER_CLOSE = '-->';
++const KLAI_MARKER_PAYLOAD = '[A-Za-z0-9_-]+={0,2}';
 +
-+/** Sources can arrive on the chunk itself rather than inline; providers differ. */
-+function getChunkSources(chunk?: any): unknown[] | undefined {
-+  const candidates = [
-+    chunk?.sources,
-+    chunk?.additional_kwargs?.sources,
-+    chunk?.response_metadata?.sources,
-+    chunk?.additional_kwargs?.delta?.sources,
-+  ];
-+  for (const candidate of candidates) {
-+    if (Array.isArray(candidate) && candidate.length > 0) return candidate;
-+  }
-+  return undefined;
-+}
-+
-+const KLAI_SOURCES_MARKER_RE =
-+  /<!--\s*klai_sources=([A-Za-z0-9_-]+={0,2})\s*-->/g;
-+
-+const _klaiStreamWarned = new Set<string>();
-+function klaiWarnOnce(message: string): void {
-+  if (_klaiStreamWarned.has(message)) return;
-+  _klaiStreamWarned.add(message);
-+  console.warn(`[klai-patch] ${message}`);
-+}
-+
-+function decodeKlaiSourcesMarker(encoded: string): unknown[] | undefined {
-+  try {
-+    const padded = encoded + '='.repeat((4 - (encoded.length % 4)) % 4);
-+    const json = Buffer.from(
-+      padded.replace(/-/g, '+').replace(/_/g, '/'),
-+      'base64'
-+    ).toString('utf8');
-+    const parsed = JSON.parse(json);
-+    return Array.isArray(parsed) ? parsed : undefined;
-+  } catch (_error) {
-+    klaiWarnOnce('stream.decodeKlaiSourcesMarker decode failed');
-+    return undefined;
-+  }
-+}
-+
-+const KLAI_MARKER_HEAD = '<!-- klai_sources=';
-+/** Cap on how much text may be held back waiting for a marker to complete. */
-+const KLAI_FRAMER_MAX_TAIL = 8192;
-+
-+function isPotentialPartialKlaiMarker(tail: string): boolean {
-+  if (tail.length > KLAI_FRAMER_MAX_TAIL) return false;
-+  if (tail.length < KLAI_MARKER_HEAD.length) {
-+    return KLAI_MARKER_HEAD.startsWith(tail);
-+  }
-+  if (!tail.startsWith(KLAI_MARKER_HEAD)) return false;
-+  return /^[A-Za-z0-9_-]*={0,2}(?: ?-{0,2})?$/.test(
-+    tail.slice(KLAI_MARKER_HEAD.length)
-+  );
-+}
-+
-+/** Index where a possibly-incomplete marker starts, or -1. */
-+function findPartialKlaiMarkerStart(text: string): number {
-+  if (typeof text !== 'string' || text === '') return -1;
-+  const idx = text.lastIndexOf('<');
-+  if (idx === -1) return -1;
-+  return isPotentialPartialKlaiMarker(text.slice(idx)) ? idx : -1;
-+}
-+
-+function extractKlaiSourcesFromText(text: string): {
-+  text: string;
-+  sources?: unknown[];
-+} {
-+  let sources: unknown[] | undefined;
-+  const cleanText = text.replace(
-+    KLAI_SOURCES_MARKER_RE,
-+    (_match, encoded: string) => {
-+      const decoded = decodeKlaiSourcesMarker(encoded);
-+      if (decoded && decoded.length > 0) sources = decoded;
-+      return '';
-+    }
-+  );
-+  return { text: cleanText, sources };
-+}
-+
-+/** Stateful framer for the live-dispatch path: holds back a partial marker. */
-+function createKlaiSourcesFramer(): {
-+  push(fragment: string): { text: string; sources?: unknown[] };
-+} {
-+  let buffer = '';
-+  return {
-+    push(fragment: string) {
-+      const combined =
-+        buffer + (typeof fragment === 'string' ? fragment : '');
-+      buffer = '';
-+      const extracted = extractKlaiSourcesFromText(combined);
-+      let out = extracted.text;
-+      const splitIdx = findPartialKlaiMarkerStart(out);
-+      if (splitIdx !== -1) {
-+        const tail = out.slice(splitIdx);
-+        if (tail.length <= KLAI_FRAMER_MAX_TAIL) {
-+          buffer = tail;
-+          out = out.slice(0, splitIdx);
-+        } else {
-+          klaiWarnOnce(
-+            'stream.klai_sources framer overflow — tail flushed as text'
-+          );
-+        }
-+      }
-+      return { text: out, sources: extracted.sources };
-+    },
-+  };
-+}
-+
-+/** Where the per-run framer is parked. Local cast keeps the patch to one file. */
-+type KlaiFramerHost = {
-+  _klaiSourcesFramer?: ReturnType<typeof createKlaiSourcesFramer>;
-+};
-+
-+export {
-+  extractKlaiSourcesFromText,
-+  createKlaiSourcesFramer,
-+  findPartialKlaiMarkerStart,
-+  getChunkSources,
-+};
-+
- const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
-   LOCAL_CODING_BUNDLE_NAMES
- );
-@@ -1564,6 +1701,14 @@ hasToolCallChunks: ${hasToolCallChunks}
-     ) {
-       return;
-     } else if (typeof content === 'string') {
-+      /* Klai patch: strip the inline klai_sources marker before this text is
-+         dispatched to the client, and attach the decoded sources. The framer
-+         is per-agentContext because a marker can span fragments. */
-+      const framerHost = agentContext as unknown as KlaiFramerHost;
-+      framerHost._klaiSourcesFramer ??= createKlaiSourcesFramer();
-+      const extracted = framerHost._klaiSourcesFramer.push(content);
-+      const textContent = extracted.text;
-+      const sources = getChunkSources(chunk) ?? extracted.sources;
-       if (agentContext.currentTokenType === ContentTypes.TEXT) {
-         await graph.dispatchMessageDelta(
-           stepId,
-@@ -1571,14 +1716,15 @@ hasToolCallChunks: ${hasToolCallChunks}
-             content: [
-               {
-                 type: ContentTypes.TEXT,
--                text: content,
-+                text: textContent,
-+                ...(sources ? { sources } : {}),
-               },
-             ],
-           },
-           metadata
-         );
-       } else if (agentContext.currentTokenType === 'think_and_text') {
--        const { text, thinking } = parseThinkingContent(content);
-+        const { text, thinking } = parseThinkingContent(textContent);
-         if (thinking) {
-           await graph.dispatchReasoningDelta(
-             stepId,
-@@ -1617,6 +1763,7 @@ hasToolCallChunks: ${hasToolCallChunks}
-                 {
-                   type: ContentTypes.TEXT,
-                   text: text,
-+                  ...(sources ? { sources } : {}),
-                 },
-               ],
-             },
-@@ -1800,14 +1947,39 @@ export function createContentAggregator(): t.ContentAggregatorResult {
-     ) {
-       // TODO: update this!!
-       const currentContent = contentParts[index] as t.MessageDeltaUpdate;
-+      /* Klai patch: a klai_sources marker can be split across delta fragments.
-+         Any leaked partial-marker prefix sits at the END of the accumulated
-+         text (it matched nothing, so it passed through) -- re-extract on the
-+         seam of accumulated tail + new fragment instead of the new fragment
-+         alone. Stateless on purpose: the "buffer" IS the accumulated text, so
-+         a stream ending mid-marker keeps its characters as plain text. */
-+      const accumulated = currentContent.text || '';
-+      const seamIdx = findPartialKlaiMarkerStart(accumulated);
-+      const head = seamIdx === -1 ? accumulated : accumulated.slice(0, seamIdx);
-+      const carry = seamIdx === -1 ? '' : accumulated.slice(seamIdx);
-+      const extracted = extractKlaiSourcesFromText(carry + contentPart.text);
-       const update: t.MessageDeltaUpdate = {
-         type: ContentTypes.TEXT,
--        text: (currentContent.text || '') + contentPart.text,
-+        text: head + extracted.text,
-       };
++const KLAI_SOURCES_MARKER_RE = new RegExp(
++  `${KLAI_MARKER_OPEN}\\s*${KLAI_MARKER_KEY}(${KLAI_MARKER_PAYLOAD})\\s*${KLAI_MARKER_CLOSE}`,
++  'g'
++);
  
+ const _klaiStreamWarned = new Set<string>();
+ function klaiWarnOnce(message: string): void {
+@@ -97,18 +110,39 @@ function decodeKlaiSourcesMarker(encoded: string): unknown[] | undefined {
+   }
+ }
+ 
+-const KLAI_MARKER_HEAD = '<!-- klai_sources=';
+-/** Cap on how much text may be held back waiting for a marker to complete. */
+-const KLAI_FRAMER_MAX_TAIL = 8192;
++/**
++ * Protocol contract: the longest a marker may be. It bounds how much text the
++ * framer will hold back waiting for a marker to complete, so a producer that
++ * emits `<!--` and never closes it cannot stall the stream. Sized far above
++ * anything the real producer emits (a handful of sources base64-encodes to
++ * ~1-2 KB) so the bound is a safety valve, never a normal limit -- at 8 KB a
++ * legitimately large marker split past the cap leaked in full.
++ */
++const KLAI_MARKER_MAX_LENGTH = 65536;
+ 
++/**
++ * True when `tail` could still grow into a marker the complete grammar matches.
++ * Walks the same pieces as KLAI_SOURCES_MARKER_RE, in order, so the two cannot
++ * drift apart.
++ */
+ function isPotentialPartialKlaiMarker(tail: string): boolean {
+-  if (tail.length > KLAI_FRAMER_MAX_TAIL) return false;
+-  if (tail.length < KLAI_MARKER_HEAD.length) {
+-    return KLAI_MARKER_HEAD.startsWith(tail);
+-  }
+-  if (!tail.startsWith(KLAI_MARKER_HEAD)) return false;
+-  return /^[A-Za-z0-9_-]*={0,2}(?: ?-{0,2})?$/.test(
+-    tail.slice(KLAI_MARKER_HEAD.length)
++  if (tail.length > KLAI_MARKER_MAX_LENGTH) return false;
++
++  // Still typing the opening "<!--".
++  if (KLAI_MARKER_OPEN.startsWith(tail)) return true;
++  if (!tail.startsWith(KLAI_MARKER_OPEN)) return false;
++
++  let rest = tail.slice(KLAI_MARKER_OPEN.length);
++  rest = rest.slice((rest.match(/^\s*/) ?? [''])[0].length);
++  if (rest === '') return true;
++
++  // Partway through "klai_sources=".
++  if (KLAI_MARKER_KEY.startsWith(rest)) return true;
++  if (!rest.startsWith(KLAI_MARKER_KEY)) return false;
++
++  // Payload, then optional whitespace, then a partial "-->".
++  return new RegExp(`^[A-Za-z0-9_-]*={0,2}\\s*-{0,2}$`).test(
++    rest.slice(KLAI_MARKER_KEY.length)
+   );
+ }
+ 
+@@ -151,7 +185,7 @@ function createKlaiSourcesFramer(): {
+       const splitIdx = findPartialKlaiMarkerStart(out);
+       if (splitIdx !== -1) {
+         const tail = out.slice(splitIdx);
+-        if (tail.length <= KLAI_FRAMER_MAX_TAIL) {
++        if (tail.length <= KLAI_MARKER_MAX_LENGTH) {
+           buffer = tail;
+           out = out.slice(0, splitIdx);
+         } else {
+@@ -1966,9 +2000,16 @@ export function createContentAggregator(): t.ContentAggregatorResult {
        if (contentPart.tool_call_ids) {
          update.tool_call_ids = contentPart.tool_call_ids;
        }
-+      /* Newly-seen sources win; otherwise keep what we already accumulated. */
-+      const incomingSources =
-+        (contentPart as { sources?: unknown[] }).sources ?? extracted.sources;
-+      if (Array.isArray(incomingSources) && incomingSources.length > 0) {
-+        (update as { sources?: unknown[] }).sources = incomingSources;
-+      } else if (
-+        Array.isArray((currentContent as { sources?: unknown[] }).sources) &&
-+        ((currentContent as { sources?: unknown[] }).sources as unknown[])
-+          .length > 0
-+      ) {
-+        (update as { sources?: unknown[] }).sources = (
-+          currentContent as { sources?: unknown[] }
-+        ).sources;
-+      }
-       contentParts[index] = update;
-     } else if (
-       partType.startsWith(ContentTypes.THINK) &&
-@@ -2041,9 +2213,20 @@ export function createContentAggregator(): t.ContentAggregatorResult {
-         return;
-       }
- 
--      const contentPart = getFirstContentPart(messageDelta.delta.content);
--      if (contentPart != null) {
--        updateContent(runStep.index, contentPart);
-+      /* Klai patch: upstream only ever reads content[0]. A provider that emits
-+         a multi-part delta silently loses everything after the first part --
-+         including a content part carrying klai_sources. Iterate all of them
-+         and warn once so the frequency is queryable. */
-+      const messageDeltaContent = Array.isArray(messageDelta.delta.content)
-+        ? messageDelta.delta.content
-+        : [messageDelta.delta.content];
-+      if (messageDeltaContent.length > 1) {
-+        klaiWarnOnce('stream.delta-array guard saw multi-part delta (message)');
-+      }
-+      for (const contentPart of messageDeltaContent) {
-+        if (contentPart != null) {
-+          updateContent(runStep.index, contentPart);
-+        }
-       }
-     } else if (
-       event === GraphEvents.ON_AGENT_UPDATE &&
-@@ -2062,9 +2245,18 @@ export function createContentAggregator(): t.ContentAggregatorResult {
-         return;
-       }
- 
--      const contentPart = getFirstContentPart(reasoningDelta.delta.content);
--      if (contentPart != null) {
--        updateContent(runStep.index, contentPart);
-+      const reasoningDeltaContent = Array.isArray(reasoningDelta.delta.content)
-+        ? reasoningDelta.delta.content
-+        : [reasoningDelta.delta.content];
-+      if (reasoningDeltaContent.length > 1) {
-+        klaiWarnOnce(
-+          'stream.delta-array guard saw multi-part delta (reasoning)'
-+        );
-+      }
-+      for (const contentPart of reasoningDeltaContent) {
-+        if (contentPart != null) {
-+          updateContent(runStep.index, contentPart);
-+        }
-       }
-     } else if (event === GraphEvents.ON_RUN_STEP_DELTA) {
-       const runStepDelta = data as t.RunStepDeltaEvent;
+-      /* Newly-seen sources win; otherwise keep what we already accumulated. */
++      /* Newly-seen sources win; otherwise keep what we already accumulated.
++         `??` is wrong here: an empty array is not nullish, so a delta carrying
++         `sources: []` alongside a valid inline marker would suppress the
++         marker's sources entirely (adversarial review 2026-08-14, finding 4).
++         Only a NON-EMPTY list counts as "the producer said something". */
++      const partSources = (contentPart as { sources?: unknown[] }).sources;
+       const incomingSources =
+-        (contentPart as { sources?: unknown[] }).sources ?? extracted.sources;
++        Array.isArray(partSources) && partSources.length > 0
++          ? partSources
++          : extracted.sources;
+       if (Array.isArray(incomingSources) && incomingSources.length > 0) {
+         (update as { sources?: unknown[] }).sources = incomingSources;
+       } else if (

--- a/deploy/librechat/tests/_stream-sandbox.cjs
+++ b/deploy/librechat/tests/_stream-sandbox.cjs
@@ -1,0 +1,97 @@
+/**
+ * Shared sandbox for loading the bundled `@librechat/agents` stream.cjs.
+ *
+ * The bundle requires a handful of sibling chunks that these tests never
+ * exercise. Stubbing them here, once, keeps stream_sources.test.cjs (which
+ * guards the currently bind-mounted patch) and built_artifacts.test.cjs (which
+ * guards the CI-built artifact) loading the module identically — otherwise the
+ * two harnesses drift and a difference in test outcome could come from the
+ * stub rather than from the code.
+ *
+ * An unexpected require throws rather than returning a permissive stub: a
+ * silently-satisfied dependency is how a load-time regression hides.
+ */
+const vm = require('node:vm');
+
+function makeRequire() {
+  return (id) => {
+    if (id === './common/enum.cjs') {
+      return {
+        ContentTypes: {
+          TEXT: 'text',
+          THINK: 'think',
+          THINKING: 'thinking',
+          REASONING: 'reasoning',
+          REASONING_CONTENT: 'reasoning_content',
+          TOOL_CALL: 'tool_call',
+          AGENT_UPDATE: 'agent_update',
+          IMAGE_URL: 'image_url',
+          ERROR: 'error',
+          SUMMARY: 'summary',
+        },
+        GraphEvents: {
+          ON_RUN_STEP: 'on_run_step',
+          ON_MESSAGE_DELTA: 'on_message_delta',
+          ON_AGENT_UPDATE: 'on_agent_update',
+          ON_REASONING_DELTA: 'on_reasoning_delta',
+          ON_RUN_STEP_DELTA: 'on_run_step_delta',
+          ON_RUN_STEP_COMPLETED: 'on_run_step_completed',
+        },
+        Providers: {
+          OPENAI: 'openai',
+          AZURE: 'azure',
+          OPENROUTER: 'openrouter',
+        },
+        StepTypes: {
+          MESSAGE_CREATION: 'message_creation',
+          TOOL_CALLS: 'tool_calls',
+        },
+        ToolCallTypes: {
+          TOOL_CALL: 'tool_call',
+        },
+        LOCAL_CODING_BUNDLE_NAMES: [],
+      };
+    }
+    if (
+      id === './common/index.cjs' ||
+      id === './messages/index.cjs' ||
+      id === './tools/handlers.cjs' ||
+      id === './messages/core.cjs' ||
+      id === './messages/ids.cjs' ||
+      id === '@langchain/core/messages' ||
+      id === './utils/truncation.cjs' ||
+      id === 'uuid' ||
+      id === './tools/eagerEventExecution.cjs' ||
+      id === './tools/streamedToolCallSeals.cjs'
+    ) {
+      return {};
+    }
+    if (id === './utils/llm.cjs') {
+      return { isGoogleLike: () => false };
+    }
+    if (id === './utils/events.cjs') {
+      return { emitAgentLog() {} };
+    }
+    if (id === './tools/toolOutputReferences.cjs') {
+      return { TOOL_OUTPUT_REF_PATTERN: /\{\{tool_output:[^}]+\}\}/ };
+    }
+    throw new Error(`Unexpected require: ${id}`);
+  };
+}
+
+/**
+ * @param {string} source Contents of a bundled stream.cjs.
+ * @returns {Record<string, unknown>} its exports
+ */
+function loadStreamBundle(source) {
+  const sandbox = {
+    Buffer,
+    require: makeRequire(),
+    console,
+    exports: {},
+  };
+  vm.runInNewContext(source, sandbox);
+  return sandbox.exports;
+}
+
+module.exports = { loadStreamBundle };

--- a/deploy/librechat/tests/built_artifacts.test.cjs
+++ b/deploy/librechat/tests/built_artifacts.test.cjs
@@ -22,14 +22,11 @@ const vm = require('node:vm');
 const artifactsDir = process.env.KLAI_BUILT_ARTIFACTS_DIR;
 
 if (!artifactsDir) {
-  if (process.env.CI) {
-    console.error(
-      'FATAL: KLAI_BUILT_ARTIFACTS_DIR is unset in CI. This suite must run ' +
-        'against artifacts extracted from the built image; skipping it would ' +
-        'restore exactly the false coverage of finding 3.'
-    );
-    process.exit(1);
-  }
+  // Skipping here is legitimate: the generic LibreChat test workflow has no
+  // built image to point at. The protection against this suite quietly falling
+  // out of CI is not a check in this file -- it is
+  // librechat-patched-files.test.mjs asserting that the image-build workflow
+  // still runs it with KLAI_BUILT_ARTIFACTS_DIR set.
   console.log(
     'SKIPPED: built_artifacts.test.cjs needs KLAI_BUILT_ARTIFACTS_DIR ' +
       '(set by .github/workflows/librechat-image-build.yml). Nothing asserted.'

--- a/deploy/librechat/tests/built_artifacts.test.cjs
+++ b/deploy/librechat/tests/built_artifacts.test.cjs
@@ -1,0 +1,239 @@
+/**
+ * Coverage for the two built artifacts nothing else tests: search.cjs and
+ * packages/api's index.cjs.
+ *
+ * Adversarial review 2026-08-14, finding 3: the image-build workflow claimed to
+ * "run patch behaviour tests against the built image" while loading only three
+ * of five artifacts. The reviewer changed `topResults` from 3 to 999 in a built
+ * search.cjs and all three suites stayed green. index.cjs was not even copied,
+ * and stream_services.test.cjs asserts the old entrypoint transform against a
+ * synthetic fixture — not the artifact the runtime loads.
+ *
+ * Runs against a directory of artifacts extracted from a built image
+ * (KLAI_BUILT_ARTIFACTS_DIR). Under CI a missing directory is a FAILURE, not a
+ * skip: a silently-skipped test is the same coverage lie this file exists to
+ * correct.
+ */
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const artifactsDir = process.env.KLAI_BUILT_ARTIFACTS_DIR;
+
+if (!artifactsDir) {
+  if (process.env.CI) {
+    console.error(
+      'FATAL: KLAI_BUILT_ARTIFACTS_DIR is unset in CI. This suite must run ' +
+        'against artifacts extracted from the built image; skipping it would ' +
+        'restore exactly the false coverage of finding 3.'
+    );
+    process.exit(1);
+  }
+  console.log(
+    'SKIPPED: built_artifacts.test.cjs needs KLAI_BUILT_ARTIFACTS_DIR ' +
+      '(set by .github/workflows/librechat-image-build.yml). Nothing asserted.'
+  );
+  return;
+}
+
+// ---------------------------------------------------------------------------
+// search.cjs — behavioural where the surface allows it
+// ---------------------------------------------------------------------------
+const searchSource = fs.readFileSync(
+  path.join(artifactsDir, 'search.cjs'),
+  'utf8'
+);
+
+const sandbox = {
+  Buffer,
+  console,
+  process,
+  URL,
+  TextEncoder,
+  TextDecoder,
+  setTimeout,
+  clearTimeout,
+  module: { exports: {} },
+  exports: {},
+};
+sandbox.require = (id) => {
+  try {
+    return require(id);
+  } catch {
+    // The bundle pulls in scraper/LLM deps this test never exercises.
+    return new Proxy({}, { get: () => () => {} });
+  }
+};
+sandbox.module.exports = sandbox.exports;
+vm.createContext(sandbox);
+new vm.Script(searchSource, { filename: 'search.cjs' }).runInContext(sandbox);
+
+const searchExports = sandbox.module.exports;
+assert.equal(typeof searchExports.createSourceProcessor, 'function');
+assert.equal(typeof searchExports.createSearchAPI, 'function');
+
+const stubScraper = {
+  extractMetadata: () => ({}),
+  extractContent: (response) => [response.data, []],
+};
+
+// The exact mutation the reviewer used to prove the old suite was blind.
+assert.equal(
+  searchExports.createSourceProcessor({ topResults: 3 }, stubScraper).topResults,
+  3,
+  'createSourceProcessor must honour the configured topResults'
+);
+// search.ts.patch lowers upstream's default of 5 to 3 -- one of the four
+// semantic changes in that diff. Pinning it here catches both a silent revert
+// to upstream and the arbitrary value the reviewer used to prove the old
+// suite was blind.
+assert.equal(
+  searchExports.createSourceProcessor({}, stubScraper).topResults,
+  3,
+  'the Klai default of topResults=3 did not survive the build'
+);
+
+// Structural, and labelled as such. `chunker.cleanText` is module-internal and
+// only reachable through processSources, which needs a full provider-shaped
+// scrape response to drive. Asserting the guard survived the build is weaker
+// than exercising it, but it does catch the failure mode that matters here: a
+// source diff that silently stops reaching the built bundle.
+const LONE_SURROGATE_STRIP =
+  '[\\uD800-\\uDBFF](?![\\uDC00-\\uDFFF])|(?<![\\uD800-\\uDBFF])[\\uDC00-\\uDFFF]';
+const surrogateGuards = searchSource.split(LONE_SURROGATE_STRIP).length - 1;
+assert.equal(
+  surrogateGuards,
+  2,
+  `expected the lone-surrogate strip in both cleanText and the chunk splitter, found ${surrogateGuards}`
+);
+assert.ok(
+  searchSource.includes('[klai-patch] search.cleanText stripped lone UTF-16 surrogate(s)'),
+  'the cleanText surrogate warning did not survive the build'
+);
+
+// ---------------------------------------------------------------------------
+// index.cjs — the artifact the runtime actually loads
+// ---------------------------------------------------------------------------
+// This is the file whose bind-mounted .ts counterpart was inert for months:
+// the runtime loads packages/api/dist/index.cjs, and mounting the source did
+// nothing. The source-diff model is supposed to make that impossible, so the
+// check is "did the patch reach the built bundle".
+const apiSource = fs.readFileSync(path.join(artifactsDir, 'index.cjs'), 'utf8');
+
+assert.ok(
+  apiSource.includes('cleanupOnComplete: CLEANUP_ON_COMPLETE'),
+  'createStreamServices.ts.patch did not reach packages/api/dist/index.cjs — ' +
+    'the exact inert-patch failure this SPEC exists to eliminate'
+);
+assert.ok(
+  !/cleanupOnComplete:\s*true/.test(apiSource),
+  'a hardcoded cleanupOnComplete: true survives in the built bundle'
+);
+// Both call sites (the services object and the manager config) must be wired,
+// or completed jobs are still reaped on one of the two paths.
+const wiredSites = apiSource.split('cleanupOnComplete: CLEANUP_ON_COMPLETE').length - 1;
+assert.ok(
+  wiredSites >= 2,
+  `expected cleanupOnComplete wired at both call sites, found ${wiredSites}`
+);
+
+
+// ---------------------------------------------------------------------------
+// stream.cjs — the two marker edge cases the source diffs fix
+// ---------------------------------------------------------------------------
+// These assert the FIXED behaviour, so they live here rather than in
+// stream_sources.test.cjs: that suite guards the .cjs still bind-mounted in
+// production, which predates these fixes. The fixes reach users through the
+// planned canary rollout (Phase 3), not as a side effect of a build change.
+const { loadStreamBundle } = require('./_stream-sandbox.cjs');
+const streamExports = loadStreamBundle(
+  fs.readFileSync(path.join(artifactsDir, 'stream.cjs'), 'utf8')
+);
+const { createKlaiSourcesFramer, createContentAggregator } = streamExports;
+assert.equal(typeof createKlaiSourcesFramer, 'function');
+assert.equal(typeof createContentAggregator, 'function');
+
+const encodeMarker = (value) =>
+  Buffer.from(JSON.stringify(value), 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+function splitThroughFramer(body, cut) {
+  const framer = createKlaiSourcesFramer();
+  const first = framer.push(body.slice(0, cut));
+  const second = framer.push(body.slice(cut));
+  return { text: first.text + second.text, sources: first.sources ?? second.sources };
+}
+
+// Finding 6a: the complete-marker regex accepts any whitespace; the partial
+// detector used to hardcode exactly one space, so this leaked from cut=16.
+{
+  const sources = [{ label: '1', url: 'https://example.com/a' }];
+  const body = `Antwoord. <!--  klai_sources=${encodeMarker(sources)}  --> En verder.`;
+  for (let cut = 1; cut < body.length; cut++) {
+    const out = splitThroughFramer(body, cut);
+    assert.ok(
+      !out.text.includes('klai_sources'),
+      `whitespace-variant marker leaked at cut=${cut}: ${JSON.stringify(out.text)}`
+    );
+    assert.equal(
+      JSON.stringify(out.sources),
+      JSON.stringify(sources),
+      `whitespace-variant marker lost sources at cut=${cut}`
+    );
+  }
+}
+
+// Finding 6b: a legitimately large marker split past the old 8192 cap leaked
+// in full. The cap is a safety valve, not a normal limit.
+{
+  const many = Array.from({ length: 400 }, (_, i) => ({
+    label: String(i + 1),
+    url: `https://example.com/${'p'.repeat(40)}${i}`,
+  }));
+  const body = `Antwoord. <!-- klai_sources=${encodeMarker(many)} --> En verder.`;
+  assert.ok(body.length > 8192, 'this case must exceed the old cap to be meaningful');
+  const out = splitThroughFramer(body, 8300);
+  assert.ok(!out.text.includes('klai_sources'), 'oversized-but-valid marker leaked');
+  assert.equal(out.sources.length, 400, 'oversized-but-valid marker lost its sources');
+}
+
+// Finding 4: `sources: []` is not nullish, so `??` let it suppress a valid
+// inline marker. Only a non-empty list may count as "the producer spoke".
+{
+  const sources = [{ label: '1', url: 'https://example.com/a' }];
+  const agg = createContentAggregator();
+  agg.aggregateContent({
+    event: 'on_run_step',
+    data: { id: 's1', index: 0, stepDetails: { type: 'message_creation' } },
+  });
+  agg.aggregateContent({
+    event: 'on_message_delta',
+    data: {
+      id: 's1',
+      delta: {
+        content: [
+          {
+            type: 'text',
+            text: `Antwoord. <!-- klai_sources=${encodeMarker(sources)} -->`,
+            sources: [],
+          },
+        ],
+      },
+    },
+  });
+  assert.equal(agg.contentParts[0].text, 'Antwoord. ');
+  assert.equal(
+    JSON.stringify(agg.contentParts[0].sources),
+    JSON.stringify(sources),
+    'an empty sources array must not suppress the marker sources'
+  );
+}
+
+console.log(
+  'OK: built artifacts verified — search topResults + surrogate guards, ' +
+    'index.cjs cleanupOnComplete at every call site, stream marker edge cases.'
+);

--- a/deploy/librechat/tests/stream_sources.test.cjs
+++ b/deploy/librechat/tests/stream_sources.test.cjs
@@ -324,7 +324,12 @@ for (let cut = 1; cut < splitBody.length; cut++) {
 // flushed as plain text instead of buffering forever.
 {
   const framer = createKlaiSourcesFramer();
-  const hugeTail = `<!-- klai_sources=${'A'.repeat(9000)}`;
+  // Longer than every cap this file may run against: 8192 in the .cjs still
+  // bind-mounted in production, 65536 in the CI-built artifact (the cap was
+  // raised because a legitimately large marker split past 8192 leaked in full
+  // -- adversarial review 2026-08-14, finding 6). Sizing above both keeps this
+  // assertion true for either artifact instead of silently pinning one.
+  const hugeTail = `<!-- klai_sources=${'A'.repeat(70000)}`;
   const out = framer.push(`tekst ${hugeTail}`);
   assert.ok(out.text.includes(hugeTail), 'oversized tail must flush as text');
 }

--- a/deploy/scripts/tests/librechat-build-manifest.test.mjs
+++ b/deploy/scripts/tests/librechat-build-manifest.test.mjs
@@ -141,3 +141,91 @@ test('the CLI has no environment escape hatch that skips the image', () => {
     'verification succeeded against a non-existent image — an env var redirected it away from the image'
   );
 });
+
+// ---------------------------------------------------------------------------
+// Adversarial review 2026-08-14, finding 2: without external anchors the check
+// is self-attesting. It proved "this image agrees with its own manifest", not
+// "this image is what CI built from our diffs". The reviewer forged upstream
+// tag, agents ref, patch names and patch hashes and still got OK.
+// ---------------------------------------------------------------------------
+
+/** A manifest whose artifact hashes are honest but whose provenance is a lie. */
+function forgedInto(dir) {
+  const honest = generateManifest({
+    image: 'fake:tag',
+    upstreamTag: 'v0.8.7',
+    agentsRef: 'v3.2.46',
+    patchRevision: '1',
+    patchesDir,
+    extract: extractorFor(dir),
+  });
+  const forged = {
+    ...honest,
+    upstream_librechat_tag: 'v999-attacker',
+    agents_ref: 'v999-attacker',
+    klai_patch_revision: '666',
+    artifacts: honest.artifacts.map((a) => ({
+      ...a,
+      patch: `wrong-${a.patch}`,
+      patch_sha256: '0'.repeat(64),
+    })),
+  };
+  fs.writeFileSync(
+    path.join(dir, 'build-manifest.json'),
+    `${JSON.stringify(forged, null, 2)}\n`
+  );
+}
+
+test('forged provenance is caught when expectations are supplied', () => {
+  const dir = fakeImage();
+  forgedInto(dir);
+
+  assert.throws(
+    () =>
+      verifyManifest({
+        image: 'fake:tag',
+        expectUpstreamTag: 'v0.8.7',
+        expectAgentsRef: 'v3.2.46',
+        expectPatchRevision: '1',
+        patchesDir,
+        extract: extractorFor(dir),
+      }),
+    (error) => {
+      // Every lie must be named, not just the first one an operator trips over.
+      assert.match(error.message, /upstream_librechat_tag: expected v0\.8\.7/);
+      assert.match(error.message, /agents_ref: expected v3\.2\.46/);
+      assert.match(error.message, /klai_patch_revision: expected 1/);
+      assert.match(error.message, /built from wrong-/);
+      return true;
+    }
+  );
+});
+
+test('a manifest built from different diffs than this checkout is rejected', () => {
+  const dir = fakeImage();
+  const manifest = generateManifest({
+    image: 'fake:tag',
+    upstreamTag: 'v0.8.7',
+    agentsRef: 'v3.2.46',
+    patchRevision: '1',
+    patchesDir,
+    extract: extractorFor(dir),
+  });
+  // Same diff names, different content: the image was built from an older or
+  // tampered revision of our own patches.
+  manifest.artifacts[0].patch_sha256 = 'f'.repeat(64);
+  fs.writeFileSync(
+    path.join(dir, 'build-manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`
+  );
+
+  assert.throws(
+    () =>
+      verifyManifest({
+        image: 'fake:tag',
+        patchesDir,
+        extract: extractorFor(dir),
+      }),
+    /this checkout hashes to [0-9a-f]{64}, the image was built from f{64}/
+  );
+});

--- a/deploy/scripts/tests/librechat-patched-files.test.mjs
+++ b/deploy/scripts/tests/librechat-patched-files.test.mjs
@@ -83,3 +83,20 @@ test('no diff on disk is orphaned', () => {
     );
   }
 });
+
+test('the image-build workflow still runs the built-artifact suite', () => {
+  // built_artifacts.test.cjs skips when KLAI_BUILT_ARTIFACTS_DIR is unset,
+  // which is correct for the generic LibreChat workflow (no image) but means
+  // deleting the step below would silently drop search.cjs and index.cjs back
+  // out of coverage -- adversarial review finding 3, re-armed. Assert the step
+  // exists here instead of making the test itself fatal in every workflow.
+  const workflow = fs.readFileSync(
+    path.resolve(here, '../../../.github/workflows/librechat-image-build.yml'),
+    'utf8'
+  );
+  assert.match(
+    workflow,
+    /KLAI_BUILT_ARTIFACTS_DIR=\S+\s*\\?\s*\n?\s*node --test deploy\/librechat\/tests\/built_artifacts\.test\.cjs/,
+    'librechat-image-build.yml must run built_artifacts.test.cjs with KLAI_BUILT_ARTIFACTS_DIR set'
+  );
+});

--- a/deploy/scripts/verify-librechat-build-manifest.mjs
+++ b/deploy/scripts/verify-librechat-build-manifest.mjs
@@ -17,6 +17,7 @@
  * usage: verify-librechat-build-manifest.mjs --image <ref>
  */
 import fs from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
@@ -32,11 +33,23 @@ import {
 /**
  * @param {object} options
  * @param {string} options.image
+ * @param {string} [options.expectUpstreamTag]  Expected upstream LibreChat tag.
+ * @param {string} [options.expectAgentsRef]    Expected @librechat/agents ref.
+ * @param {string} [options.expectPatchRevision] Expected Klai patch revision.
+ * @param {string} [options.patchesDir] Re-hash the diffs in THIS checkout and
+ *   require the manifest to have been built from exactly them.
  * @param {typeof extractFromImage} [options.extract]
  * @returns {string} success summary
  * @throws {Error} with every mismatch listed
  */
-export function verifyManifest({ image, extract = extractFromImage }) {
+export function verifyManifest({
+  image,
+  expectUpstreamTag,
+  expectAgentsRef,
+  expectPatchRevision,
+  patchesDir,
+  extract = extractFromImage,
+}) {
   const entries = [
     ...PATCHED_FILES,
     { key: 'build-manifest.json', containerPath: MANIFEST_CONTAINER_PATH },
@@ -56,6 +69,51 @@ export function verifyManifest({ image, extract = extractFromImage }) {
 
   const byKey = new Map(manifest.artifacts.map((a) => [a.key, a]));
   const failures = [];
+
+  /* Without the checks below this function is self-attesting: it only proves
+     the image is internally consistent with its own manifest, so an image
+     built from entirely different diffs and a different upstream passes as
+     long as it agrees with itself (adversarial review 2026-08-14, finding 2 --
+     a manifest claiming upstream "v999-attacker" with zeroed patch hashes
+     verified OK). Provenance has to be anchored to something OUTSIDE the
+     artifact being checked: the caller's expectations and this checkout. */
+  const expectations = [
+    ['upstream_librechat_tag', expectUpstreamTag],
+    ['agents_ref', expectAgentsRef],
+    ['klai_patch_revision', expectPatchRevision],
+  ];
+  for (const [field, expected] of expectations) {
+    if (expected === undefined) continue;
+    if (manifest[field] !== expected) {
+      failures.push(
+        `${field}: expected ${expected}, manifest claims ${manifest[field]}`
+      );
+    }
+  }
+
+  if (patchesDir) {
+    for (const entry of PATCHED_FILES) {
+      const recorded = byKey.get(entry.key);
+      if (!recorded) continue; // reported below
+      if (recorded.patch !== entry.patch) {
+        failures.push(
+          `${entry.key}: built from ${recorded.patch}, this checkout applies ${entry.patch}`
+        );
+        continue;
+      }
+      const patchPath = path.join(patchesDir, entry.patch);
+      if (!fs.existsSync(patchPath)) {
+        failures.push(`${entry.patch}: not found in ${patchesDir}`);
+        continue;
+      }
+      const actual = sha256File(patchPath);
+      if (actual !== recorded.patch_sha256) {
+        failures.push(
+          `${entry.patch}: this checkout hashes to ${actual}, the image was built from ${recorded.patch_sha256}`
+        );
+      }
+    }
+  }
 
   for (const entry of PATCHED_FILES) {
     const recorded = byKey.get(entry.key);
@@ -96,13 +154,28 @@ const invokedDirectly =
   process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (invokedDirectly) {
-  const idx = process.argv.indexOf('--image');
-  if (idx === -1 || idx === process.argv.length - 1) {
+  const optional = (name) => {
+    const idx = process.argv.indexOf(`--${name}`);
+    return idx === -1 || idx === process.argv.length - 1
+      ? undefined
+      : process.argv[idx + 1];
+  };
+
+  const image = optional('image');
+  if (!image) {
     console.error('FATAL: missing required --image');
     process.exit(2);
   }
   try {
-    console.log(verifyManifest({ image: process.argv[idx + 1] }));
+    console.log(
+      verifyManifest({
+        image,
+        expectUpstreamTag: optional('expect-upstream-tag'),
+        expectAgentsRef: optional('expect-agents-ref'),
+        expectPatchRevision: optional('expect-patch-revision'),
+        patchesDir: optional('patches-dir'),
+      })
+    );
   } catch (error) {
     console.error(`FATAL: ${error.message}`);
     process.exit(1);


### PR DESCRIPTION
Externe adversarial review van #908. De centrale claim hield stand — de verschillen tussen herbouwde en gedeployde artifacts zijn inderdaad cosmetisch — maar er kwamen zes defecten uit, waarvan drie release-blockers voor fase 3. Alle zes gefixt, elk eerst gereproduceerd.

| # | Ernst | Bevinding |
|---|---|---|
| F1 | HIGH | image-tag was muteerbaar |
| F2 | HIGH | provenance-check was self-attesting |
| F3 | MED | testdekking claimde 5 artifacts, testte er 3 |
| F4 | MED | `sources: []` onderdrukte geldige marker-sources |
| F5 | MED | `--3way` degradeerde stil door de shallow clone |
| F6 | LOW | complete- en partiële markergrammatica verschilden |

## F1 — de tag kon bewegen

Elke push herbouwde en **overschreef** dezelfde `v0.8.7-klai.1`. Niet theoretisch: #908 pushte `sha256:518c181f…`, #913 verving hem door `sha256:42fa8a92…`. Zelf geverifieerd tegen de registry — de digest die ik vanochtend vastlegde is niet meer waar de tag naar wijst.

Een tag waar een canary op gepind staat mag niet bewegen, anders herstelt "rollback" niets. De tag draagt nu het commit dat hem maakte, de workflow weigert over een bestaande tag te pushen, en print de digest om op te pinnen.

## F2 — de check controleerde zichzelf

Hij bewees alleen dat de image het eens was met zijn eigen ingebakken manifest. Een image gebouwd uit heel andere diffs tegen een andere upstream slaagde dus, zolang hij intern consistent was. Gereproduceerd: een manifest met `upstream v999-attacker`, `wrong-*` patchnamen en nul-hashes gaf OK.

Verificatie neemt nu verwachte upstream-tag, agents-ref en patchrevisie, én herberekent de hashes van de diffs in **deze checkout** tegen wat het manifest beweert. Verankerd buiten het artefact dat gecontroleerd wordt.

## F3 — de dekkingsclaim was onwaar

`search.cjs` werd gekopieerd maar nooit geladen; `index.cjs` helemaal niet. De reviewer zette `topResults` van 3 naar 999 in een gebouwde `search.cjs` en alle drie suites bleven groen.

Nieuwe `built_artifacts.test.cjs` dekt beide. Voor `search` behavioureel op het geëxporteerde oppervlak (`topResults`) plus structureel voor de surrogaat-guards — **expliciet als structureel benoemd**, want `cleanText` is alleen bereikbaar via een volledige provider-vormige scrape-fixture. Voor `index.cjs`: dat `createStreamServices` het gebouwde bundel op élke call-site bereikte. In CI is een ontbrekende artifacts-dir een **failure**, geen skip — een stille skip is exact de valse dekking waar deze bevinding over gaat.

## F4 — pre-existing, niet door mij geïntroduceerd

`contentPart.sources ?? extracted.sources` liet `sources: []` geldige marker-sources onderdrukken, want een lege array is niet nullish. Dit zat al in de gedeployde patch; ik heb het trouw vertaald. Alleen een niet-lege lijst telt nu als "de producent heeft iets gezegd".

## F5 — de `--3way`-belofte was leeg

De Dockerfile clonede met `--depth 1` terwijl hij `git apply --3way` als bescherming noemde. Een shallow clone heeft geen basisblobs, dus 3-way degradeert stil naar gewone contextapplicatie. Clones gebruiken nu `--filter=blob:none`, en terugvallen op directe applicatie is fataal in plaats van een regel in het log.

## F6 — twee grammatica's die uit elkaar liepen

De complete regex accepteerde willekeurige whitespace, de partiële detector hardcodede één spatie, en tails boven 8192 tekens werden weggegooid. Beide lekken een hele marker in het zichtbare antwoord. Ze zijn nu afgeleid uit één grammatica, en de groottelimiet is gedocumenteerd als protocolcontract, ruim boven wat de producent ooit maakt.

## Productie blijft ongemoeid

De stream-fixes (F4, F6) veranderen gedrag, dus hun tests asserteren tegen het **gebouwde artefact**, niet tegen de `.cjs` die nog in productie gemount is. Deze PR raakt de fleet niet; die fixes bereiken gebruikers via de fase-3 canary — precies waar een canary voor is.

## Tests

11 librechat-suites + 11 script-tests groen. Elke nieuwe assertie geverifieerd als falend op de ongefixte artifact (whitespace-marker lekt bij cut=16, exact zoals gerapporteerd).

🤖 Generated with [Claude Code](https://claude.com/claude-code)