### PR TITLE
fix(renovate): merge through the API — GitHub auto-merge ignores the bypass

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,7 +6,12 @@ on:
     # runs by 1-3h under load, so this lands mid-morning at worst. The cadence
     # lives HERE and nowhere else — renovate.json5 deliberately has no top-level
     # schedule (see the comment there for the 28-week no-op it caused).
-    - cron: '0 3 * * 1'
+    # Hourly, not weekly. Renovate merges its own PRs through the API
+    # (platformAutomerge is off — see renovate.json5 for why), so a green PR
+    # only merges on the NEXT run. Weekly would mean a dependency update sits
+    # ready-to-merge for up to seven days. A run is ~2 minutes and does
+    # nothing when there is nothing to do.
+    - cron: '7 * * * *'
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,6 +31,18 @@
   // Re-enable the moment it gets a build/deploy job here.
   ignorePaths: ['klai-hubspot/**'],
 
+  // Renovate merges through the API itself instead of arming GitHub's
+  // auto-merge. Verified on PR #920 (2026-08-14): every check green, GitHub
+  // auto-merge armed, and it still sat there — GitHub's auto-merge evaluates
+  // the branch protection generically and reports REVIEW_REQUIRED, ignoring
+  // the bypass allowance granted to the klai-renovate app. Renovate's own
+  // merge call runs AS the app, so the bypass does apply.
+  //
+  // The cost is that merges happen on a Renovate run rather than the instant
+  // checks turn green, which is why the cron below is hourly rather than
+  // weekly.
+  platformAutomerge: false,
+
   // Mirrors min-release-age=7 in klai-portal/frontend/.npmrc. Without it
   // Renovate would propose a version the npm CLI then refuses to install while
   // generating the lockfile, producing a PR that cannot build. Keep the two


### PR DESCRIPTION
PR #920 was the proof: **every check green**, GitHub auto-merge **armed** by Renovate, and it still sat there for 13+ minutes.

GitHub's auto-merge evaluates branch protection generically and reports `REVIEW_REQUIRED` — it ignores the bypass allowance granted to the `klai-renovate` app on `main`. Renovate's *own* merge call runs **as the app**, so the bypass does apply there.

So: `platformAutomerge: false`. Renovate merges via the API instead of arming a feature that can never fire in this repo.

The cost is that a green PR merges on the **next** Renovate run rather than the instant checks pass — hence the cron goes **weekly → hourly**. A run is ~2 minutes and is a no-op when there's nothing to do; weekly would mean a ready-to-merge update waits up to seven days, which defeats the point of automerging.

Nothing is weakened: the required `quality` check and the 1-review rule for humans stay exactly as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)