### PR TITLE
fix(feedback): one thumb is not yet a signal + a correlation alert that admits its scope

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -390,7 +390,7 @@ services:
   librechat-getklai:
     # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 3 — the canary runs the Klai-owned
     # image, built in CI from the source diffs in deploy/librechat/patches-source/.
-    # Tag for humans: v0.8.7-klai.1-4d371b07a381 (upstream v0.8.7, agents v3.2.46).
+    # Tag for humans: v0.8.7-klai.1-7baaddde216b (upstream v0.8.7, agents v3.2.46).
     #
     # Pinned by DIGEST, and deploy/check-klai-librechat-digest.sh enforces that:
     # on 2026-08-14 the tag v0.8.7-klai.1 was pushed twice with different
@@ -398,7 +398,7 @@ services:
     #
     # Rollback: put ghcr.io/danny-avila/librechat:v0.8.7 back here and restore
     # the four patch bind-mounts removed below (git revert this commit).
-    image: ghcr.io/getklai/librechat@sha256:731263c1ae6a2496f2ccdb5b02810aa76b5e8ecb54a47e6b81bf97f939f824dc
+    image: ghcr.io/getklai/librechat@sha256:1b8fa0a19a2c7fae85b99e56b8e9a8b44fffd069e87a30705e4b23412f8485cb
     container_name: librechat-getklai
     restart: unless-stopped
     # Force light theme via the Klai entrypoint wrapper (LibreChat has no
@@ -722,7 +722,7 @@ services:
       DOCKER_HOST: tcp://klai-docker-authz:2375   # SPEC-SEC-DOCKER-AUTHZ-001
       # SPEC-LIBRECHAT-PATCH-MODEL-001 Phase 5 — the fleet default is the
       # Klai-owned image, built in CI from deploy/librechat/patches-source/.
-      # Tag for humans: v0.8.7-klai.1-4d371b07a381 (upstream v0.8.7, agents v3.2.46).
+      # Tag for humans: v0.8.7-klai.1-7baaddde216b (upstream v0.8.7, agents v3.2.46).
       #
       # Digest-pinned; deploy/check-klai-librechat-digest.sh enforces it. The
       # default in config.py deliberately stays on upstream, so a deploy that
@@ -732,7 +732,7 @@ services:
       # Rollback: delete this line, then recreate tenants (they return to the
       # config.py default). LIBRECHAT_IMAGE_OVERRIDES can pin individual
       # tenants either way during a staged move.
-      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:731263c1ae6a2496f2ccdb5b02810aa76b5e8ecb54a47e6b81bf97f939f824dc
+      LIBRECHAT_IMAGE: ghcr.io/getklai/librechat@sha256:1b8fa0a19a2c7fae85b99e56b8e9a8b44fffd069e87a30705e4b23412f8485cb
       # SPEC-SEC-HYGIENE-001 REQ-28.4: explicit deployment-environment marker.
       # Pydantic Settings reads PORTAL_ENV; the in-code default is "production"
       # (REQ-28.2). The validator at config.py:_no_debug_in_production refuses

--- a/deploy/grafana/provisioning/alerting/feedback-loop-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/feedback-loop-rules.yaml
@@ -1,0 +1,129 @@
+# SPEC-KB-015 — feedback-loop runtime health.
+#
+#   spec-kb-015-feedback-correlation-low   WARNING
+#
+# What this catches, and what it does NOT
+# ---------------------------------------
+#
+# CATCHES: feedback keeps arriving but stops correlating. That is the silent
+# degradation mode of the loop — the endpoint returns 200, the event lands in
+# portal_feedback_events with correlated=false, and Qdrant never learns
+# anything. Causes: Redis unreachable (retrieval log missing), the identity
+# used for the Redis key drifting from the one used at retrieval time, or a
+# clock skew wider than the SPEC's [-60s, +10s] window.
+#
+# DOES NOT CATCH: feedback not arriving at all. Between 2026-04-05 and
+# 2026-08-14 production recorded ZERO feedback events (verified in both
+# product_events and portal_feedback_events) because the LibreChat bundle
+# shipped without the kb-feedback forward. A ratio has no denominator then, so
+# no ratio alert can see it. That class is guarded at BUILD time instead, by
+# deploy/librechat/tests/built_artifacts.test.cjs, which asserts the forward is
+# actually present in the compiled bundle. Do not extend this rule to try to
+# cover it: real feedback volume is single digits per month, so a "zero events"
+# liveness alert cannot distinguish a broken forward from a quiet week.
+#
+# Volume gate
+# -----------
+# The HAVING clause is the noise control. With fewer than 5 non-e2e events in
+# the window the query returns no rows at all -> noData -> OK. A 1-of-2
+# uncorrelated day cannot page anyone; only a sustained pattern can.
+#
+# The e2e tenant is excluded by slug. It drives feedback at the endpoint
+# without ever writing a retrieval log first, so 100% of its events are
+# uncorrelated by construction (70 of them on 2026-08-14 alone). Including it
+# would keep this rule permanently firing on synthetic traffic.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: kb-015-feedback-loop
+    folder: Klai
+    interval: 10m
+    rules:
+
+      - uid: spec-kb-015-feedback-correlation-low
+        title: kb_feedback_correlation_low
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: portal-postgres
+            queryType: ''
+            relativeTimeRange:
+              from: 2592000
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                SELECT count(*) FILTER (WHERE pe.correlated) * 100.0
+                         / NULLIF(count(*), 0) AS value
+                  FROM portal_feedback_events pe
+                  JOIN portal_orgs o ON o.id = pe.org_id
+                 WHERE pe.occurred_at > now() - interval '30 days'
+                   AND o.slug <> 'e2e'
+                HAVING count(*) >= 5
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 2592000
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 2592000
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [50], type: lt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 1d
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-KB-015
+          domain: knowledge
+        annotations:
+          summary: 'KB feedback is arriving but under half of it correlates'
+          description: |
+            Over the last 30 days at least 5 real (non-e2e) feedback events
+            were recorded and fewer than half carried a correlated retrieval
+            log. Uncorrelated feedback is stored but teaches Qdrant nothing:
+            no quality_score, no feedback_count, no effect on ranking.
+
+            Baseline for comparison: 2026-04-05 ran at 75% (3 of 4).
+
+            First checks, in order:
+              1. Is Redis reachable from portal-api? The retrieval log lives in
+                 rl:{org_id}:{user_id} sorted sets with a 1-hour TTL, and a
+                 missing log is indistinguishable from a missing thumb here.
+              2. Does the identity on the feedback call match the one used when
+                 the retrieval log was written? These diverged before — the
+                 forward now sends identity_user_id (the Zitadel subject)
+                 alongside the LibreChat Mongo id precisely for this reason.
+              3. Is the feedback timestamp the message's own createdAt, or the
+                 moment of the click? A click-time stamp falls outside the
+                 SPEC's [-60s, +10s] window as soon as someone rates an older
+                 message.
+
+            Inspect the split directly:
+              SELECT org_id, correlated, count(*)
+                FROM portal_feedback_events
+               WHERE occurred_at > now() - interval '30 days'
+               GROUP BY 1, 2 ORDER BY 1, 2;

--- a/deploy/grafana/provisioning/alerting/policies.yaml
+++ b/deploy/grafana/provisioning/alerting/policies.yaml
@@ -7,6 +7,8 @@
 #   - spec=SPEC-OBS-001 + alert_type=heartbeat   → heartbeat-kuma (OBS-001-R22)
 #   - spec=SPEC-OBS-001                          → klai-ops-alerts-email (OBS-001-R4/R5)
 #   - spec=SPEC-INFRA-CONTAINER-HYGIENE-001      → klai-ops-alerts-email (REQ-5 orphan-audit)
+#   - spec=SPEC-INGEST-LOGIN-WALL-DETECT-001     → klai-ops-alerts-email (REQ-08 login-wall)
+#   - spec=SPEC-KB-015                           → klai-ops-alerts-email (feedback-loop health)
 #
 # Grouping + repeat_interval tuning per route:
 #   - SEC/INFRA: repeat 24h — suppress email-floods from a wedged call-path
@@ -102,4 +104,19 @@ policies:
         group_wait: 30s
         group_interval: 5m
         repeat_interval: 4h
+        continue: false
+
+      # SPEC-KB-015 — feedback-loop health. The rule evaluates a 30-day
+      # window behind a >=5-event volume gate, so it cannot burst: at most one
+      # firing state per day is meaningful. A 24h repeat matches that cadence
+      # and keeps a genuine degradation visible without re-mailing hourly
+      # about a window that barely moves between evaluations.
+      - receiver: klai-ops-alerts-email
+        matchers:
+          - spec = SPEC-KB-015
+        group_by:
+          - alertname
+        group_wait: 30s
+        group_interval: 10m
+        repeat_interval: 24h
         continue: false

--- a/klai-retrieval-api/retrieval_api/quality_floor.py
+++ b/klai-retrieval-api/retrieval_api/quality_floor.py
@@ -46,6 +46,13 @@ from __future__ import annotations
 # filtered just because their payload predates the field.
 _DEFAULT_QUALITY = 0.5
 
+# SPEC-KB-015 REQ (r.112/118/182): the feedback loop does not treat a score as
+# a signal until three votes have landed — "the cold start guard prevents a
+# single data point from affecting ranking". Mirrors _COLD_START_MIN_VOTES in
+# quality_boost.py; the two MUST stay equal or boost and floor disagree about
+# what counts as a signal.
+_COLD_START_MIN_VOTES = 3
+
 
 def filter_quality_floor(
     chunks: list[dict],
@@ -71,6 +78,20 @@ def filter_quality_floor(
         qs = c.get("quality_score", _DEFAULT_QUALITY)
         if not isinstance(qs, (int, float)):
             # Corrupt payload — treat as default rather than crash.
+            qs = _DEFAULT_QUALITY
+        fc = c.get("feedback_count", 0)
+        if not isinstance(fc, (int, float)):
+            # Corrupt count must not become an accidental exemption.
+            fc = 0
+        if 0 < fc < _COLD_START_MIN_VOTES:
+            # One or two votes are not yet a signal (SPEC-KB-015). Judge the
+            # chunk on the value it had before that feedback landed, so a
+            # cold-start chunk behaves exactly like an unvoted one. Without
+            # this, a single thumbsDown drives the running average to exactly
+            # 0.0 and drops the chunk from results entirely — a far stronger
+            # effect than the +-10% adjustment KB-015 gates behind three votes.
+            # feedback_count == 0 is untouched: that is the auth-wall degrade
+            # marker this filter exists for (LOGIN-WALL-DETECT-001 REQ-07).
             qs = _DEFAULT_QUALITY
         if qs < floor:
             n_filtered += 1

--- a/klai-retrieval-api/tests/test_quality_floor.py
+++ b/klai-retrieval-api/tests/test_quality_floor.py
@@ -104,6 +104,65 @@ class TestFilterQualityFloor:
         assert n_filtered == 0
 
 
+class TestFeedbackColdStartExemption:
+    """SPEC-KB-015 REQ r.182: a single data point must not affect ranking.
+
+    The scorer's running average ``(old * count + signal) / (count + 1)``
+    yields exactly ``0.0`` on the first thumbsDown (r.94-96). Without an
+    exemption the floor would then drop the chunk entirely — a far stronger
+    effect than the +-10%% boost that KB-015 deliberately gates behind
+    ``feedback_count >= 3``.
+
+    ``feedback_count == 0`` is untouched: that is the auth-wall ``degrade``
+    case this filter exists for (SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07).
+    """
+
+    def test_single_thumbs_down_is_not_filtered(self) -> None:
+        chunks = [{"chunk_id": "one-vote", "quality_score": 0.0, "feedback_count": 1}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.05)
+        assert n_filtered == 0
+        assert [c["chunk_id"] for c in out] == ["one-vote"]
+
+    def test_two_votes_still_below_cold_start_is_not_filtered(self) -> None:
+        chunks = [{"chunk_id": "two-votes", "quality_score": 0.0, "feedback_count": 2}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.05)
+        assert n_filtered == 0
+        assert [c["chunk_id"] for c in out] == ["two-votes"]
+
+    def test_established_negative_signal_is_filtered(self) -> None:
+        chunks = [{"chunk_id": "three-votes", "quality_score": 0.0, "feedback_count": 3}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.05)
+        assert n_filtered == 1
+        assert out == []
+
+    def test_auth_wall_degrade_chunk_still_filtered(self) -> None:
+        """feedback_count 0 = never voted on = the REQ-07 case. Unchanged."""
+        chunks = [{"chunk_id": "walled", "quality_score": 0.0, "feedback_count": 0}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.05)
+        assert n_filtered == 1
+        assert out == []
+
+    @pytest.mark.parametrize("invalid", ["1", None, [], {}])
+    def test_non_numeric_feedback_count_treated_as_zero(self, invalid: object) -> None:
+        """A corrupt count must not become an accidental exemption."""
+        chunks = [{"chunk_id": "corrupt", "quality_score": 0.0, "feedback_count": invalid}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.05)
+        assert n_filtered == 1
+        assert out == []
+
+    def test_exemption_does_not_rescue_a_high_floor_deployment(self) -> None:
+        """The exemption is scoped to cold-start feedback, not to floors at large.
+
+        An operator-raised floor (e.g. 0.6 to surface only boosted chunks) is a
+        recall decision, not a feedback signal — cold-start chunks sit below it
+        legitimately.
+        """
+        chunks = [{"chunk_id": "mid", "quality_score": 0.5, "feedback_count": 1}]
+        out, n_filtered = filter_quality_floor(chunks, floor=0.6)
+        assert n_filtered == 1
+        assert out == []
+
+
 class TestFloorPerformance:
     def test_p99_under_2ms_on_1k_chunks(self) -> None:
         """Floor filter is on the hot path; budget is < 2ms p99 on 1000


### PR DESCRIPTION
Follow-up on the critical review, triaged against the architecture documentation first. Most of the review turned out to describe deliberate design rather than defects.

## What the SPEC actually says

`SPEC-KB-015/spec.md` settles four of the six findings:

| Finding | Verdict |
|---|---|
| Scorer yields 0.0 on the first thumbsDown | **By design** — r.94-96 prescribes that formula literally. The proposed prior would have violated it. The 0.5 is the *ingest* value (r.99), not a prior in the average. |
| Correlation falls back to "closest overall" | **Not a deviation** — the candidate set is already bounded by `zrangebyscore(window)`, and the +10s tolerance in r.71 exists for exactly this. |
| Idempotency key omits the rating | **By design** — r.80 specifies `(message_id, conversation_id)`, 1 hour. |
| Retrieval log TTL is 1 hour | **By design** — r.46 + rationale r.155. |

That leaves two things worth building.

## 1. The floor ignored the cold-start guard

Two SPECs each documented an assumption, and the assumptions were incompatible:

- KB-015 r.182: *"The cold start guard (feedback_count >= 3) prevents a single data point from affecting ranking."*
- `quality_floor.py` assumes a 0.0 score can only come from the auth-wall `degrade` path, and deliberately bypasses the cold-start guard — correct for those chunks, which carry `feedback_count == 0`.

The scorer also produces exactly 0.0 on the first thumbsDown. So one thumb down did not adjust a chunk by ~10%; it dropped the chunk from results entirely — the precise outcome KB-015 gates against, reached by a path KB-015 did not know about.

A cold-start chunk is now judged at the ingest default it held before that feedback landed, so it behaves exactly like an unvoted one. `feedback_count == 0` still filters (REQ-07 untouched); `>= 3` still filters; a raised operator floor still applies, because that is a recall decision rather than a feedback signal.

No production damage: 20 chunks currently carry feedback, 0 sit below the floor.

## 2. An alert, with its limits stated

It catches feedback arriving but no longer correlating. It does **not** catch the April-to-August gap, because production recorded zero feedback events in that period — a ratio has no denominator. Verified in both `product_events` and `portal_feedback_events`; org 1 ran at 75% correlation on 2026-04-05, then nothing until today. That class is guarded at build time by `built_artifacts.test.cjs`.

`HAVING count(*) >= 5` is the noise control — real non-e2e volume is single digits per month, so a quiet week cannot page anyone. The e2e tenant is excluded by slug: it hits the endpoint without writing a retrieval log first, so 100% of its events are uncorrelated by construction (70 on 2026-08-14 alone). Routing for `spec=SPEC-KB-015` is included; without it the rule would have fired into Grafana's default receiver.

## Verification

- Red phase proven: the two behaviour tests fail against the pre-fix source; the four regression tests were already green.
- `585 passed, 1 skipped` in klai-retrieval-api; ruff check + format clean.
- Alert SQL dry-run against production returns 0 rows today (3 non-e2e events, under the gate) — silent, as intended.
- UID guard: `spec-kb-015-feedback-correlation-low`, 36 chars.

## Deliberately not done

Lost-update race on `quality_score` (read-modify-write in Qdrant) is real but unspecified and theoretical at this volume. Separately: the e2e suite exercises the feedback endpoint without a preceding retrieval log, so it never covers the correlation path — worth closing, but it is test coverage, not a defect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)