### PR TITLE
chore(security): drop three suppressions that no longer suppress anything

### DIFF
--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -69,16 +69,19 @@ jobs:
       - name: Type check (pyright)
         run: uv run --with pyright pyright
 
-      # CVE-2026-4539: ignored — package not directly exploitable in our context (sandboxed container,
-      # no user-controlled input reaches the vulnerable code path). Re-assess Q3 2026.
-      # See: https://github.com/GetKlai/klai/issues/62
       # CVE-2026-3219: advisory against pip 26.0.1 (the CI runner's bootstrap pip, not an app
       # dependency resolved by uv). Ignored until the Actions runner image bumps its default pip.
+      # This is the only suppression that survives a local run: CVE-2026-4539 and
+      # CVE-2025-71176 were dropped on 2026-08-14 after pip-audit against the same
+      # uv.lock reported "No known vulnerabilities found" without them. A suppression
+      # that suppresses nothing is worse than none — it reads as accepted risk that
+      # nobody has re-checked. This one stays because a local run cannot reproduce
+      # the runner's bootstrap pip, so its absence locally proves nothing.
       # --skip-editable: internal klai-libs are editable path dependencies in this
       # monorepo; querying PyPI for those private distribution names is both noisy
       # and outside this external-dependency audit's trust boundary.
       - name: Dependency vulnerability scan (pip-audit)
-        run: uv run --with pip-audit pip-audit --skip-editable --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2025-71176 --ignore-vuln CVE-2026-3219
+        run: uv run --with pip-audit pip-audit --skip-editable --ignore-vuln CVE-2026-3219
 
       # Guards against the two classes of alembic mistakes we've been bitten by:
       # 1. Hand-typed rev ids (SPEC-KB-020: duplicate `a1b2c3d4e5f6` crashed

--- a/klai-portal/backend/.trivyignore.yaml
+++ b/klai-portal/backend/.trivyignore.yaml
@@ -8,24 +8,6 @@
 # `trivyignores:` (added in PR #3 of SPEC-CI-TRIVY-POLICY-001).
 
 vulnerabilities:
-  - id: CVE-2026-6357
-    statement: |
-      Affects pip 26.0.1 — the GitHub Actions runner image's bootstrap pip,
-      NOT an app dependency resolved by uv at runtime. uv handles all
-      package resolution post-build; the container never invokes pip after
-      the image is built. The vulnerable code path requires user-controlled
-      package install, which the runtime container never performs.
-
-      The same CVE is already explicitly ignored in the workflow's
-      pip-audit step (.github/workflows/portal-api.yml line 74) under
-      its alternative GHSA reference CVE-2026-3219. This entry brings the
-      Trivy scan in line with that pre-existing decision.
-
-      Re-evaluate when actions/runner-images ships a default pip ≥26.1.
-    expired_at: 2026-09-01
-    purls:
-      - "pkg:pypi/pip@26.0.1"
-
   - id: GHSA-6v7p-g79w-8964
     statement: |
       msgpack 1.1.2 lives in the python:3.13-slim base-image site-packages
@@ -47,7 +29,7 @@ vulnerabilities:
       vulnerable path (PackageIndex.download path traversal) only triggers
       when installing packages at runtime; the container never invokes
       setuptools/pip after the image is built — uv resolves everything at
-      build time. Same reasoning as the existing CVE-2026-6357 pip entry.
+      build time.
 
       Re-evaluate when the python:3.13-slim base image ships
       setuptools >= 78.1.1.


### PR DESCRIPTION
A CVE suppression that matches nothing is not harmless. It reads as "accepted risk, reviewed" to the next person, while actually being a line nobody has re-checked since the day it was added. Three of portal-api's five turned out to be exactly that.

## Verified, not assumed

**pip-audit** — same `uv.lock`, no ignore flags:
```
No known vulnerabilities found
```
→ `CVE-2026-4539` and `CVE-2025-71176` match nothing. Dropped.

**Trivy** on `ghcr.io/getklai/portal-api:latest`, no ignorefile, CI's exact flags (`--severity CRITICAL,HIGH --ignore-unfixed --scanners vuln`):
```
HIGH  GHSA-6v7p-g79w-8964  msgpack 1.1.2    -> 1.2.1
HIGH  CVE-2025-47273       setuptools 70.3.0 -> 78.1.1
```
→ `CVE-2026-6357` (pip 26.0.1) matches nothing. Dropped. The other two are real, base-image-owned, and keep their entries.

## What stays

`CVE-2026-3219` — the runner's bootstrap pip, which a local run cannot reproduce. Its absence locally proves nothing, which is a different situation from the three above; the comment now says so explicitly.

Same reasoning as the caddy trivyignore emptied in 3ccaaddb9: when the finding is gone, remove the entry rather than letting it ride to its expiry date.

## Verification this PR provides

The portal-api workflow triggers on `.github/workflows/portal-api.yml`, so this PR's own run exercises both the pip-audit step and the Trivy scan with the reduced lists. A green run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)