### PR TITLE
feat(librechat): canary on the Phase 4 image; drift guard learns to skip

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -386,7 +386,7 @@ services:
   librechat-getklai:
     # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 3 — the canary runs the Klai-owned
     # image, built in CI from the source diffs in deploy/librechat/patches-source/.
-    # Tag for humans: v0.8.7-klai.1-f415a2515817 (upstream v0.8.7, agents v3.2.46).
+    # Tag for humans: v0.8.7-klai.1-80df95854928 (upstream v0.8.7, agents v3.2.46).
     #
     # Pinned by DIGEST, and deploy/check-klai-librechat-digest.sh enforces that:
     # on 2026-08-14 the tag v0.8.7-klai.1 was pushed twice with different
@@ -394,7 +394,7 @@ services:
     #
     # Rollback: put ghcr.io/danny-avila/librechat:v0.8.7 back here and restore
     # the four patch bind-mounts removed below (git revert this commit).
-    image: ghcr.io/getklai/librechat@sha256:360770c500415ef56f915d2ff71b014604a0ddec46708118008cf5019c432793
+    image: ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
     container_name: librechat-getklai
     restart: unless-stopped
     # Force light theme via the Klai entrypoint wrapper (LibreChat has no

--- a/deploy/librechat/dry-run-transforms.cjs
+++ b/deploy/librechat/dry-run-transforms.cjs
@@ -250,6 +250,27 @@ if (klaiFeedback) {
   const messagesPath = extractedPath('/app/api/server/routes/messages.js');
   if (!existsSync(messagesPath)) {
     fail('feedback', `messages.js was not extracted from the image: ${messagesPath}`);
+  } else if (readFileSync(messagesPath, 'utf8').includes('SPEC-KB-015')) {
+    // The image already carries the patch (SPEC-LIBRECHAT-PATCH-MODEL-001
+    // Phase 4 bakes messages.js in). The entrypoint greps for this exact
+    // marker and stands down, so dry-running the transform here would test a
+    // code path that never executes at boot -- and would fail, because the
+    // anchor it looks for has been consumed by the very patch it would apply.
+    //
+    // What matters for an image in this shape is that the behaviour is
+    // present, so assert that instead of the transform's applicability.
+    const content = readFileSync(messagesPath, 'utf8');
+    if (!content.includes('/internal/v1/kb-feedback')) {
+      fail(
+        'feedback',
+        'image carries the SPEC-KB-015 marker but not the kb-feedback forward call',
+      );
+    } else {
+      ok(
+        'feedback',
+        'baked into the image; runtime transform correctly stands down (marker + forward call present)',
+      );
+    }
   } else {
     const script = remapPaths(klaiFeedback);
     const result = runNode(script);
@@ -283,6 +304,26 @@ if (klaiStreamCleanup) {
   const streamBundlePath = extractedPath('/app/packages/api/dist/index.cjs');
   if (!existsSync(streamBundlePath)) {
     fail('stream-cleanup', `dist/index.cjs was not extracted from the image: ${streamBundlePath}`);
+  } else if (readFileSync(streamBundlePath, 'utf8').includes('CLEANUP_ON_COMPLETE')) {
+    // Same reasoning as the feedback block above: the image was built from
+    // createStreamServices.ts.patch, the entrypoint greps for
+    // CLEANUP_ON_COMPLETE and stands down, so dry-running the transform tests
+    // a path that never runs at boot. Unlike feedback the anchors happen to
+    // survive here, so it would "pass" while proving nothing -- assert the
+    // behaviour is present instead.
+    const content = readFileSync(streamBundlePath, 'utf8');
+    const wired = content.split('cleanupOnComplete: CLEANUP_ON_COMPLETE').length - 1;
+    if (wired < 2) {
+      fail(
+        'stream-cleanup',
+        `image carries CLEANUP_ON_COMPLETE but wires it at only ${wired} call site(s); expected both`,
+      );
+    } else {
+      ok(
+        'stream-cleanup',
+        'baked into the image; runtime transform correctly stands down (wired at both call sites)',
+      );
+    }
   } else {
     const script = remapPaths(klaiStreamCleanup);
     const result = runNode(script);


### PR DESCRIPTION
Canary naar `sha256:3b4fd8440c79…` (tag `v0.8.7-klai.1-80df95854928`) — de eerste image met alle zes gemigreerde oppervlakken, inclusief SPEC-KB-015 feedback.

## De drift-guard moest hetzelfde leren als de entrypoints

Hij dry-runt elke runtime-transform tegen bestanden uit de gepinde image. Dat klopte zolang elke image upstream was. Tegen een image die de patch al draagt test hij een pad dat bij boot nooit uitgevoerd wordt:

- **feedback faalde** — het anker dat hij zoekt is opgegeten door precies de patch die hij zou toepassen
- **stream-cleanup slaagde** — z'n ankers overleven toevallig, dus hij bewees niets terwijl hij groen stond. Dat is erger.

Beide detecteren nu de ingebakken marker en asserteren het **gedrag** in plaats van de toepasbaarheid van de transform.

Geverifieerd tegen beide images in één run: upstream meldt *"applied cleanly"*, de Klai-image meldt *"baked into the image; runtime transform correctly stands down"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)