### PR TITLE
fix(alloy): the log tailer had its own Docker host and still dialled the socket

### DIFF
--- a/.github/workflows/audit-compose.yml
+++ b/.github/workflows/audit-compose.yml
@@ -10,6 +10,8 @@ on:
       - 'scripts/audit-compose-volumes.sh'
       - 'scripts/audit-compose-orphans.sh'
       - 'scripts/audit-docker-access.sh'
+      - 'deploy/alloy/config.alloy'
+      - 'deploy/tests/test_alloy_docker_access.sh'
       - 'scripts/test-audit-compose.sh'
       - 'scripts/test-audit-compose-orphans.sh'
       - 'klai-scribe/scribe-api/app/core/config.py'
@@ -67,6 +69,9 @@ jobs:
 
       - name: Run docker-access audit (SPEC-SEC-DOCKER-AUTHZ-001)
         run: bash scripts/audit-docker-access.sh
+
+      - name: Alloy must not reach the raw Docker socket (REQ-U-002a)
+        run: bash deploy/tests/test_alloy_docker_access.sh
 
       - name: Orphan regression test — fixtures must catch known anti-patterns
         run: bash scripts/test-audit-compose-orphans.sh

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -43,7 +43,12 @@ discovery.relabel "docker_logs" {
 }
 
 loki.source.docker "containers" {
-  host       = "unix:///var/run/docker.sock"
+  // SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a. This is the SECOND host in this file:
+  // discovery.docker finds the containers, this tailer reads their logs, and
+  // they connect independently. Changing only the first left the tailer dialling
+  // a socket the container no longer mounts — discovery went green while every
+  // inspect failed, 10k errors in ten minutes.
+  host       = "http://docker-socket-proxy-ro:2375"
   targets    = discovery.relabel.docker_logs.output
   forward_to = [loki.process.extract_level.receiver]
 }

--- a/deploy/tests/test_alloy_docker_access.sh
+++ b/deploy/tests/test_alloy_docker_access.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a — Alloy must not reach the raw socket.
+#
+# config.alloy has TWO independent Docker connections: discovery.docker finds
+# containers, loki.source.docker reads their logs. They connect separately.
+# Changing only the first is the failure this guard exists to prevent — discovery
+# reported healthy while every log inspect failed, producing 10k errors in ten
+# minutes with no signal that log collection had stopped.
+
+set -eu
+CONFIG="${1:-deploy/alloy/config.alloy}"
+FAIL=0
+
+raw=$(grep -c 'unix:///var/run/docker.sock' "$CONFIG" || true)
+if [ "$raw" -ne 0 ]; then
+    echo "FAIL: $CONFIG still dials the raw socket ($raw reference(s))" >&2
+    grep -n 'unix:///var/run/docker.sock' "$CONFIG" >&2
+    echo "      Alloy has no raw socket mount; use http://docker-socket-proxy-ro:2375" >&2
+    FAIL=1
+fi
+
+hosts=$(grep -cE '^\s*host\s*=\s*"(unix|http)' "$CONFIG" || true)
+proxied=$(grep -cE '^\s*host\s*=\s*"http://docker-socket-proxy-ro:2375"' "$CONFIG" || true)
+if [ "$hosts" -ne "$proxied" ]; then
+    echo "FAIL: $CONFIG has $hosts Docker host(s) but only $proxied via the read-only proxy" >&2
+    grep -nE '^\s*host\s*=\s*"(unix|http)' "$CONFIG" >&2
+    FAIL=1
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "OK: alloy reaches Docker only via docker-socket-proxy-ro ($proxied connection(s))"
+fi
+exit "$FAIL"


### PR DESCRIPTION
`config.alloy` has **two** independent Docker connections — `discovery.docker` finds containers, `loki.source.docker` reads their logs. #963 changed only the first.

Worse than an outright break: discovery went green, the container reported healthy, and every log inspect failed — **10,505 errors in ten minutes**, log collection degraded the whole time. Alloy's health said nothing; only counting its errors did.

`deploy/tests/test_alloy_docker_access.sh` asserts both that no raw-socket reference survives **and** that the number of Docker hosts equals the number going through the read-only proxy — so a third connection added later cannot slip past by being new rather than wrong. Mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)