### PR TITLE
fix(vexa): restore the garage link an unrelated PR reverted, and guard it

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -40,6 +40,14 @@ networks:
     name: vexa12-internal
     driver: bridge
     internal: true   # only vexa12-meeting-api <-> vexa12-admin-api; no bot ever joins
+  vexa12-storage:
+    name: vexa12-storage
+    driver: bridge
+    internal: true
+    # ONLY garage <-> vexa12-meeting-api. meeting-api's MINIO_* config points at
+    # Garage, and its signal-tape janitor probes storage every sweep even with
+    # RECORDING_ENABLED=false. Garage lives on klai-net; reaching it via klai-net
+    # would undo the vexa12-portal boundary, so this is a dedicated two-party link.
   vexa12-portal:
     name: vexa12-portal
     driver: bridge
@@ -1513,6 +1521,7 @@ services:
       vexa12-portal: {}
       net-postgres: {}
       vexa12-internal: {} # reaches vexa12-admin-api without exposing it to bots
+      vexa12-storage: {}  # reaches garage for the S3 config it boots with
       vexa12-bots:
         aliases:
           - meeting-api   # the name a spawned 0.12 bot dials for its callback
@@ -1656,6 +1665,7 @@ services:
       GARAGE_ADMIN_TOKEN: ${GARAGE_ADMIN_TOKEN}
     networks:
       - klai-net
+      - vexa12-storage   # dedicated link to vexa12-meeting-api; see that network's comment
     healthcheck:
       test: ["CMD", "/garage", "status"]
       interval: 10s

--- a/klai-portal/backend/tests/contract/test_vexa_contract.py
+++ b/klai-portal/backend/tests/contract/test_vexa_contract.py
@@ -464,6 +464,45 @@ def test_bot_image_is_pinned_and_flagged_as_a_pull_prerequisite() -> None:
     )
 
 
+def test_meeting_api_can_still_reach_its_declared_dependencies() -> None:
+    """Confining meeting-api must not cut the links its own config declares.
+
+    Taking it off klai-net once severed its route to garage — its MINIO_* config
+    points at garage:3900 and the signal-tape janitor probes storage every sweep
+    even with RECORDING_ENABLED=false, so it threw a traceback per cycle. The fix
+    (a dedicated internal link) was then silently reverted by an unrelated
+    concurrent PR whose branch predated it, and nothing caught that: the boundary
+    test above only asserts where meeting-api may NOT be.
+
+    Each dependency must share at least one DEDICATED link — internal, and
+    carrying only the two parties. net-postgres is excluded: it is a shared
+    database network by design, so it proves nothing about a private route.
+    """
+    compose = _compose()
+    services = compose["services"]
+    meeting_nets = set(services["vexa12-meeting-api"]["networks"])
+    shared_infra = {"net-postgres"}
+
+    for dependency, why in (
+        ("garage", "MINIO_ENDPOINT / signal-tape janitor"),
+        ("vexa12-admin-api", "schema owner + bot-context lookup"),
+        # vexa12-redis is deliberately NOT here: the bots need the broker too, so
+        # vexa12-bots is a legitimate multi-party network, not a private link.
+    ):
+        candidates = (meeting_nets & set(services[dependency]["networks"])) - shared_infra
+        dedicated = [
+            net
+            for net in candidates
+            if compose["networks"][net].get("internal") is True
+            and sorted(n for n, v in services.items() if net in (v.get("networks") or {}))
+            == sorted(["vexa12-meeting-api", dependency])
+        ]
+        assert dedicated, (
+            f"vexa12-meeting-api has no dedicated internal link to {dependency} ({why}); "
+            f"shared non-infra networks: {sorted(candidates) or 'none'}"
+        )
+
+
 def test_meeting_api_is_not_on_a_shared_application_network() -> None:
     """meeting-api's network membership IS its authorization boundary.
 


### PR DESCRIPTION
#922's dedicated garage link is gone from main — **not** reverted by anything in this workstream. #928 (librechat Phase 3) branched before #922 and its squash merge carried the older `docker-compose.yml`, dropping the four `vexa12-storage` lines. `94627a69b` has them; its descendant `4240c0014` does not; neither #930 nor #934 touches them. Production has been throwing the janitor traceback again since.

Nothing caught it: the #918 boundary test only asserts where meeting-api may **not** be. Nothing asserted it can still reach what it depends on.

`test_meeting_api_can_still_reach_its_declared_dependencies` closes that — garage and admin-api must each share a dedicated internal two-member link. `net-postgres` excluded (shared by design), `vexa12-redis` excluded (bots legitimately share the broker). Mutation-verified both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)