### PR TITLE
fix(crawler): herstel triggeren op waarneembaar gedrag + eerlijke eindstatus

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -25,7 +25,7 @@ from knowledge_ingest import pg_store, qdrant_store
 from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import CrawlResult, _canonicalise_url, crawl_site
 from knowledge_ingest.models import IngestRequest
-from knowledge_ingest.reason_codes import FetchReasonCode
+from knowledge_ingest.reason_codes import FETCH_REASON_VALUES, FetchReasonCode
 from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
 from knowledge_ingest.utils.auth_wall_detector import (
     AuthWallSignal,
@@ -50,10 +50,18 @@ CRAWL_BUDGET_EXHAUSTED_REASON = "crawl_budget_exhausted"
 CRAWL_FRONTIER_INCOMPLETE_REASON = "crawl_frontier_incomplete"
 CRAWL_FETCH_FAILED_REASON = "crawl_fetch_failed"
 AUTH_WALL_DETECTED_REASON = "auth_wall_detected"
-# 2026-08-14: reason code for the anti-bot terminal-status guard (see
-# decide_antibot_terminal_status). Stable string — same "surfaced in UI
+# 2026-08-14, revised same day: cause-independent replacement for the
+# PR #945 "blocked_by_anti_bot"-only guard (removed — see
+# decide_fetch_failure_terminal_status). That guard never actually fired
+# in production: crawl4ai's real bulk-request 500 body is opaque
+# (``{"error":"Internal server error","correlation_id":"..."}"``), so no
+# outcome was ever classified BLOCKED_ANTI_BOT on the intermedia.com job
+# that motivated it — every one of the 17 failed pages was
+# unknown_exception instead, and a guard that only counts
+# BLOCKED_ANTI_BOT counts zero. This reason fires on ANY dominant fetch
+# failure regardless of cause. Stable string — same "surfaced in UI
 # error_summary" contract as the other *_REASON constants above.
-ANTIBOT_BLOCKED_REASON = "blocked_by_anti_bot"
+FETCH_FAILURE_DOMINANT_REASON = "fetch_failure_dominant"
 
 _NOT_FETCHED_REASON_PREFIX = "not_fetched_"
 
@@ -65,11 +73,68 @@ _AUTH_WALL_WITH_AUTH_SUGGESTION = (
     "Configured authentication did not unlock all crawled pages. Refresh the "
     "saved cookies from the connector edit page before syncing again."
 )
-_ANTIBOT_BLOCKED_SUGGESTION = (
-    "Automated access to this site is being blocked by anti-bot protection "
-    "(e.g. Cloudflare). Retry the sync later — the challenge is often "
-    "intermittent — or ask the site owner to allowlist the Klai crawler."
+_FETCH_FAILURE_SUGGESTION = (
+    "A meaningful share of the discovered pages could not be fetched. The "
+    "site may be blocking automated access (e.g. anti-bot protection such as "
+    "Cloudflare), or the pages may be unreachable for another reason. Retry "
+    "the sync later — the failure is sometimes intermittent — or try a "
+    "different start URL / path_prefix, or configure a content_selector if "
+    "only part of the site is affected."
 )
+
+# Reason codes that represent a REAL fetch failure — Klai tried to fetch
+# the URL and did not get usable content back. Cause-independent by
+# design (see FETCH_FAILURE_DOMINANT_REASON): it does not matter WHETHER
+# the failure was a 5xx, a timeout, DNS, an explicit anti-bot block, or an
+# opaque unknown_exception (the intermedia.com 2026-08-14 shape) — a
+# meaningful fraction of unreachable pages is the same operator-facing
+# problem regardless of cause.
+#
+# Deliberately excludes SUCCESS / NON_CONTENT_LISTING_PAGE (real, usable
+# fetches) and every NOT_FETCHED_* code (deliberate scheduling decisions —
+# budget/depth/exclude/duplicate — not failures; a budget-exhausted crawl
+# already has its own guard via _build_crawl_outcome_warning below).
+#
+# New FetchReasonCode members MUST be added to exactly one of these two
+# sets. The assertion right after fails at import time if a new code is
+# left uncategorized — the mechanical guard that BLOCKED_ANTI_BOT-only
+# counting did not have, and the reason this fix silently under-counted
+# for weeks.
+_FETCH_FAILURE_REASON_CODES: frozenset[str] = frozenset(
+    {
+        FetchReasonCode.HTTP_4XX.value,
+        FetchReasonCode.HTTP_5XX.value,
+        FetchReasonCode.TIMEOUT.value,
+        FetchReasonCode.DNS_ERROR.value,
+        FetchReasonCode.CONNECTION_ERROR.value,
+        FetchReasonCode.AUTH_ERROR.value,
+        FetchReasonCode.PARSE_ERROR.value,
+        FetchReasonCode.RATE_LIMITED.value,
+        FetchReasonCode.UNKNOWN_EXCEPTION.value,
+        FetchReasonCode.BLOCKED_ANTI_BOT.value,
+    }
+)
+_FETCH_NON_FAILURE_REASON_CODES: frozenset[str] = frozenset(
+    {
+        FetchReasonCode.SUCCESS.value,
+        FetchReasonCode.NON_CONTENT_LISTING_PAGE.value,
+        FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value,
+        FetchReasonCode.NOT_FETCHED_DEPTH_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_DISCOVERY_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_EXCLUDED.value,
+        FetchReasonCode.NOT_FETCHED_DUPLICATE.value,
+    }
+)
+_uncategorized_fetch_reason_codes = (
+    FETCH_REASON_VALUES - _FETCH_FAILURE_REASON_CODES - _FETCH_NON_FAILURE_REASON_CODES
+)
+if _uncategorized_fetch_reason_codes:  # pragma: no cover — fails import, not a runtime path
+    raise RuntimeError(
+        "FetchReasonCode values missing from the terminal-status failure/"
+        f"non-failure classification: {sorted(_uncategorized_fetch_reason_codes)}. "
+        "Add each to _FETCH_FAILURE_REASON_CODES or _FETCH_NON_FAILURE_REASON_CODES "
+        "in knowledge_ingest/adapters/crawler.py."
+    )
 
 
 def decide_terminal_status(
@@ -128,30 +193,38 @@ def decide_terminal_status(
     return ("failed_partial", summary)
 
 
-def decide_antibot_terminal_status(
+def decide_fetch_failure_terminal_status(
     *,
-    blocked_count: int,
-    total_count: int,
+    fetch_outcomes: list[dict],
     threshold: float,
 ) -> tuple[str, dict | None]:
     """Pure decision function — sibling of :func:`decide_terminal_status`.
 
-    Decide whether a finished ``crawl_site`` run should be marked
-    ``failed_partial`` because a meaningful fraction of discovered pages
-    ended up ``BLOCKED_ANTI_BOT`` even AFTER ``crawl_site``'s sequential
-    anti-bot recovery ran (see ``crawl4ai_client._recover_antibot_batch``).
-    Without this guard, a job that only ingested 1 of ~18 discovered pages
-    because Cloudflare blocked the rest still reports ``completed`` — the
-    same "synced N days ago, X docs indexed" lie REQ-4's auth-wall guard
-    (``decide_terminal_status``) already fixes for login walls, just with
-    a different root cause (intermedia.com, 2026-08-14).
+    Cause-independent replacement for the retired ``decide_antibot_
+    terminal_status`` (PR #945, 2026-08-14). That guard counted only
+    ``reason_code == BLOCKED_ANTI_BOT`` outcomes — but crawl4ai's real
+    bulk-request 500 body is opaque
+    (``{"error":"Internal server error","correlation_id":"..."}"``), so on
+    the intermedia.com job that motivated it, all 17 failed pages
+    classified ``unknown_exception``, never ``BLOCKED_ANTI_BOT``, and the
+    guard's ``blocked_count`` was always 0 — it never fired. This version
+    decides whether a finished ``crawl_site`` run should be marked
+    ``failed_partial`` because a meaningful fraction of discovered
+    candidates ended up as a REAL fetch failure (any reason_code in
+    ``_FETCH_FAILURE_REASON_CODES`` — 5xx, timeout, DNS, connection, auth,
+    parse, rate-limited, unknown_exception, or a confirmed anti-bot block)
+    even AFTER ``crawl_site``'s sequential bulk-5xx recovery ran (see
+    ``crawl4ai_client._recover_bulk_5xx_batch``). Without this guard, a job
+    that only ingested 1 of ~18 discovered pages still reports
+    ``completed`` — the same "synced N days ago, X docs indexed" lie
+    REQ-4's auth-wall guard (``decide_terminal_status``) already fixes for
+    login walls, just with a different root cause.
 
     Args:
-        blocked_count: outcomes with ``reason_code ==
-            FetchReasonCode.BLOCKED_ANTI_BOT`` in the job's fetch_outcomes,
-            evaluated AFTER crawl_site's sequential recovery attempted to
-            resolve them.
-        total_count: total discovered candidates (``len(fetch_outcomes)``).
+        fetch_outcomes: the job's full per-candidate outcome list (same
+            shape as ``crawl_jobs.fetch_outcomes`` JSONB) — the full list
+            is needed (not just a count) so the summary can report which
+            reason codes actually dominated.
         threshold: trip-rate at or above which the guard fires (inclusive).
 
     Returns:
@@ -160,17 +233,27 @@ def decide_antibot_terminal_status(
         fire, so the caller falls through to its existing terminal-status
         logic.
     """
-    if total_count <= 0 or blocked_count <= 0:
+    total_count = len(fetch_outcomes)
+    if total_count <= 0:
         return ("", None)
-    trip_rate = round(blocked_count / total_count, 3)
+    failure_counts = Counter(
+        reason
+        for outcome in fetch_outcomes
+        if (reason := str(outcome.get("reason_code") or "")) in _FETCH_FAILURE_REASON_CODES
+    )
+    failed_count = sum(failure_counts.values())
+    if failed_count <= 0:
+        return ("", None)
+    trip_rate = round(failed_count / total_count, 3)
     if trip_rate < threshold:
         return ("", None)
     summary: dict = {
-        "reason": ANTIBOT_BLOCKED_REASON,
+        "reason": FETCH_FAILURE_DOMINANT_REASON,
         "trip_rate": trip_rate,
-        "blocked_count": blocked_count,
+        "failed_count": failed_count,
         "total_count": total_count,
-        "suggestion": _ANTIBOT_BLOCKED_SUGGESTION,
+        "top_reason_codes": dict(failure_counts.most_common(5)),
+        "suggestion": _FETCH_FAILURE_SUGGESTION,
     }
     return ("failed_partial", summary)
 
@@ -602,35 +685,32 @@ async def run_crawl_job(
             threshold=settings.ingest_authwall_dirty_trip_rate,
         )
 
-        # 2026-08-14 anti-bot guard — sibling of the REQ-4 dirty-content
-        # guard above. ``total_count`` is deliberately len(fetch_outcomes)
-        # (every discovered candidate), not len(results): blocked pages are
-        # excluded from ``results`` entirely, so using len(results) as the
-        # denominator would understate (or even exceed 100% of) the trip
-        # rate once most of the site is blocked.
-        blocked_count = sum(
-            1
-            for outcome in fetch_outcomes
-            if outcome.get("reason_code") == FetchReasonCode.BLOCKED_ANTI_BOT.value
-        )
-        antibot_status, antibot_summary = decide_antibot_terminal_status(
-            blocked_count=blocked_count,
-            total_count=len(fetch_outcomes),
-            threshold=settings.ingest_antibot_dirty_trip_rate,
+        # 2026-08-14 (revised same day) cause-independent fetch-failure
+        # guard — sibling of the REQ-4 dirty-content guard above. Passes
+        # the full ``fetch_outcomes`` list (not a pre-counted total)
+        # because the denominator AND the failure classification both need
+        # to see every discovered candidate: not just len(results), since
+        # failed pages are excluded from ``results`` entirely (using
+        # len(results) as the denominator would understate — or even
+        # exceed 100% of — the trip rate once most of the site fails).
+        fetch_failure_status, fetch_failure_summary = decide_fetch_failure_terminal_status(
+            fetch_outcomes=fetch_outcomes,
+            threshold=settings.ingest_fetch_failure_dirty_trip_rate,
         )
 
         # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-04.2/04.3 — terminal status:
         # - failed_partial when REQ-4 dirty-content guard tripped (loud failure)
-        # - failed_partial when the anti-bot guard tripped (loud failure)
+        # - failed_partial when the fetch-failure guard tripped (loud failure)
         # - failed_partial when 0 pages ingested AND >= 1 wall skipped
         # - completed otherwise
         #
         # Deterministic order when BOTH the auth-wall guard and the
-        # anti-bot guard would fire on the same job: auth-wall wins. An
-        # auth-wall trip means Klai reached the pages (they're just
-        # login-gated); an anti-bot trip often means Klai could not reach
-        # the site at all. The auth-wall summary is the more actionable of
-        # the two when both signals are present, so it takes priority.
+        # fetch-failure guard would fire on the same job: auth-wall wins.
+        # An auth-wall trip means Klai reached the pages (they're just
+        # login-gated); a fetch-failure trip often means Klai could not
+        # reach the site at all. The auth-wall summary is the more
+        # actionable of the two when both signals are present, so it
+        # takes priority.
         if dirty_status:
             terminal_status = dirty_status
             summary_payload = dirty_summary or {}
@@ -648,9 +728,9 @@ async def run_crawl_job(
                 int(time.time()),
                 job_id,
             )
-        elif antibot_status:
-            terminal_status = antibot_status
-            summary_payload = antibot_summary or {}
+        elif fetch_failure_status:
+            terminal_status = fetch_failure_status
+            summary_payload = fetch_failure_summary or {}
             _attach_crawl_warning(summary_payload, crawl_outcome_warning)
             summary_json = json.dumps(summary_payload)
             await conn.execute(

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -47,18 +47,26 @@ class Settings(BaseSettings):
         default=0.30,
         validation_alias=AliasChoices("KLAI_INGEST_AUTHWALL_DIRTY_TRIP_RATE"),
     )
-    # 2026-08-14: same trip-rate contract as ingest_authwall_dirty_trip_rate,
-    # for BLOCKED_ANTI_BOT outcomes surviving crawl_site's sequential
-    # anti-bot recovery (see crawl4ai_client._recover_antibot_batch). A
-    # crawl_site run with blocked_count / total_count at or above this
+    # 2026-08-14 (revised same day): same trip-rate contract as
+    # ingest_authwall_dirty_trip_rate, but cause-independent — for ANY real
+    # fetch-failure reason_code (5xx, timeout, DNS, connection, auth,
+    # parse, rate-limited, unknown_exception, or a confirmed anti-bot
+    # block) surviving crawl_site's sequential bulk-5xx recovery (see
+    # crawl4ai_client._recover_bulk_5xx_batch). Originally named
+    # ingest_antibot_dirty_trip_rate / KLAI_INGEST_ANTIBOT_DIRTY_TRIP_RATE
+    # (PR #945) and keyed on BLOCKED_ANTI_BOT only, which never actually
+    # fired against real crawl4ai bulk-500 bodies (opaque, no diagnosable
+    # reason) — renamed when the guard was made cause-independent. A
+    # crawl_site run with failed_count / total_count at or above this
     # ratio ends with status='failed_partial' instead of silently reporting
     # "completed" with most of the site missing (intermedia.com incident,
     # 2026-08-14: 1 of ~18 discovered pages ingested, reported completed).
     # Reuses the auth-wall guard's 0.30 default — same "meaningful fraction
     # of the site is unreachable" semantics, just a different root cause.
-    ingest_antibot_dirty_trip_rate: float = Field(
+    # Not present in production env as of this rename — safe to rename.
+    ingest_fetch_failure_dirty_trip_rate: float = Field(
         default=0.30,
-        validation_alias=AliasChoices("KLAI_INGEST_ANTIBOT_DIRTY_TRIP_RATE"),
+        validation_alias=AliasChoices("KLAI_INGEST_FETCH_FAILURE_DIRTY_TRIP_RATE"),
     )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -114,6 +114,14 @@ class CrawlResult:
     error_message: str | None = None
     metadata: dict[str, Any] | None = None
     response_headers: dict[str, str] | None = None
+    # 2026-08-14: the real HTTP status code behind a failed fetch, when
+    # known — either from crawl4ai's page-result shape (``page["status_code"]``)
+    # or from a raised ``httpx.HTTPStatusError`` (see
+    # ``_status_code_from_exception``). Lets downstream classification
+    # (``_classify_fetch_outcome``) map a failure to HTTP_4XX/HTTP_5XX
+    # honestly instead of falling through to UNKNOWN_EXCEPTION — see the
+    # bulk-5xx sequential-recovery rework in ``crawl_site`` / adapters/crawler.py.
+    status_code: int | None = None
 
 
 DiscoverySourceKind = Literal["start", "sitemap", "page_link"]
@@ -600,8 +608,26 @@ def _classify_fetch_outcome(
     ``reason_codes.py`` AND extend the migration's allowed set first.
     """
     if error is not None:
-        if _is_antibot_block_error(error):
-            return FetchReasonCode.BLOCKED_ANTI_BOT.value
+        # 2026-08-14 (intermedia.com): a raised httpx.HTTPStatusError is
+        # classified by its HTTP status code, honestly — never guessed via
+        # a "blocked by anti-bot protection" body match. That match lived
+        # here from PR #945 until this fix and never actually fired in
+        # production: crawl4ai's real bulk-request 500 body is opaque
+        # (``{"error":"Internal server error","correlation_id":"..."}"``),
+        # so the anti-bot cause was never diagnosable client-side. See
+        # ``_is_bulk_5xx_error`` for the cause-independent trigger that
+        # replaced this, and ``_is_antibot_block_error`` (kept only for
+        # ``_is_minimal_content_antibot_error``) for the retired approach.
+        if isinstance(error, httpx.HTTPStatusError):
+            status_code = error.response.status_code
+            if status_code == 429:
+                return FetchReasonCode.RATE_LIMITED.value
+            if status_code in (401, 403):
+                return FetchReasonCode.AUTH_ERROR.value
+            if 400 <= status_code < 500:
+                return FetchReasonCode.HTTP_4XX.value
+            if 500 <= status_code < 600:
+                return FetchReasonCode.HTTP_5XX.value
         msg = str(error).lower()
         if isinstance(error, httpx.TimeoutException) or "timeout" in msg:
             return FetchReasonCode.TIMEOUT.value
@@ -620,12 +646,12 @@ def _classify_fetch_outcome(
     status = page_result.get("status_code")
     err_msg = (page_result.get("error_message") or "").lower()
 
-    # Checked before the status-code branches: crawl4ai reports a Cloudflare
-    # JS-challenge block as a 500 with this marker in the body/error_message,
-    # same detection used for the transport-exception branch above (see
-    # _is_antibot_block_error). Applies to both the bulk per-page result
-    # shape and the seed/single-page synthesized shape built in
-    # _build_outcome_from_result / _error_message_for_result.
+    # Checked before the status-code branches: crawl4ai can return HTTP 200
+    # with results[i].success=false and this marker inline in error_message —
+    # a real, confirmed shape (unlike the transport-exception body match
+    # retired above 2026-08-14). Applies to the bulk per-page result shape
+    # and the seed/single-page synthesized shape built in
+    # _build_outcome_from_result.
     if "blocked by anti-bot protection" in err_msg:
         return FetchReasonCode.BLOCKED_ANTI_BOT.value
 
@@ -742,6 +768,7 @@ def _extract_result(url: str, page: dict[str, Any]) -> CrawlResult:
         error_message=page.get("error_message"),
         metadata=page.get("metadata"),
         response_headers=page.get("response_headers"),
+        status_code=page.get("status_code"),
     )
 
 
@@ -856,7 +883,8 @@ async def _crawl_page_with_config(
                 html="",
                 word_count=0,
                 success=False,
-                error_message=_error_message_for_result(exc),
+                error_message=str(exc),
+                status_code=_status_code_from_exception(exc),
             )
 
     results = data.get("results", [])
@@ -1075,12 +1103,18 @@ def _crawl_results_from_raw_results(
 def _is_antibot_block_error(exc: BaseException) -> bool:
     """True when a crawl4ai transport failure's body reports an anti-bot block.
 
-    Generalised from :func:`_is_minimal_content_antibot_error` (which
-    additionally requires a thin-content marker to justify a same-page
-    relaxed-config retry). This broader check is used by the sequential
-    anti-bot recovery path in ``crawl_site``, where ANY anti-bot block —
-    not just the thin-content flavour — should trigger a one-URL-at-a-time
-    retry rather than losing the whole bulk batch.
+    NOTE (2026-08-14, intermedia.com): this body-text match essentially
+    never fires against a real crawl4ai deployment — a live bulk-request
+    500 was proven to carry an opaque body
+    (``{"error":"Internal server error","correlation_id":"..."}"``), never
+    the "blocked by anti-bot protection" marker this function looks for.
+    It is kept ONLY because :func:`_is_minimal_content_antibot_error` (a
+    narrower, pre-existing single-page/seed thin-content heuristic — see
+    its own docstring) still calls it; that call site was out of scope for
+    the 2026-08-14 fix. Do NOT use this function for terminal-status or
+    sequential-recovery decisions in ``crawl_site`` — see
+    :func:`_is_bulk_5xx_error` for the cause-independent replacement that
+    actually fires in production.
     """
     if not isinstance(exc, httpx.HTTPStatusError) or exc.response.status_code != 500:
         return False
@@ -1088,25 +1122,51 @@ def _is_antibot_block_error(exc: BaseException) -> bool:
 
 
 def _is_minimal_content_antibot_error(exc: Exception) -> bool:
+    """True when a seed-page 500 reports both an anti-bot block AND a
+    thin-content marker — used only to decide whether ``_fetch_seed_page``
+    should retry the SEED fetch with a relaxed config.
+
+    CAVEAT (2026-08-14): like :func:`_is_antibot_block_error` above, this
+    leans on a body-text match that real crawl4ai 500 responses do not
+    appear to carry in practice (see the bulk-request evidence there).
+    This call site was out of scope for the 2026-08-14 fix and is left
+    as-is — flagged here so the next reader does not assume it reliably
+    fires either.
+    """
     if not isinstance(exc, httpx.HTTPStatusError) or not _is_antibot_block_error(exc):
         return False
     body = exc.response.text.lower()
     return "minimal_text" in body or "no_content_elements" in body or "0 chars visible" in body
 
 
-def _error_message_for_result(exc: BaseException) -> str:
-    """Message stored on a failed ``CrawlResult.error_message``.
+def _is_bulk_5xx_error(exc: BaseException) -> bool:
+    """True when a bulk-crawl transport failure is an HTTP 5xx from crawl4ai.
 
-    For an anti-bot-block 500, preserve the raw response body (which
-    carries the "blocked by anti-bot protection" marker) instead of
-    ``str(exc)`` — ``httpx.HTTPStatusError.__str__`` reports only the
-    status line, not the body, which would otherwise silently lose the
-    signal ``_classify_fetch_outcome`` needs to map the outcome to
-    ``FetchReasonCode.BLOCKED_ANTI_BOT`` on the seed / single-page paths.
+    Cause-independent replacement for the retired antibot-body-match
+    trigger. Evidence 2026-08-14 (intermedia.com): crawl4ai's bulk
+    ``arun_many`` endpoint fails the WHOLE concurrent batch with one 500
+    the moment ANY url in it hits an anti-bot challenge — but the response
+    body is opaque
+    (``{"error":"Internal server error","correlation_id":"188834187d7d"}"``),
+    never a diagnosable reason. The client-side cause of a bulk 500 is
+    therefore UNKNOWABLE from the transport response alone. Rather than
+    guess at the cause, ``crawl_site`` treats every bulk-level 5xx as
+    worth a one-URL-at-a-time sequential retry (see
+    ``_recover_bulk_5xx_batch``): the retry is simultaneously the
+    mitigation (some URLs recover — the same intermedia.com incident saw
+    ``/products/unite`` succeed seconds after the bulk 500 while
+    ``/products/ai`` stayed blocked, via the same single-page path) and
+    the diagnosis (the per-URL retry result tells us the REAL per-URL
+    reason_code, honestly, instead of a guessed BLOCKED_ANTI_BOT).
     """
-    if isinstance(exc, httpx.HTTPStatusError) and _is_antibot_block_error(exc):
-        return exc.response.text
-    return str(exc)
+    return isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600
+
+
+def _status_code_from_exception(exc: BaseException) -> int | None:
+    """Extract the HTTP status code from a transport exception, when known."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code
+    return None
 
 
 def _relax_seed_crawl_config(crawler_config: dict[str, Any]) -> dict[str, Any]:
@@ -1264,10 +1324,10 @@ async def crawl_site(
     crawl_results: list[CrawlResult] = []
     outcomes: list[FetchOutcome] = []
     fetched_count = 0
-    # Crawl-job-wide budget for the anti-bot sequential-recovery fallback
-    # (see _recover_antibot_batch / _MAX_ANTIBOT_SEQUENTIAL_RECOVERY).
+    # Crawl-job-wide budget for the bulk-5xx sequential-recovery fallback
+    # (see _recover_bulk_5xx_batch / _MAX_SEQUENTIAL_RECOVERY).
     # Shared across every batch iteration below, not reset per batch.
-    antibot_recovery_budget = _MAX_ANTIBOT_SEQUENTIAL_RECOVERY
+    sequential_recovery_budget = _MAX_SEQUENTIAL_RECOVERY
 
     start_result = await _fetch_seed_page(
         start_url=start_url,
@@ -1297,25 +1357,28 @@ async def crawl_site(
         )
         fetched_count += len(batch)
 
-        if transport_error is not None and _is_antibot_block_error(transport_error):
+        if transport_error is not None and _is_bulk_5xx_error(transport_error):
             # crawl4ai's bulk endpoint failed the WHOLE batch with an
-            # anti-bot block (evidence + budget: see
-            # _MAX_ANTIBOT_SEQUENTIAL_RECOVERY). Recover what we can by
-            # retrying one URL at a time via the single-page path instead
-            # of writing off every URL in the batch as unknown_exception.
+            # opaque 5xx (evidence + budget: see _MAX_SEQUENTIAL_RECOVERY,
+            # _is_bulk_5xx_error). The client-side cause is unknowable from
+            # the transport response alone, so we don't guess it — recover
+            # what we can by retrying one URL at a time via the single-page
+            # path, which tells us the REAL per-URL reason_code, instead of
+            # writing off every URL in the batch as unknown_exception (or
+            # guessing blocked_anti_bot without evidence).
             (
                 batch_results,
                 link_source_results,
                 batch_outcomes,
-                antibot_attempted,
-            ) = await _recover_antibot_batch(
+                recovery_attempted,
+            ) = await _recover_bulk_5xx_batch(
                 batch,
                 crawler_config=crawler_config,
                 cookies=cookies,
                 base_domain=base_domain,
-                recovery_budget=antibot_recovery_budget,
+                recovery_budget=sequential_recovery_budget,
             )
-            antibot_recovery_budget -= antibot_attempted
+            sequential_recovery_budget -= recovery_attempted
         else:
             batch_results, batch_outcomes = _combine_bulk_responses(
                 candidates=batch,
@@ -1425,7 +1488,8 @@ async def _fetch_seed_page(
             html="",
             word_count=0,
             success=False,
-            error_message=_error_message_for_result(exc),
+            error_message=str(exc),
+            status_code=_status_code_from_exception(exc),
         )
 
     pages = _normalise_results_block(data)
@@ -1508,18 +1572,21 @@ def _build_outcome_from_result(url: str, result: CrawlResult) -> FetchOutcome:
     else:
         # Synthesise a page-shape dict for the classifier so the same
         # error_message → FetchReasonCode mapping applies as for the
-        # bulk path.
+        # bulk path. ``result.status_code`` (2026-08-14) carries the real
+        # HTTP status when the seed fetch raised an httpx.HTTPStatusError,
+        # so a seed 5xx classifies HTTP_5XX instead of falling through to
+        # unknown_exception.
         reason_code = _classify_fetch_outcome(
             {
                 "success": False,
-                "status_code": None,
+                "status_code": result.status_code,
                 "error_message": result.error_message or "",
             },
         )
     return {
         "url": url,
         "reason_code": reason_code,
-        "status_code": None,
+        "status_code": result.status_code,
         "content_length": len(result.html or ""),
     }
 
@@ -1533,7 +1600,7 @@ def _result_is_ingestable(result: CrawlResult, *, base_domain: str) -> bool:
     return _same_site_domain(urlparse(result.url).netloc.lower(), base_domain)
 
 
-async def _recover_antibot_batch(
+async def _recover_bulk_5xx_batch(
     urls: list[str],
     *,
     crawler_config: dict[str, Any],
@@ -1544,16 +1611,20 @@ async def _recover_antibot_batch(
     """Sequentially re-fetch a batch that failed WHOLESALE via bulk fetch.
 
     Called from ``crawl_site`` only when ``_chunked_bulk_fetch`` returned a
-    ``transport_error`` that is an anti-bot block (see
-    ``_is_antibot_block_error``). Reuses the single-page fetch path
-    (``_crawl_page_with_config``, same one ``crawl_page`` uses) one URL at a
-    time instead of duplicating fetch logic — see module-level comment on
-    ``_MAX_ANTIBOT_SEQUENTIAL_RECOVERY`` for the supporting evidence.
+    ``transport_error`` that is a bulk-level 5xx (see ``_is_bulk_5xx_error``
+    — the cause is unknowable from the transport response alone, so this
+    retry is both the mitigation and the diagnosis). Reuses the single-page
+    fetch path (``_crawl_page_with_config``, same one ``crawl_page`` uses)
+    one URL at a time instead of duplicating fetch logic — see module-level
+    comment on ``_MAX_SEQUENTIAL_RECOVERY`` for the supporting evidence.
 
     Bounded by ``recovery_budget`` (the crawl-job-wide remainder of
-    ``_MAX_ANTIBOT_SEQUENTIAL_RECOVERY``). Once exhausted, remaining URLs in
-    this batch are marked ``BLOCKED_ANTI_BOT`` without a network call and
-    the cap is logged once via ``crawl_antibot_recovery_capped``.
+    ``_MAX_SEQUENTIAL_RECOVERY``). Once exhausted, remaining URLs in this
+    batch are marked ``HTTP_5XX`` — honestly, matching the actual signal we
+    have (the bulk request 5xx'd; we simply ran out of budget to verify
+    these particular URLs individually) rather than guessing
+    ``BLOCKED_ANTI_BOT`` without evidence — without a network call, and the
+    cap is logged once via ``crawl_bulk_5xx_recovery_capped``.
 
     Returns ``(crawl_results, link_source_results, outcomes, attempted)``:
 
@@ -1573,7 +1644,7 @@ async def _recover_antibot_batch(
     outcomes: list[FetchOutcome] = []
     attempted = 0
     recovered = 0
-    still_blocked = 0
+    still_failing = 0
 
     for i, url in enumerate(urls):
         if attempted >= recovery_budget:
@@ -1582,17 +1653,17 @@ async def _recover_antibot_batch(
                 outcomes.append(
                     {
                         "url": leftover_url,
-                        "reason_code": FetchReasonCode.BLOCKED_ANTI_BOT.value,
+                        "reason_code": FetchReasonCode.HTTP_5XX.value,
                         "status_code": None,
                         "content_length": 0,
                     }
                 )
-            still_blocked += remaining
+            still_failing += remaining
             logger.warning(
-                "crawl_antibot_recovery_capped",
+                "crawl_bulk_5xx_recovery_capped",
                 recovered=recovered,
-                still_blocked=still_blocked,
-                capped_at=_MAX_ANTIBOT_SEQUENTIAL_RECOVERY,
+                still_failing=still_failing,
+                capped_at=_MAX_SEQUENTIAL_RECOVERY,
                 remaining=remaining,
             )
             break
@@ -1602,7 +1673,7 @@ async def _recover_antibot_batch(
         reason_code = _classify_fetch_outcome(
             {
                 "success": result.success,
-                "status_code": None,
+                "status_code": result.status_code,
                 "error_message": result.error_message or "",
             }
         )
@@ -1613,16 +1684,16 @@ async def _recover_antibot_batch(
             {
                 "url": url,
                 "reason_code": reason_code,
-                "status_code": None,
+                "status_code": result.status_code,
                 "content_length": len(result.html or ""),
             }
         )
 
-        if reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
-            still_blocked += 1
+        if not result.success:
+            still_failing += 1
             continue
 
-        if result.success and _same_site_domain(urlparse(result.url).netloc.lower(), base_domain):
+        if _same_site_domain(urlparse(result.url).netloc.lower(), base_domain):
             link_source_results.append(result)
         if _result_is_ingestable(result, base_domain=base_domain) and not is_non_content_listing:
             crawl_results.append(result)
@@ -1835,18 +1906,21 @@ _BULK_CRAWL_TIMEOUT = 5 * 60.0
 _BULK_CHUNK_SIZE = 100
 
 # Total budget (per crawl_site call) for sequential one-URL-at-a-time
-# recovery of a bulk batch that failed as a whole with an anti-bot block
-# (see _recover_antibot_batch). Evidence 2026-08-14 (intermedia.com):
-# crawl4ai's bulk arun_many fails the ENTIRE concurrent batch with one
-# opaque 500 the moment ANY url in it hits Cloudflare's intermittent JS
-# challenge, while the same URLs fetched one at a time via the single-page
-# path pass the challenge for at least some of them (/products/unite
-# succeeded, /products/ai still blocked, seconds apart) — the challenge is
-# per-request intermittent, so serial retry recovers real pages. Capped so
-# a site that blocks every request cannot turn a bulk crawl into hundreds
-# of serial round-trips; once exhausted, remaining URLs are marked
-# BLOCKED_ANTI_BOT without a network call (crawl_antibot_recovery_capped).
-_MAX_ANTIBOT_SEQUENTIAL_RECOVERY = 60
+# recovery of a bulk batch that failed as a whole with an opaque 5xx (see
+# _recover_bulk_5xx_batch, _is_bulk_5xx_error). Evidence 2026-08-14
+# (intermedia.com): crawl4ai's bulk arun_many fails the ENTIRE concurrent
+# batch with one opaque 500
+# (``{"error":"Internal server error","correlation_id":"..."}"``, no
+# diagnosable reason) the moment ANY url in it hits an anti-bot challenge,
+# while the same URLs fetched one at a time via the single-page path pass
+# the challenge for at least some of them (/products/unite succeeded,
+# /products/ai still blocked, seconds apart) — the challenge is
+# per-request intermittent, so serial retry recovers real pages AND tells
+# us the real per-URL reason honestly. Capped so a site that fails every
+# request cannot turn a bulk crawl into hundreds of serial round-trips;
+# once exhausted, remaining URLs are marked HTTP_5XX (not a guessed
+# BLOCKED_ANTI_BOT) without a network call (crawl_bulk_5xx_recovery_capped).
+_MAX_SEQUENTIAL_RECOVERY = 60
 
 # Server-side BFS deep crawl polling budget. /crawl/job is async — submit,
 # get task_id, poll status. Voys-support full-depth crawl (~500 pages

--- a/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_dirty_content_guard.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 import pytest
 
 from knowledge_ingest.adapters.crawler import (
-    ANTIBOT_BLOCKED_REASON,
     CRAWL_BUDGET_EXHAUSTED_REASON,
     CRAWL_FETCH_FAILED_REASON,
     DIRTY_CONTENT_REASON,
+    FETCH_FAILURE_DOMINANT_REASON,
     _build_crawl_outcome_warning,
     _crawl_warning_terminal_status,
-    decide_antibot_terminal_status,
+    decide_fetch_failure_terminal_status,
     decide_terminal_status,
 )
 
@@ -204,72 +204,112 @@ def test_trip_rate_rounded_to_three_decimals(trip_rate_input: float) -> None:
 
 
 # ---------------------------------------------------------------------------
-# decide_antibot_terminal_status — 2026-08-14 anti-bot guard, sibling of the
-# REQ-4 auth-wall guard above (intermedia.com incident).
+# decide_fetch_failure_terminal_status — 2026-08-14 cause-independent
+# fetch-failure guard, sibling of the REQ-4 auth-wall guard above
+# (intermedia.com incident). Replaces the retired decide_antibot_
+# terminal_status, which counted only BLOCKED_ANTI_BOT and therefore never
+# fired against a real crawl4ai deployment: production bulk-500 bodies are
+# opaque, so the intermedia.com failures classified unknown_exception, not
+# blocked_anti_bot — see FETCH_FAILURE_DOMINANT_REASON's module docstring.
 # ---------------------------------------------------------------------------
 
 
-def test_antibot_above_threshold_marks_failed_partial() -> None:
-    """16 of 18 discovered pages still BLOCKED_ANTI_BOT after sequential
-    recovery (intermedia.com shape) → failed_partial with the anti-bot
-    reason, not a silent 'completed'."""
-    status, summary = decide_antibot_terminal_status(
-        blocked_count=16,
-        total_count=18,
-        threshold=0.30,
+def _outcomes(*reason_codes: str) -> list[dict]:
+    """Build a minimal fetch_outcomes list from a sequence of reason codes."""
+    return [
+        {
+            "url": f"https://example.com/{i}",
+            "reason_code": reason_code,
+            "status_code": None,
+            "content_length": 0,
+        }
+        for i, reason_code in enumerate(reason_codes)
+    ]
+
+
+def test_fetch_failure_above_threshold_marks_failed_partial() -> None:
+    """16 of 18 discovered pages are real fetch failures (mixed reasons —
+    http_5xx, unknown_exception, blocked_anti_bot) → failed_partial with
+    the cause-independent reason, not a silent 'completed'. Mirrors the
+    intermedia.com incident shape, but with the reason_codes actually
+    produced in production (mostly unknown_exception/http_5xx, not
+    blocked_anti_bot)."""
+    outcomes = _outcomes(
+        *(
+            ["http_5xx"] * 10
+            + ["unknown_exception"] * 5
+            + ["blocked_anti_bot"] * 1
+            + ["success"] * 2
+        )
     )
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
     assert status == "failed_partial"
     assert summary is not None
-    assert summary["reason"] == ANTIBOT_BLOCKED_REASON
-    assert summary["reason"] == "blocked_by_anti_bot"
-    assert summary["blocked_count"] == 16
+    assert summary["reason"] == FETCH_FAILURE_DOMINANT_REASON
+    assert summary["reason"] == "fetch_failure_dominant"
+    assert summary["failed_count"] == 16
     assert summary["total_count"] == 18
     assert summary["trip_rate"] == round(16 / 18, 3)
+    assert summary["top_reason_codes"]["http_5xx"] == 10
+    assert summary["top_reason_codes"]["unknown_exception"] == 5
+    assert summary["top_reason_codes"]["blocked_anti_bot"] == 1
     assert "anti-bot" in summary["suggestion"].lower()
 
 
-def test_antibot_below_threshold_does_not_trip_guard() -> None:
-    """Only a couple of pages still blocked after recovery — not a
-    meaningful fraction of the site — guard must not fire."""
-    status, summary = decide_antibot_terminal_status(
-        blocked_count=2,
-        total_count=100,
-        threshold=0.30,
-    )
+def test_fetch_failure_below_threshold_does_not_trip_guard() -> None:
+    """Only 1 of 18 pages failed — not a meaningful fraction of the site —
+    guard must not fire."""
+    outcomes = _outcomes(*(["http_5xx"] * 1 + ["success"] * 17))
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
     assert status == ""
     assert summary is None
 
 
-def test_antibot_zero_blocked_does_not_trip_guard() -> None:
-    """Recovery cleared every blocked URL — nothing to report."""
-    status, summary = decide_antibot_terminal_status(
-        blocked_count=0,
-        total_count=100,
-        threshold=0.30,
-    )
+def test_fetch_failure_zero_failures_does_not_trip_guard() -> None:
+    """Every discovered page succeeded — nothing to report."""
+    outcomes = _outcomes(*(["success"] * 5))
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
     assert status == ""
     assert summary is None
 
 
-def test_antibot_zero_total_does_not_trip_guard() -> None:
+def test_fetch_failure_zero_total_does_not_trip_guard() -> None:
     """No discovered candidates at all — division-by-zero guard."""
-    status, summary = decide_antibot_terminal_status(
-        blocked_count=0,
-        total_count=0,
-        threshold=0.30,
-    )
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=[], threshold=0.30)
     assert status == ""
     assert summary is None
 
 
-def test_antibot_threshold_inclusive_at_exactly_thirty_percent() -> None:
+def test_fetch_failure_threshold_inclusive_at_exactly_thirty_percent() -> None:
     """trip_rate exactly 0.30 → guard MUST trip (>= is inclusive, mirrors
     the auth-wall guard's inclusive threshold contract)."""
-    status, summary = decide_antibot_terminal_status(
-        blocked_count=30,
-        total_count=100,
-        threshold=0.30,
-    )
+    outcomes = _outcomes(*(["http_5xx"] * 30 + ["success"] * 70))
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
     assert status == "failed_partial"
     assert summary is not None
-    assert summary["reason"] == ANTIBOT_BLOCKED_REASON
+    assert summary["reason"] == FETCH_FAILURE_DOMINANT_REASON
+
+
+def test_fetch_failure_excludes_not_fetched_codes() -> None:
+    """NOT_FETCHED_* outcomes are deliberate scheduling decisions (budget /
+    depth), never counted as failures — even though they dilute the
+    denominator. 5 not_fetched_budget_exhausted + 1 real failure + 4
+    success = 1/10 = 0.10 trip_rate, well under threshold. If NOT_FETCHED_*
+    were (wrongly) counted as failures this would be 6/10 = 0.60 and trip."""
+    outcomes = _outcomes(
+        *(["not_fetched_budget_exhausted"] * 5 + ["http_5xx"] * 1 + ["success"] * 4)
+    )
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
+    assert status == ""
+    assert summary is None
+
+
+def test_fetch_failure_only_not_fetched_codes_does_not_trip_guard() -> None:
+    """A crawl that discovered candidates but only ever recorded
+    not_fetched_* outcomes (budget/depth limits, zero actual fetch
+    attempts) must not trip the fetch-failure guard — that's a scheduling
+    outcome, not a failure."""
+    outcomes = _outcomes(*(["not_fetched_budget_exhausted"] * 5 + ["not_fetched_depth_limit"] * 5))
+    status, summary = decide_fetch_failure_terminal_status(fetch_outcomes=outcomes, threshold=0.30)
+    assert status == ""
+    assert summary is None

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -185,11 +185,38 @@ def _antibot_http_status_error(*, extra_marker: str = "") -> httpx.HTTPStatusErr
     ``test_fetch_seed_retries_relaxed_config_after_minimal_content_antibot``
     (test_crawl4ai_filter_chain.py), generalised: no thin-content marker
     required, just the "blocked by anti-bot protection" phrase in the body.
+
+    NOTE (2026-08-14): this body shape does NOT match what crawl4ai
+    actually returns for a real bulk-request 500 in production — see
+    ``_opaque_bulk_500_http_status_error`` below for that. This helper is
+    kept only for the confirmed dict-shaped path (crawl4ai returning HTTP
+    200 with an explicit "blocked by anti-bot protection" error_message)
+    and the pre-existing seed thin-content heuristic.
     """
     request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
     response = httpx.Response(
         500,
         json={"detail": f"Blocked by anti-bot protection: Cloudflare JS challenge{extra_marker}"},
+        request=request,
+    )
+    return httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+
+def _opaque_bulk_500_http_status_error(
+    *, correlation_id: str = "188834187d7d"
+) -> httpx.HTTPStatusError:
+    """Build a 500 HTTPStatusError with crawl4ai's REAL production bulk body.
+
+    2026-08-14 intermedia.com incident: a live bulk request to crawl4ai for
+    blocked pages returned exactly this shape — no diagnosable reason, no
+    "blocked by anti-bot protection" marker, just an opaque error +
+    correlation_id. This is the body every bulk-5xx transport error in
+    production actually carries.
+    """
+    request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+    response = httpx.Response(
+        500,
+        json={"error": "Internal server error", "correlation_id": correlation_id},
         request=request,
     )
     return httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
@@ -243,27 +270,47 @@ class TestClassifyFetchOutcome:
             == FetchReasonCode.DNS_ERROR.value
         )
 
-    def test_antibot_blocked_transport_error_classifies_blocked_anti_bot(self) -> None:
-        """2026-08-14 intermedia.com: a 500 whose body reports an anti-bot
-        block must classify as BLOCKED_ANTI_BOT, not unknown_exception."""
-        exc = _antibot_http_status_error()
-        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.BLOCKED_ANTI_BOT.value
+    def test_opaque_bulk_500_transport_error_classifies_http_5xx(self) -> None:
+        """2026-08-14 intermedia.com: crawl4ai's REAL production bulk-500
+        body is opaque (no diagnosable reason) — it must classify honestly
+        as HTTP_5XX, never BLOCKED_ANTI_BOT (unproven) and never
+        unknown_exception (the pre-fix bug: PR #945's body-match never
+        fired against this exact shape, so every one of the 17 failed
+        intermedia.com pages classified unknown_exception instead)."""
+        exc = _opaque_bulk_500_http_status_error()
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.HTTP_5XX.value
 
-    def test_generic_500_transport_error_still_unknown_exception(self) -> None:
-        """Regression guard: an ordinary 500 with no anti-bot marker in the
-        body must keep falling through to unknown_exception — the new
-        anti-bot check must not over-match on every 500."""
+    def test_antibot_marker_500_transport_error_also_classifies_http_5xx(self) -> None:
+        """Regression guard: even a 500 whose body DOES contain the old
+        "blocked by anti-bot protection" marker must classify as HTTP_5XX
+        now — the transport-error-path body match was retired 2026-08-14
+        because it never fires against real crawl4ai responses; status
+        code is now the only signal used on the raised-exception path."""
+        exc = _antibot_http_status_error()
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.HTTP_5XX.value
+
+    def test_4xx_transport_error_classifies_http_4xx(self) -> None:
         request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
-        response = httpx.Response(500, json={"detail": "Internal Server Error"}, request=request)
+        response = httpx.Response(404, json={"detail": "Not Found"}, request=request)
         exc = httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
-        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.UNKNOWN_EXCEPTION.value
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.HTTP_4XX.value
+
+    def test_429_transport_error_classifies_rate_limited(self) -> None:
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(429, json={"detail": "Too Many Requests"}, request=request)
+        exc = httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.RATE_LIMITED.value
 
     def test_antibot_blocked_error_message_in_page_result_classifies_blocked_anti_bot(
         self,
     ) -> None:
-        """Seed / single-page path: the anti-bot marker preserved in
-        ``error_message`` by ``_error_message_for_result`` must classify
-        the same way as the transport-exception branch above."""
+        """Dict/page-result path: the ONE confirmed real path to
+        BLOCKED_ANTI_BOT — crawl4ai returning HTTP 200 with
+        results[i].success=false and an explicit "blocked by anti-bot
+        protection" marker inline in error_message. Kept intentionally
+        (see _classify_fetch_outcome's dict-path comment); unlike the
+        transport-exception body match retired 2026-08-14, this shape is
+        real."""
         assert (
             _classify_fetch_outcome(
                 {
@@ -276,6 +323,78 @@ class TestClassifyFetchOutcome:
             )
             == FetchReasonCode.BLOCKED_ANTI_BOT.value
         )
+
+    def test_unknown_falls_through_to_unknown_exception(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": None, "error_message": ""})
+            == FetchReasonCode.UNKNOWN_EXCEPTION.value
+        )
+
+    def test_transport_timeout_exception_classifies_timeout(self) -> None:
+        assert (
+            _classify_fetch_outcome(None, error=httpx.ReadTimeout("timed out"))
+            == FetchReasonCode.TIMEOUT.value
+        )
+
+    def test_transport_connect_error_classifies_connection_error(self) -> None:
+        assert (
+            _classify_fetch_outcome(None, error=httpx.ConnectError("refused"))
+            == FetchReasonCode.CONNECTION_ERROR.value
+        )
+
+    def test_transport_dns_message_classifies_dns_error(self) -> None:
+        # Generic exception with DNS-flavoured message — common in glibc errors.
+        assert (
+            _classify_fetch_outcome(None, error=RuntimeError("nodename nor servname provided"))
+            == FetchReasonCode.DNS_ERROR.value
+        )
+
+
+class TestBuildCandidateSetExcludeStartUrl:
+    def test_excludes_start_url_from_output(self) -> None:
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            sitemap_urls=["https://example.com/page-a"],
+            bfs_seed_urls=["https://example.com/page-b"],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+            include_start_url=False,
+        )
+        assert "https://example.com" not in candidates
+        assert candidates == [
+            "https://example.com/page-a",
+            "https://example.com/page-b",
+        ]
+
+    def test_excludes_start_url_alias_in_dedupe(self) -> None:
+        """A sitemap entry that canonical-equals start_url is also excluded
+        when include_start_url=False — guards against re-introducing the
+        double fetch via a sitemap that lists the homepage."""
+        candidates = _build_candidate_set(
+            start_url="https://example.com",
+            # Variant spellings of start_url that all canonicalise to it.
+            sitemap_urls=[
+                "https://example.com/",  # trailing slash on root → canonical "/"
+                "HTTPS://Example.com",  # mixed case
+                "https://example.com#frag",  # fragment
+                "https://example.com/page",  # legitimate non-homepage
+            ],
+            bfs_seed_urls=[],
+            base_domain="example.com",
+            max_pages=10,
+            include_patterns=None,
+            include_start_url=False,
+        )
+        assert "https://example.com/page" in candidates
+        # None of the start_url-variant spellings should leak through.
+        for candidate in candidates:
+            assert candidate not in (
+                "https://example.com",
+                "https://example.com/",
+                "HTTPS://Example.com",
+                "https://example.com#frag",
+            ), f"start_url variant {candidate} leaked through include_start_url=False"
 
 
 # ---------------------------------------------------------------------------
@@ -322,31 +441,6 @@ async def test_fetch_sitemap_document_follows_index_and_coerces_apex_to_www() ->
     )
 
     assert urls == ["https://www.example.com/blog/post-a/"]
-
-    def test_unknown_falls_through_to_unknown_exception(self) -> None:
-        assert (
-            _classify_fetch_outcome({"success": False, "status_code": None, "error_message": ""})
-            == FetchReasonCode.UNKNOWN_EXCEPTION.value
-        )
-
-    def test_transport_timeout_exception_classifies_timeout(self) -> None:
-        assert (
-            _classify_fetch_outcome(None, error=httpx.ReadTimeout("timed out"))
-            == FetchReasonCode.TIMEOUT.value
-        )
-
-    def test_transport_connect_error_classifies_connection_error(self) -> None:
-        assert (
-            _classify_fetch_outcome(None, error=httpx.ConnectError("refused"))
-            == FetchReasonCode.CONNECTION_ERROR.value
-        )
-
-    def test_transport_dns_message_classifies_dns_error(self) -> None:
-        # Generic exception with DNS-flavoured message — common in glibc errors.
-        assert (
-            _classify_fetch_outcome(None, error=RuntimeError("nodename nor servname provided"))
-            == FetchReasonCode.DNS_ERROR.value
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -805,53 +899,6 @@ async def test_crawl_site_matches_redirect_response_positionally(
 # ---------------------------------------------------------------------------
 
 
-class TestBuildCandidateSetExcludeStartUrl:
-    def test_excludes_start_url_from_output(self) -> None:
-        candidates = _build_candidate_set(
-            start_url="https://example.com",
-            sitemap_urls=["https://example.com/page-a"],
-            bfs_seed_urls=["https://example.com/page-b"],
-            base_domain="example.com",
-            max_pages=10,
-            include_patterns=None,
-            include_start_url=False,
-        )
-        assert "https://example.com" not in candidates
-        assert candidates == [
-            "https://example.com/page-a",
-            "https://example.com/page-b",
-        ]
-
-    def test_excludes_start_url_alias_in_dedupe(self) -> None:
-        """A sitemap entry that canonical-equals start_url is also excluded
-        when include_start_url=False — guards against re-introducing the
-        double fetch via a sitemap that lists the homepage."""
-        candidates = _build_candidate_set(
-            start_url="https://example.com",
-            # Variant spellings of start_url that all canonicalise to it.
-            sitemap_urls=[
-                "https://example.com/",  # trailing slash on root → canonical "/"
-                "HTTPS://Example.com",  # mixed case
-                "https://example.com#frag",  # fragment
-                "https://example.com/page",  # legitimate non-homepage
-            ],
-            bfs_seed_urls=[],
-            base_domain="example.com",
-            max_pages=10,
-            include_patterns=None,
-            include_start_url=False,
-        )
-        assert "https://example.com/page" in candidates
-        # None of the start_url-variant spellings should leak through.
-        for candidate in candidates:
-            assert candidate not in (
-                "https://example.com",
-                "https://example.com/",
-                "HTTPS://Example.com",
-                "https://example.com#frag",
-            ), f"start_url variant {candidate} leaked through include_start_url=False"
-
-
 # ---------------------------------------------------------------------------
 # _combine_bulk_responses — same-domain guard on positional fallback
 # ---------------------------------------------------------------------------
@@ -1018,14 +1065,15 @@ class TestCombineBulkResponsesPositionalGuard:
 
 
 # ---------------------------------------------------------------------------
-# _combine_bulk_responses — anti-bot transport_error (2026-08-14)
+# _combine_bulk_responses — bulk 5xx transport_error (2026-08-14)
 # ---------------------------------------------------------------------------
 
 
-def test_combine_bulk_responses_antibot_transport_error_all_blocked_anti_bot() -> None:
-    """When the whole bulk batch fails with an anti-bot block, every
-    candidate gets BLOCKED_ANTI_BOT — not unknown_exception — so the
-    caller (crawl_site) can detect it and trigger sequential recovery."""
+def test_combine_bulk_responses_opaque_5xx_transport_error_all_http_5xx() -> None:
+    """When the whole bulk batch fails with crawl4ai's REAL opaque 500 body,
+    every candidate gets HTTP_5XX — not unknown_exception, and not a
+    guessed BLOCKED_ANTI_BOT — so the caller (crawl_site) can detect it and
+    trigger sequential recovery (see _is_bulk_5xx_error)."""
     candidates = [
         "https://intermedia.com/products/unite",
         "https://intermedia.com/products/ai",
@@ -1033,31 +1081,33 @@ def test_combine_bulk_responses_antibot_transport_error_all_blocked_anti_bot() -
     results, outcomes = _combine_bulk_responses(
         candidates=candidates,
         raw_results=[],
-        transport_error=_antibot_http_status_error(),
+        transport_error=_opaque_bulk_500_http_status_error(),
         base_domain="intermedia.com",
     )
     assert results == []
     assert len(outcomes) == 2
     for outcome, url in zip(outcomes, candidates, strict=True):
         assert outcome["url"] == url
-        assert outcome["reason_code"] == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        assert outcome["reason_code"] == FetchReasonCode.HTTP_5XX.value
         assert outcome["status_code"] is None
 
 
 # ---------------------------------------------------------------------------
-# crawl_site — sequential anti-bot recovery (2026-08-14, intermedia.com)
+# crawl_site — sequential bulk-5xx recovery (2026-08-14, intermedia.com)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_crawl_site_recovers_batch_via_sequential_antibot_fallback(
+async def test_crawl_site_recovers_batch_via_sequential_bulk_5xx_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Bulk fetch anti-bot-500s the whole 3-url batch; sequential single-page
-    retry recovers the URLs that pass the (intermittent) Cloudflare
-    challenge and marks the rest BLOCKED_ANTI_BOT. Mirrors the real
-    intermedia.com incident: /products/unite passed, /products/ai stayed
-    blocked, seconds apart, via the same single-page path."""
+    """Bulk fetch 500s the whole 3-url batch with crawl4ai's REAL opaque
+    production body; sequential single-page retry recovers the URLs that
+    pass the (intermittent) challenge and marks the rest HTTP_5XX
+    (honestly — never a guessed BLOCKED_ANTI_BOT). Regression test for the
+    exact intermedia.com production bug: /products/unite passed,
+    /products/ai stayed blocked, seconds apart, via the same single-page
+    path — and the bulk failure body carried no diagnosable reason at all."""
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return [
@@ -1086,11 +1136,12 @@ async def test_crawl_site_recovers_batch_via_sequential_antibot_fallback(
     ) -> dict[str, Any]:
         urls = payload["urls"]
         if len(urls) > 1:
-            # The bulk batch request — always anti-bot-blocked wholesale.
+            # The bulk batch request — always fails wholesale with crawl4ai's
+            # real, opaque production body (no diagnosable reason).
             request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
             response = httpx.Response(
                 500,
-                json={"detail": "Blocked by anti-bot protection: Cloudflare JS challenge"},
+                json={"error": "Internal server error", "correlation_id": "188834187d7d"},
                 request=request,
             )
             raise httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
@@ -1101,7 +1152,7 @@ async def test_crawl_site_recovers_batch_via_sequential_antibot_fallback(
             request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
             response = httpx.Response(
                 500,
-                json={"detail": "Blocked by anti-bot protection: Cloudflare JS challenge"},
+                json={"error": "Internal server error", "correlation_id": "188834187d7d"},
                 request=request,
             )
             raise httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
@@ -1116,10 +1167,7 @@ async def test_crawl_site_recovers_batch_via_sequential_antibot_fallback(
 
     by_url = {o["url"]: o for o in outcomes}
     assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.SUCCESS.value
-    assert (
-        by_url["https://example.com/page-b"]["reason_code"]
-        == FetchReasonCode.BLOCKED_ANTI_BOT.value
-    )
+    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.HTTP_5XX.value
     assert by_url["https://example.com/page-c"]["reason_code"] == FetchReasonCode.SUCCESS.value
 
     result_urls = {r.url for r in results}
@@ -1129,12 +1177,13 @@ async def test_crawl_site_recovers_batch_via_sequential_antibot_fallback(
 
 
 @pytest.mark.asyncio
-async def test_crawl_site_antibot_recovery_respects_and_logs_cap(
+async def test_crawl_site_bulk_5xx_recovery_respects_and_logs_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When the sequential-recovery budget is exhausted mid-batch, the
-    remaining URLs are marked BLOCKED_ANTI_BOT WITHOUT a network call, and
-    the cap event is logged exactly once."""
+    remaining URLs are marked HTTP_5XX WITHOUT a network call (honest, not
+    a guessed anti-bot verdict), and the cap event is logged exactly
+    once."""
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return [
@@ -1146,7 +1195,7 @@ async def test_crawl_site_antibot_recovery_respects_and_logs_cap(
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
     _patch_seed(monkeypatch, _seed("https://example.com"))
     # Force the cap to trip after the very first sequential retry.
-    monkeypatch.setattr(crawl4ai_client, "_MAX_ANTIBOT_SEQUENTIAL_RECOVERY", 1)
+    monkeypatch.setattr(crawl4ai_client, "_MAX_SEQUENTIAL_RECOVERY", 1)
 
     attempted_urls: list[str] = []
 
@@ -1159,7 +1208,7 @@ async def test_crawl_site_antibot_recovery_respects_and_logs_cap(
             request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
             response = httpx.Response(
                 500,
-                json={"detail": "Blocked by anti-bot protection: Cloudflare JS challenge"},
+                json={"error": "Internal server error", "correlation_id": "188834187d7d"},
                 request=request,
             )
             raise httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
@@ -1193,24 +1242,99 @@ async def test_crawl_site_antibot_recovery_respects_and_logs_cap(
 
     by_url = {o["url"]: o for o in outcomes}
     assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.SUCCESS.value
-    # Capped without a network call — both still BLOCKED_ANTI_BOT.
-    assert (
-        by_url["https://example.com/page-b"]["reason_code"]
-        == FetchReasonCode.BLOCKED_ANTI_BOT.value
-    )
-    assert (
-        by_url["https://example.com/page-c"]["reason_code"]
-        == FetchReasonCode.BLOCKED_ANTI_BOT.value
-    )
+    # Capped without a network call — both honestly HTTP_5XX, not a guessed
+    # anti-bot verdict.
+    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.HTTP_5XX.value
+    assert by_url["https://example.com/page-c"]["reason_code"] == FetchReasonCode.HTTP_5XX.value
 
     cap_log_calls = [
         call
         for call in mock_warning.call_args_list
-        if call.args[:1] == ("crawl_antibot_recovery_capped",)
+        if call.args[:1] == ("crawl_bulk_5xx_recovery_capped",)
     ]
     assert len(cap_log_calls) == 1
     _, kwargs = cap_log_calls[0]
     assert kwargs["recovered"] == 1
-    assert kwargs["still_blocked"] == 2
+    assert kwargs["still_failing"] == 2
     assert kwargs["capped_at"] == 1
     assert kwargs["remaining"] == 2
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_no_sequential_recovery_on_bulk_4xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bulk 4xx (e.g. a misconfigured request) must NOT trigger the
+    sequential-recovery fallback — that path is reserved for 5xx, where
+    the cause is genuinely unknowable. A 4xx across the whole batch is
+    classified directly via _combine_bulk_responses, unchanged."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/page-a", "https://example.com/page-b"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+
+    single_page_calls: list[str] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        urls = payload["urls"]
+        if len(urls) == 1:
+            single_page_calls.append(urls[0])
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(400, json={"detail": "Bad Request"}, request=request)
+        raise httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    # No sequential single-page recovery calls were made for the bulk batch.
+    assert single_page_calls == []
+    by_url = {o["url"]: o for o in outcomes}
+    assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.HTTP_4XX.value
+    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.HTTP_4XX.value
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_no_sequential_recovery_on_bulk_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bulk transport timeout (not an HTTPStatusError at all) must NOT
+    trigger the sequential-recovery fallback — _is_bulk_5xx_error requires
+    an httpx.HTTPStatusError with a 5xx status, which a timeout is not."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/page-a", "https://example.com/page-b"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+
+    single_page_calls: list[str] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        urls = payload["urls"]
+        if len(urls) == 1:
+            single_page_calls.append(urls[0])
+        raise httpx.ReadTimeout("simulated bulk timeout")
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    assert single_page_calls == []
+    by_url = {o["url"]: o for o in outcomes}
+    assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.TIMEOUT.value
+    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.TIMEOUT.value


### PR DESCRIPTION
## Waarom deze PR bestaat

PR #945 (al gemerged) loste dit probleem **niet** op. Ik heb na de deploy een echte crawl gedraaid en gemeten: 17 van 18 pagina's kregen nog steeds `unknown_exception`, de recovery vuurde nooit, en de job meldde `completed`.

Rootcause van die mislukte fix: mijn eigen briefing. Ik gaf op dat crawl4ai de tekst "Blocked by anti-bot protection" in de HTTP-body zet. Live gemeten is de body:

```json
{"error":"Internal server error","correlation_id":"188834187d7d"}
```

Die marker staat alleen in crawl4ai's **container-log**. De oorzaak van een bulk-500 is client-side dus principieel onbekend — elke detectie daarop is dode code.

## Wat er nu gebeurt

1. **Trigger op het waarneembare feit**: sequentiële recovery vuurt op elke bulk-level HTTP 5xx. De retry is tegelijk mitigatie én diagnose — per URL leren we de echte uitkomst. (Bewezen: losse fetches haalden `/products/unite` wél binnen terwijl de gelijktijdige burst alle 17 blokkeerde.) URLs die opnieuw falen krijgen `http_5xx` — eerlijk — in plaats van een verzonnen `blocked_anti_bot`.
2. **Oorzaak-onafhankelijke eindstatus**: `decide_fetch_failure_terminal_status` zet de job op `failed_partial` zodra een betekenisvol deel van de **ontdekte** pagina's echt niet opgehaald kon worden, met de top-reason-codes in de samenvatting. Bewuste niet-fetches (budget, diepte, exclude, duplicate) tellen niet als storing. Een import-time assertie laat de service falen als een toekomstige reason-code niet ingedeeld is — zodat deze klasse niet opnieuw stil kan wegvallen.
3. **Dode code weg**: de body-match op het transport-pad en de helper die alleen die tak voedde. `BLOCKED_ANTI_BOT` blijft alleen op het pad dat hem écht kan zetten.
4. **Vier dode tests herrezen**: stonden als class-methods ná een module-functie, dus pytest verzamelde ze nooit (1256 → 1260).

## Verificatie
- knowledge-ingest: **1260 passed**, 4 skipped — incl. een regressietest met de letterlijke opake productie-body
- parity-tests groen (enum ongewijzigd, connector-kopie hoeft niet mee)
- ruff check + format clean

Na merge draai ik opnieuw een echte Intermedia-crawl op productie en rapporteer ik de gemeten uitkomst — deze PR geldt pas als geslaagd als die cijfers kloppen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)