### PR TITLE
feat(librechat): Phase 4 — feedback forwarding becomes a source diff

### DIFF
--- a/deploy/librechat/Dockerfile.klai
+++ b/deploy/librechat/Dockerfile.klai
@@ -76,11 +76,11 @@ RUN git clone --quiet --filter=blob:none --branch "${LIBRECHAT_TAG}" \
       https://github.com/danny-avila/LibreChat.git librechat
 WORKDIR /build/librechat
 
-COPY patches-source/share.js.patch \
+COPY patches-source/share.js.patch patches-source/messages.js.patch \
      patches-source/createStreamServices.ts.patch /patches/
 
 RUN set -eu; \
-    for p in /patches/share.js.patch /patches/createStreamServices.ts.patch; do \
+    for p in /patches/share.js.patch /patches/messages.js.patch /patches/createStreamServices.ts.patch; do \
       echo "==> git apply --3way $p"; \
       out=$(git apply --3way --verbose "$p" 2>&1) || { \
         echo "$out" >&2; \
@@ -117,6 +117,8 @@ COPY --from=agents-build /build/agents/dist/cjs/tools/search/search.cjs \
      /app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs
 COPY --from=librechat-build /build/librechat/api/server/routes/share.js \
      /app/api/server/routes/share.js
+COPY --from=librechat-build /build/librechat/api/server/routes/messages.js \
+     /app/api/server/routes/messages.js
 COPY --from=librechat-build /build/librechat/packages/api/dist/index.cjs \
      /app/packages/api/dist/index.cjs
 

--- a/deploy/librechat/patches-source/messages.js.patch
+++ b/deploy/librechat/patches-source/messages.js.patch
@@ -1,0 +1,41 @@
+diff --git a/api/server/routes/messages.js b/api/server/routes/messages.js
+index 17e740c51..4fe008979 100644
+--- a/api/server/routes/messages.js
++++ b/api/server/routes/messages.js
+@@ -415,6 +415,36 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
+       }).catch((err) => logger.error('[langfuse] feedback score failed:', err));
+     }
+ 
++    // SPEC-KB-015: Forward feedback to portal-api for KB quality scoring.
++    // Fire-and-forget (REQ-KB-015-06) -- response is sent immediately below.
++    // Logs on error (REQ-KB-015-07): never surfaces to user, but visible in VictoriaLogs.
++    const portalUrl = process.env.PORTAL_INTERNAL_URL;
++    const portalSecret = process.env.PORTAL_INTERNAL_SECRET;
++    if (portalUrl && portalSecret && feedback) {
++      fetch(`${portalUrl}/internal/v1/kb-feedback`, {
++        method: 'POST',
++        headers: {
++          'Content-Type': 'application/json',
++          Authorization: `Bearer ${portalSecret}`,
++        },
++        body: JSON.stringify({
++          conversation_id: conversationId,
++          message_id: messageId,
++          message_created_at:
++            updatedMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
++          rating: feedback.rating,
++          tag: feedback.tag ?? null,
++          text: feedback.text ?? null,
++          model_alias: updatedMessage?.model ?? null,
++          librechat_user_id: req.user?.id ?? '',
++          librechat_tenant_id: process.env.KLAI_ORG_SLUG ? `librechat-${process.env.KLAI_ORG_SLUG}` : null,
++        }),
++      }).catch((err) => {
++        // REQ-KB-015-07: never surface to user, but log so failures are visible
++        logger.warn('SPEC-KB-015: kb-feedback forward failed', { error: err?.message });
++      });
++    }
++
+     res.json({
+       messageId,
+       conversationId,

--- a/deploy/librechat/tests/built_artifacts.test.cjs
+++ b/deploy/librechat/tests/built_artifacts.test.cjs
@@ -230,7 +230,38 @@ function splitThroughFramer(body, cut) {
   );
 }
 
+
+// ---------------------------------------------------------------------------
+// messages.js — SPEC-KB-015 feedback forwarding (Phase 4)
+// ---------------------------------------------------------------------------
+// Plain runtime JS, COPYed rather than bundled, so the source diff IS what
+// runs. That also makes the marker survive, which is how the runtime transform
+// in klai-entrypoint.sh knows to stand down instead of applying a second copy.
+const messagesSource = fs.readFileSync(path.join(artifactsDir, 'messages.js'), 'utf8');
+
+assert.ok(
+  messagesSource.includes('SPEC-KB-015'),
+  'messages.js.patch did not reach the built image — the runtime transform would ' +
+    'then apply on top instead of standing down'
+);
+assert.ok(
+  messagesSource.includes('/internal/v1/kb-feedback'),
+  'the kb-feedback forward call is missing from the built messages.js'
+);
+// Fire-and-forget by contract (REQ-KB-015-06): the forward must never block or
+// fail the user's response.
+assert.match(
+  messagesSource,
+  /fetch\([\s\S]{0,600}kb-feedback[\s\S]{0,900}?\.catch\(/,
+  'the kb-feedback forward must be fire-and-forget with a .catch, never awaited'
+);
+assert.ok(
+  !/await\s+fetch\(`\$\{portalUrl\}\/internal\/v1\/kb-feedback/.test(messagesSource),
+  'the kb-feedback forward must not be awaited'
+);
+
 console.log(
   'OK: built artifacts verified — search topResults + surrogate guards, ' +
-    'index.cjs cleanupOnComplete at every call site, stream marker edge cases.'
+    'index.cjs cleanupOnComplete at every call site, stream marker edge cases, ' +
+    'messages.js kb-feedback forward.'
 );

--- a/deploy/scripts/lib/librechat-patched-files.mjs
+++ b/deploy/scripts/lib/librechat-patched-files.mjs
@@ -53,6 +53,17 @@ export const PATCHED_FILES = [
     patch: 'createStreamServices.ts.patch',
     lane: 'librechat',
   },
+  {
+    // SPEC-KB-015 feedback forwarding — Phase 4. Plain runtime JS like
+    // share.js, so no build step: the patched file is what runs. The runtime
+    // transform in klai-entrypoint.sh greps this file for 'SPEC-KB-015' and
+    // stands down on its own once the patch is baked in, because this file is
+    // COPYed rather than bundled and the comment survives.
+    key: 'messages.js',
+    containerPath: '/app/api/server/routes/messages.js',
+    patch: 'messages.js.patch',
+    lane: 'librechat',
+  },
 ];
 
 /** Path of the manifest baked into the image by the Dockerfile. */


### PR DESCRIPTION
SPEC-KB-015 is sinds de review van 2026-08-13 een runtime string-rewrite van `api/server/routes/messages.js`. Fase 4 verplaatst hem naar de image, waar de SPEC hem altijd al wilde hebben.

## De diff is niet overgetypt

Ik heb het node-blok uit de entrypoint zélf tegen een schone v0.8.7-checkout gedraaid en het resultaat gediffed. De bron-patch is dus byte-voor-byte wat de runtime-transform produceert — geen kans op afwijking op het moment van vertalen. Round-trip geverifieerd: de gegenereerde patch op een tweede verse clone geeft een identieke bestandshash.

## Geen entrypoint-wijziging nodig

Dat is het aardige deel. `messages.js` wordt gekopieerd, niet gebundeld, dus de `SPEC-KB-015`-comment overleeft in de image — en de bestaande skip-check zoekt precies daarnaar. De transform staat dus vanzelf af overal waar de image de patch draagt. Dezelfde eigenschap die cleanup-on-complete in #926 kreeg, hier gratis.

De transform blijft bewust in beide entrypoints staan: de 41 tenants op de upstream-image hebben hem nodig.

## Test

`built_artifacts.test.cjs` asserteert nu ook dat de forward de gebouwde image bereikte, `/internal/v1/kb-feedback` aanroept, en **fire-and-forget** is — een awaited forward zou een hapering in portal-api de feedback-response van een gebruiker laten blokkeren, wat REQ-KB-015-06 verbiedt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)