### PR TITLE
ci: let the Trivy gate actually stop a deploy, in the eight that ignored it

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -52,17 +52,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to core-01
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            docker pull ghcr.io/getklai/caddy-hetzner:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh caddy
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -120,3 +109,23 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout of the TLS-terminating edge proxy. This
+    # step used to be the tail of build-push, so a failing scan could not
+    # stop caddy from being recreated with a vulnerable image.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to core-01
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            docker pull ghcr.io/getklai/caddy-hetzner:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh caddy

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -117,28 +117,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C lesson: an earlier version of
-      # this workflow ran the deploy step on every ``pull_request`` build,
-      # auto-publishing PR-build images to prod under the ``:latest`` tag and
-      # triggering a docker compose up -d on core-01. That dropped a broken
-      # (varchar(32)-overflow) alembic migration into prod from a PR that was
-      # never reviewed. The ``if`` condition below pins the deploy to
-      # main-branch pushes only — PRs build + scan but do not deploy.
-      - name: Deploy to core-01
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/klai-connector:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh klai-connector
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -189,3 +167,33 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C lesson: an earlier version of
+      # this workflow ran the deploy step on every ``pull_request`` build,
+      # auto-publishing PR-build images to prod under the ``:latest`` tag and
+      # triggering a docker compose up -d on core-01. That dropped a broken
+      # (varchar(32)-overflow) alembic migration into prod from a PR that was
+      # never reviewed. The ``if`` condition below pins the deploy to
+      # main-branch pushes only — PRs build + scan but do not deploy.
+      - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/klai-connector:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-connector

--- a/.github/workflows/klai-docker-authz.yml
+++ b/.github/workflows/klai-docker-authz.yml
@@ -112,29 +112,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 2026-05-05 incident: this step previously had no `if:` gate, so
-      # PR builds also auto-deployed `:latest` to prod. PR #319's first
-      # successful docker-authz build in months pushed an image with the
-      # SPEC-SEC-WEBHOOK-001 validator into prod where MAILER_WEBHOOK_SECRET
-      # had never been migrated to global SOPS — restart-loop, no email
-      # for ~30 min until manual stabilize. Mirrors the connector workflow
-      # fix from SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C: deploy ONLY on
-      # main-branch pushes, never from PR builds.
-      - name: Deploy to core-01
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/klai-docker-authz:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh klai-docker-authz
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -184,3 +161,34 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      # 2026-05-05 incident: this step previously had no `if:` gate, so
+      # PR builds also auto-deployed `:latest` to prod. PR #319's first
+      # successful docker-authz build in months pushed an image with the
+      # SPEC-SEC-WEBHOOK-001 validator into prod where MAILER_WEBHOOK_SECRET
+      # had never been migrated to global SOPS — restart-loop, no email
+      # for ~30 min until manual stabilize. Mirrors the connector workflow
+      # fix from SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C: deploy ONLY on
+      # main-branch pushes, never from PR builds.
+      - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/klai-docker-authz:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-docker-authz

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -131,21 +131,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to core-01
-        if: github.event_name == 'push'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/klai-knowledge-mcp:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh klai-knowledge-mcp
-
   scan:
     needs: build-push
     if: github.event_name == 'push'
@@ -196,3 +181,26 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to core-01
+        if: github.event_name == 'push'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/klai-knowledge-mcp:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-knowledge-mcp

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -114,29 +114,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 2026-05-05 incident: this step previously had no `if:` gate, so
-      # PR builds also auto-deployed `:latest` to prod. PR #319's first
-      # successful mailer build in months pushed an image with the
-      # SPEC-SEC-WEBHOOK-001 validator into prod where MAILER_WEBHOOK_SECRET
-      # had never been migrated to global SOPS — restart-loop, no email
-      # for ~30 min until manual stabilize. Mirrors the connector workflow
-      # fix from SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C: deploy ONLY on
-      # main-branch pushes, never from PR builds.
-      - name: Deploy to core-01
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/klai-mailer:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh klai-mailer
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -186,3 +163,34 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      # 2026-05-05 incident: this step previously had no `if:` gate, so
+      # PR builds also auto-deployed `:latest` to prod. PR #319's first
+      # successful mailer build in months pushed an image with the
+      # SPEC-SEC-WEBHOOK-001 validator into prod where MAILER_WEBHOOK_SECRET
+      # had never been migrated to global SOPS — restart-loop, no email
+      # for ~30 min until manual stabilize. Mirrors the connector workflow
+      # fix from SPEC-CONNECTOR-DELETE-LIFECYCLE-001 PR C: deploy ONLY on
+      # main-branch pushes, never from PR builds.
+      - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/klai-mailer:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh klai-mailer

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -173,24 +173,6 @@ jobs:
           # GHA layer cache disabled: it failed to invalidate on source code changes.
           # Builds are fast enough (~1 min) without caching.
 
-      # 2026-05-05 mailer-incident class: this step previously had no `if:`
-      # gate, so PR builds also auto-deployed `:latest` to prod. Same
-      # pattern that bit klai-mailer post PR #319 → hotfix #322.
-      - name: Deploy to core-01
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/knowledge-ingest:latest
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh knowledge-ingest
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -240,3 +222,29 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      # 2026-05-05 mailer-incident class: this step previously had no `if:`
+      # gate, so PR builds also auto-deployed `:latest` to prod. Same
+      # pattern that bit klai-mailer post PR #319 → hotfix #322.
+      - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/knowledge-ingest:latest
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh knowledge-ingest

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -113,22 +113,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to core-01
-        if: github.event_name == 'push'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/retrieval-api:latest
-            docker tag ghcr.io/getklai/retrieval-api:latest klai/retrieval-api:local
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
-            /opt/klai/scripts/compose-up.sh retrieval-api
-
   scan:
     needs: build-push
     if: github.event_name == 'push'
@@ -179,3 +163,27 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to core-01
+        if: github.event_name == 'push'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/retrieval-api:latest
+            docker tag ghcr.io/getklai/retrieval-api:latest klai/retrieval-api:local
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3
+            /opt/klai/scripts/compose-up.sh retrieval-api

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -110,29 +110,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # 2026-05-05 mailer-incident class: this step previously had no `if:`
-      # gate, so PR builds also auto-deployed `:latest` to prod. The first
-      # PR build that produced a recreate after a long quiet period could
-      # surface a hidden validator-env-parity regression as a 30+ minute
-      # outage. Same pattern that bit klai-mailer post PR #319 → hotfix #322.
-      - name: Deploy to core-01
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.CORE01_HOST }}
-          username: klai
-          key: ${{ secrets.CORE01_DEPLOY_KEY }}
-          script: |
-            set -e
-            source /opt/klai/.env
-            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
-            docker pull ghcr.io/getklai/scribe-api:latest
-            # SPEC-SEC-AUDIT-2026-04 C5: alembic upgrade head runs automatically
-            # via /app/entrypoint.sh at container start (klai-scribe/scribe-api/entrypoint.sh).
-            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3: compose-up.sh wraps
-            # `docker compose up -d` with image-tag + resource-limit checks.
-            /opt/klai/scripts/compose-up.sh scribe-api
-
   scan:
     needs: build-push
     runs-on: ubuntu-latest
@@ -182,3 +159,34 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy:
+    # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
+    # can actually block the rollout: this step used to be the tail of
+    # build-push, so a failing scan could not stop it from deploying.
+    needs: [build-push, scan]
+    runs-on: ubuntu-latest
+
+    steps:
+      # 2026-05-05 mailer-incident class: this step previously had no `if:`
+      # gate, so PR builds also auto-deployed `:latest` to prod. The first
+      # PR build that produced a recreate after a long quiet period could
+      # surface a hidden validator-env-parity regression as a 30+ minute
+      # outage. Same pattern that bit klai-mailer post PR #319 → hotfix #322.
+      - name: Deploy to core-01
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.CORE01_HOST }}
+          username: klai
+          key: ${{ secrets.CORE01_DEPLOY_KEY }}
+          script: |
+            set -e
+            source /opt/klai/.env
+            echo "$GHCR_READ_PAT" | docker login ghcr.io -u mvletter --password-stdin
+            docker pull ghcr.io/getklai/scribe-api:latest
+            # SPEC-SEC-AUDIT-2026-04 C5: alembic upgrade head runs automatically
+            # via /app/entrypoint.sh at container start (klai-scribe/scribe-api/entrypoint.sh).
+            # SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-3: compose-up.sh wraps
+            # `docker compose up -d` with image-tag + resource-limit checks.
+            /opt/klai/scripts/compose-up.sh scribe-api


### PR DESCRIPTION
SPEC-CI-TRIVY-POLICY-001 put a STRICT-tier scan on all ten internal image builds. **In eight of them the gate has never been able to do anything**, because the deploy is the last *step* of `build-push` while `scan` is a separate *job* with `needs: build-push`. The image reaches core-01 first and the scan reports on it afterwards.

A red scan there is a status, not a gate.

## Caddy proves it

| run | date | deploy step | scan job |
|---|---|---|---|
| 31803259364 | 2026-08-14 | ✅ ran | ❌ failed |
| 31588580685 | 2026-08-12 | ✅ ran | ❌ failed |
| 27150491855 | 2026-06-08 | ✅ ran | ❌ failed |
| 26510432521 | 2026-05-27 | ✅ ran | ❌ failed |

Four times a CVE-failing image was already serving TLS on the edge proxy while CI showed red.

## Why only eight

`docs.yml` and `portal-api.yml` were restructured when the SPEC landed, and both carry a comment explaining the `needs`. The other eight kept their pre-existing inline deploy step and were never brought along. This moves that step — verbatim — into a `deploy` job with `needs: [build-push, scan]`, so all ten now have the same shape.

## Scope

Nothing else changes. **No new SSH surface**: the same step, the same secrets, the same script, one job later.

- Each step's own `if:` moved with it unchanged.
- None of the eight referenced `steps.*`, `needs.*`, or a job-level `env:`, so the move is context-safe (verified per file).
- The workflow-level `env:` block already applies to every job, so nothing was duplicated.
- Verified: all 8 parse as YAML, each job list is exactly the old list plus `deploy`, each `deploy` has `needs: [build-push, scan]` and one step, and no deploy step remains behind in any other job.

## Behaviour change worth naming

A failing scan now leaves the previous image running instead of rolling forward and complaining. That is the point — and it is also what turns a red scan from cosmetic into urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)