### PR TITLE
fix(hygiene): the orphan audit never saw a single tenant route

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -62,6 +62,7 @@ jobs:
           # class it does not know reads as a wees — that is the librechat-voys
           # incident. This job also installs it, so its tests belong here.
           bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
+          bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -64,5 +64,8 @@ jobs:
       - name: orphan-audit managed-class suite
         run: bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
 
+      - name: orphan-audit caddy-route suite
+        run: bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
+
       - name: container-hygiene preflight suite
         run: bash .claude/hooks/klai/tests/container-hygiene-preflight.test.sh

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -48,8 +48,43 @@ CADDYFILE="${CADDYFILE:-/opt/klai/Caddyfile}"
 
 # Use a tempfile to count events across subshells (while|read pipelines)
 EVENT_TMP="$(mktemp)"
-trap 'rm -f "$EVENT_TMP"' EXIT
+CADDY_CONFIG="$(mktemp)"
+trap 'rm -f "$EVENT_TMP" "$CADDY_CONFIG"' EXIT
 echo 0 > "$EVENT_TMP"
+
+# ─── Assemble the full Caddy config ──────────────────────────────────────────
+#
+# /opt/klai/Caddyfile ends in `import /etc/caddy/tenants/*.caddyfile`, and every
+# tenant route lives in there — written by portal-api at provisioning time,
+# stored in a Docker volume, so the path in that import is container-internal and
+# does not exist on the host.
+#
+# Detections 5 and 6 read the config to decide whether a route exists. Reading
+# only the main file meant no tenant route was ever visible, so detection 6
+# reported EVERY tenant container as routeless: 42 warnings a week, none of them
+# true, while voys.getklai.com served 200 the whole time. A detection that always
+# fires cannot distinguish the case it exists to catch.
+#
+# Resolve the host path from the caddy container's mount rather than the volume
+# name, which carries a compose project prefix (klai-core_caddy-tenants) and
+# would silently stop matching if the project were ever renamed.
+CADDY_TENANTS_OK=""
+if [[ -f "$CADDYFILE" ]]; then
+    cat "$CADDYFILE" > "$CADDY_CONFIG"
+
+    if ! grep -qE '^\s*import\s+/etc/caddy/tenants/' "$CADDYFILE"; then
+        # No tenant import to follow — the main file is the whole config.
+        CADDY_TENANTS_OK="yes"
+    else
+        tenants_src=$(docker inspect klai-core-caddy-1 \
+            --format '{{range .Mounts}}{{if eq .Destination "/etc/caddy/tenants"}}{{.Source}}{{end}}{{end}}' \
+            2>/dev/null || echo "")
+        if [[ -n "$tenants_src" ]] && [[ -d "$tenants_src" ]] && [[ -r "$tenants_src" ]]; then
+            cat "$tenants_src"/*.caddyfile >> "$CADDY_CONFIG" 2>/dev/null || true
+            CADDY_TENANTS_OK="yes"
+        fi
+    fi
+fi
 
 emit_event() {
     local event_type="$1"
@@ -144,7 +179,7 @@ while read -r name; do
     # Caddy refers to klasse-B containers by container-name (e.g.
     # `reverse_proxy librechat-voys:3080`), so direct grep works for them.
     if [[ "$managed_by" == "portal-api-provisioning" ]] || [[ "$name" =~ ^librechat- ]]; then
-        if [[ -f "$CADDYFILE" ]] && ! grep -qE "(^|[[:space:]])${name}([[:space:]]|:|$)" "$CADDYFILE"; then
+        if [[ -n "$CADDY_TENANTS_OK" ]] && ! grep -qE "(^|[[:space:]])${name}([[:space:]]|:|$)" "$CADDY_CONFIG"; then
             emit_event "tenant_container_no_route" "warning" "$name" \
                 "{\"image\":\"$image\",\"tenant_slug\":\"$tenant\"}"
         fi
@@ -183,11 +218,20 @@ docker volume ls -f dangling=true -q | while read -r vol; do
     fi
 done
 
+# An unreadable tenant directory is not a reason to guess. Detections 5 and 6
+# both answer "does a route exist for this?", and on a partial config the answer
+# is wrong in the direction that generates work: every tenant looks routeless.
+# Say so once instead.
+if [[ -f "$CADDYFILE" ]] && [[ -z "$CADDY_TENANTS_OK" ]]; then
+    emit_event "caddy_config_unreadable" "critical" "klai-core-caddy-1" \
+        "{\"detail\":\"Caddyfile imports /etc/caddy/tenants/ but the host path behind that mount could not be read; route detections skipped rather than reported against partial config\"}"
+fi
+
 # ─── Detection 5: Caddy upstreams without matching container ─────────────────
 # Caddy upstreams reach docker services by their compose-service-name, not
 # the prefixed container-name. Build a service-name → running set and a
 # normalised running-name set to allow either form.
-if [[ -f "$CADDYFILE" ]]; then
+if [[ -n "$CADDY_TENANTS_OK" ]]; then
     # Set 1: full container-names (klai-core-portal-api-1, librechat-voys, etc.)
     RUNNING_NAMES=$(docker ps --format '{{.Names}}')
     # Set 2: compose-service-names (portal-api, redis, etc.)
@@ -209,7 +253,7 @@ if [[ -f "$CADDYFILE" ]]; then
         return 1
     }
 
-    grep -hE '^\s*reverse_proxy\s+' "$CADDYFILE" \
+    grep -hE '^\s*reverse_proxy\s+' "$CADDY_CONFIG" \
         | awk '{
             # reverse_proxy may have named matcher as first arg (@matcher)
             # then upstream(s). Iterate from $2 onward, filter out matchers

--- a/deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
+++ b/deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5 — route detection must read the whole config.
+#
+# /opt/klai/Caddyfile ends in `import /etc/caddy/tenants/*.caddyfile`. Every
+# tenant route lives behind that import, in a Docker volume, so the path is
+# container-internal and absent from the host. The audit read only the main file,
+# which meant no tenant route was ever visible and detection 6 reported all 42
+# tenant containers as routeless — every week, while those tenants served 200.
+#
+# A detection that always fires cannot distinguish the case it exists to catch.
+# That is the failure this pins: not "does it warn", but "does it warn only when
+# the route is genuinely missing", plus the third state — if the tenant config
+# cannot be read at all, say so once instead of blaming every tenant.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+AUDIT="$REPO_ROOT/deploy/scripts/docker-orphan-audit.sh"
+FAIL=0
+
+scenario() {
+    # $1 = tenant dir readable? (yes|no)   $2 = include a route for librechat-beta?
+    local readable="$1" beta_route="$2"
+    local tmp; tmp="$(mktemp -d)"
+
+    mkdir -p "$tmp/tenants"
+    cat > "$tmp/Caddyfile" <<'EOF'
+example.getklai.com {
+    reverse_proxy portal-api:8000
+}
+import /etc/caddy/tenants/*.caddyfile
+EOF
+    cat > "$tmp/tenants/alpha.caddyfile" <<'EOF'
+chat-alpha.getklai.com {
+    reverse_proxy librechat-alpha:3080
+}
+EOF
+    if [ "$beta_route" = "yes" ]; then
+        cat > "$tmp/tenants/beta.caddyfile" <<'EOF'
+chat-beta.getklai.com {
+    reverse_proxy librechat-beta:3080
+}
+EOF
+    fi
+
+    # Two provisioned tenants; only alpha is guaranteed a route.
+    cat > "$tmp/containers.txt" <<'EOF'
+librechat-alpha||portal-api-provisioning||false|1b8fa0a19a2c
+librechat-beta||portal-api-provisioning||false|1b8fa0a19a2c
+EOF
+
+    local tenants_src="$tmp/tenants"
+    [ "$readable" = "no" ] && tenants_src="$tmp/does-not-exist"
+
+    cat > "$tmp/docker" <<STUB
+#!/usr/bin/env bash
+FIX="$tmp/containers.txt"
+field() { awk -F'|' -v n="\$1" -v f="\$2" '\$1==n{print \$f}' "\$FIX"; }
+case "\$1" in
+  ps)
+    for a in "\$@"; do [[ "\$a" == "-a" ]] && exit 0; done
+    case "\$*" in
+      *'{{.Names}}'*) cut -d'|' -f1 "\$FIX" ;;
+      *) : ;;
+    esac
+    ;;
+  inspect)
+    if [[ "\$2" == "klai-core-caddy-1" ]]; then echo "$tenants_src"; exit 0; fi
+    name="\$2"; tpl="\$4"
+    case "\$tpl" in
+      *com.docker.compose.project*) field "\$name" 2 ;;
+      *klai.managed_by*)            field "\$name" 3 ;;
+      *klai.adhoc*)                 field "\$name" 4 ;;
+      *runtime.managed*)            field "\$name" 5 ;;
+      *.Config.Image*)              field "\$name" 6 ;;
+      *) : ;;
+    esac
+    ;;
+  *) : ;;
+esac
+exit 0
+STUB
+    chmod +x "$tmp/docker"
+
+    PATH="$tmp:$PATH" CADDYFILE="$tmp/Caddyfile" \
+        COMPOSE_FILE="$tmp/none.yml" OVERRIDE_FILE="$tmp/none.yml" DEV_FILE="$tmp/none.yml" \
+        bash "$AUDIT" 2>/dev/null
+    rm -rf "$tmp"
+}
+
+has() { echo "$1" | grep -q "\"event\":\"$2\",\"container_name\":\"$3\""; }
+
+expect() {
+    want="$1"; out="$2"; ev="$3"; name="$4"; why="$5"
+    if has "$out" "$ev" "$name"; then got=present; else got=absent; fi
+    if [ "$got" = "$want" ]; then
+        echo "OK:   $ev $want for $name — $why"
+    else
+        echo "FAIL: $ev expected $want, was $got for $name — $why" >&2
+        FAIL=1
+    fi
+}
+
+echo "── caddy route detection ──"
+
+echo "-- tenant config readable, both tenants routed --"
+OUT=$(scenario yes yes)
+expect absent "$OUT" tenant_container_no_route librechat-alpha "route lives behind the import"
+expect absent "$OUT" tenant_container_no_route librechat-beta  "route lives behind the import"
+expect absent "$OUT" caddy_config_unreadable   klai-core-caddy-1 "config was fully readable"
+
+echo "-- tenant config readable, beta genuinely has no route --"
+OUT=$(scenario yes no)
+expect absent  "$OUT" tenant_container_no_route librechat-alpha "still routed"
+expect present "$OUT" tenant_container_no_route librechat-beta  "this is the real signal"
+
+echo "-- tenant config unreadable --"
+OUT=$(scenario no yes)
+expect present "$OUT" caddy_config_unreadable   klai-core-caddy-1 "say it once"
+expect absent  "$OUT" tenant_container_no_route librechat-alpha "do not blame tenants for a config we cannot read"
+expect absent  "$OUT" tenant_container_no_route librechat-beta  "do not blame tenants for a config we cannot read"
+
+echo "───────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+    echo "caddy route detection guard: OK"
+else
+    echo "caddy route detection guard: FAILED" >&2
+fi
+exit "$FAIL"


### PR DESCRIPTION
`/opt/klai/Caddyfile` ends in `import /etc/caddy/tenants/*.caddyfile`. Every tenant route lives behind that import — written by portal-api at provisioning time into a Docker volume, so the path is container-internal and does not exist on the host.

The audit grepped only the main file. **No tenant route was ever visible**, so detection 6 reported every tenant container as routeless: 42 warnings per weekly run, none of them true.

Confirmed by running it on core-01:

```
tenant_container_no_route: 42     ← one per tenant
    librechat-getklai
    librechat-voys
    ...
$ curl -o /dev/null -w '%{http_code}' https://voys.getklai.com/
200
```

A detection that always fires cannot distinguish the case it exists to catch. This *is* the librechat-voys signal, and it has been pure noise for as long as tenants have been provisioned this way.

## Fix

The config is assembled from the main file plus the tenant directory, resolved from the **caddy container's mount** rather than the volume name — that name carries a compose project prefix (`klai-core_caddy-tenants`) and would silently stop matching if the project were renamed.

When the tenant directory cannot be read, both route detections are **skipped** and one `caddy_config_unreadable` event is emitted instead. On a partial config the answer is wrong in the direction that generates work, which is exactly how this stayed invisible.

## Guard

| scenario | expected |
|---|---|
| config readable, both tenants routed | no warnings |
| config readable, one tenant genuinely unrouted | **that tenant reported** — the signal still works |
| config unreadable | one `caddy_config_unreadable`, zero tenant warnings |

Verified by mutation: reading only the main file again, or treating an unreadable directory as fine, each turns three assertions red.

SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)