### PR TITLE
feat(librechat): digest-pin guard + idempotent cleanup-on-complete

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -16,6 +16,7 @@ on:
       - 'deploy/grafana/provisioning/**'          # SPEC-SEC-024 M4.2 — alert rule + dashboard
       - 'deploy/check-image-pullable.sh'          # public self-host image pullability guard
       - 'deploy/check-image-tags.sh'              # compose image tag policy guard
+      - 'deploy/check-klai-librechat-digest.sh'   # Klai LibreChat image must be digest-pinned
       - 'deploy/scripts/**'                       # Public-safe deploy scripts; operator health scripts live in klai-infra
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
       - '.github/workflows/deploy-compose.yml'
@@ -44,9 +45,15 @@ jobs:
       - name: Validate image tags + pullability
         run: |
           set -e
-          chmod +x deploy/check-image-tags.sh deploy/check-image-pullable.sh
+          chmod +x deploy/check-image-tags.sh deploy/check-image-pullable.sh \
+                   deploy/check-klai-librechat-digest.sh
           sh deploy/check-image-tags.sh
           sh deploy/check-image-pullable.sh
+          # The Klai LibreChat image must be pinned by digest: on 2026-08-14 the
+          # tag v0.8.7-klai.1 was overwritten with different content, so a
+          # tag-pinned canary could not be rolled back to what it ran.
+          sh deploy/scripts/tests/check-klai-librechat-digest.test.sh
+          sh deploy/check-klai-librechat-digest.sh
           sh deploy/librechat/check-patch-drift.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test

--- a/deploy/check-klai-librechat-digest.sh
+++ b/deploy/check-klai-librechat-digest.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# SPEC-LIBRECHAT-PATCH-MODEL-001 — the Klai LibreChat image is pinned by DIGEST,
+# never by tag.
+#
+# Incident 2026-08-14: `ghcr.io/getklai/librechat:v0.8.7-klai.1` was pushed
+# twice with different content. The tag silently moved from
+# sha256:518c181f… to sha256:42fa8a92…. A canary pinned to that tag could not
+# be rolled back to what it was actually running, because the tag no longer
+# named that image.
+#
+# The build workflow now refuses to overwrite a tag, but that only protects
+# tags it creates. This guard protects the consuming end: nothing may reference
+# our LibreChat image by a name that can move.
+#
+# usage: check-klai-librechat-digest.sh [file ...]
+#        (defaults to the production manifests)
+
+set -eu
+
+if [ $# -gt 0 ]; then
+    FILES="$*"
+else
+    FILES="deploy/docker-compose.yml klai-portal/backend/app/core/config.py"
+fi
+
+IMAGE='ghcr.io/getklai/librechat'
+FAIL=0
+
+for f in $FILES; do
+    [ -f "$f" ] || continue
+
+    # Every mention of the image, minus comment lines: a comment explaining the
+    # rule must not trip the rule.
+    refs=$(grep -n "$IMAGE" "$f" | grep -vE '^[0-9]+: *#' || true)
+    [ -n "$refs" ] || continue
+
+    # A digest reference is ghcr.io/getklai/librechat@sha256:<64 hex>.
+    bad=$(printf '%s\n' "$refs" | grep -vE "${IMAGE}@sha256:[0-9a-f]{64}" || true)
+    if [ -n "$bad" ]; then
+        echo "ERROR: $IMAGE referenced by tag instead of digest in $f:" >&2
+        printf '%s\n' "$bad" >&2
+        FAIL=1
+    fi
+done
+
+if [ "$FAIL" -ne 0 ]; then
+    cat >&2 <<'EOF'
+
+A tag can be moved; a digest cannot. On 2026-08-14 the tag
+ghcr.io/getklai/librechat:v0.8.7-klai.1 was overwritten with a second,
+different image, so "roll back to that tag" stopped meaning anything.
+
+Pin the digest the build workflow printed:
+
+    image: ghcr.io/getklai/librechat@sha256:<64 hex>
+
+Keep the human-readable tag in a comment next to it if you want to know which
+build it is.
+EOF
+    exit 1
+fi
+
+echo "OK: every $IMAGE reference is digest-pinned."

--- a/deploy/librechat/getklai/entrypoint.sh
+++ b/deploy/librechat/getklai/entrypoint.sh
@@ -370,8 +370,14 @@ fi
 # literals inside it, and update the anchors below IN BOTH this file and
 # klai-entrypoint.sh.
 STREAM_CLEANUP_TARGET=/app/packages/api/dist/index.cjs
-if grep -q "SPEC-STREAM-CLEANUP-001" "$STREAM_CLEANUP_TARGET" 2>/dev/null; then
-  echo "[klai-entrypoint] SPEC-STREAM-CLEANUP-001 cleanup-on-complete patch already applied, skipping"
+# Two ways this can already be satisfied: this transform ran before (leaves
+# its own marker), or the image was built from the source diff and carries
+# CLEANUP_ON_COMPLETE. The second is the SPEC-LIBRECHAT-PATCH-MODEL-001
+# model, and matching on it is what keeps the runtime transform from
+# layering a duplicate cleanupOnComplete key on top of the baked-in one.
+# The identifier is the marker, not a comment: the bundler strips comments.
+if grep -qE "SPEC-STREAM-CLEANUP-001|CLEANUP_ON_COMPLETE" "$STREAM_CLEANUP_TARGET" 2>/dev/null; then
+  echo "[klai-entrypoint] cleanup-on-complete already in place (runtime marker or baked-in CLEANUP_ON_COMPLETE), skipping"
 else
   node <<'STREAM_CLEANUP_NODE'
 const { existsSync, readFileSync, writeFileSync } = require('fs');

--- a/deploy/librechat/klai-entrypoint.sh
+++ b/deploy/librechat/klai-entrypoint.sh
@@ -373,8 +373,14 @@ fi
 # literals inside it, and update the anchors below IN BOTH this file and
 # getklai/entrypoint.sh.
 STREAM_CLEANUP_TARGET=/app/packages/api/dist/index.cjs
-if grep -q "SPEC-STREAM-CLEANUP-001" "$STREAM_CLEANUP_TARGET" 2>/dev/null; then
-  echo "[klai-entrypoint] SPEC-STREAM-CLEANUP-001 cleanup-on-complete patch already applied, skipping"
+# Two ways this can already be satisfied: this transform ran before (leaves
+# its own marker), or the image was built from the source diff and carries
+# CLEANUP_ON_COMPLETE. The second is the SPEC-LIBRECHAT-PATCH-MODEL-001
+# model, and matching on it is what keeps the runtime transform from
+# layering a duplicate cleanupOnComplete key on top of the baked-in one.
+# The identifier is the marker, not a comment: the bundler strips comments.
+if grep -qE "SPEC-STREAM-CLEANUP-001|CLEANUP_ON_COMPLETE" "$STREAM_CLEANUP_TARGET" 2>/dev/null; then
+  echo "[klai-entrypoint] cleanup-on-complete already in place (runtime marker or baked-in CLEANUP_ON_COMPLETE), skipping"
 else
   node <<'STREAM_CLEANUP_NODE'
 const { existsSync, readFileSync, writeFileSync } = require('fs');

--- a/deploy/librechat/patches-source/createStreamServices.ts.patch
+++ b/deploy/librechat/patches-source/createStreamServices.ts.patch
@@ -2,13 +2,18 @@ diff --git a/packages/api/src/stream/createStreamServices.ts b/packages/api/src/
 index 11fd535..eb98cab 100644
 --- a/packages/api/src/stream/createStreamServices.ts
 +++ b/packages/api/src/stream/createStreamServices.ts
-@@ -45,8 +45,11 @@ export interface StreamServices {
+@@ -45,8 +45,16 @@ export interface StreamServices {
    jobStore: IJobStore;
    eventTransport: IEventTransport;
    isRedis: boolean;
 +  cleanupOnComplete: boolean;
  }
 
++/* SPEC-STREAM-CLEANUP-001 — baked in at source. The runtime transform in
++   klai-entrypoint.sh stands down when it finds CLEANUP_ON_COMPLETE in the
++   built bundle, so an image carrying this patch does not get a second,
++   duplicate cleanupOnComplete key layered on top at boot. The identifier
++   is the marker, not this comment: the bundler strips comments. */
 +const CLEANUP_ON_COMPLETE = false;
 +
  /**

--- a/deploy/librechat/tests/stream_services.test.cjs
+++ b/deploy/librechat/tests/stream_services.test.cjs
@@ -63,8 +63,16 @@ for (const [name, target] of [
 ]) {
   assert.match(target, /SPEC-STREAM-CLEANUP-001/, name);
   assert.match(target, /STREAM_CLEANUP_TARGET=\/app\/packages\/api\/dist\/index\.cjs/, name);
-  assert.match(target, /grep -q "SPEC-STREAM-CLEANUP-001" "\$STREAM_CLEANUP_TARGET"/, name);
-  assert.match(target, /already applied, skipping/, name);
+  // The skip-check must recognise BOTH ways the fix can already be present:
+  // this transform having run before, and an image built from the source diff
+  // carrying CLEANUP_ON_COMPLETE. Matching only the first would layer a second,
+  // duplicate cleanupOnComplete key on top of the baked-in one on the canary.
+  assert.match(
+    target,
+    /grep -qE "SPEC-STREAM-CLEANUP-001\|CLEANUP_ON_COMPLETE" "\$STREAM_CLEANUP_TARGET"/,
+    name,
+  );
+  assert.match(target, /already in place .*skipping/, name);
   assert.match(
     target,
     /required SPEC-STREAM-CLEANUP-001 patch target is missing/,

--- a/deploy/scripts/tests/check-klai-librechat-digest.test.sh
+++ b/deploy/scripts/tests/check-klai-librechat-digest.test.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Tests for check-klai-librechat-digest.sh.
+# Run: sh deploy/scripts/tests/check-klai-librechat-digest.test.sh
+
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd)
+guard="$repo_root/deploy/check-klai-librechat-digest.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+failures=0
+
+check() {
+    if [ "$2" = "$3" ]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1 (expected exit $2, got $3)"
+        failures=$((failures + 1))
+    fi
+}
+
+run() {
+    set +e
+    sh "$guard" "$1" >"$work/out" 2>&1
+    rc=$?
+    set -e
+}
+
+echo "check-klai-librechat-digest.sh"
+
+# 1. Digest form: accepted.
+cat >"$work/good.yml" <<'EOF'
+  librechat-getklai:
+    image: ghcr.io/getklai/librechat@sha256:7d8bb076261153e20e69e04ff95f599c1002e59b782afe82e8a1a17e4058f82a
+EOF
+run "$work/good.yml"
+check "accepts a digest reference" 0 "$rc"
+
+# 2. Tag form: rejected. This is the incident.
+cat >"$work/bad.yml" <<'EOF'
+  librechat-getklai:
+    image: ghcr.io/getklai/librechat:v0.8.7-klai.1
+EOF
+run "$work/bad.yml"
+check "rejects a tag reference" 1 "$rc"
+grep -q 'v0.8.7-klai.1' "$work/out" || {
+    echo "  FAIL rejection does not name the offending line"
+    failures=$((failures + 1))
+}
+
+# 3. Even a commit-suffixed tag is rejected: immutable by convention is not
+#    immutable by construction, and the whole point is to remove the judgement
+#    call at the consuming end.
+cat >"$work/suffixed.yml" <<'EOF'
+    image: ghcr.io/getklai/librechat:v0.8.7-klai.1-cc75acb0d37c
+EOF
+run "$work/suffixed.yml"
+check "rejects even a commit-suffixed tag" 1 "$rc"
+
+# 4. A comment explaining the rule must not trip the rule.
+cat >"$work/comment.yml" <<'EOF'
+    # never: ghcr.io/getklai/librechat:some-tag
+    image: ghcr.io/getklai/librechat@sha256:7d8bb076261153e20e69e04ff95f599c1002e59b782afe82e8a1a17e4058f82a
+EOF
+run "$work/comment.yml"
+check "ignores commented-out examples" 0 "$rc"
+
+# 5. A file that never mentions the image is fine.
+cat >"$work/unrelated.yml" <<'EOF'
+    image: ghcr.io/danny-avila/librechat:v0.8.7
+EOF
+run "$work/unrelated.yml"
+check "ignores files without the Klai image" 0 "$rc"
+
+# 6. A truncated digest must not pass as one.
+cat >"$work/short.yml" <<'EOF'
+    image: ghcr.io/getklai/librechat@sha256:7d8bb076
+EOF
+run "$work/short.yml"
+check "rejects a truncated digest" 1 "$rc"
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures check(s) failed"
+    exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
Fase 3-voorwerk, in de volgorde die de canary nodig heeft: eerst de image en de guards, daarna pas de canary erop wijzen.

## Digest-guard

`deploy/check-klai-librechat-digest.sh` laat elke verwijzing naar `ghcr.io/getklai/librechat` falen die geen digest is. De build-workflow weigert al een tag te overschrijven, maar dat beschermt alleen tags die hij zelf maakt — dit beschermt de consumerende kant.

Ook een tag mét commit-suffix wordt afgewezen: onveranderlijk-per-conventie is niet onveranderlijk-per-constructie, en het doel is juist de afweging weghalen op de plek waar iemand haast heeft. 6 tests, aangesloten op de deploy-compose validatiestap.

## Idempotente cleanup-on-complete

De entrypoint-transform herschrijft `isRedis: true` → `…, cleanupOnComplete: false`, en z'n skip-check zoekt naar z'n eigen marker. Een image gebouwd uit `createStreamServices.ts.patch` draagt het gedrag al, maar die marker niet — dus op de canary zou de transform een **tweede** `cleanupOnComplete` bovenop de ingebakken variant leggen.

Zelfde uitkomst, maar twee mechanismen voor één gedrag is precies het oud-naast-nieuw dat deze repo verbiedt, en een latere wijziging aan één ervan zou stil niet aankomen.

Opgelost aan de herkenningskant in plaats van de transform per tenant te slopen: de skip-check matcht nu ook `CLEANUP_ON_COMPLETE`, zodat de runtime-transform vanzelf afstaat overal waar de image het al levert — inclusief fase 5, zonder de entrypoints dan opnieuw aan te raken.

De marker moet een identifier zijn, geen comment: tegen een echte build geverifieerd dat de bundler comments stript (0 keer) terwijl `const CLEANUP_ON_COMPLETE = false` overleeft. Dat staat nu in de bron-diff, waar een volgende lezer kijkt.

11 librechat-suites + 6 digest-guard cases groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)