### PR TITLE
feat(librechat): Phase 5 — fleet default is the Klai-owned image

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -649,17 +649,19 @@ services:
       DOMAIN: ${DOMAIN}
       FRONTEND_URL: ${FRONTEND_URL:-}
       DOCKER_HOST: tcp://docker-socket-proxy:2375
-      # SPEC-LIBRECHAT-PATCH-MODEL-001 — per-tenant canary. Provisioning-managed
-      # tenants otherwise all take LIBRECHAT_IMAGE; this runs ONE of them on the
-      # Klai-owned image so the migration gets real-conversation evidence before
-      # the fleet moves. getklai was the canary first, but it serves almost no
-      # traffic, and a canary nobody uses proves nothing over time.
+      # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5 — the fleet default is the
+      # Klai-owned image, built in CI from deploy/librechat/patches-source/.
+      # Tag for humans: v0.8.7-klai.1-80df95854928 (upstream v0.8.7, agents v3.2.46).
       #
-      # Digest-only, enforced in app/core/librechat_images.py and by
-      # deploy/check-klai-librechat-digest.sh. Rollback: delete this line and
-      # recreate the tenant -- it falls back to LIBRECHAT_IMAGE.
-      # Tag for humans: v0.8.7-klai.1-80df95854928
-      LIBRECHAT_IMAGE_OVERRIDES: voys=ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
+      # Digest-pinned; deploy/check-klai-librechat-digest.sh enforces it. The
+      # default in config.py deliberately stays on upstream, so a deploy that
+      # loses this variable falls back to a working image rather than to
+      # nothing.
+      #
+      # Rollback: delete this line, then recreate tenants (they return to the
+      # config.py default). LIBRECHAT_IMAGE_OVERRIDES can pin individual
+      # tenants either way during a staged move.
+      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
       # SPEC-SEC-HYGIENE-001 REQ-28.4: explicit deployment-environment marker.
       # Pydantic Settings reads PORTAL_ENV; the in-code default is "production"
       # (REQ-28.2). The validator at config.py:_no_debug_in_production refuses

--- a/deploy/librechat/check-patch-drift.sh
+++ b/deploy/librechat/check-patch-drift.sh
@@ -11,8 +11,27 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 MANIFEST="$ROOT_DIR/deploy/librechat/patch-manifest.txt"
 GETKLAI_MANIFEST="$ROOT_DIR/deploy/librechat/getklai/patch-manifest.txt"
-LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-ghcr.io/danny-avila/librechat:v0.8.7}"
 FAIL=0
+
+# The fleet image is what portal-api actually hands to `containers.run`, which
+# is the LIBRECHAT_IMAGE env in docker-compose.yml when set, and only otherwise
+# the config.py default. Hardcoding upstream here made the guard validate an
+# image the fleet no longer runs the moment Phase 5 flipped that env var --
+# checking the wrong artifact is worse than not checking, because it looks
+# green (SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5).
+COMPOSE_FLEET_IMAGE=$(awk -F': ' '
+  $1 ~ /^ +LIBRECHAT_IMAGE$/ { gsub(/^ +| +$/, "", $2); print $2; exit }
+' "$ROOT_DIR/deploy/docker-compose.yml")
+
+CONFIG_DEFAULT_IMAGE=$(sed -n 's/.*librechat_image: str = "\([^"]*\)".*/\1/p' \
+  "$ROOT_DIR/klai-portal/backend/app/core/config.py" | head -1)
+
+LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-${COMPOSE_FLEET_IMAGE:-$CONFIG_DEFAULT_IMAGE}}"
+
+if [ -z "$LIBRECHAT_IMAGE" ]; then
+  echo "ERROR: could not resolve the fleet LibreChat image from compose or config.py" >&2
+  exit 1
+fi
 
 COMPOSE_IMAGE=$(awk '
   $1 == "librechat-getklai:" { in_service = 1; next }
@@ -20,9 +39,12 @@ COMPOSE_IMAGE=$(awk '
   in_service && $1 ~ /^[a-zA-Z0-9_-]+:/ { exit }
 ' "$ROOT_DIR/deploy/docker-compose.yml")
 
-if ! grep -q "librechat_image: str = \"$LIBRECHAT_IMAGE\"" \
-  "$ROOT_DIR/klai-portal/backend/app/core/config.py"; then
-  echo "ERROR: portal-api default librechat_image is not pinned to $LIBRECHAT_IMAGE" >&2
+# config.py's default is the fallback when the env var is absent, so it must
+# stay a real, pullable image -- but it is NOT required to equal the fleet
+# image once compose overrides it. Requiring equality would force the fallback
+# to move in lockstep with the rollout, which defeats the point of having one.
+if [ -z "$CONFIG_DEFAULT_IMAGE" ]; then
+  echo "ERROR: could not read librechat_image default from config.py" >&2
   FAIL=1
 fi
 
@@ -210,7 +232,15 @@ dry_run_transforms() {
 
 validate_image_pin "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 validate_image_pin "$COMPOSE_IMAGE" "librechat-getklai"
-validate_manifest "$MANIFEST" "$LIBRECHAT_IMAGE"
+# The fleet manifest pins UPSTREAM hashes of files the tenants bind-mount. Once
+# the fleet image bakes those patches in, the tenants stop mounting them (see
+# image_bakes_in_patches) and the manifest describes a model that no longer
+# applies -- provenance then comes from the build manifest inside the image.
+if printf '%s' "$LIBRECHAT_IMAGE" | grep -q '^ghcr.io/getklai/librechat'; then
+  echo "SKIP [manifest]: fleet runs the Klai-owned image; patches are baked in, not mounted"
+else
+  validate_manifest "$MANIFEST" "$LIBRECHAT_IMAGE"
+fi
 validate_runtime_targets "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 dry_run_transforms "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 

--- a/deploy/librechat/tests/global_rollout_config.test.cjs
+++ b/deploy/librechat/tests/global_rollout_config.test.cjs
@@ -41,7 +41,21 @@ assert.match(workflow, /recreate_containers:/);
 assert.match(workflow, /RECREATE_CONTAINERS=/);
 assert.doesNotMatch(workflow, /regenerate\?recreate_containers=true/);
 assert.match(workflow, /timeout=600\.0/);
-assert.match(drift, /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-ghcr\.io\/danny-avila\/librechat:v0\.8\.7\}"/);
+// The drift guard used to hardcode the fleet image as upstream. It now
+// resolves it the same way portal-api does -- compose LIBRECHAT_IMAGE first,
+// config.py default as fallback -- because Phase 5 moved the fleet and a
+// hardcoded guard would have validated an image nobody runs while reporting
+// green. Pin the resolution ORDER rather than a specific image, so a future
+// rollout does not have to edit this test to stay honest.
+assert.match(drift, /COMPOSE_FLEET_IMAGE=/);
+assert.match(drift, /CONFIG_DEFAULT_IMAGE=/);
+assert.match(
+  drift,
+  /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-\$\{COMPOSE_FLEET_IMAGE:-\$CONFIG_DEFAULT_IMAGE\}\}"/,
+);
+// config.py stays on upstream on purpose: it is the fallback when the compose
+// variable is absent, so it must remain a working image rather than tracking
+// whatever the fleet currently runs.
 assert.match(portalConfig, /librechat_image: str = "ghcr\.io\/danny-avila\/librechat:v0\.8\.7"/);
 
 // Finding 3D (adversarial review 2026-08-13): the deploy step must not treat

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -53,6 +53,28 @@ _LIBRECHAT_PATCH_MOUNTS = {
 }
 
 
+# Images we build ourselves already contain the source-level patches
+# (SPEC-LIBRECHAT-PATCH-MODEL-001). Anything else does not.
+_KLAI_LIBRECHAT_IMAGE_PREFIX = "ghcr.io/getklai/librechat"
+
+
+def image_bakes_in_patches(image: str) -> bool:
+    """True when this image already contains the Klai patches.
+
+    A bind-mount WINS over the file in the image, so mounting the old
+    hand-edited bundles on top of an image built from the source diffs would
+    silently serve the old ones and make the migration apply to nothing -- the
+    inert-patch failure this SPEC exists to remove.
+
+    Deliberately fail-safe: an unrecognised image is treated as needing the
+    mounts, because serving an unpatched LibreChat is worse than a redundant
+    mount. Matching on the repository rather than the digest is also why a
+    badly pinned Klai tag still counts -- pin quality is enforced by
+    deploy/check-klai-librechat-digest.sh, not here.
+    """
+    return image.startswith(_KLAI_LIBRECHAT_IMAGE_PREFIX)
+
+
 def _tenant_librechat_image(slug: str) -> str:
     """Image for this tenant: its canary override, else the fleet default.
 
@@ -67,7 +89,7 @@ def _tenant_librechat_image(slug: str) -> str:
     return image
 
 
-def assert_shared_librechat_mount_sources_intact() -> None:
+def assert_shared_librechat_mount_sources_intact(*, require_patches: bool = True) -> None:
     """Refuse to start or restart a tenant when a fleet-shared bind source is broken.
 
     Docker resolves a bind mount at container *start*, not at create. When the
@@ -95,7 +117,11 @@ def assert_shared_librechat_mount_sources_intact() -> None:
     directory), so one run tells an operator the whole story.
     """
     base = Path(settings.librechat_container_data_path)
-    expected = [*_LIBRECHAT_PATCH_MOUNTS, "klai-entrypoint.sh"]
+    # The entrypoint wrapper is mounted on every image; the patch files only on
+    # images that do not already carry them.
+    expected = ["klai-entrypoint.sh"]
+    if require_patches:
+        expected = [*_LIBRECHAT_PATCH_MOUNTS, *expected]
 
     broken: list[str] = []
     for rel_path in expected:
@@ -594,12 +620,22 @@ def _create_and_start_librechat_container(
         f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},
         f"{librechat_host_base}/{slug}/images": {"bind": "/app/client/public/images", "mode": "rw"},
     }
+    # The patch mounts only belong on an image that does NOT already carry the
+    # patches. On a Klai-built image they would win over the baked-in files and
+    # serve the old hand-edited bundles instead (SPEC-LIBRECHAT-PATCH-MODEL-001
+    # Phase 5). Kept conditional rather than deleted so a rollback to the
+    # upstream image still gets a patched LibreChat.
+    patches_baked_in = image_bakes_in_patches(image)
+
     # Every fleet-shared bind source must be an actual FILE before we hand the
     # mount list to Docker -- see assert_shared_librechat_mount_sources_intact.
-    assert_shared_librechat_mount_sources_intact()
+    assert_shared_librechat_mount_sources_intact(require_patches=not patches_baked_in)
 
-    for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
-        volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
+    if patches_baked_in:
+        logger.info("librechat_patch_mounts_skipped", slug=slug, image=image)
+    else:
+        for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
+            volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
 
     # Klai entrypoint wrapper that forces light theme on every tenant (LibreChat
     # has no server-side theme config — see deploy/librechat/klai-entrypoint.sh).

--- a/klai-portal/backend/tests/test_librechat_patch_mounts_conditional.py
+++ b/klai-portal/backend/tests/test_librechat_patch_mounts_conditional.py
@@ -1,0 +1,41 @@
+"""Patch bind-mounts must not be layered on top of an image that bakes them in.
+
+SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5. A bind-mount wins over the file in the
+image, so a tenant recreated on the Klai-owned image WITH the four patch mounts
+still attached would serve the old hand-edited bundles -- the migration would
+apply to nothing while looking complete. That is the same failure shape as the
+createStreamServices mount that sat inert for months.
+
+Mounting stays conditional rather than deleted: rolling the fleet back to the
+upstream image must restore a patched LibreChat, and upstream only has the
+patches via those mounts.
+"""
+
+from __future__ import annotations
+
+from app.services.provisioning.infrastructure import image_bakes_in_patches
+
+UPSTREAM = "ghcr.io/danny-avila/librechat:v0.8.7"
+KLAI = "ghcr.io/getklai/librechat@sha256:" + "b" * 64
+
+
+def test_upstream_image_still_needs_the_mounts():
+    assert image_bakes_in_patches(UPSTREAM) is False
+
+
+def test_klai_image_carries_them_already():
+    assert image_bakes_in_patches(KLAI) is True
+
+
+def test_klai_image_by_tag_also_counts():
+    # Tags are rejected elsewhere (check-klai-librechat-digest.sh); this
+    # function answers "does this image carry the patches", not "is this
+    # reference acceptable" -- conflating the two would mount patches on top of
+    # a Klai image that someone pinned badly.
+    assert image_bakes_in_patches("ghcr.io/getklai/librechat:v0.8.7-klai.1") is True
+
+
+def test_unrelated_registry_is_treated_as_needing_mounts():
+    # Fail safe: an image we do not recognise gets the mounts, because serving
+    # an unpatched LibreChat is worse than a redundant mount.
+    assert image_bakes_in_patches("registry.example.com/someone/librechat:1") is False


### PR DESCRIPTION
`LIBRECHAT_IMAGE` in compose wijst nu elke provisioning-managed tenant naar `sha256:3b4fd8440c79…`. Containers veranderen pas bij hercreatie, dus dit landt als **configuratie** — de uitrol zelf gebeurt gefaseerd en apart.

De default in `config.py` blijft bewust op upstream: raakt deze variabele ooit kwijt, dan valt een tenant terug op een werkende image in plaats van op niets.

## Drie dingen moesten mee

Elk daarvan is een manier waarop deze omschakeling anders een stille no-op of een vals groen zou zijn geweest.

**Patch-mounts zijn nu voorwaardelijk.** Een mount wint van het bestand in de image. Een tenant hercreëren op de Klai-image mét de vier mounts eraan zou de oude handbewerkte bundles serveren en de migratie op niets toepassen — de `createStreamServices`-vorm opnieuw.

Voorwaardelijk in plaats van verwijderd, want terugrollen naar upstream moet nog steeds een gepatchte LibreChat opleveren, en upstream heeft die patches alléén via die mounts. Een onbekende image houdt de mounts: een ongepatchte LibreChat serveren is erger dan een overbodige mount.

**De drift-guard hardcodeerde het fleet-image als upstream.** Zodra dit omging zou hij een image valideren die de fleet niet meer draait — groen terwijl hij het verkeerde artefact controleert. Hij resolvet nu zoals portal-api dat doet: compose-env, anders de `config.py`-default.

**Diezelfde guard eiste dat `config.py` gelijk was aan het fleet-image.** Dat zou de fallback in lockstep met de uitrol dwingen te bewegen, wat het nut van een fallback opheft. Nu eist hij alleen dat de fallback bestaat.

## Fleet-manifest overgeslagen

Zolang de fleet de Klai-image draait pint `patch-manifest.txt` upstream-hashes van bestanden die niet meer gemount worden. Provenance komt daar uit het build-manifest ín de image.

4 nieuwe tests, 3572 backend-breed, 10 librechat-suites groen.