### PR TITLE
feat(security): finish SPEC-SEC-DOCKER-AUTHZ-001 — alert, docs, alloy, and the missing proof

### DIFF
--- a/.claude/rules/klai/platform/docker-socket-proxy.md
+++ b/.claude/rules/klai/platform/docker-socket-proxy.md
@@ -10,6 +10,80 @@ SEC-021 routes all portal-api and runtime-api Docker API traffic through
 `tecnativa/docker-socket-proxy` instead of binding `/var/run/docker.sock`
 directly. The proxy restricts which Docker API endpoints are reachable.
 
+## Two layers, and what each one can see (CRIT)
+
+There are now TWO controls in front of the daemon, and confusing them is how the
+gap below stayed open for months:
+
+```
+portal-api ──────────────► klai-docker-authz :2375 ┐
+                                                    ├─► docker-socket-proxy ─► /var/run/docker.sock
+runtime-api-socket-proxy ► klai-docker-authz :2376 ┘        (method + path)
+                                    (request BODY)
+```
+
+| Layer | Authorises on | Cannot see |
+|---|---|---|
+| `docker-socket-proxy` | method + path (`CONTAINERS`, `NETWORKS`, `POST`, `DELETE`) | anything inside the request body |
+| `klai-docker-authz` | the `HostConfig` inside `POST /containers/create` | nothing else — every other endpoint passes straight through |
+
+**Why the second layer exists.** `POST /containers/create` is on the path
+whitelist and its body was never parsed. `HostConfig` lives in that body, and
+`HostConfig` is where container isolation is decided. Proven on 2026-08-14
+against `tecnativa/docker-socket-proxy:v0.5.0` with production's exact env: a
+create carrying `Binds: ["/:/host"]`, `Privileged: true`, `PidMode: "host"`
+returned **201**, started **204**, and the container read the host's
+`/etc/hostname`. Endpoint whitelisting does not constrain `HostConfig` — that is
+documented Docker behaviour, not a proxy bug. SPEC-SEC-DOCKER-AUTHZ-001.
+
+### Per-principal allowlist
+
+Identity comes from the listener port, not from a peer address — the Vexa runtime
+arrives through a socat bridge and would otherwise present the sidecar's address.
+
+| Port | Principal | Binds | NetworkMode |
+|---|---|---|---|
+| 2375 | `portal-api` | only under `/opt/klai/librechat` | any (provisioning attaches networks separately) |
+| 2376 | `vexa12-runtime` | **none at all** | `vexa12-bots` only |
+
+Forbidden for BOTH, regardless of port: `Privileged`, `CapAdd`, `Devices`,
+`DeviceCgroupRules`, `CgroupParent`, `PidMode`, `IpcMode`, `UsernsMode`,
+`SecurityOpt`, `Sysctls`, `Runtime`, and `NetworkMode: host|none`.
+
+The two allowlists are not guesses. Every bind in
+`_start_librechat_container` sits under that one prefix, and the Vexa runtime's
+three bind sources all belong to Vexa's agent feature, which Klai does not deploy
+(`AGENT_IMAGE` empty, `HOST_CLAUDE_CREDENTIALS` / `VEXA_AGENT_SRC_MOUNT` unset).
+
+### Extending it
+
+Widening a policy is a security-review event, not a routing tweak.
+
+1. Change `klai-docker-authz/app/policy.py` — the `Policy` for that principal.
+2. Add a test in `klai-docker-authz/tests/test_policy.py` proving the NEW shape
+   passes AND the escalation shape still fails. Both directions, or it is not a
+   test.
+3. Say in the diff WHY the caller's shape changed. "To unblock the deploy" is not
+   a reason; it is the symptom that something upstream changed unnoticed.
+
+Note on falsy values: `Privileged: false` and `CapAdd: null` are what docker-py
+sends on every create and are explicitly ALLOWED. A policy keyed on key-presence
+rather than on a requested value passes every hostile-input test and then refuses
+all tenant provisioning.
+
+### Who may reach the daemon at all
+
+`scripts/audit-docker-access.sh` pins two sets in CI (via `audit-compose.yml`):
+the `socket-proxy` network members, and the containers mounting the raw
+`/var/run/docker.sock`. The MUST-NOT list further down this file enumerates the
+*forbidden*, so a new service is permitted by default; the audit inverts that.
+
+`alloy` mounts the raw socket and therefore bypasses `klai-docker-authz`
+entirely. Its mount is `RW=false`, which protects the socket FILE but does not
+make the Docker API read-only — a process that can write the byte stream can
+still `POST /containers/create`. It needs `GET` only. Recorded as an open item in
+SPEC-SEC-DOCKER-AUTHZ-001; do not treat the read-only flag as containment.
+
 ## Containers that MUST NOT join the socket-proxy network (SPEC-SEC-SSRF-001 REQ-5)
 
 Any container that accepts a user-supplied URL and fetches it is one

--- a/.moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md
+++ b/.moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-SEC-DOCKER-AUTHZ-001
-version: "0.1.0"
-status: draft
+version: "1.0.0"
+status: implemented
 created: "2026-08-14"
 updated: "2026-08-14"
 author: MoAI
@@ -13,6 +13,7 @@ issue_number: 0
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.0.0 | 2026-08-14 | MoAI | Implemented. REQ-1 spike executed and the escalation demonstrated (see §Spike result); klai-docker-authz shipped and deployed; alloy moved off the raw socket; interim guards landed. Two success criteria remain open and are named as such at the bottom. |
 | 0.1.0 | 2026-08-14 | MoAI | Initial draft. Raised by the SPEC-VEXA-004 adversarial review (finding 3), which observed that `docker-socket-proxy`'s endpoint whitelist does not constrain `HostConfig`, so `POST /containers/create` remains a host-root primitive for any principal allowed to call it. Pre-existing since SPEC-SEC-021; not introduced by the Vexa migration. |
 
 # SPEC-SEC-DOCKER-AUTHZ-001: Constrain container-create, not just the endpoint
@@ -65,11 +66,33 @@ service becomes host root, and from there every tenant's data on the box. It
 converts "one service is broken" into "the machine is gone". That is why it is
 `high` and not `critical`, and also why it should not sit open indefinitely.
 
-The review that raised it did **not** demonstrate the exploit against
-production. The mechanism is inferred from Docker's documented semantics and
-from reading the proxy's own authorisation model; that inference is strong, but
-REQ-1 below exists to convert it into evidence before anything is designed
-around it.
+The review that raised it did **not** demonstrate the exploit. The mechanism was
+inferred from Docker's documented semantics and from the proxy's own
+authorisation model. REQ-1 existed to convert that inference into evidence before
+anything was designed around it — and it did.
+
+### Spike result (REQ-1, 2026-08-14)
+
+Run on a local host, never against production, using
+`tecnativa/docker-socket-proxy:v0.5.0` with production's exact environment
+(`CONTAINERS=1 NETWORKS=1 POST=1 DELETE=1`):
+
+```
+GET  /images/json                                        -> 403   (SEC-021 intact)
+POST /exec/x/start                                       -> 403   (SEC-021 intact)
+GET  /containers/json                                    -> 200
+
+POST /containers/create
+     {"HostConfig":{"Binds":["/:/host"],
+                    "Privileged":true,"PidMode":"host"}} -> 201
+POST /containers/{id}/start                              -> 204
+container stdout: /host/etc/hostname -> "orbstack"
+docker inspect  : Privileged true, PidMode host, Binds [/:/host]
+```
+
+The escalation is real, the endpoint whitelist is intact and irrelevant to it,
+and the two facts are independent — SEC-021 does what it says; it simply cannot
+see a request body. Everything below rests on this, not on inference.
 
 ## Why this is tractable
 
@@ -253,19 +276,59 @@ Both are hours, not weeks, and neither depends on which option is chosen.
 
 ## Success criteria
 
-- [ ] REQ-1 spike: the escalation is demonstrated on a non-production host and
-      written down, or shown not to apply — no implementation starts on an
-      inferred mechanism.
-- [ ] A `HostConfig` carrying `Privileged`, `Binds: ["/:/host"]`, `PidMode:
-      host` or `CapAdd` is rejected for both principals, proven by a test that
-      fails when the policy is removed.
-- [ ] portal-api can still provision a tenant end to end; vexa12-runtime can
-      still spawn a bot that joins a real meeting and produces a transcript.
-- [ ] A denial emits a structured event and raises the Grafana alert.
-- [ ] The interim CI guards land regardless of chosen option.
-- [ ] `.claude/rules/klai/platform/docker-socket-proxy.md` documents the policy
-      layer, its allowlist per principal, and how to extend it — the existing
-      per-verb rationale table is the model.
+- [x] **REQ-1 spike** — escalation demonstrated on a local host and written up
+      above. No implementation started before it.
+- [x] **Forbidden `HostConfig` rejected for both principals, proven by tests that
+      fail when the policy is removed.** 47 tests; four mutations run against
+      `policy.py` itself — dropping the forbidden-key loop (11 red), the bind
+      check (12 red), the `Mounts` arm (3 red), and path normalisation (1 red).
+      A test that cannot fail proves nothing, so this was verified rather than
+      assumed.
+- [ ] **portal-api can still provision a tenant end to end; vexa12-runtime can
+      still spawn a bot that joins a real meeting and produces a transcript.**
+      PARTIAL. Verified in production: portal-api's real docker-py client lists
+      86 containers, inspects, and resolves networks through the proxy; a bot
+      spawn ran the full chain (`docker_authz_allowed` → container on
+      `vexaai/vexa-bot:v0.12.22` → terminal event → webhook `delivered/200` →
+      dedupe receipt). NOT verified: a real tenant provisioned since the proxy
+      landed, and a real meeting producing a transcript. Neither can be
+      manufactured — one creates a customer tenant, the other needs a human in a
+      meeting. The provisioning body itself is covered by a unit test using the
+      exact shape from `_start_librechat_container`.
+- [x] **A denial emits a structured event and raises the Grafana alert.**
+      Structured event verified in production (`docker_authz_denied` with
+      principal, reason, container name). Alert:
+      `deploy/grafana/provisioning/alerting/docker-authz-rules.yaml`, fires on
+      the FIRST denial — a threshold above zero would mean deciding how much
+      attempted privilege escalation per interval is acceptable.
+- [x] **Interim CI guards landed.** `scripts/audit-docker-access.sh`, wired into
+      `audit-compose.yml`. Pins four sets: mutating-lane membership, GET-only-lane
+      membership, the GET-only proxy's allowed verbs, and raw-socket mounters.
+      The verb check exists because mutating the script found that membership
+      alone would pass while `POST: 1` quietly turned the read-only lane into a
+      second unpoliced create path.
+- [x] **`docker-socket-proxy.md` documents the policy layer**, its per-principal
+      allowlist, how to extend it (both directions tested, and say why the
+      caller's shape changed), and why falsy values are allowed.
+
+### Also delivered beyond the original criteria
+
+- [x] **REQ-U-002a — alloy no longer bypasses the controls.** It mounted the raw
+      socket with `:ro`, which protects the socket FILE and not the Docker API. It
+      now reaches the daemon through `docker-socket-proxy-ro`, where `POST` and
+      `DELETE` are unset, so the read-only intent is structural instead of a
+      mount flag.
+
+### Still open
+
+- **REQ-U-004 — the availability answer.** `klai-docker-authz` is now on the
+  tenant-provisioning and meeting-start paths, and REQ-S-001 makes it fail
+  closed. That trade is deliberate, but "acceptable, or does it need redundancy?"
+  has not been answered. It is a single container with a healthcheck and
+  `restart: unless-stopped`; nothing more.
+- **Option C for bot workloads.** Unchanged: a separate rootless daemon remains
+  the stronger answer for the ephemeral bot containers specifically. This SPEC
+  does not block it, and the policy layer would stay useful alongside it.
 
 ## Open questions
 

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -13,7 +13,10 @@
 // ─── Docker container log collection ─────────────────────────────────────────
 
 discovery.docker "containers" {
-  host = "unix:///var/run/docker.sock"
+  // SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a: no raw socket. docker-socket-proxy-ro
+  // serves GET only (POST and DELETE unset), so log discovery and streaming work
+  // while container-create is structurally impossible from here.
+  host = "http://docker-socket-proxy-ro:2375"
 }
 
 // Labels must be applied via discovery.relabel BEFORE loki.source.docker.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,6 +8,10 @@ networks:
     driver: bridge
     name: klai-socket-proxy
     internal: true   # portal-api + runtime-api-socket-proxy (socat) <-> docker-socket-proxy
+  socket-proxy-ro:
+    driver: bridge
+    name: klai-socket-proxy-ro
+    internal: true   # alloy <-> docker-socket-proxy-ro (GET only, no POST/DELETE)
   inference:
     driver: bridge
     name: klai-inference
@@ -495,6 +499,33 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - socket-proxy
+
+  # ─── docker-socket-proxy-ro (read-only, for observability) ───────────────
+  # SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a. Alloy mounted the raw host socket, so
+  # it bypassed every control in this stack. Its mount was `:ro`, which protects
+  # the socket FILE and NOT the Docker API — a process that can write the byte
+  # stream can still POST /containers/create. It only ever needed to list and
+  # inspect containers to attach log streams.
+  #
+  # POST and DELETE are unset here, so this instance cannot create, start, or
+  # remove anything. That makes the read-only intent structural rather than a
+  # property of a mount flag.
+  docker-socket-proxy-ro:
+    image: tecnativa/docker-socket-proxy:v0.5.0
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1   # GET /containers/json + /containers/{id}/json — discovery
+      # POST / DELETE deliberately unset: this principal never mutates.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - socket-proxy-ro
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    security_opt:
+      - no-new-privileges:true
 
   # ─── klai-docker-authz (body-inspecting Docker authorization) ────────────
   # SPEC-SEC-DOCKER-AUTHZ-001. docker-socket-proxy above authorises on
@@ -1017,7 +1048,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a: no raw socket. Alloy reaches the
+      # daemon through docker-socket-proxy-ro, which serves GET only.
       # Host-side synthetic probes write JSON logs here for Alloy file scraping.
       - /opt/klai/logs:/opt/klai/logs:ro
       # SPEC-INFRA-005 Phase 6: textfile collector reads .prom files written
@@ -1039,6 +1071,7 @@ services:
     networks:
       - klai-net
       - monitoring
+      - socket-proxy-ro   # SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a: GET-only daemon access
 
   grafana:
     image: grafana/grafana:13.1.3

--- a/deploy/grafana/provisioning/alerting/docker-authz-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/docker-authz-rules.yaml
@@ -1,0 +1,118 @@
+# SPEC-SEC-DOCKER-AUTHZ-001 — Docker container-create authorization denials.
+#
+# Routed via spec=SPEC-SEC-DOCKER-AUTHZ-001 → klai-ops-alerts-email (policies.yaml).
+#
+# Baseline is ZERO. `klai-docker-authz` denies a container-create only when a
+# principal asked for something its policy forbids: a host bind, Privileged,
+# PidMode:host, a CapAdd, an escape from its network. Neither portal-api's tenant
+# provisioning nor the Vexa bot spawn produces any of those — both were read off
+# their callsites and both are covered by tests. So a denial is one of exactly
+# two things:
+#
+#   1. Someone with code execution inside portal-api or vexa12-runtime is trying
+#      to escalate to host root. That is the attack this service exists to stop,
+#      and the denial is the ONLY signal it happened — the caller sees a 403 and
+#      the operation simply fails, which from the outside looks like a bug.
+#   2. A legitimate need nobody wrote down: upstream Vexa started sending a bind,
+#      or provisioning gained a mount outside /opt/klai/librechat. Then the
+#      allowlist in klai-docker-authz/app/policy.py needs a reviewed change, not
+#      a silent widening.
+#
+# Both want a human, immediately, which is why this fires on the FIRST denial
+# rather than on a rate. A threshold above zero here would mean deciding how much
+# attempted privilege escalation is acceptable per interval.
+#
+# Field shape verified against the live service (2026-08-14):
+#   {"event":"docker_authz_denied","principal":"portal-api",
+#    "reason":"portal-api may not set HostConfig.PidMode (got 'host') — ...",
+#    "container_name":"...","service":"klai-docker-authz","level":"error"}
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: sec-docker-authz-001
+    folder: Klai
+    interval: 1m
+    rules:
+
+      # ── Any denied container-create ──────────────────────────────────────
+      - uid: spec-authz-001-create-denied
+        title: docker_authz_create_denied
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:klai-docker-authz AND event:docker_authz_denied'
+              queryType: instant
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        # execErrState: OK — same VictoriaLogs-plugin/Grafana-SSE shape hiccup
+        # documented in caddy-rules.yaml. Missing a fire on a plugin error is
+        # preferable to paging on one; the denial is also in the service's own
+        # logs, so the evidence survives a missed alert.
+        execErrState: OK
+        # for: 0m — fire on the first evaluation that sees a denial. A sustained
+        # window would delay exactly the signal that matters most.
+        for: 0m
+        keepFiringFor: 15m
+        isPaused: false
+        labels:
+          severity: critical
+          spec: SPEC-SEC-DOCKER-AUTHZ-001
+          service_group: security
+        annotations:
+          summary: 'klai-docker-authz refused a container-create — privilege escalation attempt or an undocumented need'
+          description: |
+            A principal asked the Docker daemon to create a container with a
+            HostConfig its policy forbids, and klai-docker-authz refused.
+
+            Baseline is zero: neither tenant provisioning nor a bot spawn sends
+            any forbidden field.
+
+            Find the denial and read `principal` + `reason`:
+              service:klai-docker-authz AND event:docker_authz_denied
+
+            If `reason` names Privileged / PidMode / CapAdd / Devices / a bind
+            outside the allowlist, treat it as a compromise of that principal
+            until proven otherwise — that combination has no legitimate caller.
+
+            If it names a bind that looks plausible (a new mount in provisioning,
+            or a Vexa upstream change), the allowlist in
+            klai-docker-authz/app/policy.py needs a reviewed change. Do NOT widen
+            it to unblock a deploy without understanding why the shape changed.
+
+            The proven escalation this service blocks is recorded in
+            .moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md.

--- a/scripts/audit-docker-access.sh
+++ b/scripts/audit-docker-access.sh
@@ -1,61 +1,68 @@
 #!/bin/sh
 # SPEC-SEC-DOCKER-AUTHZ-001 — pin who may reach the Docker daemon.
 #
-# The existing rule in .claude/rules/klai/platform/docker-socket-proxy.md
-# enumerates which containers MUST NOT join the socket-proxy network. That is an
-# open policy: a new service is permitted by default and only a human reading the
-# rule would notice. This inverts it — the member set and the raw-socket mount set
-# are both pinned, so an addition fails CI and has to be argued for in a diff.
+# The rule in .claude/rules/klai/platform/docker-socket-proxy.md enumerates which
+# containers MUST NOT join the socket-proxy network. That is an open policy: a new
+# service is permitted by default and only a human reading the rule would notice.
+# This inverts it — every set below is pinned, so an addition fails CI and has to
+# be argued for in a diff.
 #
-# Runs on the compose file, not on a live host, so it gates the change rather
-# than reporting after the fact.
+# Runs against the compose file rather than a live host, so it gates the change
+# instead of reporting after the fact.
 
 set -eu
 
 COMPOSE="${1:-deploy/docker-compose.yml}"
 FAIL=0
 
-# Services permitted on the socket-proxy network. Adding one means the service can
-# reach the Docker API; that is a security-review event.
+# ── The mutating lane ────────────────────────────────────────────────────────
+# Members can create, start and remove containers. Every one of them goes through
+# klai-docker-authz, which inspects the container-create body.
 EXPECTED_NETWORK_MEMBERS="docker-socket-proxy klai-docker-authz portal-api runtime-api-socket-proxy"
 
-# Services permitted to bind the raw host socket. Everything else must go through
-# klai-docker-authz, whose whole purpose is to inspect what they send.
-#   docker-socket-proxy — the proxy itself
-#   alloy               — log collection; needs GET only, tracked in the SPEC as
-#                         an open item because a read-only socket FILE mount does
-#                         not make the Docker API read-only
-EXPECTED_SOCKET_MOUNTERS="docker-socket-proxy alloy"
+# ── The GET-only lane ────────────────────────────────────────────────────────
+# POST and DELETE are unset on docker-socket-proxy-ro, so members here can list,
+# inspect and stream logs but cannot create, start or remove anything. A member
+# that needs to mutate belongs on socket-proxy, behind klai-docker-authz.
+EXPECTED_RO_NETWORK_MEMBERS="alloy docker-socket-proxy-ro"
 
-actual_network_members=$(
-    uv run --quiet --with pyyaml python - "$COMPOSE" <<'PY'
+# ── Raw socket ───────────────────────────────────────────────────────────────
+# Only the two proxies. Alloy used to be here: it mounted the socket with `:ro`,
+# which protects the socket FILE and not the Docker API — a process that can write
+# the byte stream can still POST /containers/create. It now uses the GET-only
+# proxy, so the read-only intent is structural rather than a mount flag
+# (SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a).
+EXPECTED_SOCKET_MOUNTERS="docker-socket-proxy docker-socket-proxy-ro"
+
+network_members() {
+    uv run --quiet --with pyyaml python -c "
 import sys, yaml
 d = yaml.safe_load(open(sys.argv[1]))
-print(" ".join(sorted(
-    n for n, v in d["services"].items()
-    if "socket-proxy" in (v.get("networks") or [])
+net = sys.argv[2]
+print(' '.join(sorted(
+    n for n, v in d['services'].items() if net in (v.get('networks') or [])
 )))
-PY
-)
+" "$COMPOSE" "$1"
+}
 
-actual_socket_mounters=$(
-    uv run --quiet --with pyyaml python - "$COMPOSE" <<'PY'
+socket_mounters() {
+    uv run --quiet --with pyyaml python -c "
 import sys, yaml
 d = yaml.safe_load(open(sys.argv[1]))
 out = []
-for name, svc in d["services"].items():
-    for vol in svc.get("volumes") or []:
-        spec = vol if isinstance(vol, str) else f"{vol.get('source','')}:{vol.get('target','')}"
-        if spec.split(":")[0] == "/var/run/docker.sock":
+for name, svc in d['services'].items():
+    for vol in svc.get('volumes') or []:
+        spec = vol if isinstance(vol, str) else f\"{vol.get('source','')}:{vol.get('target','')}\"
+        if spec.split(':')[0] == '/var/run/docker.sock':
             out.append(name)
-print(" ".join(sorted(set(out))))
-PY
-)
+print(' '.join(sorted(set(out))))
+" "$COMPOSE"
+}
 
 check() {
     label="$1"; expected="$2"; actual="$3"; fix="$4"
-    exp=$(echo "$expected" | tr ' ' '\n' | sort | tr '\n' ' ')
-    act=$(echo "$actual"   | tr ' ' '\n' | sort | tr '\n' ' ')
+    exp=$(echo "$expected" | tr ' ' '\n' | sed '/^$/d' | sort | tr '\n' ' ')
+    act=$(echo "$actual"   | tr ' ' '\n' | sed '/^$/d' | sort | tr '\n' ' ')
     if [ "$exp" = "$act" ]; then
         echo "OK:   $label — $act"
     else
@@ -68,11 +75,34 @@ check() {
 }
 
 echo "── SPEC-SEC-DOCKER-AUTHZ-001 docker-access audit ──"
-check "socket-proxy network members" "$EXPECTED_NETWORK_MEMBERS" "$actual_network_members" \
-    "A service here can reach the Docker API. Justify it, then update EXPECTED_NETWORK_MEMBERS."
-check "raw docker.sock mounters" "$EXPECTED_SOCKET_MOUNTERS" "$actual_socket_mounters" \
-    "A raw socket mount bypasses klai-docker-authz entirely. Route it through the proxy, or justify and update EXPECTED_SOCKET_MOUNTERS."
+
+check "socket-proxy members (mutating)" "$EXPECTED_NETWORK_MEMBERS" "$(network_members socket-proxy)" \
+    "A service here can create containers. Justify it, then update EXPECTED_NETWORK_MEMBERS."
+
+check "socket-proxy-ro members (GET-only)" "$EXPECTED_RO_NETWORK_MEMBERS" "$(network_members socket-proxy-ro)" \
+    "This lane cannot mutate. A member that needs to belongs on socket-proxy, behind klai-docker-authz."
+
+# The GET-only lane is only GET-only while its proxy has no mutating verbs. A
+# membership check alone would pass while POST: 1 quietly turned the lane into a
+# second, unpoliced create path — found by mutating this very script.
+ro_verbs=$(
+    uv run --quiet --with pyyaml python -c "
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+env = d['services'].get('docker-socket-proxy-ro', {}).get('environment') or {}
+print(' '.join(sorted(k for k, v in env.items() if str(v) == '1')))
+" "$COMPOSE"
+)
+check "socket-proxy-ro allowed verbs" "CONTAINERS" "$ro_verbs" \
+    "This proxy must stay GET-only. POST or DELETE here creates a second, unpoliced container-create path."
+
+check "raw docker.sock mounters" "$EXPECTED_SOCKET_MOUNTERS" "$(socket_mounters)" \
+    "A raw socket mount bypasses both proxies. Route it through one, or justify and update EXPECTED_SOCKET_MOUNTERS."
 
 echo "───────────────────────────────────────────────────"
-[ "$FAIL" -eq 0 ] && echo "docker-access audit: OK" || echo "docker-access audit: FAILED" >&2
+if [ "$FAIL" -eq 0 ]; then
+    echo "docker-access audit: OK"
+else
+    echo "docker-access audit: FAILED" >&2
+fi
 exit "$FAIL"


### PR DESCRIPTION
#950 shipped the proxy. Checked against the SPEC's **own success criteria** rather than my impression, three were unmet and one half-met.

**The policy tests were never mutation-verified.** Criterion 2 says "proven by a test that fails when the policy is removed" — I never removed it. Four mutations on `policy.py`: forbidden-key loop (11 red), bind check (12 red), `Mounts` arm (3 red), path normalisation (1 red).

**No Grafana alert existed.** A denial is invisible to an operator — the caller gets a 403 and the operation just fails, which looks like a bug. Fires on the **first** denial; a threshold above zero would mean deciding how much attempted escalation per interval is acceptable.

**The rules doc described one layer.** Now both, with the per-principal allowlist, how to extend it (tests in *both* directions), and why falsy values are allowed — the mistake that passes every hostile-input test then refuses all provisioning.

**REQ-U-002a: alloy bypassed everything.** Raw socket, `:ro` — which protects the socket *file*, not the API. Added `docker-socket-proxy-ro` (POST/DELETE unset) and moved alloy onto it, so read-only is structural.

**The guard grew a check because mutating it found a hole:** lane membership alone would pass while `POST: 1` turned the read-only lane into a second unpoliced create path.

**Not done, named in the SPEC:** a real tenant provisioned and a real meeting transcribed since the proxy landed — neither can be manufactured. REQ-U-004's availability question stays open.

SPEC: draft → implemented, spike result written in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)