### PR TITLE
fix(vexa): refuse cross-tenant webhook fallback for typed events; retire a dead secret

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -723,7 +723,6 @@ services:
       # @MX:NOTE in config.py — no runtime reader yet; kept declared so
       # a future admin-api caller picks up the real token, matching the
       # pre-migration env-shape.
-      VEXA_ADMIN_TOKEN: ${VEXA_ADMIN_TOKEN}
       # ─── Garage S3 — KB-image auth-proxy (SPEC-TI-009 + SPEC-PORTAL-DOCS-IMAGE-PASTE-001) ─
       # portal-api is the auth-proxy for /kb-images/{org_id}/{kb_slug}/{filename}
       # (read: SPEC-TI-009 GET; write: SPEC-PORTAL-DOCS-IMAGE-PASTE-001 POST).

--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -765,6 +765,27 @@ async def vexa_webhook(
     # scoped to the meeting's own org via tenant_scoped_session.
     from app.core.database import cross_org_session, set_tenant, tenant_scoped_session
 
+    # The (platform, native_meeting_id) fallback picks the newest ACTIVE match
+    # ACROSS ALL TENANTS, because a meeting code is not globally unique — two
+    # tenants can legitimately hold the same Google Meet code. That is only safe
+    # while no better key exists, which is the pre-spawn "pending" phase.
+    #
+    # A typed 0.12 envelope always carries the globally unique Vexa meeting id
+    # (it is minted by the same service that sends the webhook), so if one
+    # arrives WITHOUT it, something is wrong with the sender — and silently
+    # falling back to a cross-tenant code match is how such an event lands on
+    # the wrong tenant's meeting. Refuse instead. `event_id` is the marker: only
+    # webhook.v1 envelopes carry it.
+    if payload.event_id and payload.vexa_meeting_id is None:
+        logger.warning(
+            "Vexa webhook: typed event without vexa_meeting_id, refusing cross-tenant fallback",
+            event_id=payload.event_id,
+            event_type=payload.event_type,
+            platform=payload.platform,
+            native_meeting_id=payload.native_meeting_id,
+        )
+        return {"status": "ignored"}
+
     async with cross_org_session() as lookup_db:
         # Prefer vexa_meeting_id (unambiguous FK); fall back to
         # (platform, native_meeting_id) pair which can correlate even

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -254,9 +254,16 @@ class Settings(BaseSettings):
 
     # Vexa meeting API (agentic-runtime)
     vexa_meeting_api_url: str = "http://vexa-meeting-api:8080"
-    # @MX:NOTE: reserved for Vexa admin API calls (tenant provisioning, quota inspection).
-    # Stored in SOPS + compose; no runtime reader yet. Keep until admin surface lands.
-    vexa_admin_token: str = ""
+    # vexa_admin_token was "reserved for a future admin surface" since SPEC-VEXA-003
+    # and never gained a reader. Vexa 0.12 deploys its own admin-api with its own
+    # VEXA12_ADMIN_TOKEN, so the reservation can no longer be redeemed by this
+    # field. Removed rather than left as a secret nobody reads.
+    #
+    # vexa_api_key survives ONLY as the X-API-Key header on VexaClient. Vexa 0.12's
+    # meeting-api does not authenticate it (no gateway is deployed, and the raw API
+    # ignores the header) — it is inert defence-in-depth for the day a gateway or
+    # service-authority boundary returns. Do NOT treat it as authentication:
+    # meeting-api's network membership is the real boundary (SPEC-VEXA-004).
     vexa_api_key: str = ""
     vexa_webhook_secret: str = ""
 

--- a/klai-portal/backend/tests/test_vexa_webhook.py
+++ b/klai-portal/backend/tests/test_vexa_webhook.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.api import meetings as meetings_module
 from app.api.meetings import VexaWebhookPayload
 
 
@@ -282,3 +284,24 @@ class TestWebhookIdempotency:
         )
         assert flat.event_id is None
         assert flat.vexa_meeting_id == 5
+
+    def test_typed_event_without_meeting_id_is_refused(self) -> None:
+        """A 0.12 envelope always carries the globally unique Vexa meeting id.
+
+        The (platform, native_meeting_id) fallback matches ACROSS TENANTS — a
+        meeting code is not globally unique — so it is only safe pre-spawn. A
+        typed event missing the id means the sender is wrong, and falling back
+        would land the event on another tenant's meeting.
+        """
+        parsed = VexaWebhookPayload.model_validate(
+            {
+                "event_id": "evt_no_meeting_id",
+                "event_type": "meeting.completed",
+                "data": {"meeting": {"platform": "google_meet", "native_meeting_id": "shared-code"}},
+            }
+        )
+        assert parsed.event_id == "evt_no_meeting_id"
+        assert parsed.vexa_meeting_id is None
+        # The handler refuses this combination; see meetings.py::vexa_webhook.
+        source = Path(meetings_module.__file__).read_text()
+        assert "refusing cross-tenant fallback" in source


### PR DESCRIPTION
Findings 9 and 10 — the last two open items from the adversarial review.

**Cross-tenant correlation.** With no `vexa_meeting_id` the handler falls back to the newest active `(platform, native_meeting_id)` match **across all tenants** — necessary pre-spawn, since a meeting code is not globally unique. But a typed 0.12 envelope always carries the Vexa id, so one arriving without it means the sender is wrong and the fallback would land the event on another tenant's meeting. Now refused, keyed on `event_id` so legacy shapes keep the fallback. No live leak existed; this closes the residual path.

**Dead secret.** `vexa_admin_token` was reserved for a future admin surface in SPEC-VEXA-003 and never gained a reader; 0.12 ships its own admin-api with its own token. Removed from Settings and portal-api's compose env. `vexa_api_key` stays with its reason documented — inert defence-in-depth, explicitly **not** authentication.

SOPS keys deliberately **not** removed in the same change that removes their last reader — that leaves no window to notice a missed consumer, and sync-env's guard wants a separate deliberate step.

Verified: 53 backend tests (1 xfail) · alembic single head · volume + orphan audits · deploy contract tests · tag guard · pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)