### PR TITLE
fix(vexa)!: take meeting-api off klai-net — forged X-User-Id read any transcript

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -40,6 +40,16 @@ networks:
     name: vexa12-internal
     driver: bridge
     internal: true   # only vexa12-meeting-api <-> vexa12-admin-api; no bot ever joins
+  vexa12-portal:
+    name: vexa12-portal
+    driver: bridge
+    internal: true
+    # ONLY portal-api <-> vexa12-meeting-api. meeting-api has no auth of its own in
+    # 0.12 (it trusts the X-User-Id header the absent gateway would set, and defaults
+    # to AllowAllServiceAuthority), so whatever network it sits on IS its authorization
+    # boundary. It was briefly on klai-net, which carries 70 containers including 42
+    # tenant LibreChat instances — any one of them could read any tenant's transcript
+    # with a forged X-User-Id. This network has exactly two members.
   vexa12-bots:
     name: vexa12-bots
     driver: bridge
@@ -760,6 +770,7 @@ services:
       - net-postgres
       - net-mongodb
       - net-redis
+      - vexa12-portal   # SPEC-VEXA-004: reaches vexa12-meeting-api; nothing else may
       - net-meilisearch  # SPEC-INFRA-TENANT-DELETE-003 Bug A — deprovisioning step 6 (_delete_meilisearch_index) needs DNS for meilisearch:7700
       - socket-proxy
 
@@ -1481,7 +1492,9 @@ services:
       vexa12-runtime:
         condition: service_started
     networks:
-      klai-net: {}        # portal-api reaches this directly; no gateway in front
+      # NOT klai-net — see the vexa12-portal network comment. meeting-api's network
+      # membership is its only authorization boundary.
+      vexa12-portal: {}
       net-postgres: {}
       vexa12-internal: {} # reaches vexa12-admin-api without exposing it to bots
       vexa12-bots:

--- a/klai-portal/backend/tests/contract/test_vexa_contract.py
+++ b/klai-portal/backend/tests/contract/test_vexa_contract.py
@@ -464,6 +464,41 @@ def test_bot_image_is_pinned_and_flagged_as_a_pull_prerequisite() -> None:
     )
 
 
+def test_meeting_api_is_not_on_a_shared_application_network() -> None:
+    """meeting-api's network membership IS its authorization boundary.
+
+    Vexa 0.12's meeting-api has no auth of its own: it trusts the X-User-Id header
+    the gateway would normally set (bot_spawn/router.py::_resolve_user_id accepts any
+    integer) and falls back to AllowAllServiceAuthority when no service-authority
+    config is present — which is Klai's configuration. Whatever network it sits on can
+    therefore read any tenant's transcripts and stop or spawn bots with a forged header.
+
+    It was briefly on klai-net, which carries ~70 containers including ~42 tenant
+    LibreChat instances. An adversarial review proved the spoof from an unrelated
+    container. Its network must stay a closed two-party link with portal-api.
+    """
+    compose = _compose()
+    services = compose["services"]
+    meeting_nets = set(services["vexa12-meeting-api"]["networks"])
+
+    shared = {"klai-net", "net-redis", "net-mongodb", "net-meilisearch", "socket-proxy"}
+    assert not (meeting_nets & shared), (
+        f"vexa12-meeting-api is on shared network(s) {sorted(meeting_nets & shared)}; any "
+        "container there can forge X-User-Id and read every tenant's transcripts"
+    )
+
+    link = meeting_nets & set(services["portal-api"]["networks"])
+    link.discard("net-postgres")  # both need the DB; that is not the API link
+    assert link, "portal-api has no dedicated network in common with vexa12-meeting-api"
+
+    for net in link:
+        members = sorted(n for n, v in services.items() if net in (v.get("networks") or {}))
+        assert members == ["portal-api", "vexa12-meeting-api"], (
+            f"network {net!r} must have exactly portal-api + vexa12-meeting-api, has {members}"
+        )
+        assert compose["networks"][net].get("internal") is True, f"{net!r} must be internal"
+
+
 def test_admin_api_is_not_reachable_from_the_bot_network() -> None:
     """Bot containers are the least-trusted thing in the stack.
 


### PR DESCRIPTION
Live authorization bypass found by adversarial review, introduced by me today.

Vexa 0.12's meeting-api has **no auth of its own** — it accepts any integer `X-User-Id` and falls back to `AllowAllServiceAuthority`. I dropped the gateway deliberately and wrote "klai-net isolation is the only boundary, accepted deliberately" — without measuring that klai-net carries **70 containers, 42 of them tenant LibreChat instances**.

Reproduced from `klai-knowledge-mcp`:
```
no header          -> 401
X-User-Id: 999999  -> 200
X-User-Id: 1 on GET /transcripts/google_meet/<real meeting> -> 200, 8 segments
```

**Fix:** meeting-api leaves klai-net for a dedicated `internal` network with exactly two members (portal-api + meeting-api). Locked by `test_meeting_api_is_not_on_a_shared_application_network`, mutation-verified.

**Does NOT close the root weakness** — the identity header is still unauthenticated, so the network IS the boundary. Restoring gateway/service-authority enforcement is the real fix and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)