### PR TITLE
ci: watch every deploy on main, not just the eight Python services

### DIFF
--- a/.github/workflows/ci-failure-notice.yml
+++ b/.github/workflows/ci-failure-notice.yml
@@ -21,7 +21,12 @@ name: CI failure notice
 
 on:
   workflow_run:
+    # Everything that publishes an image or writes to core-01. The rule for
+    # this list is "did main just fail to ship something", not "did a check go
+    # red" — a red gate is already blocking at the PR, while a red deploy has
+    # nothing else shouting about it.
     workflows:
+      # Python + frontend services
       - Build and push portal-api
       - Build and deploy portal-frontend
       - Build and push knowledge-ingest
@@ -30,8 +35,27 @@ on:
       - Build and push klai-mailer
       - Build and push scribe-api
       - Build and push klai-knowledge-mcp
+      # Images that are not a Python service but still ship
+      - Build Klai LibreChat image
+      - Build and push caddy-hetzner
+      - Build and push whisper-server
+      - Build and push klai-docker-authz
+      - Build and deploy docs
+      # Things that write directly to core-01
       - Sync docker-compose.yml + config + smoke-test to core-01
+      - Sync LibreChat base config to core-01
+      - Deploy LiteLLM hooks
     types: [completed]
+
+    # Deliberately NOT watched, so the open-issue list stays a list of real
+    # breakage:
+    #   - E2E prod-tenant — flaky enough that it would file more noise than
+    #     signal; it cancels itself constantly on concurrent main pushes.
+    #   - Semgrep / trivyignore validate / rules-tests / audit compose /
+    #     env-scope-guard / tenant-isolation / alerting checks / litellm hook
+    #     tests / LibreChat patch tests — these are PR gates. They block the
+    #     merge, so a red one on main means somebody used --admin, and the
+    #     conversation about that belongs on the PR.
 
 permissions:
   contents: read


### PR DESCRIPTION
The notifier shipped watching the 8 service builds plus compose-sync. That left **seven** workflows that also publish an image or write to core-01 with no alerting at all.

One of them went red on main today — `Build Klai LibreChat image`, its own patch-behaviour guard failing against the built image — with nothing anywhere to say so. Exactly the gap the workflow was written to close, just one list short.

## Added

| Workflow | Why it counts |
|---|---|
| Build Klai LibreChat image | publishes the tenant chat image |
| Build and push caddy-hetzner | the edge proxy |
| Build and push whisper-server | |
| Build and push klai-docker-authz | |
| Build and deploy docs | |
| Sync LibreChat base config to core-01 | writes to prod |
| Deploy LiteLLM hooks | writes to prod |

## Deliberately still not watched (now stated in the file)

- **E2E prod-tenant** — cancels itself on concurrent main pushes often enough to file more noise than signal.
- **The PR gates** (Semgrep, trivyignore validate, rules-tests, audit compose, env-scope-guard, tenant-isolation, alerting checks, hook/patch tests). They block the merge, so a red one on main means somebody used `--admin`, and that conversation belongs on the PR.

The selection rule is *"did main just fail to ship something"*, not *"did a check go red"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)