### PR TITLE
chore(hygiene): teach the orphan guards about Vexa's per-meeting containers

### DIFF
--- a/.claude/hooks/klai/container-hygiene-preflight.sh
+++ b/.claude/hooks/klai/container-hygiene-preflight.sh
@@ -134,12 +134,20 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
     exit 0
 fi
 
-# Locate klai-infra checkout once; reuse across targets
+# Locate klai-infra checkout once; reuse across targets.
+#
+# CLAUDE_PROJECT_DIR is set by Claude Code but not by anything else that might
+# run this script. Under `set -u` an unset variable aborted here — BEFORE the
+# blocking checks below — so the guard degraded to an error message and stopped
+# guarding. Derive the fallback from the script's own location: this lookup only
+# feeds the best-effort Check 3 and must never be able to take down Check 2.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+
 KLAI_INFRA=""
 for candidate in \
-    "$CLAUDE_PROJECT_DIR/../klai-infra" \
-    "$CLAUDE_PROJECT_DIR/../../klai-infra" \
-    "$CLAUDE_PROJECT_DIR/klai-infra" \
+    "$PROJECT_DIR/../klai-infra" \
+    "$PROJECT_DIR/../../klai-infra" \
+    "$PROJECT_DIR/klai-infra" \
     "/opt/klai-infra"; do
     if [[ -d "$candidate/.git" ]]; then
         KLAI_INFRA="$candidate"
@@ -152,6 +160,15 @@ for TARGET in "${TARGETS[@]}"; do
     # Check 2: tenant-naam / klasse-B prefix pattern
     if [[ "$TARGET" =~ -voys$|-getklai$|-[a-z]+-tenant$ ]] || [[ "$TARGET" =~ ^librechat- ]]; then
         emit_block "$TARGET matches a tenant-managed naming pattern ($OPERATION). If this is a portal-api-provisioning-managed tenant container (klasse B, see SPEC REQ-2), use the deprovision flow instead: portal-api orchestrator.deprovision_tenant() — never delete directly via 'docker rm'. If this is a different match, verify customer impact and override with explicit user approval."
+    fi
+
+    # Check 2b: klasse-C — per-meeting Vexa bot workload.
+    # vexa12-runtime names these vexa-mtg-<id>. A RUNNING one is an in-progress
+    # meeting recording, so removing it destroys a transcript that has no other
+    # source. Once exited they are harmless and the daily docker-cleanup.timer
+    # reaps them (until=24h) — there is never a reason to remove one by hand.
+    if [[ "$TARGET" =~ ^vexa-mtg- ]]; then
+        emit_block "$TARGET is a Vexa per-meeting bot workload (klasse C, see infra/container-hygiene.md). If it is running, removing it destroys an in-progress meeting recording that has no other source. If it has exited, leave it — the daily docker-cleanup.timer prunes exited containers older than 24h. Override only with explicit user approval."
     fi
 
     # Check 3: compose git-history (best-effort)

--- a/.claude/hooks/klai/tests/container-hygiene-preflight.test.sh
+++ b/.claude/hooks/klai/tests/container-hygiene-preflight.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1 — the preflight hook must actually block.
+#
+# The hook is the enforcement layer for the librechat-voys class: a markdown rule
+# is a gap that reopens with every context truncation, so the block is the only
+# thing that survives all failure modes. It had no tests, and that cost a real
+# defect: `CLAUDE_PROJECT_DIR` was dereferenced under `set -u` BEFORE the blocking
+# checks, so anything running the hook without that variable got an error message
+# instead of a guard. It failed open, quietly, with exit 1 rather than 2.
+#
+# So this suite runs every case twice — with the variable and without it. A guard
+# that only guards under one environment is the bug, not the fix.
+
+set -uo pipefail
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/container-hygiene-preflight.sh"
+FAIL=0
+
+run() {
+    printf '%s' "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$1\"}}" \
+        | bash "$HOOK" >/dev/null 2>&1
+    echo $?
+}
+
+expect() {
+    want="$1"; cmd="$2"; why="$3"
+    case "$want" in block) code=2 ;; allow) code=0 ;; esac
+    got=$(run "$cmd")
+    if [ "$got" = "$code" ]; then
+        echo "OK:   $want  $cmd"
+    else
+        echo "FAIL: expected $want (exit $code), got exit $got — $cmd ($why)" >&2
+        FAIL=1
+    fi
+}
+
+cases() {
+    # Klasse C — a running one is an in-progress recording with no other source.
+    expect block "docker rm vexa-mtg-5-9a935aa1"     "klasse-C bot workload"
+    expect block "docker rm -f vexa-mtg-3-37b44f92"  "klasse-C, flag before target"
+    # Klasse B — the original incident.
+    expect block "docker rm librechat-voys"          "klasse-B tenant container"
+    # Global prunes that have no safe one-shot use.
+    expect block "docker volume prune"               "customer data"
+    # Reversible and read-only operations must stay out of the way.
+    expect allow "docker ps --filter name=vexa-mtg"  "read-only"
+    expect allow "docker logs vexa-mtg-5-9a935aa1"   "read-only"
+    expect allow "docker stop vexa-mtg-5-9a935aa1"   "reversible"
+    # Check 2 is an open policy by design: an unrecognised name is not blocked.
+    expect allow "docker rm some-scratch-box"        "no pattern match"
+}
+
+echo "── container-hygiene preflight, WITHOUT CLAUDE_PROJECT_DIR ──"
+unset CLAUDE_PROJECT_DIR
+cases
+
+echo "── container-hygiene preflight, WITH CLAUDE_PROJECT_DIR ──"
+export CLAUDE_PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cases
+
+echo "─────────────────────────────────────────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+    echo "container-hygiene preflight guard: OK"
+else
+    echo "container-hygiene preflight guard: FAILED" >&2
+fi
+exit "$FAIL"

--- a/.claude/rules/klai/infra/container-hygiene.md
+++ b/.claude/rules/klai/infra/container-hygiene.md
@@ -56,6 +56,25 @@ tooling MUST recognise both:
   (`provisioning/orchestrator.py::deprovision_tenant`), NEVER via
   direct `docker rm`
 
+### Klasse C — upstream-managed ephemeral workloads
+
+- Created by `vexa12-runtime` — one container per meeting, named
+  `vexa-mtg-<id>`, spawned through `klai-docker-authz`
+- Carries UPSTREAM's labels, not ours: `runtime.managed=true` and
+  `runtime.workload_id=<id>`. We do not control the container spec, so we
+  cannot add `klai.*` labels to it
+- `AutoRemove=false`, so it stays on the host after the meeting. The daily
+  `docker-cleanup.timer` reaps it once exited (REQ-6, `until=24h`) — that is
+  the intended lifecycle, not a leak
+- Cleanup: leave it. Never `docker rm` a running `vexa-mtg-*`; that kills a
+  live meeting recording
+
+`docker-orphan-audit.sh` recognises this class only when the label AND a
+`vexaai/*` image both match. `runtime.managed` is upstream's generic name and
+much easier to collide with than our own `klai.*` labels, so a container
+claiming the class from another image is still reported.
+`deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh` pins both halves.
+
 A container without ANY of these labels (and without a
 `klai.adhoc=*` opt-in for ad-hoc debug — see below) is a wees and
 warrants human review before removal.

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -58,6 +58,10 @@ jobs:
           # every service. This job is the only thing that installs it on
           # core-01, so its tests belong here.
           bash deploy/scripts/tests/compose-up-verify.test.sh
+          # The orphan audit decides which live containers look abandoned. A
+          # class it does not know reads as a wees — that is the librechat-voys
+          # incident. This job also installs it, so its tests belong here.
+          bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -19,12 +19,16 @@ on:
     paths:
       - 'deploy/scripts/**'
       - 'deploy/librechat/tests/**'
+      - '.claude/hooks/klai/container-hygiene-preflight.sh'
+      - '.claude/hooks/klai/tests/**'
       - '.github/workflows/deploy-scripts-tests.yml'
   push:
     branches: [main]
     paths:
       - 'deploy/scripts/**'
       - 'deploy/librechat/tests/**'
+      - '.claude/hooks/klai/container-hygiene-preflight.sh'
+      - '.claude/hooks/klai/tests/**'
       - '.github/workflows/deploy-scripts-tests.yml'
 
 permissions:
@@ -53,3 +57,12 @@ jobs:
 
       - name: klai-librechat digest guard suite
         run: sh deploy/scripts/tests/check-klai-librechat-digest.test.sh
+
+      # The orphan audit and the preflight hook are the two things standing
+      # between a cleanup pass and the librechat-voys incident. Both gained a
+      # container class today; neither had coverage before.
+      - name: orphan-audit managed-class suite
+        run: bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
+
+      - name: container-hygiene preflight suite
+        run: bash .claude/hooks/klai/tests/container-hygiene-preflight.test.sh

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -7,6 +7,7 @@
 #   1. orphan_no_managed_label
 #      Running container without klasse-A (compose-project=klai-core)
 #      OR klasse-B (klai.managed_by=portal-api-provisioning) OR
+#      klasse-C (runtime.managed=true on a vexaai/* image) OR
 #      klai.adhoc=* opt-in label.
 #
 #   2. orphan_service_removed
@@ -108,8 +109,26 @@ while read -r name; do
     adhoc=$(docker inspect "$name" --format '{{index .Config.Labels "klai.adhoc"}}' 2>/dev/null || echo "")
     image=$(docker inspect "$name" --format '{{.Config.Image}}' 2>/dev/null || echo "unknown")
 
+    # Klasse C — per-meeting Vexa bot workloads.
+    #
+    # vexa12-runtime creates one container per meeting (vexa-mtg-<id>) through
+    # klai-docker-authz. They carry upstream's labels, not ours, so before this
+    # they read as klasse-A-and-B-less: exactly the shape that got librechat-voys
+    # deleted. They are legitimate and short-lived — AutoRemove is false, and the
+    # daily docker-cleanup.timer reaps them once exited (REQ-6, until=24h).
+    #
+    # Both the label and the image namespace must match. `runtime.managed` is
+    # upstream's generic name and far more collidable than our own klai.* labels,
+    # so a container claiming the class from a non-vexaai image falls through to
+    # orphan_no_managed_label rather than being waved past.
+    runtime_managed=$(docker inspect "$name" --format '{{index .Config.Labels "runtime.managed"}}' 2>/dev/null || echo "")
+    klasse_c=""
+    if [[ "$runtime_managed" == "true" ]] && [[ "$image" == vexaai/* ]]; then
+        klasse_c="yes"
+    fi
+
     # Detection 1: no managed label
-    if [[ "$proj" != "klai-core" ]] && [[ "$managed_by" != "portal-api-provisioning" ]] && [[ -z "$adhoc" ]]; then
+    if [[ "$proj" != "klai-core" ]] && [[ "$managed_by" != "portal-api-provisioning" ]] && [[ -z "$klasse_c" ]] && [[ -z "$adhoc" ]]; then
         emit_event "orphan_no_managed_label" "warning" "$name" \
             "{\"image\":\"$image\"}"
         continue

--- a/deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
+++ b/deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# SPEC-INFRA-CONTAINER-HYGIENE-001 — the audit must know all three managed classes.
+#
+# vexa12-runtime creates one container per meeting. They carry upstream's labels
+# (runtime.managed / runtime.workload_id), not ours, so to an audit that only
+# knows klasse-A and klasse-B they look exactly like the container that got
+# deleted in the librechat-voys incident: legitimate, production-relevant, and
+# unlabelled by our conventions.
+#
+# The exemption is deliberately narrow. `runtime.managed` is upstream's generic
+# name, much easier to collide with than our own klai.* labels, so the class only
+# counts when the image is also from the vexaai namespace. This pins both halves:
+# a real bot must be recognised, and an impostor claiming the label from another
+# image must still be reported.
+#
+# Driven by a docker stub on PATH — no daemon required, so it runs in CI.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+AUDIT="$REPO_ROOT/deploy/scripts/docker-orphan-audit.sh"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+# Fixture: name|compose-project|klai.managed_by|klai.adhoc|runtime.managed|image
+cat > "$STUB_DIR/containers.txt" <<'EOF'
+klai-core-portal-api-1|klai-core|||false|ghcr.io/getklai/portal-api:latest
+librechat-voys||portal-api-provisioning||false|1b8fa0a19a2c
+vexa-mtg-5-9a935aa1||||true|vexaai/vexa-bot:v0.12.22
+debug-shell||||false|alpine:3.22
+impostor-bot||||true|alpine:3.22
+EOF
+
+cat > "$STUB_DIR/docker" <<'STUB'
+#!/usr/bin/env bash
+# Minimal docker stub: answers `ps` and `inspect` from the fixture, and returns
+# empty for everything else so the audit's other detections find nothing.
+FIX="$(dirname "$0")/containers.txt"
+
+field() { awk -F'|' -v n="$1" -v f="$2" '$1==n{print $f}' "$FIX"; }
+
+case "$1" in
+  ps)
+    # Only the plain running-name listing is used by detection 1.
+    for a in "$@"; do [[ "$a" == "-a" ]] && exit 0; done
+    case "$*" in
+      *'{{.Names}}'*) cut -d'|' -f1 "$FIX" ;;
+      *) : ;;
+    esac
+    ;;
+  inspect)
+    name="$2"; tpl="$4"
+    case "$tpl" in
+      *com.docker.compose.project*) field "$name" 2 ;;
+      *com.docker.compose.service*) : ;;
+      *klai.managed_by*)            field "$name" 3 ;;
+      *klai.tenant_slug*)           : ;;
+      *klai.adhoc*)                 field "$name" 4 ;;
+      *runtime.managed*)            field "$name" 5 ;;
+      *.Config.Image*)              field "$name" 6 ;;
+      *) : ;;
+    esac
+    ;;
+  *) : ;;
+esac
+exit 0
+STUB
+chmod +x "$STUB_DIR/docker"
+
+OUT=$(PATH="$STUB_DIR:$PATH" bash "$AUDIT" 2>/dev/null || true)
+
+FAIL=0
+flagged() { echo "$OUT" | grep -q "\"event\":\"orphan_no_managed_label\",\"container_name\":\"$1\""; }
+
+expect() {
+    want="$1"; name="$2"; why="$3"
+    if [ "$want" = "flagged" ]; then
+        if flagged "$name"; then echo "OK:   flagged   $name — $why"
+        else echo "FAIL: $name was NOT flagged — $why" >&2; FAIL=1; fi
+    else
+        if flagged "$name"; then echo "FAIL: $name WAS flagged — $why" >&2; FAIL=1
+        else echo "OK:   exempt    $name — $why"; fi
+    fi
+}
+
+echo "── orphan-audit managed-class guard ──"
+expect exempt  klai-core-portal-api-1 "klasse A — compose-project=klai-core"
+expect exempt  librechat-voys         "klasse B — klai.managed_by=portal-api-provisioning"
+expect exempt  vexa-mtg-5-9a935aa1    "klasse C — runtime.managed=true on a vexaai/* image"
+expect flagged debug-shell            "no class and no klai.adhoc opt-in"
+expect flagged impostor-bot           "claims runtime.managed from a non-vexaai image"
+
+echo "──────────────────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+    echo "orphan-audit managed-class guard: OK"
+else
+    echo "orphan-audit managed-class guard: FAILED" >&2
+fi
+exit "$FAIL"


### PR DESCRIPTION
The 0.12 stack creates one container per meeting (`vexa-mtg-<id>`) through `klai-docker-authz`. They carry upstream's labels — `runtime.managed`, `runtime.workload_id` — and none of ours, because we do not control the container spec.

To the orphan audit, which knew only klasse-A (compose) and klasse-B (provisioning), a running bot read as unlabelled and production-relevant. That is the exact shape that got `librechat-voys` deleted.

They are **not** a leak: `AutoRemove` is false, but the daily `docker-cleanup.timer` prunes exited containers older than 24h (REQ-6), so the lifecycle already terminates. What was missing was anything that *knew* that.

## Changes

- **`docker-orphan-audit.sh`** gains klasse C — recognised only when the label AND a `vexaai/*` image both match. `runtime.managed` is upstream's generic name and far easier to collide with than our `klai.*` labels, so a container claiming the class from another image is still reported.
- **`container-hygiene-preflight.sh`** blocks `docker rm` on `vexa-mtg-*`. A running one is an in-progress recording with no other source; an exited one needs no manual removal.

## A real defect, found because these had no tests

The hook dereferenced `CLAUDE_PROJECT_DIR` under `set -u` **before** its blocking checks. Anything running it without that variable got exit 1 and an error message instead of a guard — it failed open, quietly. The fallback now derives from the script's own path.

The suite runs every case twice, with the variable and without, because a guard that only guards under one environment is the bug, not the fix.

| | blocked | allowed |
|---|---|---|
| klasse C | `docker rm vexa-mtg-5`, `docker rm -f vexa-mtg-3` | `docker logs`, `docker stop`, `docker ps` |
| klasse B | `docker rm librechat-voys` | |
| global | `docker volume prune` | `docker rm some-scratch-box` (check 2 is an open policy by design) |

Verified by mutation: reverting the fallback, or removing the klasse-C check, each turns four assertions red. Both suites now run pre-merge in `deploy-scripts-tests.yml` — neither had any coverage before.

SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-1, REQ-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)