### PR TITLE
feat(librechat): per-tenant canary image + single-tenant apply

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -649,6 +649,17 @@ services:
       DOMAIN: ${DOMAIN}
       FRONTEND_URL: ${FRONTEND_URL:-}
       DOCKER_HOST: tcp://docker-socket-proxy:2375
+      # SPEC-LIBRECHAT-PATCH-MODEL-001 — per-tenant canary. Provisioning-managed
+      # tenants otherwise all take LIBRECHAT_IMAGE; this runs ONE of them on the
+      # Klai-owned image so the migration gets real-conversation evidence before
+      # the fleet moves. getklai was the canary first, but it serves almost no
+      # traffic, and a canary nobody uses proves nothing over time.
+      #
+      # Digest-only, enforced in app/core/librechat_images.py and by
+      # deploy/check-klai-librechat-digest.sh. Rollback: delete this line and
+      # recreate the tenant -- it falls back to LIBRECHAT_IMAGE.
+      # Tag for humans: v0.8.7-klai.1-80df95854928
+      LIBRECHAT_IMAGE_OVERRIDES: voys=ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
       # SPEC-SEC-HYGIENE-001 REQ-28.4: explicit deployment-environment marker.
       # Pydantic Settings reads PORTAL_ENV; the in-code default is "production"
       # (REQ-28.2). The validator at config.py:_no_debug_in_production refuses

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1695,6 +1695,19 @@ async def regenerate_librechat_configs(
     result = await db.execute(select(PortalOrg).where(PortalOrg.provisioning_status == "ready"))
     tenants = result.scalars().all()
 
+    # ?tenant=<slug> narrows the whole operation to one tenant. A canary
+    # rollout needs to recreate exactly one container; without this the only
+    # option was recreating all 42, which turns "try it on one tenant" into a
+    # fleet-wide restart and defeats the point.
+    only_tenant = request.query_params.get("tenant")
+    if only_tenant:
+        tenants = [org for org in tenants if org.slug == only_tenant]
+        if not tenants:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No ready tenant with slug {only_tenant!r}",
+            )
+
     loop = asyncio.get_running_loop()
     skipped: list[str] = []
 

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -117,6 +117,10 @@ class Settings(BaseSettings):
     librechat_container_data_path: str = "/librechat"  # base dir for per-tenant librechat files
     librechat_host_data_path: str = "/opt/klai/librechat"  # HOST path for Docker volume mounts
     librechat_image: str = "ghcr.io/danny-avila/librechat:v0.8.7"
+    # Per-tenant canary overrides: "slug=image[,slug=image]", digest-only.
+    # Empty by default, so a deploy without the env var behaves exactly as
+    # before (no validator-vs-env-parity crash). See core/librechat_images.py.
+    librechat_image_overrides: str = ""
     caddy_container_name: str = "klai-core-caddy-1"  # Docker container name for Caddy reload
     redis_container_name: str = "klai-core-redis-1"  # Docker container name; legacy operational reference
 

--- a/klai-portal/backend/app/core/librechat_images.py
+++ b/klai-portal/backend/app/core/librechat_images.py
@@ -1,0 +1,75 @@
+"""Per-tenant LibreChat image selection.
+
+SPEC-LIBRECHAT-PATCH-MODEL-001. Provisioning-managed tenants all took
+``settings.librechat_image``, so the only way to run one tenant on a new image
+was to move all 42. That made "canary" a synonym for "declared in
+docker-compose.yml", which fits exactly one tenant (getklai) -- and getklai
+serves almost no traffic, so it could not produce the evidence a canary exists
+to produce.
+
+An override maps ``slug -> image``. Digest-only by design: on 2026-08-14 the
+tag ``v0.8.7-klai.1`` was pushed twice with different content, so a
+tag-referenced canary cannot be rolled back to what it was actually running.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+__all__ = [
+    "ImageOverrideError",
+    "parse_librechat_image_overrides",
+    "resolve_librechat_image",
+]
+
+_DIGEST_REF: Final = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+
+
+class ImageOverrideError(ValueError):
+    """Raised when the override string is malformed or not digest-pinned."""
+
+
+def parse_librechat_image_overrides(raw: str) -> dict[str, str]:
+    """Parse ``slug=image[,slug=image]`` into a mapping.
+
+    Fails loud on anything ambiguous rather than dropping entries: a canary
+    that silently did not take is worse than a deploy that refuses to start,
+    because it looks like evidence while producing none.
+    """
+    overrides: dict[str, str] = {}
+    if not raw or not raw.strip():
+        return overrides
+
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            raise ImageOverrideError(f"malformed LibreChat image override {entry!r}: expected slug=image")
+        slug, _, image = entry.partition("=")
+        slug, image = slug.strip(), image.strip()
+        if not slug:
+            raise ImageOverrideError(f"empty slug in LibreChat image override {entry!r}")
+        if not image:
+            raise ImageOverrideError(f"empty image in LibreChat image override {entry!r}")
+        if slug in overrides:
+            raise ImageOverrideError(
+                f"duplicate LibreChat image override for slug {slug!r}; "
+                "two entries for one tenant means one of them is not what you think"
+            )
+        if not _DIGEST_REF.match(image):
+            raise ImageOverrideError(
+                f"LibreChat image override for {slug!r} must be pinned by digest "
+                f"(name@sha256:<64 hex>), got {image!r}. A tag can be moved -- "
+                "v0.8.7-klai.1 was overwritten in place on 2026-08-14 -- so a "
+                "tag-pinned canary cannot be rolled back to what it ran."
+            )
+        overrides[slug] = image
+
+    return overrides
+
+
+def resolve_librechat_image(slug: str, default_image: str, overrides: dict[str, str]) -> str:
+    """The image this tenant should run: its override, else the fleet default."""
+    return overrides.get(slug, default_image)

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -25,6 +25,10 @@ import structlog
 from pymongo.errors import OperationFailure
 
 from app.core.config import settings
+from app.core.librechat_images import (
+    parse_librechat_image_overrides,
+    resolve_librechat_image,
+)
 from app.core.provisioning_names import validate_slug_for_provisioning
 from app.services.provisioning._slug_guard import _assert_safe_slug
 from app.services.provisioning.generators import _generate_librechat_yaml
@@ -47,6 +51,20 @@ _LIBRECHAT_PATCH_MOUNTS = {
     "patches/stream.cjs": "/app/node_modules/@librechat/agents/dist/cjs/stream.cjs",
     "patches/search.cjs": "/app/node_modules/@librechat/agents/dist/cjs/tools/search/search.cjs",
 }
+
+
+def _tenant_librechat_image(slug: str) -> str:
+    """Image for this tenant: its canary override, else the fleet default.
+
+    Parsed per call rather than cached: the override string comes from the
+    container environment, so a stale cache would mean a deploy that changed it
+    did not take -- the silent-no-op failure this SPEC exists to remove.
+    """
+    overrides = parse_librechat_image_overrides(settings.librechat_image_overrides)
+    image = resolve_librechat_image(slug, settings.librechat_image, overrides)
+    if image != settings.librechat_image:
+        logger.info("librechat_image_override_applied", slug=slug, image=image)
+    return image
 
 
 def assert_shared_librechat_mount_sources_intact() -> None:
@@ -752,7 +770,7 @@ def _start_librechat_container(
             slug,
             env_file_host_path,
             mcp_servers,
-            image=settings.librechat_image,
+            image=_tenant_librechat_image(slug),
         )
     except Exception:
         if rollback_on_failure and old_image_ref:

--- a/klai-portal/backend/tests/test_librechat_image_overrides.py
+++ b/klai-portal/backend/tests/test_librechat_image_overrides.py
@@ -1,0 +1,70 @@
+"""Per-tenant LibreChat image overrides (canary rollout).
+
+Every provisioning-managed tenant used to get `settings.librechat_image`, so
+there was no way to run one tenant on a new image without moving all 42. That
+made "canary" mean "a container declared in compose", which only worked for
+getklai -- and getklai serves no traffic, so it proved nothing over time.
+
+An override maps slug -> image. It is deliberately digest-only: a canary you
+cannot roll back to is not a canary, and 2026-08-14 showed a tag being
+overwritten in place.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.librechat_images import (
+    ImageOverrideError,
+    parse_librechat_image_overrides,
+    resolve_librechat_image,
+)
+
+DIGEST = "sha256:" + "a" * 64
+KLAI_IMAGE = f"ghcr.io/getklai/librechat@{DIGEST}"
+DEFAULT = "ghcr.io/danny-avila/librechat:v0.8.7"
+
+
+class TestParsing:
+    def test_empty_means_no_overrides(self):
+        assert parse_librechat_image_overrides("") == {}
+        assert parse_librechat_image_overrides("   ") == {}
+
+    def test_single_and_multiple_entries(self):
+        assert parse_librechat_image_overrides(f"voys={KLAI_IMAGE}") == {"voys": KLAI_IMAGE}
+        parsed = parse_librechat_image_overrides(f"voys={KLAI_IMAGE}, getklai={KLAI_IMAGE}")
+        assert parsed == {"voys": KLAI_IMAGE, "getklai": KLAI_IMAGE}
+
+    def test_rejects_a_tag_reference(self):
+        # The whole point: an override you cannot roll back to is worthless.
+        with pytest.raises(ImageOverrideError, match="digest"):
+            parse_librechat_image_overrides("voys=ghcr.io/getklai/librechat:v0.8.7-klai.1")
+
+    def test_rejects_a_truncated_digest(self):
+        with pytest.raises(ImageOverrideError, match="digest"):
+            parse_librechat_image_overrides("voys=ghcr.io/getklai/librechat@sha256:abc123")
+
+    def test_rejects_malformed_entries(self):
+        with pytest.raises(ImageOverrideError, match="slug=image"):
+            parse_librechat_image_overrides("voys")
+
+    def test_rejects_an_empty_slug(self):
+        with pytest.raises(ImageOverrideError, match="slug"):
+            parse_librechat_image_overrides(f"={KLAI_IMAGE}")
+
+    def test_rejects_a_duplicate_slug(self):
+        # Two entries for one tenant means somebody edited without looking;
+        # silently taking the last one is how a canary lands on the wrong image.
+        with pytest.raises(ImageOverrideError, match="duplicate"):
+            parse_librechat_image_overrides(f"voys={KLAI_IMAGE},voys={KLAI_IMAGE}")
+
+
+class TestResolution:
+    def test_tenant_without_override_gets_the_fleet_default(self):
+        assert resolve_librechat_image("acme", DEFAULT, {"voys": KLAI_IMAGE}) == DEFAULT
+
+    def test_tenant_with_override_gets_it(self):
+        assert resolve_librechat_image("voys", DEFAULT, {"voys": KLAI_IMAGE}) == KLAI_IMAGE
+
+    def test_no_overrides_at_all(self):
+        assert resolve_librechat_image("voys", DEFAULT, {}) == DEFAULT


### PR DESCRIPTION
De canary was `getklai` omdat dat de enige LibreChat-container is die in `docker-compose.yml` staat. Daarmee was "welke tenant is de canary" een gevolg van hóe een container beheerd wordt, geen keuze — en getklai heeft nauwelijks verkeer (laatste gesprek vóór vandaag: 9 juli). Een canary die niemand gebruikt levert geen bewijs, hoe lang je hem ook laat staan.

## Wat ontbrak

1. Elke provisioning-managed tenant nam `settings.librechat_image`. `LIBRECHAT_IMAGE_OVERRIDES` (`slug=image[,slug=image]`) benoemt nu uitzonderingen.
2. De regenerate-endpoint was alleen fleet-breed. `?tenant=<slug>` versmalt hem, zodat een image op één tenant proberen niet betekent dat je 42 containers herstart.

## Digest-only, fail loud

Overrides weigeren een tag, een lege slug, een malformed entry, en een **dubbele slug**. Dat laatste telt zwaarder dan het lijkt: stilletjes de laatste nemen zet de canary op een image die niemand gekozen heeft — precies het faalpatroon waar deze SPEC over gaat.

De tag-regel is ook niet theoretisch: de tag `v0.8.7-klai.1` is vanochtend in-place overschreven, dus een tag-gepinde canary is niet terug te rollen naar wat hij draaide.

Default is leeg, dus een deploy zonder de env-var gedraagt zich exact als voorheen — geen validator-vs-env-parity crash bij binnenkomst.

## Aangezet voor voys

Daar zit het echte verkeer. Rollback is één compose-regel weghalen en die tenant hercreëren.

10 nieuwe tests, 3568 backend-breed groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)