### PR TITLE
fix(caddy): close CVE-2026-46600 at source, empty the ignore list

### DIFF
--- a/deploy/caddy/.trivyignore.yaml
+++ b/deploy/caddy/.trivyignore.yaml
@@ -11,26 +11,15 @@
 
 # NOTE 2026-08-12: entries below renewed from expired_at 2026-08-01 to
 # 2026-09-15 to unblock CI (the repo-wide REQ-5 validator hard-fails on any
-# past date, which blocked unrelated portal deploys). Upstream fixes were
-# still not shipped in the pinned base images at renewal time; a proper
-# re-evaluation is owed before 2026-09-15.
-vulnerabilities:
-  - id: CVE-2026-34986
-    statement: |
-      Go JOSE DoS via crafted JWE on go-jose v3.0.4 + v4.1.3
-      (fix in v3.0.5 / v4.1.4). Caddy uses go-jose only for ACME-style
-      flows (Let's Encrypt JWS-signed orders); our deployment terminates
-      ACME via Hetzner DNS-01 and never accepts user-supplied JWE,
-      so the DoS attack surface (crafted external JWE → CPU starvation)
-      has no path. Re-evaluate when Caddy 2.11.3+ bumps go-jose.
-    expired_at: 2026-09-15
-
-  - id: CVE-2026-42504
-    statement: |
-      Go stdlib MIME header parsing DoS fixed in Go 1.26.4. The published
-      caddy:2.11.3-builder-alpine image still uses Go 1.26.3, and xcaddy
-      embeds that stdlib in /usr/bin/caddy. This deployment does parse
-      inbound HTTP headers, so this is not dismissed as impossible; it is a
-      temporary upstream-image gap until Caddy publishes a builder/runtime
-      image compiled with Go 1.26.4 or later.
-    expired_at: 2026-09-15
+# past date, which blocked unrelated portal deploys).
+#
+# 2026-08-14: that re-evaluation happened. The 2.11.4 rebuild's Trivy scan
+# reports exactly ONE finding against usr/bin/caddy (CVE-2026-46600,
+# golang.org/x/net) — CVE-2026-34986 and CVE-2026-42504 are gone, so their
+# entries were removed rather than left to ride to their expiry. The
+# remaining one is fixed at source by the x/net pin in the Dockerfile's
+# xcaddy invocation, so this file needs no entry for it either.
+#
+# The list is intentionally empty. An empty list is a statement: nothing in
+# this image is currently accepted-with-known-risk.
+vulnerabilities: []

--- a/deploy/caddy/Dockerfile
+++ b/deploy/caddy/Dockerfile
@@ -13,9 +13,15 @@
 # production once CI rebuilds and republishes ghcr.io/getklai/caddy-hetzner.
 FROM caddy:2.11.4-builder-alpine AS builder
 
+# The trailing --with pins a dependency, not a plugin: xcaddy turns it into a
+# require+replace, so the built binary links x/net 0.56.0 instead of the 0.55.0
+# Caddy 2.11.4 ships. That closes CVE-2026-46600 properly rather than adding a
+# fourth .trivyignore entry for something with an available fix.
+# Drop the pin once Caddy ships a release that already requires >= 0.56.0.
 RUN xcaddy build \
     --with github.com/caddy-dns/hetzner/v2 \
-    --with github.com/mholt/caddy-ratelimit
+    --with github.com/mholt/caddy-ratelimit \
+    --with golang.org/x/net@v0.56.0
 
 FROM caddy:2.11.4-alpine
 


### PR DESCRIPTION
The 2.11.4 rebuild's Trivy scan failed. Reading it properly changes the picture.

Repo-wide code-scanning alerts mixed **two** sources: a pile of Go 1.22.9 stdlib findings belonging to third-party images (zitadel, glitchtip, listmonk, calcom — WARN-tier, not this gate), and exactly **one** finding against `usr/bin/caddy`:

```
CVE-2026-46600   golang.org/x/net   v0.55.0 -> 0.56.0
```

## The bump worked

`CVE-2026-34986` (go-jose) and `CVE-2026-42504` (Go stdlib MIME parsing) are **gone** from the binary — 2.11.4's builder closed both. Their `.trivyignore` entries are removed rather than left to ride to their 2026-09-15 expiry, which is what the note added in b000c127e asked for.

## The remaining one gets fixed, not ignored

`xcaddy`'s `--with` also accepts a plain `module@version`, which it turns into a require+replace. So the binary now links **x/net 0.56.0** instead of the 0.55.0 Caddy 2.11.4 ships. A fourth ignore entry for something upstream already fixed would have been the lazy read.

The ignore list is now **empty**, deliberately: nothing in this image is currently accepted-with-known-risk.

## Worth knowing

This gate was **already red before today's bump** — the 2026-08-12 run (8394b4f08) failed on the same scan job. Inherited, not caused. It also means the caddy image on core-01 has not been rebuilt since then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)