### PR TITLE
fix(vexa): adversarial-review follow-ups — webhook idempotency, edge block, ops tooling

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -515,26 +515,15 @@
     # That handler pulls the Zitadel access_token from the BFF session and
     # forwards to the internal service with Authorization: Bearer injected.
 
-    # Vexa meeting bot gateway (SEC-013 F-030 — fix dead route from VEXA-003 migration)
-    # Route maps /bots/<path> → api-gateway:8000/<path>. The old `vexa-bot-manager`
-    # service was replaced by `api-gateway` during the upstream-main rebuild.
-    handle /bots/* {
-        rate_limit {
-            zone bots_per_ip {
-                key {remote_host}
-                events 10
-                window 1m
-            }
-        }
-        uri strip_prefix /bots
-        reverse_proxy api-gateway:8000 {
-            header_up -X-Internal-Secret
-            header_up -X-Caller-Service
-            header_up -X-Org-ID
-            header_up -X-Org-Slug
-            header_up -X-User-ID
-        }
-    }
+    # No public /bots/* route. It proxied to the 0.10 api-gateway, which
+    # SPEC-VEXA-004 deleted, so it had been answering 502 — and Caddy logs show
+    # zero requests in the preceding 7 days. Klai's own client calls
+    # /api/bots/* (portal-api), never this path.
+    #
+    # Do not reintroduce it. Vexa 0.12's meeting-api has no authentication of
+    # its own: it trusts an X-User-Id header any caller can set, so a public
+    # route to it is a transcript-read primitive for anyone. meeting-api is
+    # deliberately confined to the two-member vexa12-portal network.
 
     # Portal Vite assets. This block must stay before the SPA fallback so
     # deleted chunks return 404 instead of /srv/portal/index.html.

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -391,6 +391,19 @@
     # Place BEFORE the general /api/* handler so `handle` first-match
     # wins on the narrow path; everything else keeps Caddy's default
     # request-body limit.
+    # Internal-only endpoints: reachable from inside the Docker networks, never
+    # from the internet. The Vexa webhook is the live case — vexa12-meeting-api
+    # POSTs it over the vexa12-portal network, and no external caller has any
+    # business reaching it. It was publicly routable via the /api/* catch-all
+    # below; Bearer auth kept anonymous forgery out (401), but the handler still
+    # parsed attacker-supplied bodies and had no replay or body-integrity check.
+    # 404 rather than 403: do not confirm the path exists.
+    # Place BEFORE the general /api/* handler — `handle` is first-match.
+    @internal-only path /api/bots/internal/*
+    handle @internal-only {
+        respond 404
+    }
+
     @kb-file-upload path_regexp kb_file_upload ^/api/app/knowledge-bases/[^/]+/sources/file$
     handle @kb-file-upload {
         request_body {

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -259,16 +259,29 @@ backup_redis() {
 backup_vexa_redis() {
   local container
   local output
+  local password
 
-  container="$(ctr vexa-redis)"
-  output="${BACKUP_DIR}/vexa-redis-dump.rdb"
+  # SPEC-VEXA-004: vexa-redis -> vexa12-redis. The instance runs with
+  # --requirepass, so an unauthenticated BGSAVE returns NOAUTH; the previous
+  # version discarded that on stdout and copied whatever dump.rdb happened to be
+  # on disk, so a silent no-op looked like a successful backup.
+  container="$(ctr vexa12-redis)"
+  output="${BACKUP_DIR}/vexa12-redis-dump.rdb"
 
   if ! container_running "${container}"; then
     log "      Skipped (container not running)"
     return 0
   fi
 
-  docker exec "${container}" redis-cli BGSAVE >/dev/null
+  password="$(docker inspect "${container}" \
+    --format '{{range .Config.Env}}{{println .}}{{end}}' \
+    | grep '^VEXA_REDIS_PASSWORD=' | head -1 | cut -d= -f2-)"
+
+  if ! docker exec "${container}" \
+       redis-cli ${password:+-a "${password}"} --no-auth-warning BGSAVE >/dev/null; then
+    log "      FAILED (BGSAVE rejected — check VEXA_REDIS_PASSWORD)"
+    return 1
+  fi
   sleep 3
   docker cp "${container}:/data/dump.rdb" "${output}"
   record_file "${output}"

--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -130,7 +130,7 @@ check_litellm_prisma_migration_baseline() {
 }
 
 pull_vexa_runtime_images() {
-    # Vexa bot containers are spawned by runtime-api from profile/env image refs
+    # Vexa bot containers are spawned by vexa12-runtime from profile/env image refs
     # such as BOT_IMAGE_NAME / BROWSER_IMAGE. They are not compose services, so
     # `docker compose pull` will not fetch them. Missing bot images surface only
     # later as Docker /containers/create 404s when a user starts Scribe.
@@ -153,7 +153,11 @@ if [[ "$SERVICE" == "litellm" ]]; then
     check_litellm_prisma_migration_baseline
 fi
 
-if [[ -z "$SERVICE" || "$SERVICE" == "runtime-api" || "$SERVICE" == "meeting-api" ]]; then
+# SPEC-VEXA-004 renamed the services; a targeted deploy of the new names used to
+# skip the pre-pull entirely, so a bot image absent from the host surfaced only as
+# a /containers/create 404 on the next real meeting. docker-socket-proxy has IMAGES
+# disabled, so the runtime cannot recover by pulling it itself.
+if [[ -z "$SERVICE" || "$SERVICE" == "vexa12-runtime" || "$SERVICE" == "vexa12-meeting-api" ]]; then
     pull_vexa_runtime_images
 fi
 

--- a/deploy/scripts/persistence-probe.sh
+++ b/deploy/scripts/persistence-probe.sh
@@ -65,8 +65,8 @@ if p=$(_named_volume_path klai-core_redis-data) && [ -n "${p}" ]; then
 fi
 
 # Vexa-Redis (named volume, AOF)
-if p=$(_named_volume_path klai-core_vexa-redis-data) && [ -n "${p}" ]; then
-  TARGETS+=("vexa-redis|${p}/appendonlydir")
+if p=$(_named_volume_path klai-core_vexa12-redis-data) && [ -n "${p}" ]; then
+  TARGETS+=("vexa12-redis|${p}/appendonlydir")
 fi
 
 # Postgres — newest file inside pg_wal (varies by image layout).

--- a/klai-portal/backend/alembic/versions/8ad64a1112d9_vexa_webhook_idempotency_receipts.py
+++ b/klai-portal/backend/alembic/versions/8ad64a1112d9_vexa_webhook_idempotency_receipts.py
@@ -1,0 +1,69 @@
+"""vexa webhook idempotency receipts
+
+Vexa's webhook.v1 contract is explicitly at-least-once: "A logical event may be
+POSTed more than once — the initial send, a retry-queue drain, a restart replay,
+or a cross-replica race can all re-emit it", with a 60/300/1800/7200s retry
+schedule. `event_id` is the receiver's idempotency key and is stable across
+redeliveries; `created_at` and the HMAC signature deliberately are not.
+
+Klai's handler discarded `event_id` entirely, so a redelivered
+`meeting.completed` set the meeting back to `stopping`, re-ran transcription and
+recording cleanup, and re-emitted the product event. A transient failure on the
+second pass could overwrite a good `done` with `failed`.
+
+This table is the dedupe ledger. `event_id` is globally unique on Vexa's side
+(derived from connection_id · event_type · new_status), so the constraint is a
+plain unique index rather than a composite with org_id — and the webhook has no
+tenant context at insert time anyway.
+
+Retention: rows older than 48h are prunable (contract says receivers must dedupe
+for at least 48 hours). Pruning is not scheduled here; the table is tiny and a
+follow-up sweep can add it.
+
+Not RLS-protected: it holds no tenant data (an opaque upstream id, a timestamp
+and the meeting FK), and it is written on the pre-tenant-context path where a
+Cat-D policy would raise 42501.
+
+Revision ID: 8ad64a1112d9
+Revises: p4q5r6s7t8u9
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "8ad64a1112d9"
+down_revision = "p4q5r6s7t8u9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vexa_webhook_receipts",
+        sa.Column("event_id", sa.String(length=128), primary_key=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("vexa_meeting_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_vexa_webhook_receipts_received_at",
+        "vexa_webhook_receipts",
+        ["received_at"],
+        unique=False,
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_vexa_webhook_receipts_received_at",
+        table_name="vexa_webhook_receipts",
+        if_exists=True,
+    )
+    op.drop_table("vexa_webhook_receipts", if_exists=True)

--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -484,6 +484,11 @@ class VexaWebhookPayload(BaseModel):
     ended_at: str | None = None
     speaker_events: list[SpeakerEvent] = []
     recording_id: int | None = None  # for recording cleanup via API
+    # webhook.v1 is at-least-once and `event_id` is the receiver's idempotency
+    # key — stable across redeliveries, unlike created_at and the signature.
+    # None on the legacy shapes, which predate the contract.
+    event_id: str | None = None
+    event_type: str | None = None
 
     model_config = {"extra": "ignore"}
 
@@ -505,6 +510,8 @@ class VexaWebhookPayload(BaseModel):
                 "status": meeting.get("status"),
                 "ended_at": meeting.get("end_time"),
                 "recording_id": recording.get("id") if isinstance(recording, dict) else None,
+                "event_id": data.get("event_id"),
+                "event_type": data.get("event_type"),
             }
 
         # Shape 2: legacy envelope — `meeting` at top level.
@@ -519,6 +526,8 @@ class VexaWebhookPayload(BaseModel):
                 "recording_id": data.get("recording", {}).get("id")
                 if isinstance(data.get("recording"), dict)
                 else None,
+                "event_id": data.get("event_id"),
+                "event_type": data.get("event_type"),
             }
 
         # Shape 3: flat completion format.
@@ -665,6 +674,48 @@ async def run_transcription(meeting: VexaMeeting, db: AsyncSession) -> None:
         meeting.error_message = str(exc)
 
 
+async def _claim_webhook_event(payload: "VexaWebhookPayload") -> bool:
+    """Insert the delivery receipt. False means this event_id was already handled.
+
+    Uses its own session, not the request session: the claim must survive whatever
+    the rest of the handler does, and the handler later switches to a
+    tenant-scoped session it cannot share. ON CONFLICT DO NOTHING makes the race
+    between two concurrent deliveries resolve in the database rather than in
+    Python — exactly one insert reports a row.
+
+    Fails OPEN on an unexpected DB error: dropping a real completion is worse
+    than processing a duplicate, and the duplicate path is idempotent-ish
+    (re-running transcription is wasteful, not destructive). The error is logged
+    with a traceback so the degradation is visible rather than silent.
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.core.database import AsyncSessionLocal
+    from app.models.meetings import VexaWebhookReceipt
+
+    try:
+        async with AsyncSessionLocal() as claim_db:
+            result = await claim_db.execute(
+                pg_insert(VexaWebhookReceipt)
+                .values(
+                    event_id=payload.event_id,
+                    event_type=payload.event_type or "unknown",
+                    vexa_meeting_id=payload.vexa_meeting_id,
+                )
+                .on_conflict_do_nothing(index_elements=["event_id"])
+                .returning(VexaWebhookReceipt.event_id)
+            )
+            claimed = result.scalar_one_or_none() is not None
+            await claim_db.commit()
+            return claimed
+    except Exception:
+        logger.exception(
+            "Vexa webhook: idempotency claim failed, processing anyway",
+            event_id=payload.event_id,
+        )
+        return True
+
+
 @router.post("/internal/webhook", status_code=status.HTTP_200_OK)
 async def vexa_webhook(
     payload: VexaWebhookPayload,
@@ -672,6 +723,22 @@ async def vexa_webhook(
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     _require_webhook_secret(request)
+
+    # webhook.v1 is at-least-once by contract: the initial send, a retry-queue
+    # drain (60/300/1800/7200s), a restart replay or a cross-replica race can all
+    # re-emit the SAME logical event, carrying the SAME event_id. Without this
+    # gate a redelivered meeting.completed rewinds the meeting to `stopping`,
+    # re-runs transcription and recording cleanup, and re-emits the product
+    # event — and a transient failure on the replay can overwrite a good `done`
+    # with `failed`. Claim the event_id first; a duplicate is a 200 no-op.
+    if payload.event_id and not await _claim_webhook_event(payload):
+        logger.info(
+            "Vexa webhook: duplicate delivery ignored",
+            event_id=payload.event_id,
+            event_type=payload.event_type,
+            vexa_meeting_id=payload.vexa_meeting_id,
+        )
+        return {"status": "duplicate"}
 
     # SPEC-VEXA-003: upstream `fire_post_meeting_hooks` omits native_meeting_id from the
     # payload (only `meeting.id` + `meeting.platform`). Fall back to vexa_meeting_id

--- a/klai-portal/backend/app/models/meetings.py
+++ b/klai-portal/backend/app/models/meetings.py
@@ -45,3 +45,20 @@ class VexaMeeting(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+
+
+class VexaWebhookReceipt(Base):
+    """Idempotency ledger for Vexa's at-least-once webhook deliveries.
+
+    `event_id` is stable across redeliveries of one logical event (upstream
+    derives it from connection_id · event_type · new_status), so it is the
+    contract's designated idempotency key. Rows older than 48h are prunable —
+    that is the dedupe window webhook.v1 requires receivers to honour.
+    """
+
+    __tablename__ = "vexa_webhook_receipts"
+
+    event_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    vexa_meeting_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/klai-portal/backend/app/services/vexa.py
+++ b/klai-portal/backend/app/services/vexa.py
@@ -191,8 +191,18 @@ class VexaClient:
     async def delete_recording(self, recording_id: int) -> bool:
         """Delete a recording by ID. Returns True on success, False on failure.
 
-        404 (already gone) counts as success: nothing to delete and the caller
-        can mark the recording as cleaned up so we do not re-queue it forever.
+        404 (already gone) and 405 (route not served) both count as success:
+        nothing to delete and the caller can mark the recording as cleaned up so
+        we do not re-queue it forever.
+
+        405 is the Vexa 0.12 case. DELETE /recordings/{id} is declared in the
+        sealed api.v1 but sits on upstream's KNOWN_GAPS waiver list (issue #591),
+        so the router never registers it and FastAPI answers 405 rather than 404.
+        Treating that as a failure made recording_cleanup retry forever, logging a
+        warning per pass — observed in production right after the 0.12 cutover.
+        Blast radius stays nil because start_bot sends recording_enabled=false, so
+        no recording is ever produced; if recordings are ever enabled this must be
+        revisited together with the waiver.
         Other errors return False and are logged with traceback. Never raises.
         """
         try:
@@ -200,11 +210,11 @@ class VexaClient:
             resp.raise_for_status()
             return True
         except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
+            if exc.response.status_code in (404, 405):
                 logger.info(
                     "Recording already absent on upstream, marking as deleted",
                     recording_id=recording_id,
-                    upstream_status=404,
+                    upstream_status=exc.response.status_code,
                 )
                 return True
             logger.warning(

--- a/klai-portal/backend/tests/test_vexa_client.py
+++ b/klai-portal/backend/tests/test_vexa_client.py
@@ -56,3 +56,26 @@ async def test_delete_recording_network_error_returns_false() -> None:
             side_effect=httpx.ConnectError("boom", request=httpx.Request("DELETE", "http://x/recordings/42"))
         )
         assert await client.delete_recording(42) is False
+
+
+@pytest.mark.anyio
+async def test_delete_recording_405_treated_as_success() -> None:
+    """Vexa 0.12 answers 405, not 404, for the waived DELETE /recordings route.
+
+    The route is declared in the sealed api.v1 but sits on upstream's KNOWN_GAPS
+    list (issue #591), so the router never registers it and FastAPI replies 405.
+    Before this was handled, recording_cleanup treated it as a failure and
+    re-queued forever, logging a warning per pass — seen in production minutes
+    after the 0.12 cutover.
+    """
+    client = VexaClient()
+    with patch.object(client, "_http") as http:
+        http.delete = AsyncMock(return_value=_response(405))
+        assert await client.delete_recording(42) is True
+
+
+@pytest.mark.anyio
+async def test_client_sends_x_user_id() -> None:
+    """0.12 rejects a spawn without X-User-Id (401 Invalid user identity)."""
+    client = VexaClient()
+    assert client._http.headers.get("X-User-Id") == VexaClient.VEXA_USER_ID

--- a/klai-portal/backend/tests/test_vexa_webhook.py
+++ b/klai-portal/backend/tests/test_vexa_webhook.py
@@ -229,3 +229,56 @@ async def test_webhook_rearms_tenant_context_after_stopping_commit(monkeypatch) 
     assert events == ["commit", "set_tenant", "run_transcription", "commit"]
     cleanup_recording.assert_awaited_once_with(meeting, scoped_db, recording_id=None)
     emit_event.assert_called_once()
+
+
+class TestWebhookIdempotency:
+    """webhook.v1 is at-least-once; event_id is the receiver's idempotency key.
+
+    Upstream retries a failed delivery on a 60/300/1800/7200s schedule and replays
+    the queue after a restart, always with the SAME event_id. Without a dedupe
+    gate a redelivered meeting.completed rewinds the meeting to `stopping` and
+    re-runs transcription and cleanup.
+    """
+
+    def test_payload_carries_event_id_from_the_typed_envelope(self) -> None:
+        envelope = {
+            "event_id": "evt_5f3c1a9b8d2e4f6a7b0c1d2e3f4a5b6c",
+            "event_type": "meeting.completed",
+            "api_version": "2026-03-01",
+            "created_at": "2026-06-18T10:42:00.000Z",
+            "data": {
+                "meeting": {
+                    "id": 11367,
+                    "platform": "google_meet",
+                    "native_meeting_id": "abc-defg-hij",
+                    "status": "completed",
+                    "end_time": "2026-06-18T10:42:00.000Z",
+                }
+            },
+        }
+        parsed = VexaWebhookPayload.model_validate(envelope)
+        assert parsed.event_id == envelope["event_id"]
+        assert parsed.event_type == "meeting.completed"
+
+    def test_event_id_is_stable_across_redeliveries(self) -> None:
+        """created_at and the signature change per delivery; event_id must not.
+
+        Keying on the body would treat every retry as a new event — the exact
+        mistake upstream's contract calls out ("Do NOT key on the body").
+        """
+        base = {
+            "event_id": "evt_stable",
+            "event_type": "meeting.completed",
+            "data": {"meeting": {"id": 7, "platform": "google_meet", "native_meeting_id": "x-y-z"}},
+        }
+        first = VexaWebhookPayload.model_validate({**base, "created_at": "2026-06-18T10:42:00Z"})
+        retry = VexaWebhookPayload.model_validate({**base, "created_at": "2026-06-18T10:43:00Z"})
+        assert first.event_id == retry.event_id
+
+    def test_legacy_shapes_have_no_event_id_and_stay_processable(self) -> None:
+        """The flat/legacy envelopes predate the contract — they must not be dropped."""
+        flat = VexaWebhookPayload.model_validate(
+            {"id": 5, "platform": "google_meet", "native_meeting_id": "a-b-c", "status": "completed"}
+        )
+        assert flat.event_id is None
+        assert flat.vexa_meeting_id == 5

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -68,10 +68,12 @@ KLASSE_B_PATTERNS=(
 CADDY_WHITELIST=(
     '^localhost$'
     '^127\.0\.0\.1$'
-    '^api-gateway$'              # Vexa internal — managed by Vexa stack
-    '^admin-api$'                # Vexa internal
-    '^meeting-api$'              # Vexa internal
-    '^runtime-api$'              # Vexa internal
+    # SPEC-VEXA-004: the 0.10 names (api-gateway, admin-api, meeting-api,
+    # runtime-api) are deliberately NOT whitelisted — they no longer exist, so a
+    # Caddy upstream naming one is a resurrected orphan the audit must surface.
+    '^vexa12-meeting-api$'       # Vexa internal — managed by the Vexa stack
+    '^vexa12-admin-api$'         # Vexa internal
+    '^vexa12-runtime$'           # Vexa internal
     '^portal-api-dev$'           # protected dev environment outside prod compose
 )
 

--- a/scripts/vexa-egress-capture.sh
+++ b/scripts/vexa-egress-capture.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # vexa-egress-capture.sh — SPEC-SEC-022 Phase 1 data collection.
 #
-# Captures outbound packets from the vexa-bots Docker bridge (172.27.0.0/16)
+# Captures outbound packets from the vexa12-bots Docker bridge (172.29.0.0/16)
 # to any destination outside klai-net (172.18.0.0/16). Produces:
 #   - a raw pcap file for forensic re-analysis
 #   - a per-destination summary with ports
@@ -18,7 +18,8 @@ set -euo pipefail
 
 DURATION="${1:-14400}"
 OUTPUT_DIR="${2:-/opt/klai/captures/vexa-egress}"
-BRIDGE_CIDR="172.27.0.0/16"           # vexa-bots
+BRIDGE_CIDR="172.29.0.0/16"           # vexa12-bots (SPEC-VEXA-004; verify with
+                                      # docker network inspect vexa12-bots)
 KLAINET_CIDR="172.18.0.0/16"          # exclude: klai-net internal
 MAX_RESOLVE_PARALLEL=10               # rDNS lookups in parallel
 
@@ -37,7 +38,7 @@ LOG="$OUTPUT_DIR/vexa-egress-$TS.log"
 
 echo "=== SPEC-SEC-022 Phase 1 capture ==="
 echo "Duration:   ${DURATION}s ($(printf "%dh%dm" $((DURATION/3600)) $(((DURATION/60)%60))))"
-echo "Source net: $BRIDGE_CIDR (vexa-bots)"
+echo "Source net: $BRIDGE_CIDR (vexa12-bots)"
 echo "Exclude:    dst net $KLAINET_CIDR (klai-net internal)"
 echo "Output:     $OUTPUT_DIR"
 echo


### PR DESCRIPTION
Findings 2, 5, 6, 7 and the 405 retry loop from the SPEC-VEXA-004 adversarial review. Finding 1 shipped in #918/#922.

**Webhook idempotency (HIGH).** webhook.v1 is at-least-once with a 60/300/1800/7200s retry schedule; `event_id` is the receiver's key. Klai discarded it, so a redelivery rewound the meeting to `stopping`, re-ran transcription and cleanup, and could overwrite a good `done` with `failed`. Adds `vexa_webhook_receipts` + an ON CONFLICT DO NOTHING claim before any processing. Fails **open** on DB error (dropping a real completion is worse) and logs it.

**Webhook was publicly routable (MEDIUM).** I called it internal-only; it was not — verified an external POST reaches the handler (401, not edge-blocked). `/api/bots/internal/*` now 404s at Caddy. Delivery unaffected: meeting-api reaches portal-api over `vexa12-portal`.

**405, not 404.** `DELETE /recordings` is on upstream's KNOWN_GAPS list, so FastAPI answers 405 — treated as failure, so cleanup re-queued forever. Seen in prod after cutover.

**Ops tooling.** backup.sh retargeted **and** BGSAVE now authenticates (the old unauthenticated call silently copied a stale dump); persistence-probe; compose-up pre-pull trigger; egress CIDR 172.27→172.29 (verified live); orphan-audit whitelist no longer hides the deleted names.

Verified: 66 backend tests (1 xfail) · alembic single head · deploy contract tests · tag + volume guards · pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)