### PR TITLE
fix(kb-feedback): use the message's own timestamp, not the moment of the click

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -386,7 +386,7 @@ services:
   librechat-getklai:
     # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 3 — the canary runs the Klai-owned
     # image, built in CI from the source diffs in deploy/librechat/patches-source/.
-    # Tag for humans: v0.8.7-klai.1-80df95854928 (upstream v0.8.7, agents v3.2.46).
+    # Tag for humans: v0.8.7-klai.1-4d371b07a381 (upstream v0.8.7, agents v3.2.46).
     #
     # Pinned by DIGEST, and deploy/check-klai-librechat-digest.sh enforces that:
     # on 2026-08-14 the tag v0.8.7-klai.1 was pushed twice with different
@@ -394,7 +394,7 @@ services:
     #
     # Rollback: put ghcr.io/danny-avila/librechat:v0.8.7 back here and restore
     # the four patch bind-mounts removed below (git revert this commit).
-    image: ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
+    image: ghcr.io/getklai/librechat@sha256:731263c1ae6a2496f2ccdb5b02810aa76b5e8ecb54a47e6b81bf97f939f824dc
     container_name: librechat-getklai
     restart: unless-stopped
     # Force light theme via the Klai entrypoint wrapper (LibreChat has no
@@ -686,7 +686,7 @@ services:
       DOCKER_HOST: tcp://klai-docker-authz:2375   # SPEC-SEC-DOCKER-AUTHZ-001
       # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5 — the fleet default is the
       # Klai-owned image, built in CI from deploy/librechat/patches-source/.
-      # Tag for humans: v0.8.7-klai.1-80df95854928 (upstream v0.8.7, agents v3.2.46).
+      # Tag for humans: v0.8.7-klai.1-4d371b07a381 (upstream v0.8.7, agents v3.2.46).
       #
       # Digest-pinned; deploy/check-klai-librechat-digest.sh enforces it. The
       # default in config.py deliberately stays on upstream, so a deploy that
@@ -696,7 +696,7 @@ services:
       # Rollback: delete this line, then recreate tenants (they return to the
       # config.py default). LIBRECHAT_IMAGE_OVERRIDES can pin individual
       # tenants either way during a staged move.
-      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:3b4fd8440c79a6ff8c345eb25a6b41fd407a1167e49c84873230c2a38e0d4ebf
+      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:731263c1ae6a2496f2ccdb5b02810aa76b5e8ecb54a47e6b81bf97f939f824dc
       # SPEC-SEC-HYGIENE-001 REQ-28.4: explicit deployment-environment marker.
       # Pydantic Settings reads PORTAL_ENV; the in-code default is "production"
       # (REQ-28.2). The validator at config.py:_no_debug_in_production refuses

--- a/deploy/librechat/getklai/entrypoint.sh
+++ b/deploy/librechat/getklai/entrypoint.sh
@@ -292,6 +292,10 @@ const REPLACE = `      { context: 'updateFeedback' },
     // SPEC-KB-015: Forward feedback to portal-api for KB quality scoring.
     // Fire-and-forget (REQ-KB-015-06) -- response is sent immediately below.
     // Logs on error (REQ-KB-015-07): never surfaces to user, but visible in VictoriaLogs.
+    const feedbackMessage = await db
+      .getMessage({ user: req.user?.id, messageId })
+      .catch(() => null);
+
     const portalUrl = process.env.PORTAL_INTERNAL_URL;
     const portalSecret = process.env.PORTAL_INTERNAL_SECRET;
     if (portalUrl && portalSecret && feedback) {
@@ -305,11 +309,11 @@ const REPLACE = `      { context: 'updateFeedback' },
           conversation_id: conversationId,
           message_id: messageId,
           message_created_at:
-            updatedMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
+            feedbackMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
           rating: feedback.rating,
           tag: feedback.tag ?? null,
           text: feedback.text ?? null,
-          model_alias: updatedMessage?.model ?? null,
+          model_alias: feedbackMessage?.model ?? updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
           identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,

--- a/deploy/librechat/klai-entrypoint.sh
+++ b/deploy/librechat/klai-entrypoint.sh
@@ -295,6 +295,10 @@ const REPLACE = `      { context: 'updateFeedback' },
     // SPEC-KB-015: Forward feedback to portal-api for KB quality scoring.
     // Fire-and-forget (REQ-KB-015-06) -- response is sent immediately below.
     // Logs on error (REQ-KB-015-07): never surfaces to user, but visible in VictoriaLogs.
+    const feedbackMessage = await db
+      .getMessage({ user: req.user?.id, messageId })
+      .catch(() => null);
+
     const portalUrl = process.env.PORTAL_INTERNAL_URL;
     const portalSecret = process.env.PORTAL_INTERNAL_SECRET;
     if (portalUrl && portalSecret && feedback) {
@@ -308,11 +312,11 @@ const REPLACE = `      { context: 'updateFeedback' },
           conversation_id: conversationId,
           message_id: messageId,
           message_created_at:
-            updatedMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
+            feedbackMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
           rating: feedback.rating,
           tag: feedback.tag ?? null,
           text: feedback.text ?? null,
-          model_alias: updatedMessage?.model ?? null,
+          model_alias: feedbackMessage?.model ?? updatedMessage?.model ?? null,
           librechat_user_id: req.user?.id ?? '',
           identity_user_id: req.user?.openidId ?? null,
           librechat_tenant_id: process.env.KLAI_ORG_SLUG ? \`librechat-\${process.env.KLAI_ORG_SLUG}\` : null,

--- a/deploy/librechat/patches-source/messages.js.patch
+++ b/deploy/librechat/patches-source/messages.js.patch
@@ -1,14 +1,25 @@
 diff --git a/api/server/routes/messages.js b/api/server/routes/messages.js
-index 17e740c51..eeb650ac1 100644
+index 17e740c51..19ac18009 100644
 --- a/api/server/routes/messages.js
 +++ b/api/server/routes/messages.js
-@@ -415,6 +415,43 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
+@@ -415,6 +415,54 @@ router.put('/:conversationId/:messageId/feedback', validateMessageReq, async (re
        }).catch((err) => logger.error('[langfuse] feedback score failed:', err));
      }
  
 +    // SPEC-KB-015: Forward feedback to portal-api for KB quality scoring.
 +    // Fire-and-forget (REQ-KB-015-06) -- response is sent immediately below.
 +    // Logs on error (REQ-KB-015-07): never surfaces to user, but visible in VictoriaLogs.
++    // db.updateMessage returns a hand-built object with nine fields and does
++    // NOT include createdAt or model. Reading them off it meant
++    // message_created_at silently fell back to Date.now() -- so the retrieval
++    // correlation window was centred on the moment the user clicked the thumb
++    // instead of on the answer, and matched only if they happened to click
++    // within 60s. Fetch the real document (indexed findOne, click path, not a
++    // stream) so both fields are the message's own.
++    const feedbackMessage = await db
++      .getMessage({ user: req.user?.id, messageId })
++      .catch(() => null);
++
 +    const portalUrl = process.env.PORTAL_INTERNAL_URL;
 +    const portalSecret = process.env.PORTAL_INTERNAL_SECRET;
 +    if (portalUrl && portalSecret && feedback) {
@@ -22,11 +33,11 @@ index 17e740c51..eeb650ac1 100644
 +          conversation_id: conversationId,
 +          message_id: messageId,
 +          message_created_at:
-+            updatedMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
++            feedbackMessage?.createdAt?.toISOString?.() ?? new Date().toISOString(),
 +          rating: feedback.rating,
 +          tag: feedback.tag ?? null,
 +          text: feedback.text ?? null,
-+          model_alias: updatedMessage?.model ?? null,
++          model_alias: feedbackMessage?.model ?? updatedMessage?.model ?? null,
 +          librechat_user_id: req.user?.id ?? '',
 +          // The retrieval log is keyed by the Zitadel subject, which
 +          // LibreChat stores as openidId. Sending only req.user.id (a

--- a/deploy/librechat/tests/built_artifacts.test.cjs
+++ b/deploy/librechat/tests/built_artifacts.test.cjs
@@ -275,6 +275,27 @@ assert.ok(
   'the forward must send identity_user_id (the Zitadel subject the retrieval log is keyed by)'
 );
 
+// db.updateMessage returns a hand-built object of nine fields with no createdAt
+// and no model, so reading those off it silently degraded to Date.now() and
+// null. That centred the correlation window on the thumb-click instead of the
+// answer and made correlation succeed only when someone clicked within 60s --
+// 3 hits in four months. Both must come from the re-fetched message.
+assert.ok(
+  /message_created_at:\s*\n?\s*feedbackMessage\?\.createdAt/.test(forwardBlock),
+  'message_created_at must come from the re-fetched message, not from updateMessage ' +
+    '(which does not return createdAt and would fall back to now())'
+);
+assert.ok(
+  forwardBlock.includes('feedbackMessage?.model'),
+  'model_alias must prefer the re-fetched message: updateMessage does not return model, ' +
+    'which is why 69 of 70 events stored model_alias = NULL'
+);
+assert.ok(
+  messagesSource.includes('db.getMessage({ user: req.user?.id, messageId })') ||
+    /getMessage\(\{\s*user:\s*req\.user\?\.id,\s*messageId\s*\}\)/.test(messagesSource),
+  'the forward must re-fetch the message to get its real createdAt'
+);
+
 console.log(
   'OK: built artifacts verified — search topResults + surrogate guards, ' +
     'index.cjs cleanupOnComplete at every call site, stream marker edge cases, ' +


### PR DESCRIPTION
Mijn vorige fix was nodig maar niet voldoende. De correlatie bleef `false`, dus ben ik doorgegaan: er lagen **twee bugs op elkaar**, en dit is degene die het meeste schade deed.

## De oorzaak

`db.updateMessage` geeft een handgebouwd object van negen velden terug:

```
messageId, conversationId, parentMessageId, sender, text,
isCreatedByUser, tokenCount, feedback, endpoint
```

Geen `createdAt`. Geen `model`. Dus deze regel nam altijd de terugval:

```js
message_created_at: updatedMessage?.createdAt?.toISOString?.() ?? new Date()...
```

Het correlatievenster `[msg−60s, msg+10s]` lag daarmee rond het moment van de **duimklik** in plaats van rond het **antwoord**. Retrieval gebeurt seconden vóór het antwoord; de duim kan minuten of uren later komen.

Het kon dus alleen raken als iemand toevallig binnen 60 seconden klikte — en dat is precies de vorm van de data: **3 gecorreleerde hits, allemaal op één dag in april, van de 70**.

## Tweede symptoom, zelfde object

`model_alias` is `NULL` op **69 van de 70** opgeslagen events, want `updateMessage` geeft `model` evenmin terug.

## Fix

Beide komen nu uit een re-fetch van het echte document via `db.getMessage`. Dat is een geïndexeerde `findOne` op een klikpad, geen stream, en `.catch()`-afgeschermd zodat een leesfout terugvalt op het oude gedrag in plaats van de feedback van de gebruiker te laten falen.

De built-artifact test pint nu alle drie: `created_at` en `model` moeten uit de re-fetch komen, en de re-fetch moet bestaan. Een stille terugval naar `Date.now()` is precies wat dit vier maanden verborgen hield — dat verdient een assertie, geen comment.

Entrypoint-transforms krijgen dezelfde wijziging; ze uit elkaar laten lopen zou de bug terugzetten op elke tenant die naar upstream teruggerold wordt.