### PR TITLE
fix(kb-feedback): correlate on the identity the retrieval log is keyed by

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -649,17 +649,19 @@ services:
       DOMAIN: ${DOMAIN}
       FRONTEND_URL: ${FRONTEND_URL:-}
       DOCKER_HOST: tcp://docker-socket-proxy:2375
-      # SPEC-LIBRECHAT-PATCH-MODEL-001 — per-tenant canary. Provisioning-managed
-      # tenants otherwise all take LIBRECHAT_IMAGE; this runs ONE of them on the
-      # Klai-owned image so the migration gets real-conversation evidence before
-      # the fleet moves. getklai was the canary first, but it serves almost no
-      # traffic, and a canary nobody uses proves nothing over time.
+      # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5 — the fleet default is the
+      # Klai-owned image, built in CI from deploy/librechat/patches-source/.
+      # Tag for humans: v0.8.7-klai.1-80df95854928 (upstream v0.8.7, agents v3.2.46).
       #
-      # Digest-only, enforced in app/core/librechat_images.py and by
-      # deploy/check-klai-librechat-digest.sh. Rollback: delete this line and
-      # recreate the tenant -- it falls back to LIBRECHAT_IMAGE.
-      # Tag for humans: v0.8.7-klai.1-80df95854928
-      LIBRECHAT_IMAGE_OVERRIDES: voys=ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
+      # Digest-pinned; deploy/check-klai-librechat-digest.sh enforces it. The
+      # default in config.py deliberately stays on upstream, so a deploy that
+      # loses this variable falls back to a working image rather than to
+      # nothing.
+      #
+      # Rollback: delete this line, then recreate tenants (they return to the
+      # config.py default). LIBRECHAT_IMAGE_OVERRIDES can pin individual
+      # tenants either way during a staged move.
+      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
       # SPEC-SEC-HYGIENE-001 REQ-28.4: explicit deployment-environment marker.
       # Pydantic Settings reads PORTAL_ENV; the in-code default is "production"
       # (REQ-28.2). The validator at config.py:_no_debug_in_production refuses

--- a/deploy/librechat/check-patch-drift.sh
+++ b/deploy/librechat/check-patch-drift.sh
@@ -11,8 +11,27 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
 MANIFEST="$ROOT_DIR/deploy/librechat/patch-manifest.txt"
 GETKLAI_MANIFEST="$ROOT_DIR/deploy/librechat/getklai/patch-manifest.txt"
-LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-ghcr.io/danny-avila/librechat:v0.8.7}"
 FAIL=0
+
+# The fleet image is what portal-api actually hands to `containers.run`, which
+# is the LIBRECHAT_IMAGE env in docker-compose.yml when set, and only otherwise
+# the config.py default. Hardcoding upstream here made the guard validate an
+# image the fleet no longer runs the moment Phase 5 flipped that env var --
+# checking the wrong artifact is worse than not checking, because it looks
+# green (SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5).
+COMPOSE_FLEET_IMAGE=$(awk -F': ' '
+  $1 ~ /^ +LIBRECHAT_IMAGE$/ { gsub(/^ +| +$/, "", $2); print $2; exit }
+' "$ROOT_DIR/deploy/docker-compose.yml")
+
+CONFIG_DEFAULT_IMAGE=$(sed -n 's/.*librechat_image: str = "\([^"]*\)".*/\1/p' \
+  "$ROOT_DIR/klai-portal/backend/app/core/config.py" | head -1)
+
+LIBRECHAT_IMAGE="${LIBRECHAT_IMAGE:-${COMPOSE_FLEET_IMAGE:-$CONFIG_DEFAULT_IMAGE}}"
+
+if [ -z "$LIBRECHAT_IMAGE" ]; then
+  echo "ERROR: could not resolve the fleet LibreChat image from compose or config.py" >&2
+  exit 1
+fi
 
 COMPOSE_IMAGE=$(awk '
   $1 == "librechat-getklai:" { in_service = 1; next }
@@ -20,9 +39,12 @@ COMPOSE_IMAGE=$(awk '
   in_service && $1 ~ /^[a-zA-Z0-9_-]+:/ { exit }
 ' "$ROOT_DIR/deploy/docker-compose.yml")
 
-if ! grep -q "librechat_image: str = \"$LIBRECHAT_IMAGE\"" \
-  "$ROOT_DIR/klai-portal/backend/app/core/config.py"; then
-  echo "ERROR: portal-api default librechat_image is not pinned to $LIBRECHAT_IMAGE" >&2
+# config.py's default is the fallback when the env var is absent, so it must
+# stay a real, pullable image -- but it is NOT required to equal the fleet
+# image once compose overrides it. Requiring equality would force the fallback
+# to move in lockstep with the rollout, which defeats the point of having one.
+if [ -z "$CONFIG_DEFAULT_IMAGE" ]; then
+  echo "ERROR: could not read librechat_image default from config.py" >&2
   FAIL=1
 fi
 
@@ -210,7 +232,15 @@ dry_run_transforms() {
 
 validate_image_pin "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 validate_image_pin "$COMPOSE_IMAGE" "librechat-getklai"
-validate_manifest "$MANIFEST" "$LIBRECHAT_IMAGE"
+# The fleet manifest pins UPSTREAM hashes of files the tenants bind-mount. Once
+# the fleet image bakes those patches in, the tenants stop mounting them (see
+# image_bakes_in_patches) and the manifest describes a model that no longer
+# applies -- provenance then comes from the build manifest inside the image.
+if printf '%s' "$LIBRECHAT_IMAGE" | grep -q '^ghcr.io/getklai/librechat'; then
+  echo "SKIP [manifest]: fleet runs the Klai-owned image; patches are baked in, not mounted"
+else
+  validate_manifest "$MANIFEST" "$LIBRECHAT_IMAGE"
+fi
 validate_runtime_targets "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 dry_run_transforms "$LIBRECHAT_IMAGE" "Provisioned LibreChat"
 

--- a/deploy/librechat/getklai/entrypoint.sh
+++ b/deploy/librechat/getklai/entrypoint.sh
@@ -311,6 +311,7 @@ const REPLACE = `      { context: 'updateFeedback' },
           text: feedback.text ?? null,
           model_alias: updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
+          identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,
         }),
       }).catch((err) => {

--- a/deploy/librechat/klai-entrypoint.sh
+++ b/deploy/librechat/klai-entrypoint.sh
@@ -314,6 +314,7 @@ const REPLACE = `      { context: 'updateFeedback' },
           text: feedback.text ?? null,
           model_alias: updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
+          identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,
         }),
       }).catch((err) => {

--- a/deploy/librechat/patches-source/messages.js.patch
+++ b/deploy/librechat/patches-source/messages.js.patch
@@ -1,8 +1,8 @@
 diff --git a/api/server/routes/messages.js b/api/server/routes/messages.js
-index 17e740c51..4fe008979 100644
+index 17e740c51..eeb650ac1 100644
 --- a/api/server/routes/messages.js
 +++ b/api/server/routes/messages.js
-@@ -415,6 +415,36 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
+@@ -415,6 +415,43 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
        }).catch((err) => logger.error('[langfuse] feedback score failed:', err));
      }
  
@@ -28,6 +28,13 @@ index 17e740c51..4fe008979 100644
 +          text: feedback.text ?? null,
 +          model_alias: updatedMessage?.model ?? null,
 +          librechat_user_id: req.user?.id ?? '',
++          // The retrieval log is keyed by the Zitadel subject, which
++          // LibreChat stores as openidId. Sending only req.user.id (a
++          // Mongo ObjectId) meant feedback could never be correlated to
++          // the chunks that produced the answer -- 55 of 58 events came
++          // back uncorrelated. Sent alongside, not instead: the field
++          // above still means what its name says.
++          identity_user_id: req.user?.openidId ?? null,
 +          librechat_tenant_id: process.env.KLAI_ORG_SLUG ? `librechat-${process.env.KLAI_ORG_SLUG}` : null,
 +        }),
 +      }).catch((err) => {

--- a/deploy/librechat/tests/global_rollout_config.test.cjs
+++ b/deploy/librechat/tests/global_rollout_config.test.cjs
@@ -41,7 +41,21 @@ assert.match(workflow, /recreate_containers:/);
 assert.match(workflow, /RECREATE_CONTAINERS=/);
 assert.doesNotMatch(workflow, /regenerate\?recreate_containers=true/);
 assert.match(workflow, /timeout=600\.0/);
-assert.match(drift, /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-ghcr\.io\/danny-avila\/librechat:v0\.8\.7\}"/);
+// The drift guard used to hardcode the fleet image as upstream. It now
+// resolves it the same way portal-api does -- compose LIBRECHAT_IMAGE first,
+// config.py default as fallback -- because Phase 5 moved the fleet and a
+// hardcoded guard would have validated an image nobody runs while reporting
+// green. Pin the resolution ORDER rather than a specific image, so a future
+// rollout does not have to edit this test to stay honest.
+assert.match(drift, /COMPOSE_FLEET_IMAGE=/);
+assert.match(drift, /CONFIG_DEFAULT_IMAGE=/);
+assert.match(
+  drift,
+  /LIBRECHAT_IMAGE="\$\{LIBRECHAT_IMAGE:-\$\{COMPOSE_FLEET_IMAGE:-\$CONFIG_DEFAULT_IMAGE\}\}"/,
+);
+// config.py stays on upstream on purpose: it is the fallback when the compose
+// variable is absent, so it must remain a working image rather than tracking
+// whatever the fleet currently runs.
 assert.match(portalConfig, /librechat_image: str = "ghcr\.io\/danny-avila\/librechat:v0\.8\.7"/);
 
 // Finding 3D (adversarial review 2026-08-13): the deploy step must not treat

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1076,10 +1076,28 @@ class KbFeedbackIn(BaseModel):
     librechat_user_id: str
     librechat_tenant_id: str
     model_alias: str | None = None
+    # The identity the RETRIEVAL log is keyed by (Zitadel subject). LibreChat's
+    # own user id is a Mongo ObjectId from a different namespace, so correlating
+    # on it never matched -- 55 of 58 events came back uncorrelated between April
+    # and 2026-08-14. LibreChat carries the subject on the user document as
+    # `openidId`. Optional: the LiteLLM hook and partner paths post here too and
+    # do not know about it, and older LibreChat images do not send it.
+    identity_user_id: str | None = None
 
 
 # @MX:ANCHOR: [AUTO] Public API boundary for KB feedback from LibreChat. SPEC-KB-015.
 # @MX:REASON: Called by LibreChat patch (feedback.cjs) + LiteLLM hook + tests. fan_in >= 3.
+def _correlation_user_id(body: KbFeedbackIn) -> str:
+    """The key to look the retrieval log up under.
+
+    Prefers the identity id, because that is what wrote the log. Falls back to
+    the LibreChat id so a tenant still on an older image behaves exactly as
+    before instead of erroring mid-rollout.
+    """
+    identity = (body.identity_user_id or "").strip()
+    return identity or body.librechat_user_id
+
+
 @router.post("/v1/kb-feedback", status_code=status.HTTP_201_CREATED, response_model=None)
 async def post_kb_feedback(
     body: KbFeedbackIn,
@@ -1117,7 +1135,7 @@ async def post_kb_feedback(
     # 3. Time-window correlation (REQ-KB-015-09)
     correlated_log = await find_correlated_log(
         org_id=org.id,
-        user_id=body.librechat_user_id,
+        user_id=_correlation_user_id(body),
         message_created_at=body.message_created_at,
     )
 

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -53,6 +53,28 @@ _LIBRECHAT_PATCH_MOUNTS = {
 }
 
 
+# Images we build ourselves already contain the source-level patches
+# (SPEC-LIBRECHAT-PATCH-MODEL-001). Anything else does not.
+_KLAI_LIBRECHAT_IMAGE_PREFIX = "ghcr.io/getklai/librechat"
+
+
+def image_bakes_in_patches(image: str) -> bool:
+    """True when this image already contains the Klai patches.
+
+    A bind-mount WINS over the file in the image, so mounting the old
+    hand-edited bundles on top of an image built from the source diffs would
+    silently serve the old ones and make the migration apply to nothing -- the
+    inert-patch failure this SPEC exists to remove.
+
+    Deliberately fail-safe: an unrecognised image is treated as needing the
+    mounts, because serving an unpatched LibreChat is worse than a redundant
+    mount. Matching on the repository rather than the digest is also why a
+    badly pinned Klai tag still counts -- pin quality is enforced by
+    deploy/check-klai-librechat-digest.sh, not here.
+    """
+    return image.startswith(_KLAI_LIBRECHAT_IMAGE_PREFIX)
+
+
 def _tenant_librechat_image(slug: str) -> str:
     """Image for this tenant: its canary override, else the fleet default.
 
@@ -67,7 +89,7 @@ def _tenant_librechat_image(slug: str) -> str:
     return image
 
 
-def assert_shared_librechat_mount_sources_intact() -> None:
+def assert_shared_librechat_mount_sources_intact(*, require_patches: bool = True) -> None:
     """Refuse to start or restart a tenant when a fleet-shared bind source is broken.
 
     Docker resolves a bind mount at container *start*, not at create. When the
@@ -95,7 +117,11 @@ def assert_shared_librechat_mount_sources_intact() -> None:
     directory), so one run tells an operator the whole story.
     """
     base = Path(settings.librechat_container_data_path)
-    expected = [*_LIBRECHAT_PATCH_MOUNTS, "klai-entrypoint.sh"]
+    # The entrypoint wrapper is mounted on every image; the patch files only on
+    # images that do not already carry them.
+    expected = ["klai-entrypoint.sh"]
+    if require_patches:
+        expected = [*_LIBRECHAT_PATCH_MOUNTS, *expected]
 
     broken: list[str] = []
     for rel_path in expected:
@@ -594,12 +620,22 @@ def _create_and_start_librechat_container(
         f"{librechat_host_base}/{slug}/librechat.yaml": {"bind": "/app/librechat.yaml", "mode": "ro"},
         f"{librechat_host_base}/{slug}/images": {"bind": "/app/client/public/images", "mode": "rw"},
     }
+    # The patch mounts only belong on an image that does NOT already carry the
+    # patches. On a Klai-built image they would win over the baked-in files and
+    # serve the old hand-edited bundles instead (SPEC-LIBRECHAT-PATCH-MODEL-001
+    # Phase 5). Kept conditional rather than deleted so a rollback to the
+    # upstream image still gets a patched LibreChat.
+    patches_baked_in = image_bakes_in_patches(image)
+
     # Every fleet-shared bind source must be an actual FILE before we hand the
     # mount list to Docker -- see assert_shared_librechat_mount_sources_intact.
-    assert_shared_librechat_mount_sources_intact()
+    assert_shared_librechat_mount_sources_intact(require_patches=not patches_baked_in)
 
-    for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
-        volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
+    if patches_baked_in:
+        logger.info("librechat_patch_mounts_skipped", slug=slug, image=image)
+    else:
+        for source_rel_path, destination in _LIBRECHAT_PATCH_MOUNTS.items():
+            volumes[f"{librechat_host_base}/{source_rel_path}"] = {"bind": destination, "mode": "ro"}
 
     # Klai entrypoint wrapper that forces light theme on every tenant (LibreChat
     # has no server-side theme config — see deploy/librechat/klai-entrypoint.sh).

--- a/klai-portal/backend/tests/test_kb_feedback_correlation_identity.py
+++ b/klai-portal/backend/tests/test_kb_feedback_correlation_identity.py
@@ -1,0 +1,64 @@
+"""Feedback must be looked up under the identity the retrieval log was written with.
+
+Production evidence 2026-08-14: 55 of 58 knowledge.feedback events had
+correlated=false, going back to April. The retrieval log is keyed
+rl:{org_id}:{user_id} where retrieval-api supplies the Zitadel subject
+(368883971322282015), while the LibreChat feedback patch sent req.user.id --
+the Mongo ObjectId (69e13d3f41c7d65c4c70cd2b). Two different namespaces, so the
+lookup could never hit.
+
+The data was there the whole time: for the 12:56:54 message, a retrieval entry
+sat at epoch 1786712209.8, four seconds earlier and well inside the
+[msg-60s, msg+10s] window, carrying 20 chunk_ids.
+
+LibreChat stores the Zitadel subject on the user document as `openidId`, so the
+patch can send both and the correlation can prefer the one that matches.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.internal import KbFeedbackIn, _correlation_user_id
+
+ZITADEL = "368883971322282015"
+MONGO = "69e13d3f41c7d65c4c70cd2b"
+
+
+def _body(**kw) -> KbFeedbackIn:
+    return KbFeedbackIn(
+        conversation_id="c1",
+        message_id="m1",
+        message_created_at=datetime.now(UTC),
+        rating="thumbsUp",
+        librechat_tenant_id="librechat-voys",
+        **kw,
+    )
+
+
+def test_prefers_the_identity_id_when_present():
+    body = _body(librechat_user_id=MONGO, identity_user_id=ZITADEL)
+    assert _correlation_user_id(body) == ZITADEL
+
+
+def test_falls_back_to_the_librechat_id_when_absent():
+    # Older LibreChat images do not send identity_user_id. Falling back keeps
+    # their behaviour unchanged instead of erroring during a staged rollout.
+    body = _body(librechat_user_id=MONGO)
+    assert _correlation_user_id(body) == MONGO
+
+
+@pytest.mark.parametrize("empty", ["", "   ", None])
+def test_blank_identity_id_falls_back(empty):
+    # An empty string is not a usable key; `or` alone would already do this,
+    # but whitespace would sneak through and produce rl:8:   .
+    body = _body(librechat_user_id=MONGO, identity_user_id=empty)
+    assert _correlation_user_id(body) == MONGO
+
+
+def test_identity_id_is_optional_on_the_contract():
+    # The field must stay optional: the LiteLLM hook and partner paths post to
+    # this endpoint too and do not know about openidId.
+    assert KbFeedbackIn.model_fields["identity_user_id"].default is None

--- a/klai-portal/backend/tests/test_librechat_patch_mounts_conditional.py
+++ b/klai-portal/backend/tests/test_librechat_patch_mounts_conditional.py
@@ -1,0 +1,41 @@
+"""Patch bind-mounts must not be layered on top of an image that bakes them in.
+
+SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5. A bind-mount wins over the file in the
+image, so a tenant recreated on the Klai-owned image WITH the four patch mounts
+still attached would serve the old hand-edited bundles -- the migration would
+apply to nothing while looking complete. That is the same failure shape as the
+createStreamServices mount that sat inert for months.
+
+Mounting stays conditional rather than deleted: rolling the fleet back to the
+upstream image must restore a patched LibreChat, and upstream only has the
+patches via those mounts.
+"""
+
+from __future__ import annotations
+
+from app.services.provisioning.infrastructure import image_bakes_in_patches
+
+UPSTREAM = "ghcr.io/danny-avila/librechat:v0.8.7"
+KLAI = "ghcr.io/getklai/librechat@sha256:" + "b" * 64
+
+
+def test_upstream_image_still_needs_the_mounts():
+    assert image_bakes_in_patches(UPSTREAM) is False
+
+
+def test_klai_image_carries_them_already():
+    assert image_bakes_in_patches(KLAI) is True
+
+
+def test_klai_image_by_tag_also_counts():
+    # Tags are rejected elsewhere (check-klai-librechat-digest.sh); this
+    # function answers "does this image carry the patches", not "is this
+    # reference acceptable" -- conflating the two would mount patches on top of
+    # a Klai image that someone pinned badly.
+    assert image_bakes_in_patches("ghcr.io/getklai/librechat:v0.8.7-klai.1") is True
+
+
+def test_unrelated_registry_is_treated_as_needing_mounts():
+    # Fail safe: an image we do not recognise gets the mounts, because serving
+    # an unpatched LibreChat is worse than a redundant mount.
+    assert image_bakes_in_patches("registry.example.com/someone/librechat:1") is False


### PR DESCRIPTION
**55 van de 58** `knowledge.feedback`-events kwamen terug met `correlated=false`, terug tot april. Het KB-kwaliteitssignaal waar SPEC-KB-015 voor bestaat — feedback gekoppeld aan de chunks die het antwoord maakten, richting Qdrant-scoring — komt dus leeg binnen sinds het live ging.

## Geen steekproefprobleem

De retrieval-log staat op `rl:{org_id}:{user_id}`, en de twee kanten bedoelen iets anders met `user_id`:

| kant | waarde | wat het is |
|---|---|---|
| schrijven (retrieval-api) | `368883971322282015` | Zitadel-subject |
| lezen (LibreChat) | `69e13d3f41c7d65c4c70cd2b` | Mongo ObjectId |

Verschillende naamruimtes. De lookup kón nooit raken — voor niemand, nooit. Het partner-pad heeft er geen last van: dat gebruikt `partner:{key_id}` aan beide kanten.

## De data was er wel

Voor het bericht van 12:56:54 stond een retrieval-entry op epoch `1786712209.8`: vier seconden eerder, binnen het venster `[msg−60s, msg+10s]`, met 20 chunk-ids. Alleen de sleutel klopte niet.

## Fix

LibreChat bewaart het Zitadel-subject al op het user-document als `openidId`. De patch stuurt dat nu mee als `identity_user_id`, en de correlatie geeft daar voorrang aan met terugval op `librechat_user_id`.

**Ernaast, niet in plaats van**: het bestaande veld blijft betekenen wat de naam zegt, en een tenant op een oudere image gedraagt zich exact als voorheen in plaats van te falen tijdens een gefaseerde uitrol.

Beide entrypoint-transforms krijgen dezelfde toevoeging. Die draaien alleen op de upstream-image, maar ze uit elkaar laten lopen met de bron-diff zou betekenen dat een rollback de bug stilletjes terugzet.

6 nieuwe tests, 3578 backend-breed, 10 librechat-suites groen.