### PR TITLE
feat(crawler): afkoelpauze + circuit-breaker in sequentiële recovery (optie A)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -68,6 +68,26 @@ class Settings(BaseSettings):
         default=0.30,
         validation_alias=AliasChoices("KLAI_INGEST_FETCH_FAILURE_DIRTY_TRIP_RATE"),
     )
+    # Sequential bulk-5xx recovery (crawl4ai_client._recover_bulk_5xx_batch).
+    # Three independent bounds; see that function for why all three exist.
+    # Cooldown: crawl4ai reuses ONE browser instance for the duration of a
+    # crawl, so once an anti-bot challenge flags it, every following request
+    # in that session is blocked too — retrying sequentially without a pause
+    # changes nothing. Its pool closes an idle browser after ~53s (measured:
+    # "Closing cold browser (sig=..., idle=53s)"), and a fresh session passes
+    # again. 75s gives margin over that recycle window.
+    crawl_sequential_recovery_cooldown_seconds: float = Field(
+        default=75.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_COOLDOWN_SECONDS"),
+    )
+    crawl_sequential_recovery_max_consecutive_failures: int = Field(
+        default=3,
+        validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_MAX_CONSECUTIVE_FAILURES"),
+    )
+    crawl_sequential_recovery_max_seconds: float = Field(
+        default=1200.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_MAX_SECONDS"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -12,6 +12,7 @@ import copy
 import fnmatch
 import json
 import re
+import time
 from dataclasses import dataclass, field
 from html import unescape
 from html.parser import HTMLParser
@@ -1645,19 +1646,38 @@ async def _recover_bulk_5xx_batch(
     attempted = 0
     recovered = 0
     still_failing = 0
+    consecutive_failures = 0
+
+    cooldown = settings.crawl_sequential_recovery_cooldown_seconds
+    max_consecutive = settings.crawl_sequential_recovery_max_consecutive_failures
+    time_budget = settings.crawl_sequential_recovery_max_seconds
+    started_at = _recovery_monotonic()
+
+    logger.info(
+        "crawl_sequential_recovery_started",
+        urls=len(urls),
+        budget=recovery_budget,
+        cooldown_seconds=cooldown,
+        max_consecutive_failures=max_consecutive,
+        max_seconds=time_budget,
+    )
+
+    def _abandon_remaining(index: int) -> int:
+        """Mark every not-yet-attempted URL HTTP_5XX; return how many."""
+        for leftover_url in urls[index:]:
+            outcomes.append(
+                {
+                    "url": leftover_url,
+                    "reason_code": FetchReasonCode.HTTP_5XX.value,
+                    "status_code": None,
+                    "content_length": 0,
+                }
+            )
+        return len(urls) - index
 
     for i, url in enumerate(urls):
         if attempted >= recovery_budget:
-            remaining = len(urls) - i
-            for leftover_url in urls[i:]:
-                outcomes.append(
-                    {
-                        "url": leftover_url,
-                        "reason_code": FetchReasonCode.HTTP_5XX.value,
-                        "status_code": None,
-                        "content_length": 0,
-                    }
-                )
+            remaining = _abandon_remaining(i)
             still_failing += remaining
             logger.warning(
                 "crawl_bulk_5xx_recovery_capped",
@@ -1667,6 +1687,40 @@ async def _recover_bulk_5xx_batch(
                 remaining=remaining,
             )
             break
+
+        # Circuit breaker: the cooldown below buys a fresh browser session
+        # per attempt, so a run of failures despite it means the site is not
+        # recoverable — every further attempt would burn another cooldown for
+        # nothing.
+        if consecutive_failures >= max_consecutive:
+            remaining = _abandon_remaining(i)
+            still_failing += remaining
+            logger.warning(
+                "crawl_sequential_recovery_circuit_open",
+                consecutive_failures=consecutive_failures,
+                recovered=recovered,
+                still_failing=still_failing,
+                remaining=remaining,
+            )
+            break
+
+        elapsed = _recovery_monotonic() - started_at
+        if elapsed >= time_budget:
+            remaining = _abandon_remaining(i)
+            still_failing += remaining
+            logger.warning(
+                "crawl_sequential_recovery_time_budget_exhausted",
+                elapsed_seconds=round(elapsed, 1),
+                recovered=recovered,
+                still_failing=still_failing,
+                remaining=remaining,
+            )
+            break
+
+        # Before EVERY attempt, including the first: the bulk burst that just
+        # failed is exactly what left crawl4ai's browser flagged, so attempt
+        # one needs the recycle window as much as the rest.
+        await _recovery_sleep(cooldown)
 
         attempted += 1
         result = await _crawl_page_with_config(url, crawler_config, cookies=cookies, selector=None)
@@ -1691,8 +1745,10 @@ async def _recover_bulk_5xx_batch(
 
         if not result.success:
             still_failing += 1
+            consecutive_failures += 1
             continue
 
+        consecutive_failures = 0
         if _same_site_domain(urlparse(result.url).netloc.lower(), base_domain):
             link_source_results.append(result)
         if _result_is_ingestable(result, base_domain=base_domain) and not is_non_content_listing:
@@ -1921,6 +1977,12 @@ _BULK_CHUNK_SIZE = 100
 # once exhausted, remaining URLs are marked HTTP_5XX (not a guessed
 # BLOCKED_ANTI_BOT) without a network call (crawl_bulk_5xx_recovery_capped).
 _MAX_SEQUENTIAL_RECOVERY = 60
+
+# Indirection so tests can drive the recovery loop's pacing without ever
+# sleeping for real: a suite that honours the 75s production cooldown would
+# take hours. Patch these, not asyncio/time, so nothing else is affected.
+_recovery_sleep = asyncio.sleep
+_recovery_monotonic = time.monotonic
 
 # Server-side BFS deep crawl polling budget. /crawl/job is async — submit,
 # get task_id, poll status. Voys-support full-depth crawl (~500 pages

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -289,6 +289,24 @@ def _reset_shared_klai_fast_limiter():
     _llm_throttle_mod._shared_limiter = None
 
 
+@pytest.fixture(autouse=True)
+def _no_real_recovery_cooldown(monkeypatch):
+    """Never sleep the production cooldown in tests.
+
+    ``crawl4ai_client._recover_bulk_5xx_batch`` waits
+    ``crawl_sequential_recovery_cooldown_seconds`` (75s in production)
+    before every attempt so crawl4ai's browser pool can recycle. Honouring
+    that in the suite would turn a handful of recovery tests into hours.
+    Tests that assert ON the pacing patch this themselves with a recorder.
+    """
+    import knowledge_ingest.crawl4ai_client as _crawl_mod
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_crawl_mod, "_recovery_sleep", _instant)
+
+
 @pytest.fixture
 def client(mock_pool):
     """Test client with auth middleware.

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 
 from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import (
     CrawlResult,
     _build_candidate_set,
@@ -1338,3 +1339,144 @@ async def test_crawl_site_no_sequential_recovery_on_bulk_timeout(
     by_url = {o["url"]: o for o in outcomes}
     assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.TIMEOUT.value
     assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.TIMEOUT.value
+
+
+# ---------------------------------------------------------------------------
+# Sequential recovery pacing: cooldown, circuit breaker, wall-clock budget
+#
+# crawl4ai reuses ONE browser per crawl, so a flagged session stays flagged:
+# measured on intermedia.com 2026-08-14, the 1st standalone fetch succeeded
+# and the 2nd and 3rd both 500'd. Its pool drops an idle browser after ~53s,
+# after which a fresh session passes again. The recovery therefore waits
+# before every attempt, and bounds that waiting three ways.
+# ---------------------------------------------------------------------------
+
+
+def _blocked_result() -> CrawlResult:
+    return CrawlResult(
+        url="",
+        fit_markdown="",
+        raw_markdown="",
+        html="",
+        word_count=0,
+        success=False,
+        status_code=500,
+        error_message="boom",
+    )
+
+
+def _ok_result(url: str) -> CrawlResult:
+    body = "Real page content with plenty of genuine words in it, enough to ingest."
+    return CrawlResult(
+        url=url,
+        fit_markdown=body,
+        raw_markdown=body,
+        html=f"<html><body><p>{body}</p></body></html>",
+        word_count=len(body.split()),
+        success=True,
+        status_code=200,
+    )
+
+
+async def _recover(monkeypatch, urls, outcomes_by_url, *, budget=60):
+    """Drive _recover_bulk_5xx_batch with scripted per-URL results."""
+    slept: list[float] = []
+
+    async def _record_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    async def _fake_fetch(url, _config, *, cookies=None, selector=None, **_kw):
+        return outcomes_by_url[url]
+
+    monkeypatch.setattr(crawl4ai_client, "_recovery_sleep", _record_sleep)
+    monkeypatch.setattr(crawl4ai_client, "_crawl_page_with_config", _fake_fetch)
+
+    result = await crawl4ai_client._recover_bulk_5xx_batch(
+        urls,
+        crawler_config={},
+        cookies=None,
+        base_domain="example.com",
+        recovery_budget=budget,
+    )
+    return result, slept
+
+
+@pytest.mark.asyncio
+async def test_recovery_cools_down_before_every_attempt_including_the_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bulk burst that just failed is what flagged the browser, so the
+    first attempt needs the recycle window as much as the rest."""
+    urls = [f"https://example.com/p{i}" for i in range(3)]
+    scripted = {u: _ok_result(u) for u in urls}
+
+    (_results, _links, outcomes, attempted), slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 3
+    assert len(slept) == 3, "one cooldown per attempt, first one included"
+    assert all(s == settings.crawl_sequential_recovery_cooldown_seconds for s in slept)
+    assert all(o["reason_code"] == FetchReasonCode.SUCCESS.value for o in outcomes)
+
+
+@pytest.mark.asyncio
+async def test_recovery_circuit_opens_after_consecutive_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run of failures despite the cooldown means the site is not
+    recoverable — stop instead of burning a cooldown per remaining URL."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 3)
+    urls = [f"https://example.com/p{i}" for i in range(10)]
+    scripted = {u: _blocked_result() for u in urls}
+
+    (_results, _links, outcomes, attempted), slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 3, "stopped after the 3rd consecutive failure"
+    assert len(slept) == 3, "no cooldown burned on the abandoned URLs"
+    assert len(outcomes) == len(urls), "every URL still gets an honest outcome"
+    assert all(o["reason_code"] == FetchReasonCode.HTTP_5XX.value for o in outcomes)
+
+
+@pytest.mark.asyncio
+async def test_recovery_success_resets_the_consecutive_failure_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fail, fail, success, fail, fail must NOT trip a breaker set at 3 —
+    the intermittent-challenge case this recovery exists for."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 3)
+    urls = [f"https://example.com/p{i}" for i in range(5)]
+    scripted = {
+        urls[0]: _blocked_result(),
+        urls[1]: _blocked_result(),
+        urls[2]: _ok_result(urls[2]),
+        urls[3]: _blocked_result(),
+        urls[4]: _blocked_result(),
+    }
+
+    (results, _links, outcomes, attempted), _slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 5, "breaker must not fire; the run was never 3 in a row"
+    assert [r.url for r in results] == [urls[2]]
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url[urls[2]] == FetchReasonCode.SUCCESS.value
+
+
+@pytest.mark.asyncio
+async def test_recovery_stops_when_wall_clock_budget_is_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One crawl job must not hold a worker slot indefinitely: 60 attempts
+    x 75s would be 75 minutes without this bound."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_seconds", 100.0)
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 99)
+
+    ticks = iter([0.0, 40.0, 80.0, 120.0, 160.0, 200.0])
+    monkeypatch.setattr(crawl4ai_client, "_recovery_monotonic", lambda: next(ticks))
+
+    urls = [f"https://example.com/p{i}" for i in range(5)]
+    scripted = {u: _ok_result(u) for u in urls}
+
+    (_results, _links, outcomes, attempted), _slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 2, "stopped once the elapsed clock passed the budget"
+    assert len(outcomes) == len(urls)
+    assert outcomes[-1]["reason_code"] == FetchReasonCode.HTTP_5XX.value


### PR DESCRIPTION
## Waarom

De bulk-5xx recovery vuurde correct op intermedia.com maar leverde 0 pagina's op: 17 pogingen tussen 14:55 en 15:03, allemaal geblokkeerd — terwijl dezelfde URL 45 seconden later wél slaagde.

Gemeten oorzaak: **crawl4ai hergebruikt één browser per crawl.** Zodra Cloudflare die sessie challenge't, is elke volgende request in diezelfde sessie ook geblokkeerd; sequentieel opnieuw proberen verandert daar niets aan. Drie losse fetches achter elkaar toonden de vorm: 1e slaagt, 2e en 3e falen. crawl4ai's pool sluit een idle browser na ~53s (`Closing cold browser (sig=..., idle=53s)`), waarna een verse sessie weer passeert.

## Wat er nu gebeurt

De recovery wacht `crawl_sequential_recovery_cooldown_seconds` (75s, env-tunable) vóór **elke** poging — ook de eerste, want juist de zojuist mislukte burst heeft de browser gemarkeerd.

Dat wachten is drievoudig begrensd, zodat een site die simpelweg plat ligt geen worker-slot een uur bezet houdt:

| Grens | Waarde | Waarom |
|---|---|---|
| Pogingen | 60 (bestaand) | ongewijzigd |
| Opeenvolgende mislukkingen | 3 | falen ondanks een verse sessie = niet herstelbaar; stoppen in plaats van per URL een cooldown verbranden. Een succes reset de teller — precies het intermitterende geval waarvoor deze recovery bestaat |
| Wall-clock | 20 min | 60 x 75s zou anders 75 minuten zijn |

Welke grens ook afgaat: resterende URLs krijgen een eerlijke `HTTP_5XX`-uitkomst en de reden wordt gelogd (`crawl_sequential_recovery_circuit_open`, `crawl_sequential_recovery_time_budget_exhausted`, `crawl_bulk_5xx_recovery_capped`). Geen stilzwijgende truncatie.

## Kosten

Een herstelronde van 17 pagina's duurt nu ongeveer 20 minuten in plaats van 9. Bewust geaccepteerd: dat is de enige manier om deze pagina's binnen te halen. Gezonde sites raken dit pad nooit — het vuurt alleen na een bulk-5xx.

## Verificatie

- **1264 passed**, 4 skipped; suite draait in 30s (een autouse-fixture maakt de cooldown een no-op, de vier nieuwe tests sturen de pacing met recorders — er slaapt niets echt)
- ruff check + format clean

Na merge draai ik opnieuw een echte Intermedia-crawl en rapporteer ik hoeveel pagina's er nu binnenkomen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
