### PR TITLE
fix(kb-feedback): correlate on the identity the retrieval log is keyed by

### DIFF
--- a/deploy/librechat/getklai/entrypoint.sh
+++ b/deploy/librechat/getklai/entrypoint.sh
@@ -311,6 +311,7 @@ const REPLACE = `      { context: 'updateFeedback' },
           text: feedback.text ?? null,
           model_alias: updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
+          identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,
         }),
       }).catch((err) => {

--- a/deploy/librechat/klai-entrypoint.sh
+++ b/deploy/librechat/klai-entrypoint.sh
@@ -314,6 +314,7 @@ const REPLACE = `      { context: 'updateFeedback' },
           text: feedback.text ?? null,
           model_alias: updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
+          identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,
         }),
       }).catch((err) => {

--- a/deploy/librechat/patches-source/messages.js.patch
+++ b/deploy/librechat/patches-source/messages.js.patch
@@ -1,8 +1,8 @@
 diff --git a/api/server/routes/messages.js b/api/server/routes/messages.js
-index 17e740c51..4fe008979 100644
+index 17e740c51..eeb650ac1 100644
 --- a/api/server/routes/messages.js
 +++ b/api/server/routes/messages.js
-@@ -415,6 +415,36 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
+@@ -415,6 +415,43 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
        }).catch((err) => logger.error('[langfuse] feedback score failed:', err));
      }
  
@@ -28,6 +28,13 @@ index 17e740c51..4fe008979 100644
 +          text: feedback.text ?? null,
 +          model_alias: updatedMessage?.model ?? null,
 +          librechat_user_id: req.user?.id ?? '',
++          // The retrieval log is keyed by the Zitadel subject, which
++          // LibreChat stores as openidId. Sending only req.user.id (a
++          // Mongo ObjectId) meant feedback could never be correlated to
++          // the chunks that produced the answer -- 55 of 58 events came
++          // back uncorrelated. Sent alongside, not instead: the field
++          // above still means what its name says.
++          identity_user_id: req.user?.openidId ?? null,
 +          librechat_tenant_id: process.env.KLAI_ORG_SLUG ? `librechat-${process.env.KLAI_ORG_SLUG}` : null,
 +        }),
 +      }).catch((err) => {

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -1076,10 +1076,28 @@ class KbFeedbackIn(BaseModel):
     librechat_user_id: str
     librechat_tenant_id: str
     model_alias: str | None = None
+    # The identity the RETRIEVAL log is keyed by (Zitadel subject). LibreChat's
+    # own user id is a Mongo ObjectId from a different namespace, so correlating
+    # on it never matched -- 55 of 58 events came back uncorrelated between April
+    # and 2026-08-14. LibreChat carries the subject on the user document as
+    # `openidId`. Optional: the LiteLLM hook and partner paths post here too and
+    # do not know about it, and older LibreChat images do not send it.
+    identity_user_id: str | None = None
 
 
 # @MX:ANCHOR: [AUTO] Public API boundary for KB feedback from LibreChat. SPEC-KB-015.
 # @MX:REASON: Called by LibreChat patch (feedback.cjs) + LiteLLM hook + tests. fan_in >= 3.
+def _correlation_user_id(body: KbFeedbackIn) -> str:
+    """The key to look the retrieval log up under.
+
+    Prefers the identity id, because that is what wrote the log. Falls back to
+    the LibreChat id so a tenant still on an older image behaves exactly as
+    before instead of erroring mid-rollout.
+    """
+    identity = (body.identity_user_id or "").strip()
+    return identity or body.librechat_user_id
+
+
 @router.post("/v1/kb-feedback", status_code=status.HTTP_201_CREATED, response_model=None)
 async def post_kb_feedback(
     body: KbFeedbackIn,
@@ -1117,7 +1135,7 @@ async def post_kb_feedback(
     # 3. Time-window correlation (REQ-KB-015-09)
     correlated_log = await find_correlated_log(
         org_id=org.id,
-        user_id=body.librechat_user_id,
+        user_id=_correlation_user_id(body),
         message_created_at=body.message_created_at,
     )
 

--- a/klai-portal/backend/tests/test_kb_feedback_correlation_identity.py
+++ b/klai-portal/backend/tests/test_kb_feedback_correlation_identity.py
@@ -1,0 +1,64 @@
+"""Feedback must be looked up under the identity the retrieval log was written with.
+
+Production evidence 2026-08-14: 55 of 58 knowledge.feedback events had
+correlated=false, going back to April. The retrieval log is keyed
+rl:{org_id}:{user_id} where retrieval-api supplies the Zitadel subject
+(368883971322282015), while the LibreChat feedback patch sent req.user.id --
+the Mongo ObjectId (69e13d3f41c7d65c4c70cd2b). Two different namespaces, so the
+lookup could never hit.
+
+The data was there the whole time: for the 12:56:54 message, a retrieval entry
+sat at epoch 1786712209.8, four seconds earlier and well inside the
+[msg-60s, msg+10s] window, carrying 20 chunk_ids.
+
+LibreChat stores the Zitadel subject on the user document as `openidId`, so the
+patch can send both and the correlation can prefer the one that matches.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.internal import KbFeedbackIn, _correlation_user_id
+
+ZITADEL = "368883971322282015"
+MONGO = "69e13d3f41c7d65c4c70cd2b"
+
+
+def _body(**kw) -> KbFeedbackIn:
+    return KbFeedbackIn(
+        conversation_id="c1",
+        message_id="m1",
+        message_created_at=datetime.now(UTC),
+        rating="thumbsUp",
+        librechat_tenant_id="librechat-voys",
+        **kw,
+    )
+
+
+def test_prefers_the_identity_id_when_present():
+    body = _body(librechat_user_id=MONGO, identity_user_id=ZITADEL)
+    assert _correlation_user_id(body) == ZITADEL
+
+
+def test_falls_back_to_the_librechat_id_when_absent():
+    # Older LibreChat images do not send identity_user_id. Falling back keeps
+    # their behaviour unchanged instead of erroring during a staged rollout.
+    body = _body(librechat_user_id=MONGO)
+    assert _correlation_user_id(body) == MONGO
+
+
+@pytest.mark.parametrize("empty", ["", "   ", None])
+def test_blank_identity_id_falls_back(empty):
+    # An empty string is not a usable key; `or` alone would already do this,
+    # but whitespace would sneak through and produce rl:8:   .
+    body = _body(librechat_user_id=MONGO, identity_user_id=empty)
+    assert _correlation_user_id(body) == MONGO
+
+
+def test_identity_id_is_optional_on_the_contract():
+    # The field must stay optional: the LiteLLM hook and partner paths post to
+    # this endpoint too and do not know about openidId.
+    assert KbFeedbackIn.model_fields["identity_user_id"].default is None


### PR DESCRIPTION
**55 van de 58** `knowledge.feedback`-events kwamen terug met `correlated=false`, terug tot april. Het KB-kwaliteitssignaal waar SPEC-KB-015 voor bestaat — feedback gekoppeld aan de chunks die het antwoord maakten, richting Qdrant-scoring — komt dus leeg binnen sinds het live ging.

## Geen steekproefprobleem

De retrieval-log staat op `rl:{org_id}:{user_id}`, en de twee kanten bedoelen iets anders met `user_id`:

| kant | waarde | wat het is |
|---|---|---|
| schrijven (retrieval-api) | `368883971322282015` | Zitadel-subject |
| lezen (LibreChat) | `69e13d3f41c7d65c4c70cd2b` | Mongo ObjectId |

Verschillende naamruimtes. De lookup kón nooit raken — voor niemand, nooit. Het partner-pad heeft er geen last van: dat gebruikt `partner:{key_id}` aan beide kanten.

## De data was er wel

Voor het bericht van 12:56:54 stond een retrieval-entry op epoch `1786712209.8`: vier seconden eerder, binnen het venster `[msg−60s, msg+10s]`, met 20 chunk-ids. Alleen de sleutel klopte niet.

## Fix

LibreChat bewaart het Zitadel-subject al op het user-document als `openidId`. De patch stuurt dat nu mee als `identity_user_id`, en de correlatie geeft daar voorrang aan met terugval op `librechat_user_id`.

**Ernaast, niet in plaats van**: het bestaande veld blijft betekenen wat de naam zegt, en een tenant op een oudere image gedraagt zich exact als voorheen in plaats van te falen tijdens een gefaseerde uitrol.

Beide entrypoint-transforms krijgen dezelfde toevoeging. Die draaien alleen op de upstream-image, maar ze uit elkaar laten lopen met de bron-diff zou betekenen dat een rollback de bug stilletjes terugzet.

6 nieuwe tests, 10 librechat-suites groen, drift-guard exit 0.