### PR TITLE
fix(obs): the feedback alert could not read its own data

### DIFF
--- a/deploy/grafana/provisioning/alerting/feedback-loop-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/feedback-loop-rules.yaml
@@ -28,6 +28,15 @@
 # the window the query returns no rows at all -> noData -> OK. A 1-of-2
 # uncorrelated day cannot page anyone; only a sustained pattern can.
 #
+# Reading the data at all needs plumbing
+# ----------------------------------------
+# The rule reads portal_feedback_correlation_stats, a view, NOT the base table.
+# portal_feedback_events is category-C RLS with a SELECT policy scoped to role
+# portal_api, so grafana_reader has no applicable policy and reads zero rows
+# even when granted -- and the base table holds feedback_text, user free text
+# that a dashboard role should never reach. See deploy/grafana/sql/
+# grafana-reader-setup.sql; the view must exist before this rule can evaluate.
+#
 # The e2e tenant is excluded by slug. It drives feedback at the endpoint
 # without ever writing a retrieval log first, so 100% of its events are
 # uncorrelated by construction (70 of them on 2026-08-14 alone). Including it
@@ -61,7 +70,7 @@ groups:
               rawSql: |
                 SELECT count(*) FILTER (WHERE pe.correlated) * 100.0
                          / NULLIF(count(*), 0) AS value
-                  FROM portal_feedback_events pe
+                  FROM portal_feedback_correlation_stats pe
                   JOIN portal_orgs o ON o.id = pe.org_id
                  WHERE pe.occurred_at > now() - interval '30 days'
                    AND o.slug <> 'e2e'
@@ -91,7 +100,12 @@ groups:
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
-        execErrState: OK
+        # Error, not OK. The first cut of this rule queried portal_feedback_events
+        # directly and would have thrown "permission denied" on every evaluation
+        # -- with execErrState OK that is indistinguishable from a healthy loop.
+        # A rule whose whole purpose is catching silence must not be able to fail
+        # silently itself.
+        execErrState: Error
         for: 0s
         keepFiringFor: 1d
         isPaused: false

--- a/deploy/grafana/sql/grafana-reader-setup.sql
+++ b/deploy/grafana/sql/grafana-reader-setup.sql
@@ -15,3 +15,38 @@ GRANT CONNECT ON DATABASE portal TO grafana_reader;
 GRANT USAGE ON SCHEMA public TO grafana_reader;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_reader;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_reader;
+
+-- NOTE: the ALTER DEFAULT PRIVILEGES above only covers tables created by the
+-- role that ran it. Alembic creates tables as portal_api, so anything added
+-- after the last run of this script is NOT readable by grafana_reader. Check
+-- with the query at the bottom of this file before wiring a new alert.
+
+-- ── SPEC-KB-015 — feedback-loop observability ────────────────────────────
+--
+-- Two separate reasons a plain grant is not enough here:
+--
+--   1. portal_feedback_events is a category-C RLS table and its SELECT policy
+--      is scoped to role portal_api. grafana_reader therefore has NO
+--      applicable policy, and a table with RLS enabled and no matching policy
+--      returns zero rows -- silently, with a grant in place.
+--   2. The table stores feedback_text, user-written free text that has no
+--      business being reachable from a dashboard role.
+--
+-- The view solves both. It exposes only the three columns the correlation
+-- alert needs, and because it is created by the superuser and is NOT
+-- security_invoker, Postgres evaluates the base table's RLS as the view owner.
+-- No base-table grant is widened.
+CREATE OR REPLACE VIEW portal_feedback_correlation_stats AS
+    SELECT org_id, correlated, occurred_at
+      FROM portal_feedback_events;
+
+GRANT SELECT ON portal_feedback_correlation_stats TO grafana_reader;
+
+-- Verify after running (must return a non-zero count, not an error and not 0):
+--   SET ROLE grafana_reader;
+--   SELECT count(*) FROM portal_feedback_correlation_stats;
+--
+-- Audit which granted tables still read as empty for this role -- an RLS
+-- policy scoped to another role looks identical to "no data" from Grafana:
+--   SELECT table_name FROM information_schema.role_table_grants
+--    WHERE grantee = 'grafana_reader' AND privilege_type = 'SELECT';


### PR DESCRIPTION
Follow-up on #978, found while verifying it end-to-end on production rather than assuming CI-green meant working.

## The defect

The rule queried `portal_feedback_events` directly. Checked against production:

```
SELECT ... FROM portal_feedback_events;
ERROR:  permission denied for table portal_feedback_events
```

`grafana_reader` has no SELECT grant on it. And a grant alone would not have helped — the category-C SELECT policy is scoped to role `portal_api`, so no policy applies to `grafana_reader` and RLS default-denies. Combined with `execErrState: OK` (copied from the neighbouring privacy rule), every evaluation would have failed indistinguishably from a healthy feedback loop.

An alert built to catch silence was itself silent. That is worse than not shipping one.

## Fix

- **A view**, `portal_feedback_correlation_stats`, exposing only `org_id`, `correlated`, `occurred_at`. Created by the superuser and not `security_invoker`, so the base table's RLS is evaluated as the view owner. This deliberately does not widen the base-table grant: `portal_feedback_events` also holds `feedback_text`, user-written free text that a dashboard role should never reach.
- **`execErrState: Error`**, so the next plumbing break pages rather than hides.
- **The setup script explains the trap**: `ALTER DEFAULT PRIVILEGES` only covers tables created by the role that ran it, and alembic creates tables as `portal_api` — so anything added after the last run of that script is invisible to `grafana_reader`. It now also carries the audit query, because a granted table that reads empty because of a role-scoped policy looks exactly like "no data" from Grafana.

## Verified as grafana_reader on production

| Check | Result |
|---|---|
| `SELECT count(*) FROM portal_feedback_correlation_stats` | 79 |
| Full alert query | 0 rows — only 3 non-e2e events inside the 30-day window, under the `>= 5` gate |

Silent for the right reason now, and provably so from the role that actually runs it.

The view was applied to production before this merge, since the rule cannot evaluate without it. It is recorded in `deploy/grafana/sql/grafana-reader-setup.sql` so a rebuild reproduces it.

## Separate pre-existing finding, not touched here

The same audit shows `spec-priv-001-tenant-stuck-full` (SPEC-PRIVACY-QUERY-SHADOW-001) has the identical defect: `portal_audit_log` returns 0 rows for `grafana_reader` because its `tenant_isolation_read` policy is org-scoped and no tenant context is set, so the rule's `id IN (SELECT org_id FROM portal_audit_log ...)` subquery is always empty and the alert can never fire. Different SPEC — flagged rather than silently rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)