### PR TITLE
feat(kb): per-connector failed-page teller + qdrant-client 1.19

### DIFF
--- a/.claude/rules/klai/pitfalls/process-rules.md
+++ b/.claude/rules/klai/pitfalls/process-rules.md
@@ -2382,3 +2382,61 @@ because nobody runs `gh run list --branch main` between merges.
 Manual playbook is the current state. Option 1 (Husky pre-push
 hook) is the cheapest mechanical guard and would have caught
 this incident before either dev pushed.
+
+## queue-is-not-a-rate-limiter (HIGH)
+A job queue orders work and prevents loss — it does not throttle the pace at
+which queue workers hit a downstream rate-limited service. knowledge-ingest
+runs LLM-enrichment jobs through Procrastinate worker-lanes, but the job
+bodies fired their LiteLLM calls unthrottled. The `klai-fast` alias budget in
+`deploy/litellm/config.yaml` is 45 rpm. During a bulk crawl of 550 jobs on
+2026-08-14, enrichment blew straight through it.
+
+**Reference incident:** 641 `enrichment_llm_error` (429) events over two
+weeks, 1165 permanently-failed enrich-bulk jobs, and one customer-visible
+source (intermedia.com, Ascend-KB) stuck on "failed" for 8 days before
+anyone noticed. Three independent rate-limiters existed on the same budget
+with no shared accounting — graphiti's own token bucket (30 rpm by itself),
+a separate limiter inside `taxonomy_classifier`/`content_labeler`, and none
+at all for enrichment. Each was correct in isolation; combined they offered
+structurally more throughput than the 45 rpm budget allowed. Retries made it
+worse: `RetryStrategy(max_attempts=2)` had no backoff, so both attempts of
+every job burned inside the same 20-second rate-limit window instead of
+spreading out.
+
+**Why:** Rate limits are a property of the downstream API's configured
+budget, not of any single caller. A queue only guarantees ordering and
+at-least-once delivery; nothing about "queue" implies "paced." When more
+than one limiter exists for the same budget/alias, their individual limits
+do not compose into a shared ceiling — they add up, and the real ceiling is
+silently exceeded the moment more than one caller is active concurrently.
+
+**Prevention (mechanical):**
+
+1. **One shared token bucket per budget/alias, not per caller.** All
+   chat/completions callsites in knowledge-ingest now route through
+   `knowledge_ingest/llm_throttle.py::shared_klai_fast_limiter()` — 0.6 rps
+   sustained, burst 10 — sized to the `klai-fast` alias's 45 rpm. Delete
+   any caller-local limiter once it targets the same alias; a second
+   independent limiter is not defense-in-depth, it's a budget leak.
+
+2. **Backoff on retries against a rate-limited call.** `RetryStrategy`
+   without an exponential wait means every retry attempt lands inside the
+   same rate-limit window as the original call, guaranteeing a second
+   429. Any retry policy wrapping an LLM/HTTP call MUST specify backoff
+   (procrastinate: `RetryStrategy(max_attempts=N, exponential_wait=S)` —
+   waits `S ** (attempts + 1)` seconds), not just `max_attempts`.
+
+3. **Drift-guard test, source-scan pattern.**
+   `klai-knowledge-ingest/tests/test_llm_throttle.py` fails CI if any
+   module contains the literal `"chat/completions"` without also
+   referencing `"shared_klai_fast_limiter"` in the same file. Same
+   mechanical shape as the ast-grep guards in `url-shape-multi-file-drift`
+   above: when a contract (here, "every LLM call goes through the shared
+   limiter") can drift silently across files, encode it as a source-scan
+   test rather than trusting code review to catch every new callsite.
+
+4. **Alert on the failure class, not just the root cause.** This was
+   invisible for two weeks because nothing paged on sustained 429s.
+   `deploy/grafana/provisioning/alerting/knowledge-ingest-llm-rules.yaml`
+   adds a rule on `enrichment_llm_error` rate — apply the same pattern to
+   any other queue-consumer calling a rate-limited external API.

--- a/deploy/grafana/provisioning/alerting/knowledge-ingest-llm-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/knowledge-ingest-llm-rules.yaml
@@ -1,0 +1,200 @@
+# knowledge-ingest LLM-throttle observability gap — two silent failure
+# classes ran undetected for two weeks (2026-07-31 to 2026-08-14): 641
+# `enrichment_llm_error` 429-storm events (see llm_throttle.py docstring)
+# and an unmonitored `stale_pending_artifacts_failed` reaper. Both events
+# exist in VictoriaLogs today under service:knowledge-ingest but had no
+# alert rule watching them.
+#
+# Pattern mirrored from ingest-rules.yaml (obs-001-ingest group, R16
+# ingest_error_rate_elevated): same folder, same instant-query LogsQL +
+# reduce(count) + threshold(gt) shape, same noDataState/execErrState,
+# same spec label so this routes through the existing SPEC-OBS-001 →
+# klai-ops-alerts-email policy in policies.yaml without adding a new
+# route (see that file's routing comment header).
+#
+# UID convention: spec-llm-0NN-<verb> — kept well under Grafana's hard
+# 40-char UID limit (see .claude/rules/klai/pitfalls/process-rules.md
+# grafana-uid-40-char-limit; a longer UID crashloops Grafana on
+# provisioning). Verified via scripts/audit-alert-uid-length.sh.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: obs-001-ingest-llm
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── R1: enrichment LLM-error burst (429 storm) ───────────────────
+      # Baseline is near-zero: isolated retried-and-recovered LLM calls are
+      # expected and must not page. A real 429 storm (the reference
+      # incident) produced hundreds of these in two weeks — >30 in a 15m
+      # window is well above single-flake noise and below "one bad batch
+      # of a dozen docs".
+      - uid: spec-llm-001-enrich-429-burst
+        title: knowledge_ingest_enrichment_llm_error_burst
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:knowledge-ingest AND event:enrichment_llm_error'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 900
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [30], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 30m
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-OBS-001
+          service_group: ingest
+        annotations:
+          summary: 'knowledge-ingest emitted >30 enrichment_llm_error events in 15 min'
+          description: |
+            knowledge-ingest logged more than 30 `enrichment_llm_error`
+            events (structlog warning from enrichment.py) in the last 15
+            minutes. This is the signature of a LiteLLM `klai-fast` alias
+            429 storm — the reference incident produced 641 of these
+            events over two weeks with zero alerting, causing 1165
+            permanently-failed enrich-bulk jobs.
+
+            The client-side token bucket in
+            `knowledge_ingest/llm_throttle.py` (`shared_klai_fast_limiter`)
+            is meant to keep enrichment traffic under the `klai-fast`
+            alias budget (45 rpm / 45k tpm, shared with klai-primary).
+            The pacing rate is controlled by the `LITELLM_KLAI_FAST_RPS`
+            env var (`Settings.litellm_klai_fast_rps`, default 0.6).
+
+            Triage:
+              1. service:knowledge-ingest AND event:enrichment_llm_error | sort by(_time) desc | limit 20
+              2. Confirm the error field on a sample of lines — 429 vs
+                 timeout vs a different upstream failure needs a different
+                 fix.
+              3. If genuinely 429-bound: check current concurrency (worker
+                 lane count) against `LITELLM_KLAI_FAST_RPS` — either the
+                 rate is set too high for current load, or a new caller of
+                 `/v1/chat/completions` is bypassing the shared limiter
+                 (see the drift-guard in tests/test_llm_throttle.py).
+              4. Failed jobs from the storm need manual re-enrichment once
+                 the throttle is corrected — they do not auto-retry
+                 indefinitely.
+
+      # ── R2: stale-pending-artifact reaper fired ───────────────────────
+      # The reaper (stale_pending_artifact_reaper.py) is a final safety
+      # net: normal enrichment should always set index_status to synced or
+      # failed itself. Baseline is zero fires; if the reaper catches
+      # anything, upstream enrichment is leaving artifacts stuck in
+      # `pending` — a single occurrence in the 30m window is worth paging
+      # on, same reasoning as the pg_qdrant_reconcile_failed rule (R17) in
+      # ingest-rules.yaml.
+      - uid: spec-llm-002-reaper-fired
+        title: knowledge_ingest_stale_pending_reaper_fired
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:knowledge-ingest AND event:stale_pending_artifacts_failed'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 1800
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 4h
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-OBS-001
+          service_group: ingest
+        annotations:
+          summary: 'knowledge-ingest stale-pending-artifact reaper failed one or more artifacts'
+          description: |
+            `stale_pending_artifact_reaper.py::reap_stale_pending_artifacts`
+            logged `stale_pending_artifacts_failed` — it force-failed one
+            or more knowledge artifacts that had been stuck in `pending`
+            for over 30 minutes with no runnable Procrastinate enrichment
+            job. This is a vangnet, not the normal path: normal enrichment
+            sets `index_status` to `synced` or `failed` itself.
+
+            A reaper fire means something upstream stopped an enrichment
+            job from ever completing or being retried — a crashed worker,
+            a Procrastinate job that silently dropped, or an enrichment
+            call that hung past the job's own timeout without raising.
+
+            Triage:
+              1. service:knowledge-ingest AND event:stale_pending_artifacts_failed | sort by(_time) desc | limit 20
+              2. The log line includes `count`, `cutoff_created_at`, and
+                 an `artifacts` list — identify the org_id / kb_id / path
+                 of each failed artifact.
+              3. Check whether the enrichment_llm_error burst rule
+                 (spec-llm-001-enrich-429-burst) also fired around the
+                 same window — a 429 storm can starve jobs long enough to
+                 go stale.
+              4. Failed artifacts are NOT automatically retried; re-trigger
+                 enrichment for the affected paths once the root cause is
+                 fixed.

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -50,6 +50,13 @@ class Settings(BaseSettings):
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""
+    # SPEC-INGEST-LLM-THROTTLE-001 — shared client-side rate limit for every
+    # klai-fast LiteLLM call (enrichment, Graphiti, taxonomy, selector-AI,
+    # labelers, RAGAS judge). See knowledge_ingest/llm_throttle.py. Default
+    # 0.6 rps = 36 rpm, under the 45 rpm klai-fast alias budget in
+    # deploy/litellm/config.yaml, leaving headroom for retries.
+    litellm_klai_fast_rps: float = 0.6
+    litellm_klai_fast_burst: float = 10.0
     enrichment_enabled: bool = True  # global kill switch
     # Seconds to wait after the last Gitea save before ingesting into the knowledge layer.
     # Prevents LLM enrichment calls on every auto-save during active editing.
@@ -81,12 +88,6 @@ class Settings(BaseSettings):
     graphiti_llm_model: str = "klai-fast"
     graphiti_max_concurrent: int = 1  # concurrent episodes; increase with paid LLM plan
     graphiti_episode_delay: float = 10.0
-    # Token bucket rate limit for LLM calls inside add_episode().
-    # Graphiti makes ~5 sequential HTTP calls per episode; this ensures they never
-    # exceed the upstream API limit regardless of LLM response time.
-    # Mistral Small is 100 RPM / 100k TPM for our production key. Keep Graphiti
-    # below that because enrichment and user-facing calls share klai-fast.
-    graphiti_llm_rps: float = 0.5
     # Portal integration for taxonomy (SPEC-KB-021)
     portal_url: str = "http://portal-api:8000"
     # Bearer token for outbound calls to portal-api internal endpoints

--- a/klai-knowledge-ingest/knowledge_ingest/content_labeler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/content_labeler.py
@@ -8,10 +8,12 @@ This is a deliberate separation of concerns (SPEC-KB-023):
 
 The blind label is the raw material for clustering in SPEC-KB-024.
 
-Rate limiting: shares the module-level _TokenBucketLimiter from taxonomy_classifier
-(same 1 req/s default) so label generation and taxonomy classification never race.
-Since labeling runs first and classification runs second, the two calls are
-naturally sequential with the shared limiter enforcing the upstream rate limit.
+Rate limiting: acquires from the process-wide shared klai-fast token bucket
+(knowledge_ingest.llm_throttle.shared_klai_fast_limiter), the same bucket
+taxonomy_classifier and every other klai-fast caller draws from, so label
+generation and taxonomy classification never combine to exceed the alias
+budget. Since labeling runs first and classification runs second, the two
+calls are naturally sequential.
 """
 
 from __future__ import annotations
@@ -23,8 +25,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
-from knowledge_ingest.graph import _RateLimitedTransport
-from knowledge_ingest.taxonomy_classifier import _get_llm_limiter
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -85,14 +86,10 @@ async def generate_content_label(
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for blind content label generation.
 
-    Uses _RateLimitedTransport with the shared taxonomy limiter (graphiti_llm_rps).
+    Acquires from the shared klai-fast token bucket before calling out.
     """
-    transport = _RateLimitedTransport(
-        wrapped=httpx.AsyncHTTPTransport(),
-        limiter=_get_llm_limiter(),
-    )
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(
-        transport=transport,
         timeout=settings.content_label_timeout,
     ) as client:
         resp = await client.post(

--- a/klai-knowledge-ingest/knowledge_ingest/contextual.py
+++ b/klai-knowledge-ingest/knowledge_ingest/contextual.py
@@ -40,6 +40,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -208,6 +209,7 @@ async def generate_document_summary(
         client_kwargs["transport"] = _transport
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(**client_kwargs) as client:
             resp = await asyncio.wait_for(
                 client.post(url, json=payload, headers=headers),

--- a/klai-knowledge-ingest/knowledge_ingest/description_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/description_generator.py
@@ -3,6 +3,7 @@ Generate short descriptions for taxonomy nodes using klai-fast.
 
 Max 200 chars, 5-second timeout, empty string fallback on error.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -12,6 +13,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -65,6 +67,7 @@ async def generate_node_description(
 
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for description generation."""
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=5.0) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ValidationError
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.context_strategies import STRATEGIES
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -169,6 +170,7 @@ async def _call_llm(prompt: str, path: str) -> dict:
         headers["Authorization"] = f"Bearer {settings.litellm_api_key}"
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=settings.enrichment_timeout) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/v1/chat/completions",
@@ -422,9 +424,7 @@ async def enrich_chunks(
             )
         enriched_text = f"{result.context_prefix}\n\n{chunk_text}"
         heading_path = (
-            heading_paths[chunk_index]
-            if heading_paths and chunk_index < len(heading_paths)
-            else ""
+            heading_paths[chunk_index] if heading_paths and chunk_index < len(heading_paths) else ""
         )
         return EnrichedChunk(
             original_text=chunk_text,

--- a/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py
@@ -40,6 +40,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -214,6 +215,7 @@ async def generate_answer(
     url = f"{settings.litellm_url}/v1/chat/completions"
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with _build_http_client(float(settings.rag_eval_judge_timeout), _transport) as client:
             resp = await client.post(url, json=payload, headers=headers)
             resp.raise_for_status()

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -34,6 +34,7 @@ import structlog
 
 import knowledge_ingest.qdrant_store as qdrant_store
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import TokenBucketLimiter, shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -42,31 +43,8 @@ logger = structlog.get_logger()
 _episode_semaphore: asyncio.Semaphore | None = None
 
 
-class _TokenBucketLimiter:
-    """Token bucket: enforces at most `rate` HTTP calls per second, no burst.
-
-    Applied to the AsyncOpenAI httpx transport so every LLM call Graphiti makes
-    internally (entity extraction, deduplication, etc.) is throttled — regardless
-    of how fast the upstream API responds.
-    """
-
-    def __init__(self, rate: float) -> None:
-        self._min_interval = 1.0 / rate
-        self._lock = asyncio.Lock()
-        self._next_allowed: float = 0.0
-
-    async def acquire(self) -> None:
-        async with self._lock:
-            loop = asyncio.get_event_loop()
-            now = loop.time()
-            wait = self._next_allowed - now
-            if wait > 0:
-                await asyncio.sleep(wait)
-            self._next_allowed = loop.time() + self._min_interval
-
-
 class _RateLimitedTransport(httpx.AsyncBaseTransport):
-    def __init__(self, wrapped: httpx.AsyncBaseTransport, limiter: _TokenBucketLimiter) -> None:
+    def __init__(self, wrapped: httpx.AsyncBaseTransport, limiter: TokenBucketLimiter) -> None:
         self._wrapped = wrapped
         self._limiter = limiter
 
@@ -185,7 +163,7 @@ def _graphiti_retry_delay(exc: Exception, attempt: int) -> tuple[str, float]:
         "503" in exc_str
         or "service unavailable" in exc_str
         or "internal_server_error" in exc_str
-        or "code\":\"3800" in exc_str
+        or 'code":"3800' in exc_str
         or "code': '3800" in exc_str
     ):
         return "provider_unavailable", 30.0 * (2**attempt)
@@ -217,9 +195,11 @@ def _get_graphiti() -> Graphiti:
         # max_retries=0: 429s surface immediately to our ingest_episode() retry loop
         # instead of being silently swallowed by the openai client for minutes.
         # Token bucket transport: throttles every HTTP call Graphiti makes internally
-        # (entity extraction, deduplication, embedding, etc.) to graphiti_llm_rps req/s.
-        # This prevents bursts that would exceed the upstream Mistral 1 req/s org limit.
-        _llm_limiter = _TokenBucketLimiter(rate=settings.graphiti_llm_rps)
+        # (entity extraction, deduplication, embedding, etc.) via the SHARED
+        # klai-fast budget (knowledge_ingest.llm_throttle), not a Graphiti-only
+        # rate. This prevents Graphiti's bursts from exceeding the upstream
+        # klai-fast alias budget in combination with every other klai-fast caller.
+        _llm_limiter = shared_klai_fast_limiter()
         openai_client = AsyncOpenAI(
             api_key=api_key,
             base_url=litellm_base_url,

--- a/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
+++ b/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
@@ -1,0 +1,96 @@
+"""Shared client-side rate limiter for every LiteLLM ``klai-fast`` call.
+
+Why this exists
+---------------
+
+The ``klai-fast`` alias in ``deploy/litellm/config.yaml`` has a 45 rpm / 45k
+tpm budget (half of mistral-small's upstream 100 rpm, shared with
+``klai-primary``). Before 2026-08-14, knowledge-ingest offered LiteLLM far
+more than that during bulk crawls: the LLM worker-lane ran 4 concurrent
+enrichment jobs firing one unthrottled chat call per chunk, while Graphiti
+paced only its OWN calls (0.5 rps ≈ 30 rpm — already most of the alias
+budget on its own). The overflow bounced as 429s: 641 ``enrichment_llm_error``
+events in two weeks, 1165 permanently-failed enrich-bulk jobs, and the
+intermedia.com source that stayed broken for 8 days.
+
+A Procrastinate queue orders the *jobs* but does not pace the *HTTP calls*
+the job bodies make. This module is that missing pacing layer: one
+process-wide token bucket that every ``klai-fast`` chat call acquires from,
+tuned under the alias budget so sustained bulk work simply runs slower
+instead of erroring.
+
+Burst capacity keeps interactive work snappy: an idle bucket lets the first
+``litellm_klai_fast_burst`` calls through immediately (a single-document
+re-sync mostly fits in the burst), and only sustained load degrades to the
+refill rate.
+
+Usage::
+
+    from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
+
+    await shared_klai_fast_limiter().acquire()
+    resp = await client.post(f"{settings.litellm_url}/v1/chat/completions", ...)
+
+``tests/test_llm_throttle.py`` contains a drift-guard that fails when a
+module POSTs to ``chat/completions`` without referencing this limiter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from knowledge_ingest.config import settings
+
+
+class TokenBucketLimiter:
+    """Async token bucket: ``rate`` sustained calls/sec with ``capacity`` burst.
+
+    ``acquire()`` returns immediately while burst tokens remain and sleeps
+    just long enough for the next token otherwise. The sleep happens while
+    holding the internal lock, so concurrent acquirers are served strictly
+    in arrival order — same serialisation behaviour as the previous
+    graph.py ``_TokenBucketLimiter``, now with a burst allowance.
+    """
+
+    def __init__(self, rate: float, capacity: float | None = None) -> None:
+        if rate <= 0:
+            raise ValueError(f"rate must be > 0, got {rate}")
+        self._rate = rate
+        self._capacity = max(1.0, capacity if capacity is not None else rate)
+        self._tokens = self._capacity
+        self._last: float | None = None
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            loop = asyncio.get_event_loop()
+            now = loop.time()
+            if self._last is not None:
+                self._tokens = min(self._capacity, self._tokens + (now - self._last) * self._rate)
+            self._last = now
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                return
+            wait = (1.0 - self._tokens) / self._rate
+            self._tokens = 0.0
+            await asyncio.sleep(wait)
+            self._last = loop.time()
+
+
+_shared_limiter: TokenBucketLimiter | None = None
+
+
+def shared_klai_fast_limiter() -> TokenBucketLimiter:
+    """Process-wide limiter for ALL klai-fast LiteLLM calls (lazy singleton).
+
+    Shared across enrichment, Graphiti, taxonomy, selector-AI, labelers and
+    the RAGAS judge so their combined rate stays under the 45 rpm alias
+    budget. Default 0.6 rps = 36 rpm, leaving headroom for retries.
+    """
+    global _shared_limiter
+    if _shared_limiter is None:
+        _shared_limiter = TokenBucketLimiter(
+            rate=settings.litellm_klai_fast_rps,
+            capacity=settings.litellm_klai_fast_burst,
+        )
+    return _shared_limiter

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -1521,7 +1521,8 @@ async def list_kb_sources(
 
     Returns ``{"connectors": [...], "uploads": [...]}`` where:
       - connectors: one row per distinct ``source_connector_id`` found in
-        artifacts.extra, with aggregate item_count + chunks_count
+        artifacts.extra, with aggregate items_count + items_failed_count
+        (active artifacts with index_status='failed') + chunks_count
       - uploads: one row per artifact whose ``source_connector_id`` is null
         (direct file/url/text/image uploads), with chunks_count
 
@@ -1529,12 +1530,18 @@ async def list_kb_sources(
     sync status, and last_sync_at from the portal-side ``connectors`` table.
     Knowledge-ingest does NOT know connector display metadata.
     """
-    # Connectors: one row per source_connector_id, with aggregate counts
+    # Connectors: one row per source_connector_id, with aggregate counts.
+    # items_count and items_failed_count both use COUNT(DISTINCT a.id [FILTER]) —
+    # the LEFT JOIN to parent_chunks fans out one row per chunk, so a plain
+    # COUNT(*) FILTER would overcount artifacts with >1 chunk. COUNT(DISTINCT)
+    # collapses the fanout back to one count per artifact regardless of how
+    # many chunk rows the join produced for it.
     connector_rows = await conn.fetch(
         """
         SELECT
             a.extra::jsonb->>'source_connector_id' AS connector_id,
             COUNT(DISTINCT a.id) AS items_count,
+            COUNT(DISTINCT a.id) FILTER (WHERE a.index_status = 'failed') AS items_failed_count,
             COUNT(pc.id) AS chunks_count
         FROM knowledge.artifacts a
         LEFT JOIN knowledge.parent_chunks pc ON pc.artifact_id = a.id
@@ -1552,6 +1559,7 @@ async def list_kb_sources(
         {
             "connector_id": row["connector_id"],
             "items_count": int(row["items_count"] or 0),
+            "items_failed_count": int(row["items_failed_count"] or 0),
             "chunks_count": int(row["chunks_count"] or 0),
         }
         for row in connector_rows

--- a/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
+++ b/klai-knowledge-ingest/knowledge_ingest/proposal_generator.py
@@ -71,6 +71,7 @@ import structlog
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.description_generator import generate_node_description
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 from knowledge_ingest.portal_client import TaxonomyProposal, submit_taxonomy_proposal
 from knowledge_ingest.taxonomy_classifier import TaxonomyNode
 
@@ -286,6 +287,7 @@ async def _suggest_cluster_name(
     doc_lines = "\n".join(f"- {doc.title}: {doc.content_preview[:200]}" for doc in cluster_docs)
     user_message = f"{len(cluster_docs)} documents in this cluster:\n{doc_lines}"
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",
@@ -385,6 +387,7 @@ async def _suggest_cluster_names_batched(
     user_message = "\n\n".join(cluster_lines)
 
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/chat/completions",
@@ -623,6 +626,7 @@ async def _consolidate_to_parents(
 
     max_tokens = 600 + 80 * n_clusters
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",
@@ -1184,6 +1188,7 @@ async def _suggest_category_name(documents: list[DocumentSummary]) -> str | None
     )
     user_message = f"Documents that don't fit existing categories:\n{doc_summaries}"
 
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
@@ -53,6 +53,7 @@ router = APIRouter()
 class ConnectorAggregate(BaseModel):
     connector_id: str
     items_count: int = 0
+    items_failed_count: int = 0
     chunks_count: int = 0
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/dry_run_merge_consolidate.py
@@ -59,6 +59,7 @@ from knowledge_ingest.clustering import (
 )
 from knowledge_ingest.config import settings
 from knowledge_ingest.description_generator import generate_node_description
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 from knowledge_ingest.portal_client import (
     fetch_kb_metadata,
     fetch_taxonomy_nodes,
@@ -413,6 +414,7 @@ async def _group_and_assign(
         max_tokens,
     )
     t0 = time.monotonic()
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(timeout=settings.taxonomy_classification_timeout) as client:
         resp = await client.post(
             f"{settings.litellm_url}/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/requeue_failed_artifacts.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/requeue_failed_artifacts.py
@@ -1,0 +1,271 @@
+"""Operator script: requeue failed artifacts for bulk enrichment.
+
+Context: before the shared LiteLLM token bucket (``knowledge_ingest/llm_throttle.py``)
+existed, concurrent crawls/imports routinely burned through every retry on
+``enrich_document_bulk`` (see ``knowledge_ingest/enrichment_tasks.py``) with
+429s. Roughly 1165 artifacts ended up permanently ``index_status='failed'``
+with no enriched chunks -- a silent quality regression, because ingest
+itself already reported success before enrichment ran. The 429 root cause
+is fixed now; this script re-enqueues bulk enrichment for the artifacts
+that were affected so they get a fair retry under the fixed throttle.
+
+Usage (inside the running container):
+
+    docker exec klai-core-knowledge-ingest-1 \\
+        python -m knowledge_ingest.scripts.requeue_failed_artifacts --dry-run
+
+    docker exec klai-core-knowledge-ingest-1 \\
+        python -m knowledge_ingest.scripts.requeue_failed_artifacts --execute
+
+    docker exec klai-core-knowledge-ingest-1 \\
+        python -m knowledge_ingest.scripts.requeue_failed_artifacts \\
+        --execute --org <org_id> --kb <kb_slug> --limit 200
+
+Selection: active artifacts (``belief_time_end = _SENTINEL`` -- the same
+"still current" marker every other active-artifact query in ``pg_store.py``
+uses) with ``index_status = 'failed'``, oldest ``created_at`` first,
+optionally scoped by ``--org`` / ``--kb``.
+
+Enqueue: defers ``enrich_document_bulk`` -- the exact task normal bulk
+ingest defers (see ``knowledge_ingest/routes/ingest.py``) -- with
+``queueing_lock=f"requeue:{artifact_id}"``. That lock namespace is
+deliberately distinct from normal ingest's
+``f"{org_id}:{kb_slug}:{path}:{artifact_id}"`` lock so a requeue can never
+collide with (or silently no-op against) a legitimate concurrent re-ingest
+of the same document.
+
+This script does NOT touch ``index_status`` itself. ``enrich_document_bulk``
+(via ``_load_and_enrich`` / ``_set_direct_upload_index_status`` in
+``enrichment_tasks.py``) is the sole owner of that field and sets it to
+``synced`` or ``failed`` once the retry completes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from knowledge_ingest.config import settings
+from knowledge_ingest.db import cross_org_admin_connection
+from knowledge_ingest.pg_store import _SENTINEL  # single source of truth -- do not re-literal
+
+if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import AsyncIterator
+
+    import asyncpg
+
+logger = structlog.get_logger()
+
+DEFAULT_LIMIT = 1000
+_LOG_EVERY = 100
+
+
+async def _select_failed_artifacts(
+    conn: asyncpg.Connection,
+    *,
+    org_id: str | None,
+    kb_slug: str | None,
+    limit: int,
+) -> list[dict]:
+    """Select active, failed artifacts oldest-``created_at``-first.
+
+    ``belief_time_end = _SENTINEL`` restricts to the currently-active
+    belief-time row per artifact -- a superseded/soft-deleted row must
+    never be requeued. ``org_id`` / ``kb_slug`` are optional scoping
+    filters: a static query with ``$N::text IS NULL OR ...`` clauses is
+    used (rather than building the WHERE clause with an f-string) so the
+    SQL text itself never varies with caller input.
+    """
+    params: list[Any] = [_SENTINEL, org_id, kb_slug, limit]
+
+    rows = await conn.fetch(
+        """
+        SELECT
+            a.id::text AS artifact_id,
+            a.org_id AS org_id,
+            a.kb_slug AS kb_slug,
+            a.path AS path,
+            a.created_at AS created_at
+        FROM knowledge.artifacts a
+        WHERE a.index_status = 'failed'
+          AND a.belief_time_end = $1
+          AND ($2::text IS NULL OR a.org_id = $2)
+          AND ($3::text IS NULL OR a.kb_slug = $3)
+        ORDER BY a.created_at ASC
+        LIMIT $4
+        """,
+        *params,
+    )
+    return [
+        {
+            "artifact_id": row["artifact_id"],
+            "org_id": row["org_id"],
+            "kb_slug": row["kb_slug"],
+            "path": row["path"],
+            "created_at": row["created_at"],
+        }
+        for row in rows
+    ]
+
+
+@asynccontextmanager
+async def _procrastinate_app() -> AsyncIterator[Any]:
+    """Bootstrap a standalone Procrastinate App with tasks registered.
+
+    Mirrors ``knowledge_ingest.worker.WorkerLifecycle.__aenter__``: this
+    script runs as a one-shot ``docker exec`` process outside the FastAPI
+    lifespan, so there is no already-open app to reuse via
+    ``enrichment_tasks.get_app()`` -- it has to build and open its own
+    connector pool, exactly like the worker does at container startup.
+    """
+    import procrastinate
+
+    from knowledge_ingest import enrichment_tasks
+    from knowledge_ingest.worker import _build_libpq_dsn
+
+    conninfo = _build_libpq_dsn(settings.postgres_dsn)
+    connector = procrastinate.PsycopgConnector(conninfo=conninfo, kwargs={})
+    app = enrichment_tasks.init_app(connector)
+    async with app.open_async():
+        yield app
+
+
+def _print_dry_run_summary(artifacts: list[dict]) -> None:
+    print(f"[dry-run] {len(artifacts)} failed artifact(s) would be requeued")
+    groups: dict[tuple[str, str], int] = {}
+    for artifact in artifacts:
+        key = (artifact["org_id"], artifact["kb_slug"])
+        groups[key] = groups.get(key, 0) + 1
+    for (org_id, kb_slug), count in sorted(groups.items()):
+        print(f"  org={org_id} kb={kb_slug}: {count}")
+    preview = artifacts[:10]
+    print(f"First {len(preview)} artifact(s):")
+    for artifact in preview:
+        print(
+            f"  {artifact['artifact_id']}  "
+            f"{artifact['org_id']}/{artifact['kb_slug']}/{artifact['path']}"
+        )
+
+
+async def _requeue(artifacts: list[dict]) -> tuple[int, int]:
+    """Defer ``enrich_document_bulk`` for every artifact.
+
+    Returns ``(enqueued, skipped_already_enqueued)``. ``AlreadyEnqueued`` is
+    expected (concurrent requeue run, or a live job already covers the
+    artifact) and must not abort the remaining batch.
+    """
+    from procrastinate.exceptions import AlreadyEnqueued
+
+    total = len(artifacts)
+    enqueued = 0
+    skipped = 0
+    async with _procrastinate_app() as proc_app:
+        for idx, artifact in enumerate(artifacts, start=1):
+            artifact_id = artifact["artifact_id"]
+            try:
+                await proc_app.enrich_document_bulk.configure(  # type: ignore[attr-defined]
+                    queueing_lock=f"requeue:{artifact_id}",
+                ).defer_async(artifact_id=artifact_id)
+                enqueued += 1
+            except AlreadyEnqueued:
+                skipped += 1
+                logger.info(
+                    "requeue_failed_artifact_already_enqueued",
+                    artifact_id=artifact_id,
+                    org_id=artifact["org_id"],
+                    kb_slug=artifact["kb_slug"],
+                )
+                continue
+
+            if idx % _LOG_EVERY == 0 or idx == total:
+                logger.info(
+                    "requeue_failed_artifacts_progress",
+                    processed=idx,
+                    total=total,
+                    enqueued=enqueued,
+                    skipped_already_enqueued=skipped,
+                )
+    return enqueued, skipped
+
+
+async def main(
+    *,
+    dry_run: bool,
+    limit: int,
+    org_id: str | None,
+    kb_slug: str | None,
+) -> None:
+    async with cross_org_admin_connection() as conn:
+        artifacts = await _select_failed_artifacts(
+            conn, org_id=org_id, kb_slug=kb_slug, limit=limit
+        )
+
+    if not artifacts:
+        logger.info(
+            "requeue_failed_artifacts_none_selected",
+            org_id=org_id,
+            kb_slug=kb_slug,
+        )
+        return
+
+    if dry_run:
+        _print_dry_run_summary(artifacts)
+        return
+
+    enqueued, skipped = await _requeue(artifacts)
+    logger.info(
+        "requeue_failed_artifacts_done",
+        selected=len(artifacts),
+        enqueued=enqueued,
+        skipped_already_enqueued=skipped,
+    )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Requeue index_status='failed' artifacts for bulk enrichment "
+            "(recovery from LiteLLM 429 exhaustion prior to the shared "
+            "token-bucket fix)."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Select and print candidates without enqueueing anything (default).",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually defer enrich_document_bulk for every selected artifact.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=f"Maximum artifacts to select, oldest first (default: {DEFAULT_LIMIT}).",
+    )
+    parser.add_argument("--org", dest="org_id", default=None, help="Restrict to one org_id.")
+    parser.add_argument("--kb", dest="kb_slug", default=None, help="Restrict to one kb_slug.")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    from knowledge_ingest.logging_setup import setup_logging
+
+    setup_logging("knowledge-ingest")
+
+    args = _parse_args()
+    asyncio.run(
+        main(
+            dry_run=not args.execute,
+            limit=args.limit,
+            org_id=args.org_id,
+            kb_slug=args.kb_slug,
+        )
+    )

--- a/klai-knowledge-ingest/knowledge_ingest/selector_ai.py
+++ b/klai-knowledge-ingest/knowledge_ingest/selector_ai.py
@@ -17,6 +17,7 @@ import structlog
 from klai_llm_safety import SafetyPhase, SafetyRequest, SafetySurface, check_text
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
 
@@ -47,6 +48,7 @@ DOM Summary:
 async def _call_llm(prompt: str, log_event: str) -> str | None:
     """Shared LLM call via LiteLLM proxy. Returns stripped response or None."""
     try:
+        await shared_klai_fast_limiter().acquire()
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
                 f"{settings.litellm_url}/v1/chat/completions",

--- a/klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py
+++ b/klai-knowledge-ingest/knowledge_ingest/taxonomy_classifier.py
@@ -8,9 +8,12 @@ Returns (matched_nodes, suggested_tags):
 Threshold: confidence >= 0.5, max 5 nodes, max 5 tags.
 30-second timeout; falls back to ([], []) on error without failing the ingest.
 
-Rate limiting: uses the same _TokenBucketLimiter/_RateLimitedTransport from graph.py,
-throttled to settings.graphiti_llm_rps (default 1 req/s) to avoid 429s on LiteLLM.
+Rate limiting: acquires from the process-wide shared klai-fast token bucket
+(knowledge_ingest.llm_throttle.shared_klai_fast_limiter) so this shares the
+same 45 rpm alias budget as every other klai-fast caller instead of pacing
+against its own separate rate.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -20,23 +23,14 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
-from knowledge_ingest.graph import _RateLimitedTransport, _TokenBucketLimiter
+from knowledge_ingest.llm_throttle import shared_klai_fast_limiter
 
 logger = structlog.get_logger()
-
-# Module-level rate limiter shared across all classify_document calls
-_llm_limiter: _TokenBucketLimiter | None = None
-
-
-def _get_llm_limiter() -> _TokenBucketLimiter:
-    global _llm_limiter
-    if _llm_limiter is None:
-        _llm_limiter = _TokenBucketLimiter(rate=settings.graphiti_llm_rps)
-    return _llm_limiter
 
 
 class TaxonomyNode:
     """Lightweight DTO for taxonomy nodes from the portal."""
+
     __slots__ = ("description", "id", "name")
 
     def __init__(self, id: int, name: str, description: str | None = None) -> None:
@@ -53,7 +47,7 @@ _SYSTEM_PROMPT = (
     "Only include nodes with confidence >= 0.5. Maximum 5 nodes and 5 tags. "
     "Return empty nodes list if no category matches with confidence >= 0.5. "
     "Tags should be lowercase, concise keywords describing the document content."
-    '\n\nReply with ONLY a JSON object, no markdown, no explanation: '
+    "\n\nReply with ONLY a JSON object, no markdown, no explanation: "
     '{"nodes": [{"node_id": <int>, "confidence": <float 0-1>}], '
     '"tags": ["<string>"]}'
 )
@@ -133,14 +127,10 @@ async def classify_document(
 async def _call_litellm(user_message: str) -> dict:
     """Call LiteLLM proxy for taxonomy classification.
 
-    Uses _RateLimitedTransport to throttle calls to graphiti_llm_rps (default 1/s).
+    Acquires from the shared klai-fast token bucket before calling out.
     """
-    transport = _RateLimitedTransport(
-        wrapped=httpx.AsyncHTTPTransport(),
-        limiter=_get_llm_limiter(),
-    )
+    await shared_klai_fast_limiter().acquire()
     async with httpx.AsyncClient(
-        transport=transport,
         timeout=settings.taxonomy_classification_timeout,
     ) as client:
         resp = await client.post(

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -269,6 +269,26 @@ def _mock_db_helpers(request):
                 pass
 
 
+@pytest.fixture(autouse=True)
+def _reset_shared_klai_fast_limiter():
+    """Reset the process-wide klai-fast token bucket before each test.
+
+    ``knowledge_ingest.llm_throttle.shared_klai_fast_limiter()`` is a lazy
+    singleton by design (one bucket per production process). Left
+    unreset across the test suite, its default burst capacity (10)
+    would be exhausted after the first ~10 tests that exercise a real
+    ``_call_litellm``/``_call_llm`` path, and every test after that
+    would pay the 1/0.6s pacing delay -- silently multiplying suite
+    runtime without any test asserting on it. Resetting to ``None``
+    gives each test a fresh, full-burst bucket.
+    """
+    import knowledge_ingest.llm_throttle as _llm_throttle_mod
+
+    _llm_throttle_mod._shared_limiter = None
+    yield
+    _llm_throttle_mod._shared_limiter = None
+
+
 @pytest.fixture
 def client(mock_pool):
     """Test client with auth middleware.

--- a/klai-knowledge-ingest/tests/test_kb_sources.py
+++ b/klai-knowledge-ingest/tests/test_kb_sources.py
@@ -37,6 +37,7 @@ def test_chunks_summary_response_uses_canonical_source_count_key() -> None:
         "sources_by_kb": {"kb-a": 4},
     }
 
+
 # -- count_chunks_per_kb ----------------------------------------------------
 
 
@@ -127,7 +128,12 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
         side_effect=[
             # Query 1 — connectors
             [
-                {"connector_id": "conn-x", "items_count": 5, "chunks_count": 23},
+                {
+                    "connector_id": "conn-x",
+                    "items_count": 5,
+                    "items_failed_count": 0,
+                    "chunks_count": 23,
+                },
             ],
             # Query 2 — uploads
             [
@@ -149,7 +155,12 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
     result = await pg_store.list_kb_sources(conn, "org-1", "kb-a")
 
     assert result["connectors"] == [
-        {"connector_id": "conn-x", "items_count": 5, "chunks_count": 23},
+        {
+            "connector_id": "conn-x",
+            "items_count": 5,
+            "items_failed_count": 0,
+            "chunks_count": 23,
+        },
     ]
     assert result["uploads"] == [
         {
@@ -174,6 +185,66 @@ async def test_list_kb_sources_groups_connectors_and_uploads() -> None:
     assert "display_name" in upload_sql
     assert "source_url" in upload_sql
     assert "ORDER BY a.created_at DESC" in upload_sql
+
+
+@pytest.mark.asyncio
+async def test_list_kb_sources_connector_items_failed_count() -> None:
+    """A connector with 2 failed + 3 synced active artifacts reports
+    items_failed_count == 2 (out of items_count == 5)."""
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        side_effect=[
+            # Query 1 — connectors: DB already aggregated 2 failed of 5 items.
+            [
+                {
+                    "connector_id": "conn-y",
+                    "items_count": 5,
+                    "items_failed_count": 2,
+                    "chunks_count": 30,
+                },
+            ],
+            # Query 2 — uploads (none)
+            [],
+        ]
+    )
+
+    result = await pg_store.list_kb_sources(conn, "org-1", "kb-a")
+
+    assert result["connectors"] == [
+        {
+            "connector_id": "conn-y",
+            "items_count": 5,
+            "items_failed_count": 2,
+            "chunks_count": 30,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_kb_sources_connector_query_avoids_join_fanout_on_failed_count() -> None:
+    """items_failed_count must be COUNT(DISTINCT a.id) FILTER(...), not a plain
+    COUNT(*) FILTER(...).
+
+    The connector query LEFT JOINs knowledge.parent_chunks onto artifacts, so a
+    single failed artifact with N parent_chunks produces N joined rows. A plain
+    ``COUNT(*) FILTER (WHERE a.index_status = 'failed')`` would count that one
+    failed artifact N times. ``COUNT(DISTINCT a.id) FILTER (...)`` collapses the
+    join fanout back to one count per distinct artifact — mirroring the
+    pre-existing items_count column, which uses the same DISTINCT pattern for
+    the same reason.
+    """
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[[], []])
+
+    await pg_store.list_kb_sources(conn, "org-1", "kb-a")
+
+    connector_sql = conn.fetch.await_args_list[0].args[0]
+    assert "COUNT(DISTINCT a.id) FILTER (WHERE a.index_status = 'failed')" in (
+        " ".join(connector_sql.split())
+    )
+    # Structural guard: no un-guarded COUNT(*) FILTER on index_status, which
+    # would double-count artifacts with more than one parent_chunk row.
+    assert "COUNT(*) FILTER" not in connector_sql
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_llm_throttle.py
+++ b/klai-knowledge-ingest/tests/test_llm_throttle.py
@@ -1,0 +1,84 @@
+"""Tests for knowledge_ingest.llm_throttle -- shared klai-fast token bucket.
+
+See knowledge_ingest/llm_throttle.py module docstring for the incident this
+module fixes (641 enrichment_llm_error 429s in two weeks, pre-2026-08-14).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from knowledge_ingest.llm_throttle import TokenBucketLimiter, shared_klai_fast_limiter
+
+
+class TestTokenBucketLimiterBurst:
+    @pytest.mark.asyncio
+    async def test_burst_capacity_returns_near_instantly(self):
+        """Acquires within the burst capacity must not sleep meaningfully."""
+        limiter = TokenBucketLimiter(rate=100, capacity=3)
+
+        t0 = time.monotonic()
+        for _ in range(3):
+            await limiter.acquire()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 0.1
+
+
+class TestTokenBucketLimiterPacing:
+    @pytest.mark.asyncio
+    async def test_exhausted_burst_paces_to_rate(self):
+        """Once the single-token burst is spent, subsequent acquires pace at ``rate``."""
+        limiter = TokenBucketLimiter(rate=50, capacity=1)
+
+        t0 = time.monotonic()
+        for _ in range(5):
+            await limiter.acquire()
+        elapsed = time.monotonic() - t0
+
+        # First acquire is free (burst=1); the remaining 4 pace at 1/50s each,
+        # so the floor is 4/50 = 0.08s. Assert a slightly looser floor to
+        # absorb scheduler jitter while still catching a broken/no-op limiter.
+        assert elapsed >= 0.06
+        # Keep the test fast — must stay well under a second.
+        assert elapsed < 1.0
+
+
+class TestSharedKlaiFastLimiterSingleton:
+    def test_returns_same_instance_across_calls(self):
+        first = shared_klai_fast_limiter()
+        second = shared_klai_fast_limiter()
+
+        assert first is second
+
+
+class TestChatCompletionsThrottleDriftGuard:
+    """Fails loudly when a new klai-fast caller forgets to throttle.
+
+    Every module under ``knowledge_ingest/`` (excluding tests) that POSTs to
+    a ``chat/completions`` endpoint MUST also reference
+    ``shared_klai_fast_limiter`` -- otherwise it bypasses the shared budget
+    and can trigger 429s on LiteLLM again, exactly like the incident this
+    module was built to fix.
+    """
+
+    def test_every_chat_completions_caller_uses_shared_limiter(self):
+        package_root = Path(__file__).resolve().parent.parent / "knowledge_ingest"
+        offenders: list[str] = []
+
+        for path in sorted(package_root.rglob("*.py")):
+            relative = path.relative_to(package_root)
+            if "tests" in relative.parts:
+                continue
+            source = path.read_text(encoding="utf-8")
+            if "chat/completions" in source and "shared_klai_fast_limiter" not in source:
+                offenders.append(str(relative))
+
+        assert not offenders, (
+            "These files POST to chat/completions without acquiring from "
+            "shared_klai_fast_limiter() -- they bypass the shared klai-fast "
+            f"rate budget: {offenders}"
+        )

--- a/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
+++ b/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
@@ -475,3 +475,48 @@ class TestListKbSourcesIndexStatus:
         assert len(uploads) == 1
         assert uploads[0]["index_status"] == "pending"
         assert uploads[0]["index_status_changed_at"] == 1751330000
+
+
+# ---------------------------------------------------------------------------
+# Smoke: list_kb_sources returns items_failed_count on connectors
+# ---------------------------------------------------------------------------
+class TestListKbSourcesConnectorFailedCount:
+    def test_connector_row_includes_items_failed_count(self) -> None:
+        """End-to-end: the connectors sub-list carries items_failed_count
+        from the DB row through ConnectorAggregate to the JSON response."""
+        conn = _make_mock_conn()
+
+        connector_row = {
+            "connector_id": "conn-z",
+            "items_count": 5,
+            "items_failed_count": 2,
+            "chunks_count": 30,
+        }
+        # list_kb_sources makes two fetch calls: connectors then uploads.
+        call_count = 0
+
+        async def _side_effect(sql: str, *args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [connector_row]
+            return []
+
+        conn.fetch = AsyncMock(side_effect=_side_effect)
+
+        with patch(
+            "knowledge_ingest.routes.kb_sources.assert_caller_identity_tenant_only",
+            AsyncMock(return_value=_ORG),
+        ):
+            with _client_with_conn(conn) as client:
+                resp = client.get(
+                    f"/knowledge/v1/kb/{_KB}/sources",
+                    params={"org_id": _ORG},
+                )
+
+        assert resp.status_code == 200
+        connectors = resp.json()["connectors"]
+        assert len(connectors) == 1
+        assert connectors[0]["items_count"] == 5
+        assert connectors[0]["items_failed_count"] == 2
+        assert connectors[0]["chunks_count"] == 30

--- a/klai-knowledge-ingest/tests/test_requeue_failed_artifacts.py
+++ b/klai-knowledge-ingest/tests/test_requeue_failed_artifacts.py
@@ -1,0 +1,217 @@
+"""Tests for the requeue_failed_artifacts operator script.
+
+Mirrors the mock style of ``tests/test_stale_pending_artifact_reaper.py``:
+``cross_org_admin_connection`` and the Procrastinate app bootstrap are both
+patched out, so no real Postgres/psycopg connection is ever required.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog.testing
+
+from knowledge_ingest.scripts import requeue_failed_artifacts as script
+
+_SENTINEL = 253402300800
+
+
+def _row(
+    artifact_id: str,
+    *,
+    org_id: str = "org1",
+    kb_slug: str = "kb1",
+    path: str = "a.md",
+    created_at: int = 1700000000,
+) -> dict:
+    return {
+        "artifact_id": artifact_id,
+        "org_id": org_id,
+        "kb_slug": kb_slug,
+        "path": path,
+        "created_at": created_at,
+    }
+
+
+def _make_conn(rows: list[dict]) -> MagicMock:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    return conn
+
+
+class _FakeBulkTask:
+    """Stand-in for ``proc_app.enrich_document_bulk``."""
+
+    def __init__(self, fail_for: set[str] | None = None) -> None:
+        self.configure_calls: list[dict] = []
+        self.defer_calls: list[str] = []
+        self._fail_for = fail_for or set()
+
+    def configure(self, **kwargs: object) -> _FakeBulkTask:
+        self.configure_calls.append(kwargs)
+        return self
+
+    async def defer_async(self, *, artifact_id: str) -> None:
+        self.defer_calls.append(artifact_id)
+        if artifact_id in self._fail_for:
+            from procrastinate.exceptions import AlreadyEnqueued
+
+            raise AlreadyEnqueued()
+
+
+class _FakeApp:
+    def __init__(self, fail_for: set[str] | None = None) -> None:
+        self.enrich_document_bulk = _FakeBulkTask(fail_for=fail_for)
+
+
+@asynccontextmanager
+async def _conn_ctx(conn: MagicMock):
+    yield conn
+
+
+@asynccontextmanager
+async def _app_ctx(app: _FakeApp):
+    yield app
+
+
+# ---------------------------------------------------------------------------
+# (a) selection SQL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_select_failed_artifacts_uses_expected_filters_no_scoping():
+    conn = _make_conn([])
+
+    await script._select_failed_artifacts(conn, org_id=None, kb_slug=None, limit=500)
+
+    assert conn.fetch.await_count == 1
+    sql, *params = conn.fetch.call_args.args
+    assert "index_status = 'failed'" in sql
+    assert "belief_time_end = $1" in sql
+    assert "$2::text IS NULL OR a.org_id = $2" in sql
+    assert "$3::text IS NULL OR a.kb_slug = $3" in sql
+    assert "ORDER BY a.created_at ASC" in sql
+    assert "LIMIT $4" in sql
+    assert params == [_SENTINEL, None, None, 500]
+
+
+@pytest.mark.asyncio
+async def test_select_failed_artifacts_applies_org_and_kb_scoping():
+    conn = _make_conn([])
+
+    await script._select_failed_artifacts(conn, org_id="org1", kb_slug="kb1", limit=10)
+
+    _sql, *params = conn.fetch.call_args.args
+    assert params == [_SENTINEL, "org1", "kb1", 10]
+
+
+@pytest.mark.asyncio
+async def test_select_failed_artifacts_maps_rows_to_dicts():
+    conn = _make_conn([_row("11111111-2222-3333-4444-555555555555")])
+
+    result = await script._select_failed_artifacts(conn, org_id=None, kb_slug=None, limit=500)
+
+    assert result == [_row("11111111-2222-3333-4444-555555555555")]
+
+
+# ---------------------------------------------------------------------------
+# (b) dry-run defers nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dry_run_prints_summary_and_never_requeues(capsys):
+    rows = [_row("a1"), _row("a2", org_id="org2", kb_slug="kb2")]
+    conn = _make_conn(rows)
+
+    with (
+        patch.object(script, "cross_org_admin_connection", return_value=_conn_ctx(conn)),
+        patch.object(script, "_requeue", new_callable=AsyncMock) as mock_requeue,
+    ):
+        await script.main(dry_run=True, limit=1000, org_id=None, kb_slug=None)
+
+    mock_requeue.assert_not_called()
+    out = capsys.readouterr().out
+    assert "dry-run" in out
+    assert "2 failed artifact(s)" in out
+    assert "a1" in out
+    assert "a2" in out
+
+
+@pytest.mark.asyncio
+async def test_no_artifacts_selected_returns_early_without_requeue():
+    conn = _make_conn([])
+
+    with (
+        patch.object(script, "cross_org_admin_connection", return_value=_conn_ctx(conn)),
+        patch.object(script, "_requeue", new_callable=AsyncMock) as mock_requeue,
+    ):
+        await script.main(dry_run=False, limit=1000, org_id=None, kb_slug=None)
+
+    mock_requeue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (c) execute defers with the requeue-specific queueing_lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_defers_enrich_document_bulk_with_requeue_lock():
+    rows = [_row("a1"), _row("a2")]
+    conn = _make_conn(rows)
+    fake_app = _FakeApp()
+
+    with (
+        patch.object(script, "cross_org_admin_connection", return_value=_conn_ctx(conn)),
+        patch.object(script, "_procrastinate_app", return_value=_app_ctx(fake_app)),
+    ):
+        await script.main(dry_run=False, limit=1000, org_id=None, kb_slug=None)
+
+    task = fake_app.enrich_document_bulk
+    assert task.defer_calls == ["a1", "a2"]
+    assert task.configure_calls == [
+        {"queueing_lock": "requeue:a1"},
+        {"queueing_lock": "requeue:a2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_emits_done_summary_log_event():
+    rows = [_row("a1")]
+    conn = _make_conn(rows)
+    fake_app = _FakeApp()
+
+    with (
+        patch.object(script, "cross_org_admin_connection", return_value=_conn_ctx(conn)),
+        patch.object(script, "_procrastinate_app", return_value=_app_ctx(fake_app)),
+        structlog.testing.capture_logs() as captured,
+    ):
+        await script.main(dry_run=False, limit=1000, org_id=None, kb_slug=None)
+
+    done_events = [e for e in captured if e["event"] == "requeue_failed_artifacts_done"]
+    assert len(done_events) == 1
+    assert done_events[0]["selected"] == 1
+    assert done_events[0]["enqueued"] == 1
+    assert done_events[0]["skipped_already_enqueued"] == 0
+
+
+# ---------------------------------------------------------------------------
+# (d) AlreadyEnqueued -> skipped, loop continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_already_enqueued_is_skipped_and_does_not_stop_the_batch():
+    rows = [_row("a1"), _row("a2"), _row("a3")]
+    fake_app = _FakeApp(fail_for={"a2"})
+
+    with patch.object(script, "_procrastinate_app", return_value=_app_ctx(fake_app)):
+        enqueued, skipped = await script._requeue(rows)
+
+    assert fake_app.enrich_document_bulk.defer_calls == ["a1", "a2", "a3"]
+    assert enqueued == 2
+    assert skipped == 1

--- a/klai-knowledge-ingest/uv.lock
+++ b/klai-knowledge-ingest/uv.lock
@@ -2806,7 +2806,7 @@ wheels = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.17.1"
+version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
@@ -2817,9 +2817,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/33/c6e4ec45b4fca5a0b808e8804e60be54a6d7505b68b53c0b1d0d62ba86c1/qdrant_client-1.19.0.tar.gz", hash = "sha256:365395a04b0a26c309b25b7d8b1c99ef2071ec9a2b74bc8a5fd3b7a3642fe963", size = 350953, upload-time = "2026-08-04T14:32:56.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/69/77d1a971c4b933e8c79403e99bcbb790463da5e48333cc4fd5d412c63c98/qdrant_client-1.17.1-py3-none-any.whl", hash = "sha256:6cda4064adfeaf211c751f3fbc00edbbdb499850918c7aff4855a9a759d56cbd", size = 389947, upload-time = "2026-03-13T17:13:43.156Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/3c/480c61cc8d5a3e76bb44e86231f408c93643e5498beadbbeb381ab55d02b/qdrant_client-1.19.0-py3-none-any.whl", hash = "sha256:13602a2b3478a95ecdf42f97b93d7f703b63a3361cd912a04495a33a5ac14121", size = 396157, upload-time = "2026-08-04T14:32:55.734Z" },
 ]
 
 [[package]]

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -1022,6 +1022,7 @@ class SourceOut(BaseModel):
     source_url: str | None = None  # direct URL uploads only; stable source URL for drill-down display
     items_count: int = 0  # number of artifacts under a connector; 1 for direct uploads
     chunks_count: int = 0  # parent_chunks across the bron's artifact(s)
+    items_failed_count: int = 0  # connector pages that failed processing; 0 for uploads
     status: str | None = None  # raw last_sync_status for connectors; None for uploads
     last_sync_at: datetime | None = None
     created_at: datetime | None = None  # for uploads — sort key
@@ -1219,6 +1220,7 @@ async def list_kb_sources(
                     connector_type=None,
                     items_count=int(agg.get("items_count") or 0),
                     chunks_count=int(agg.get("chunks_count") or 0),
+                    items_failed_count=int(agg.get("items_failed_count") or 0),
                     status="orphan",
                 )
             )
@@ -1232,6 +1234,7 @@ async def list_kb_sources(
                     connector_type=portal_conn.connector_type,
                     items_count=int(agg.get("items_count") or 0),
                     chunks_count=int(agg.get("chunks_count") or 0),
+                    items_failed_count=int(agg.get("items_failed_count") or 0),
                     status=portal_conn.last_sync_status,
                     last_sync_at=portal_conn.last_sync_at,
                 )
@@ -1251,6 +1254,7 @@ async def list_kb_sources(
                 connector_type=portal_conn.connector_type,
                 items_count=0,
                 chunks_count=0,
+                items_failed_count=0,
                 status=portal_conn.last_sync_status,
                 last_sync_at=portal_conn.last_sync_at,
             )

--- a/klai-portal/backend/tests/test_app_knowledge_sources_list.py
+++ b/klai-portal/backend/tests/test_app_knowledge_sources_list.py
@@ -173,7 +173,7 @@ async def test_list_kb_sources_merges_connectors_and_uploads() -> None:
 
     aggregates = {
         "connectors": [
-            {"connector_id": "conn-1", "items_count": 5, "chunks_count": 23},
+            {"connector_id": "conn-1", "items_count": 5, "chunks_count": 23, "items_failed_count": 3},
         ],
         "uploads": [
             {
@@ -216,11 +216,13 @@ async def test_list_kb_sources_merges_connectors_and_uploads() -> None:
     assert by_id["conn-1"].kind == "connector"
     assert by_id["conn-1"].items_count == 5
     assert by_id["conn-1"].chunks_count == 23
+    assert by_id["conn-1"].items_failed_count == 3
     assert by_id["conn-1"].name == "Productdocs"
     assert by_id["conn-1"].type_label == "Notion"
 
     assert by_id["conn-2"].items_count == 0
     assert by_id["conn-2"].chunks_count == 0
+    assert by_id["conn-2"].items_failed_count == 0
     assert by_id["conn-2"].status == "pending"
 
     assert by_id["art-1"].kind == "upload"
@@ -228,6 +230,7 @@ async def test_list_kb_sources_merges_connectors_and_uploads() -> None:
     assert by_id["art-1"].type_label == "PDF"
     assert by_id["art-1"].source_url is None
     assert by_id["art-1"].chunks_count == 7
+    assert by_id["art-1"].items_failed_count == 0
     assert by_id["art-1"].created_at is not None
     # index_status_changed_at (epoch) surfaces as last_sync_at so the frontend
     # measures "Bezig sinds Xm" from the (re)sync start, not artifact creation.
@@ -328,6 +331,9 @@ async def test_list_kb_sources_handles_orphan_connector_id() -> None:
     bron = result.sources[0]
     assert bron.id == "deleted-conn"
     assert bron.status == "orphan"
+    # Older knowledge-ingest versions may not emit items_failed_count yet —
+    # absence must not crash and must default to 0.
+    assert bron.items_failed_count == 0
     assert "verwijderde" in bron.name
 
 

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -750,6 +750,7 @@
   "kb_status_probleem": "Issue",
   "kb_status_failed_tooltip": "Processing this source failed. Click the refresh icon to retry.",
   "kb_status_leeg": "Not synced",
+  "kb_connector_failed_items": "{count} pages failed processing",
   "knowledge_page_meta_items": "{count} items",
   "knowledge_page_meta_items_personal": "{count} items remembered",
   "knowledge_page_meta_connectors": "{count} connectors",

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -750,6 +750,7 @@
   "kb_status_probleem": "Probleem",
   "kb_status_failed_tooltip": "De verwerking van deze bron is mislukt. Klik op het refresh-icoon hiernaast om het opnieuw te proberen.",
   "kb_status_leeg": "Niet gesynct",
+  "kb_connector_failed_items": "{count} pagina's niet verwerkt",
   "knowledge_page_meta_items": "{count} items",
   "knowledge_page_meta_items_personal": "{count} items onthouden",
   "knowledge_page_meta_connectors": "{count} connectors",

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -17,10 +17,11 @@ import type { Source } from './-sources-types'
  * Below this we just show "Bezig sinds Xm" as informational; at/above it
  * the badge flips to a warning ("Hangt al Xm") so the user knows to retry.
  *
- * Lives here (not in a backend SPEC) until SPEC-KB-INGEST-RELIABILITY-001
- * adds a proper backend timeout + auto-fail reaper for url/upload sources.
- * Mirrors the connector-side `sync_run_reaper._FORCE_FAIL_AFTER_S` logic
- * but on the frontend only, so it's an indicator — not enforcement.
+ * This is a frontend-only indicator, not enforcement: the backend reaper
+ * (knowledge-ingest `stale_pending_artifact_reaper`) auto-fails artifacts
+ * stuck in 'pending' for over 30 minutes, running every 15 minutes. This
+ * threshold is intentionally shorter so the badge warns the user well
+ * before the backend gives up.
  */
 const STUCK_THRESHOLD_MINUTES = 10
 
@@ -144,6 +145,24 @@ export function StatusBadge({ source }: { source: Source }) {
     not_synced: 'secondary' as const,
   }
   return <Badge variant={variantMap[status]}>{labelMap[status]}</Badge>
+}
+
+/**
+ * Partial-failure indicator for connector rows. The connector as a whole
+ * can be "Gesynct" while individual pages under it silently failed — this
+ * surfaces that instead of letting the aggregate status hide it. Deliberately
+ * NOT the destructive/red treatment: the connector itself is healthy, this
+ * is a sub-count warning, not a broken-connector signal.
+ */
+export function FailedItemsWarning({ source }: { source: Source }) {
+  if (source.kind !== 'connector') return null
+  const failedCount = source.items_failed_count ?? 0
+  if (failedCount <= 0) return null
+  return (
+    <span className="text-xs text-[var(--color-warning)]">
+      {m.kb_connector_failed_items({ count: String(failedCount) })}
+    </span>
+  )
 }
 
 export function SourceIcon({ source }: { source: Source }) {

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-row.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-row.tsx
@@ -32,7 +32,7 @@ import {
 import * as m from '@/paraglide/messages'
 import { SourceContent } from './-sources-content'
 import { SourceRowActions } from './-sources-row-actions'
-import { SourceIcon, StatusBadge } from './-sources-helpers'
+import { FailedItemsWarning, SourceIcon, StatusBadge } from './-sources-helpers'
 import { useSourceRename } from './-sources-hooks'
 import type { Source } from './-sources-types'
 
@@ -104,6 +104,7 @@ export function SourceRow({ source, expanded, onToggle, kbSlug, editablePageId }
             >
               <ListRowTitle className="block min-w-0">{source.name}</ListRowTitle>
               <ListRowDescription>{meta}</ListRowDescription>
+              <FailedItemsWarning source={source} />
             </button>
           </InlineEdit>
         </ListRowContent>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-types.ts
@@ -7,6 +7,8 @@ export interface Source {
   source_url?: string | null
   items_count: number
   chunks_count: number
+  /** Connector-only: pages that failed processing during the last sync. */
+  items_failed_count?: number
   status: string | null
   last_sync_at: string | null
   created_at: string | null

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-failed-items-warning.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-failed-items-warning.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/paraglide/messages', () => ({
+  kb_connector_failed_items: ({ count }: { count: string }) => `${count} pagina's niet verwerkt`,
+}))
+
+import { FailedItemsWarning } from '../-sources-helpers'
+import type { Source } from '../-sources-types'
+
+function connectorSource(overrides: Partial<Source> = {}): Source {
+  return {
+    kind: 'connector',
+    id: 'conn-1',
+    name: 'Website (pagina\'s)',
+    type_label: 'Website (pagina\'s)',
+    connector_type: 'web_crawler',
+    items_count: 42,
+    chunks_count: 120,
+    status: 'ok',
+    last_sync_at: '2026-08-14T09:00:00Z',
+    created_at: null,
+    ...overrides,
+  }
+}
+
+function uploadSource(overrides: Partial<Source> = {}): Source {
+  return {
+    kind: 'upload',
+    id: 'art-1',
+    name: 'report.pdf',
+    type_label: 'PDF',
+    connector_type: null,
+    items_count: 1,
+    chunks_count: 3,
+    status: null,
+    last_sync_at: null,
+    created_at: null,
+    index_status: 'synced',
+    ...overrides,
+  }
+}
+
+describe('FailedItemsWarning', () => {
+  it('shows the failed-pages count for a connector with items_failed_count > 0', () => {
+    render(<FailedItemsWarning source={connectorSource({ items_failed_count: 8 })} />)
+    expect(screen.getByText("8 pagina's niet verwerkt")).toBeTruthy()
+  })
+
+  it('renders nothing when items_failed_count is 0', () => {
+    const { container } = render(<FailedItemsWarning source={connectorSource({ items_failed_count: 0 })} />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing when items_failed_count is undefined (older knowledge-ingest versions)', () => {
+    const { container } = render(<FailedItemsWarning source={connectorSource({ items_failed_count: undefined })} />)
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders nothing for uploads, even if items_failed_count were set', () => {
+    const { container } = render(<FailedItemsWarning source={uploadSource({ items_failed_count: 5 })} />)
+    expect(container.textContent).toBe('')
+  })
+})

--- a/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
@@ -12,6 +12,7 @@ import * as m from '@/paraglide/messages'
 import { ProductGuard } from '@/components/layout/ProductGuard'
 import { apiFetch } from '@/lib/apiFetch'
 import { activeMeetingInfoKind } from './-status-copy'
+import { formatSegmentTimestamp, relativeSegmentSeconds } from './-transcript-timestamp'
 
 type TabId = 'summary' | 'transcript'
 
@@ -42,6 +43,7 @@ interface TranscriptSegment {
   end: number
   text: string
   speaker: string
+  absolute_start_time?: string | null
 }
 
 interface SummaryStructured {
@@ -74,15 +76,6 @@ interface MeetingDetail {
   ended_at: string | null
   created_at: string
   summary_json: SummaryJson | null
-}
-
-function formatTimestamp(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const mins = Math.floor((seconds % 3600) / 60)
-  const secs = Math.floor(seconds % 60)
-  if (h > 0)
-    return `${h}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
-  return `${mins}:${secs.toString().padStart(2, '0')}`
 }
 
 function StatusBadge({ status }: { status: string }) {
@@ -448,19 +441,32 @@ function MeetingDetailPage() {
             <section aria-label={m.app_meetings_transcript_title()}>
               {meeting.transcript_segments && meeting.transcript_segments.length > 0 ? (
                 <div className="space-y-2 text-sm">
-                  {meeting.transcript_segments.map((seg, i) => (
-                    <div key={i} className="flex gap-3">
-                      <span className="shrink-0 text-xs text-gray-400 tabular-nums mt-0.5 w-14">
-                        [{formatTimestamp(seg.start)}]
-                      </span>
-                      <div>
-                        <span className="font-medium text-gray-900">
-                          {seg.speaker}:{' '}
-                        </span>
-                        <span className="text-gray-900">{seg.text}</span>
-                      </div>
-                    </div>
-                  ))}
+                  {(() => {
+                    const firstSegmentStart = meeting.transcript_segments[0].start
+                    return meeting.transcript_segments.map((seg, i) => {
+                      const relSeconds = relativeSegmentSeconds(
+                        seg,
+                        meeting.started_at,
+                        firstSegmentStart,
+                      )
+                      const timestamp = formatSegmentTimestamp(relSeconds)
+                      return (
+                        <div key={i} className="flex gap-3">
+                          {timestamp && (
+                            <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-gray-400 tabular-nums">
+                              [{timestamp}]
+                            </span>
+                          )}
+                          <div className="min-w-0">
+                            <span className="font-medium text-gray-900">
+                              {seg.speaker}:{' '}
+                            </span>
+                            <span className="text-gray-900">{seg.text}</span>
+                          </div>
+                        </div>
+                      )
+                    })
+                  })()}
                 </div>
               ) : (
                 <p className="text-sm text-gray-400 whitespace-pre-wrap">

--- a/klai-portal/frontend/src/routes/app/meetings/-transcript-timestamp.ts
+++ b/klai-portal/frontend/src/routes/app/meetings/-transcript-timestamp.ts
@@ -1,0 +1,57 @@
+/** Segment shape needed to compute a display-relative timestamp. */
+export interface TranscriptSegmentLike {
+  start: number
+  absolute_start_time?: string | null
+}
+
+const MAX_DISPLAYABLE_SECONDS = 24 * 60 * 60
+
+/**
+ * Elapsed seconds for a transcript segment, relative to the meeting.
+ *
+ * Vexa's raw `start` field is relative to the underlying bot recording's
+ * own internal clock, not to this specific meeting -- when a bot session
+ * runs far longer than expected (see the "Fix Vexa lifecycle" incident),
+ * `start` can be a huge, meaningless offset.
+ *
+ * When both the segment's `absolute_start_time` (a real UTC timestamp)
+ * and the meeting's `started_at` are available, elapsed time is derived
+ * from those wall-clock values instead, sidestepping any drift in
+ * Vexa's own clock. Otherwise this falls back to the segment's own
+ * `start` minus the first segment's `start` -- still the same unit, so
+ * always self-consistent even without wall-clock data.
+ */
+export function relativeSegmentSeconds(
+  segment: TranscriptSegmentLike,
+  meetingStartedAt: string | null,
+  firstSegmentStart: number,
+): number {
+  if (meetingStartedAt && segment.absolute_start_time) {
+    const meetingStart = Date.parse(meetingStartedAt)
+    const segStart = Date.parse(segment.absolute_start_time)
+    if (Number.isFinite(meetingStart) && Number.isFinite(segStart)) {
+      return (segStart - meetingStart) / 1000
+    }
+  }
+  return segment.start - firstSegmentStart
+}
+
+/**
+ * Format elapsed seconds as `m:ss` (or `h:mm:ss` once past the hour).
+ *
+ * Returns `null` for negative or absurdly large (>= 24h) input rather
+ * than rendering a nonsensical timestamp -- a bad upstream `start`
+ * value should hide the timestamp, not display garbage.
+ */
+export function formatSegmentTimestamp(seconds: number): string | null {
+  if (!Number.isFinite(seconds) || seconds < 0 || seconds >= MAX_DISPLAYABLE_SECONDS) {
+    return null
+  }
+  const h = Math.floor(seconds / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const secs = Math.floor(seconds % 60)
+  if (h > 0) {
+    return `${h}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}

--- a/klai-portal/frontend/src/routes/app/meetings/__tests__/-transcript-timestamp.test.ts
+++ b/klai-portal/frontend/src/routes/app/meetings/__tests__/-transcript-timestamp.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatSegmentTimestamp, relativeSegmentSeconds } from '../-transcript-timestamp'
+
+describe('formatSegmentTimestamp', () => {
+  it('formats zero seconds', () => {
+    expect(formatSegmentTimestamp(0)).toBe('0:00')
+  })
+
+  it('formats sub-hour durations as m:ss', () => {
+    expect(formatSegmentTimestamp(65)).toBe('1:05')
+  })
+
+  it('formats durations past the hour as h:mm:ss', () => {
+    expect(formatSegmentTimestamp(3661)).toBe('1:01:01')
+  })
+
+  it('hides absurdly large durations (>= 24h) instead of showing garbage', () => {
+    // The 2026-08-14 production bug: a stale Vexa bot clock produced a
+    // `start` value of 496306.28s (~137.9h) for a segment mid-meeting.
+    expect(formatSegmentTimestamp(496306.28)).toBeNull()
+    expect(formatSegmentTimestamp(24 * 60 * 60)).toBeNull()
+  })
+
+  it('hides negative durations instead of showing garbage', () => {
+    expect(formatSegmentTimestamp(-5)).toBeNull()
+  })
+
+  it('hides non-finite input', () => {
+    expect(formatSegmentTimestamp(Number.NaN)).toBeNull()
+    expect(formatSegmentTimestamp(Number.POSITIVE_INFINITY)).toBeNull()
+  })
+})
+
+describe('relativeSegmentSeconds', () => {
+  it('derives elapsed time from absolute_start_time vs meeting.started_at when both are present', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 999999, absolute_start_time: '2026-08-14T10:05:30.000Z' },
+      '2026-08-14T10:00:00.000Z',
+      0,
+    )
+    expect(seconds).toBe(330)
+  })
+
+  it('falls back to start-minus-first-segment-start when absolute_start_time is missing', () => {
+    const seconds = relativeSegmentSeconds({ start: 620 }, '2026-08-14T10:00:00.000Z', 500)
+    expect(seconds).toBe(120)
+  })
+
+  it('falls back to start-minus-first-segment-start when meeting.started_at is missing', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 620, absolute_start_time: '2026-08-14T10:05:30.000Z' },
+      null,
+      500,
+    )
+    expect(seconds).toBe(120)
+  })
+
+  it('falls back when absolute_start_time is unparseable', () => {
+    const seconds = relativeSegmentSeconds(
+      { start: 620, absolute_start_time: 'not-a-date' },
+      '2026-08-14T10:00:00.000Z',
+      500,
+    )
+    expect(seconds).toBe(120)
+  })
+
+  it('reproduces the production bug scenario: stale Vexa clock produces a huge start value', () => {
+    // Without a meeting-relative anchor, a bot reused across sessions can
+    // report `start` as seconds-since-bot-boot rather than since this
+    // meeting -- e.g. 496306.28s (~137.9h) for a segment actually a few
+    // minutes into the meeting. Falling back to first-segment-start still
+    // yields a sane elapsed time because both values share the same
+    // (buggy) clock.
+    const seconds = relativeSegmentSeconds({ start: 496306.28 }, null, 496300.0)
+    expect(seconds).toBeCloseTo(6.28, 5)
+    expect(formatSegmentTimestamp(seconds)).toBe('0:06')
+  })
+})


### PR DESCRIPTION
## Wat (3 subagent-taken, gereviewd + onafhankelijk geverifieerd)

1. **Per-pagina-schade zichtbaar op website-connectors.** De sources-aggregatie levert nu `items_failed_count` per connector (fanout-veilig via `COUNT(DISTINCT a.id) FILTER`, gespiegeld aan het bestaande `items_count`-patroon + structurele SQL-guard-test). Portal geeft het door; de connector-rij toont "{n} pagina's niet verwerkt" in de warning-token. Daarmee is het laatste gat gedicht uit de vraag "waarom zie ik failures bij een pagina wel en bij een website niet".
2. **qdrant-client 1.17.1 → 1.19.0** (server draait 1.19.0; startup-warning weg). Release-notes-audit: verwijderde/deprecated API's (`add`/`query`/`search*`) zitten niet in onze call-surface; lock-diff is 3 regels, alleen qdrant-client. retrieval-api zit al op 1.18.0 (compatibel) en is bewust niet aangeraakt.
3. **Opruiming**: verouderd frontend-comment over de niet-meer-ontbrekende backend-reaper geactualiseerd.

## Verificatie (door mij herdraaid)
- knowledge-ingest: 1239 passed · portal-backend: 3550 passed · frontend: 42 tests groen, tsc clean, eslint clean
- Nieuwe Paraglide-keys nl+en gecompileerd

## Live-verificatie na deploy
De Ascend-crawl van vanochtend heeft 8 niet-verwerkte pagina's (395/403) — die connector is de real-world testcase; ik check na rollout dat de teller verschijnt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)