### PR TITLE
fix(alloy): re-apply the read-only lane — the revert was based on my own bad query

### DIFF
--- a/.claude/rules/klai/platform/docker-socket-proxy.md
+++ b/.claude/rules/klai/platform/docker-socket-proxy.md
@@ -73,16 +73,37 @@ all tenant provisioning.
 
 ### Who may reach the daemon at all
 
-`scripts/audit-docker-access.sh` pins two sets in CI (via `audit-compose.yml`):
-the `socket-proxy` network members, and the containers mounting the raw
+There are two lanes, and `scripts/audit-docker-access.sh` pins both in CI (via
+`audit-compose.yml`) along with the set of containers mounting the raw
 `/var/run/docker.sock`. The MUST-NOT list further down this file enumerates the
-*forbidden*, so a new service is permitted by default; the audit inverts that.
+*forbidden*, so a new service would be permitted by default; the audit inverts
+that.
 
-`alloy` mounts the raw socket and therefore bypasses `klai-docker-authz`
-entirely. Its mount is `RW=false`, which protects the socket FILE but does not
-make the Docker API read-only — a process that can write the byte stream can
-still `POST /containers/create`. It needs `GET` only. Recorded as an open item in
-SPEC-SEC-DOCKER-AUTHZ-001; do not treat the read-only flag as containment.
+| Lane | Proxy | Verbs | Members |
+|---|---|---|---|
+| Mutating | `docker-socket-proxy` | `CONTAINERS NETWORKS POST DELETE` | portal-api, runtime-api-socket-proxy — both via `klai-docker-authz` |
+| GET-only | `docker-socket-proxy-ro` | `CONTAINERS NETWORKS` | alloy |
+
+`alloy` used to mount the raw socket. That mount was `:ro`, which protects the
+socket FILE and **not** the Docker API — a process that can write that byte
+stream can still `POST /containers/create`. It now uses the GET-only lane, where
+`POST` and `DELETE` are unset, so the read-only intent is structural rather than
+a property of a mount flag.
+
+`NETWORKS` on the read-only lane is required, not incidental: Alloy's
+`discovery.docker` computes network labels per target and 403s without it.
+Read access to the network list is not a mutation primitive — `POST` stays unset,
+so `/networks/{id}/connect` is still refused.
+
+**If you touch `config.alloy`, it has TWO Docker connections.**
+`discovery.docker` finds containers; `loki.source.docker` reads their logs. They
+connect independently. Changing only one produced ~10k
+"error inspecting Docker container" failures on 2026-08-14 while Alloy still
+reported healthy and total log volume stayed in the same order of magnitude —
+nothing looked broken from the outside. `deploy/tests/test_alloy_docker_access.sh`
+now asserts that the count of Docker hosts equals the count going through the
+proxy, so a third connection added later cannot slip past by being new rather
+than by being wrong.
 
 ## Containers that MUST NOT join the socket-proxy network (SPEC-SEC-SSRF-001 REQ-5)
 

--- a/.github/workflows/audit-compose.yml
+++ b/.github/workflows/audit-compose.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/audit-compose-volumes.sh'
       - 'scripts/audit-compose-orphans.sh'
       - 'scripts/audit-docker-access.sh'
+      - 'deploy/tests/test_alloy_docker_access.sh'
       - 'deploy/alloy/config.alloy'
       - 'scripts/test-audit-compose.sh'
       - 'scripts/test-audit-compose-orphans.sh'
@@ -68,6 +69,9 @@ jobs:
 
       - name: Run docker-access audit (SPEC-SEC-DOCKER-AUTHZ-001)
         run: bash scripts/audit-docker-access.sh
+
+      - name: Alloy must not reach the raw Docker socket (REQ-U-002a)
+        run: bash deploy/tests/test_alloy_docker_access.sh
 
 
       - name: Orphan regression test — fixtures must catch known anti-patterns

--- a/.moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md
+++ b/.moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md
@@ -323,6 +323,29 @@ Both are hours, not weeks, and neither depends on which option is chosen.
       `DELETE` are unset, so the read-only intent is structural instead of a
       mount flag.
 
+      This took three attempts and one unnecessary revert; the record matters
+      more than the outcome.
+
+      1. Moving only `discovery.docker` left `loki.source.docker` — a SECOND,
+         independent Docker connection in the same file — dialling a socket the
+         container no longer mounted. ~10k `error inspecting Docker container`
+         failures.
+      2. The read-only proxy needed `NETWORKS` as well as `CONTAINERS`; discovery
+         computes network labels per target and 403s without it.
+      3. I then reverted the whole change, recording in the commit and in this
+         SPEC that it had "stopped log collection". **That was wrong.** A
+         `hits()` query over the full window shows log ingestion never dropped:
+         236k / 74k / 110k / 70k / 111k / 219k / 93k / 106k entries per 5-minute
+         bucket straight through, including the window I called an outage. My
+         earlier queries had start timestamps in the FUTURE relative to server
+         time, and I read the empty result as absence of data.
+
+      Two lessons, both now mechanical rather than remembered:
+      `deploy/tests/test_alloy_docker_access.sh` asserts the host COUNT matches
+      the proxied count, so a third connection cannot slip past; and any claim
+      about log flow must come from a bounded `hits()` window that ends in the
+      past, not from a `start=` guess.
+
 ### Still open
 
 - **REQ-U-004 — the availability answer.** `klai-docker-authz` is now on the

--- a/deploy/alloy/config.alloy
+++ b/deploy/alloy/config.alloy
@@ -13,10 +13,15 @@
 // ─── Docker container log collection ─────────────────────────────────────────
 
 discovery.docker "containers" {
-  // REVERTED 2026-08-14. Routing Alloy through docker-socket-proxy-ro stopped log
-  // collection entirely — see the REQ-U-002a note in
-  // .moai/specs/SPEC-SEC-DOCKER-AUTHZ-001/spec.md before trying again.
-  host = "unix:///var/run/docker.sock"
+  // SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a. No raw socket: docker-socket-proxy-ro
+  // serves CONTAINERS + NETWORKS and nothing else, so discovery and log
+  // streaming work while container-create is structurally impossible from here.
+  //
+  // NOTE — there are TWO Docker hosts in this file. discovery.docker (here) finds
+  // containers; loki.source.docker below reads their logs. They connect
+  // independently, so both must move together. Changing only this one produced
+  // ~10k "error inspecting Docker container" failures on 2026-08-14.
+  host = "http://docker-socket-proxy-ro:2375"
 }
 
 // Labels must be applied via discovery.relabel BEFORE loki.source.docker.
@@ -43,10 +48,9 @@ discovery.relabel "docker_logs" {
 }
 
 loki.source.docker "containers" {
-  // REVERTED 2026-08-14 with the discovery host above. NOTE for the retry: this
-  // is a SECOND, independent Docker connection — discovery finds containers,
-  // this tailer reads their logs. Both must move together.
-  host       = "unix:///var/run/docker.sock"
+  // The SECOND Docker host — see the note on discovery.docker above. This is the
+  // connection that actually reads log content; discovery only finds targets.
+  host       = "http://docker-socket-proxy-ro:2375"
   targets    = discovery.relabel.docker_logs.output
   forward_to = [loki.process.extract_level.receiver]
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1053,10 +1053,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
-      # REVERTED 2026-08-14 (REQ-U-002a attempt 1): routing Alloy through
-      # docker-socket-proxy-ro stopped log collection. Raw socket restored so
-      # observability works; the requirement stays open in the SPEC.
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a: no raw socket. Alloy reaches the
+      # daemon through docker-socket-proxy-ro, which serves GET only.
       # Host-side synthetic probes write JSON logs here for Alloy file scraping.
       - /opt/klai/logs:/opt/klai/logs:ro
       # SPEC-INFRA-005 Phase 6: textfile collector reads .prom files written
@@ -1078,6 +1076,7 @@ services:
     networks:
       - klai-net
       - monitoring
+      - socket-proxy-ro   # SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a: GET-only daemon access
 
   grafana:
     image: grafana/grafana:13.1.3

--- a/deploy/tests/test_alloy_docker_access.sh
+++ b/deploy/tests/test_alloy_docker_access.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a — Alloy must not reach the raw socket.
+#
+# config.alloy holds TWO independent Docker connections: discovery.docker finds
+# containers, loki.source.docker reads their logs. Changing only one is the
+# failure this guard exists to prevent — on 2026-08-14 that produced ~10k
+# "error inspecting Docker container" failures while Alloy still reported
+# healthy and log volume stayed high enough that nothing looked wrong.
+#
+# The count check matters as much as the grep: a THIRD Docker connection added
+# later would slip past a raw-socket search by being new rather than by being
+# wrong.
+
+set -eu
+CONFIG="${1:-deploy/alloy/config.alloy}"
+FAIL=0
+
+raw=$(grep -c 'unix:///var/run/docker.sock' "$CONFIG" || true)
+if [ "$raw" -ne 0 ]; then
+    echo "FAIL: $CONFIG still dials the raw socket ($raw reference(s))" >&2
+    grep -n 'unix:///var/run/docker.sock' "$CONFIG" >&2
+    echo "      Alloy has no raw socket mount; use http://docker-socket-proxy-ro:2375" >&2
+    FAIL=1
+fi
+
+hosts=$(grep -cE '^[[:space:]]*host[[:space:]]*=[[:space:]]*"(unix|http)' "$CONFIG" || true)
+proxied=$(grep -cE '^[[:space:]]*host[[:space:]]*=[[:space:]]*"http://docker-socket-proxy-ro:2375"' "$CONFIG" || true)
+if [ "$hosts" -ne "$proxied" ]; then
+    echo "FAIL: $CONFIG has $hosts Docker host(s) but only $proxied via the read-only proxy" >&2
+    grep -nE '^[[:space:]]*host[[:space:]]*=[[:space:]]*"(unix|http)' "$CONFIG" >&2
+    FAIL=1
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    echo "OK: alloy reaches Docker only via docker-socket-proxy-ro ($proxied connection(s))"
+fi
+exit "$FAIL"

--- a/scripts/audit-docker-access.sh
+++ b/scripts/audit-docker-access.sh
@@ -26,16 +26,15 @@ EXPECTED_NETWORK_MEMBERS="docker-socket-proxy klai-docker-authz portal-api runti
 # remove or connect anything. NETWORKS is required: Alloy's docker discovery
 # computes network labels per target and 403s without it. A member that needs to
 # mutate belongs on socket-proxy, behind klai-docker-authz.
-EXPECTED_RO_NETWORK_MEMBERS="docker-socket-proxy-ro"
+EXPECTED_RO_NETWORK_MEMBERS="alloy docker-socket-proxy-ro"
 
 # ── Raw socket ───────────────────────────────────────────────────────────────
-# The two proxies, plus alloy — which is NOT where it should be. Its `:ro` mount
-# protects the socket FILE, not the Docker API: a process that can write that
-# byte stream can still POST /containers/create. Moving it to the GET-only proxy
-# was attempted on 2026-08-14 and REVERTED because it stopped log collection.
-# REQ-U-002a stays open in SPEC-SEC-DOCKER-AUTHZ-001; this entry is a known gap
-# that is pinned so it cannot silently grow, not an endorsement.
-EXPECTED_SOCKET_MOUNTERS="alloy docker-socket-proxy docker-socket-proxy-ro"
+# Only the two proxies. Alloy used to be here: its `:ro` mount protected the
+# socket FILE and not the Docker API — a process that can write that byte stream
+# can still POST /containers/create. It now uses the GET-only proxy, so the
+# read-only intent is structural rather than a mount flag
+# (SPEC-SEC-DOCKER-AUTHZ-001 REQ-U-002a).
+EXPECTED_SOCKET_MOUNTERS="docker-socket-proxy docker-socket-proxy-ro"
 
 network_members() {
     uv run --quiet --with pyyaml python -c "


### PR DESCRIPTION
I reverted this in #971 and recorded that the proxy route "stopped log collection". That claim is false, and it is now sitting in a commit message, in `config.alloy`, in the audit script and in the SPEC. This re-applies the change and corrects the record.

## What actually happened

My VictoriaLogs queries had start timestamps in the **future** relative to server time, and I read the empty result as absence of data. A bounded `hits()` over the same window shows ingestion never dropped:

| 5-min bucket | entries |
|---|---|
| 14:00 | 236 290 |
| 14:05 | 74 565 |
| 14:10 | 110 382 |
| 14:15 | 70 401 |
| 14:20 | 111 706 |
| 14:25 | 219 669 |
| 14:30 | **93 725** ← the window I called an outage |
| 14:35 | 106 132 |

## The real bug, twice

`config.alloy` has **two independent Docker connections**. `discovery.docker` finds containers; `loki.source.docker` reads their logs. Moving only the first left the second dialling a socket the container no longer mounted — ~10k `error inspecting Docker container` failures, while Alloy still reported healthy and total volume stayed the same order of magnitude. Nothing looked broken from the outside. The read-only proxy also needed `NETWORKS`, because discovery computes network labels per target.

Both hosts now point at `docker-socket-proxy-ro`, where `POST` and `DELETE` are unset. Alloy's read-only intent becomes structural rather than a property of a `:ro` mount flag — which only ever protected the socket FILE, not the Docker API.

## Guard

`deploy/tests/test_alloy_docker_access.sh` asserts the count of Docker hosts equals the count going through the proxy, so a third connection added later cannot pass by being new rather than by being wrong. Verified by mutation — send only the tailer back to the socket and it fails.

Closes REQ-U-002a of SPEC-SEC-DOCKER-AUTHZ-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)