### PR TITLE
fix(security): the GET-only Docker lane needs NETWORKS for log discovery

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -515,7 +515,12 @@ services:
     restart: unless-stopped
     environment:
       CONTAINERS: 1   # GET /containers/json + /containers/{id}/json — discovery
-      # POST / DELETE deliberately unset: this principal never mutates.
+      NETWORKS: 1     # GET /networks — Alloy's docker discovery computes network
+                      # labels per target and 403s on this without it, which
+                      # breaks log discovery entirely (found on deploy, not in
+                      # review). Still read-only: no POST means no /connect.
+      # POST / DELETE deliberately unset: this principal never mutates. That is
+      # what keeps this a GET-only lane rather than a second create path.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:

--- a/scripts/audit-docker-access.sh
+++ b/scripts/audit-docker-access.sh
@@ -21,9 +21,11 @@ FAIL=0
 EXPECTED_NETWORK_MEMBERS="docker-socket-proxy klai-docker-authz portal-api runtime-api-socket-proxy"
 
 # ── The GET-only lane ────────────────────────────────────────────────────────
-# POST and DELETE are unset on docker-socket-proxy-ro, so members here can list,
-# inspect and stream logs but cannot create, start or remove anything. A member
-# that needs to mutate belongs on socket-proxy, behind klai-docker-authz.
+# CONTAINERS and NETWORKS are GET-side reads; POST and DELETE are unset, so
+# members here can list, inspect and stream logs but cannot create, start,
+# remove or connect anything. NETWORKS is required: Alloy's docker discovery
+# computes network labels per target and 403s without it. A member that needs to
+# mutate belongs on socket-proxy, behind klai-docker-authz.
 EXPECTED_RO_NETWORK_MEMBERS="alloy docker-socket-proxy-ro"
 
 # ── Raw socket ───────────────────────────────────────────────────────────────
@@ -93,7 +95,7 @@ env = d['services'].get('docker-socket-proxy-ro', {}).get('environment') or {}
 print(' '.join(sorted(k for k, v in env.items() if str(v) == '1')))
 " "$COMPOSE"
 )
-check "socket-proxy-ro allowed verbs" "CONTAINERS" "$ro_verbs" \
+check "socket-proxy-ro allowed verbs" "CONTAINERS NETWORKS" "$ro_verbs" \
     "This proxy must stay GET-only. POST or DELETE here creates a second, unpoliced container-create path."
 
 check "raw docker.sock mounters" "$EXPECTED_SOCKET_MOUNTERS" "$(socket_mounters)" \


### PR DESCRIPTION
Moving Alloy off the raw socket (#962) broke log discovery:

```
Unable to refresh target groups ... error while computing network labels:
Error response from daemon: 403 Forbidden
```

`discovery.docker` computes network labels per target → `GET /networks`, which `docker-socket-proxy-ro` did not allow.

Adds `NETWORKS: 1`. **Still GET-only** — POST and DELETE remain unset, so `/networks/{id}/connect` is refused and there is no path to `/containers/create`. The audit's expected verb set moves with it, so the lane stays pinned.

Found on deploy by checking whether logs still flowed — Alloy reports healthy either way; only the log stream tells the truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)