### PR TITLE
fix(crawler): recovery-deadline job-breed maken (zoals beloofd)

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -1325,10 +1325,16 @@ async def crawl_site(
     crawl_results: list[CrawlResult] = []
     outcomes: list[FetchOutcome] = []
     fetched_count = 0
-    # Crawl-job-wide budget for the bulk-5xx sequential-recovery fallback
-    # (see _recover_bulk_5xx_batch / _MAX_SEQUENTIAL_RECOVERY).
-    # Shared across every batch iteration below, not reset per batch.
+    # Crawl-job-wide budgets for the bulk-5xx sequential-recovery fallback
+    # (see _recover_bulk_5xx_batch / _MAX_SEQUENTIAL_RECOVERY). BOTH are
+    # shared across every batch iteration below, not reset per batch — a
+    # per-batch clock would let a many-batch crawl spend its full wall-clock
+    # allowance again and again, which is exactly the "one job holds a worker
+    # slot for over an hour" case the budget exists to prevent.
     sequential_recovery_budget = _MAX_SEQUENTIAL_RECOVERY
+    sequential_recovery_deadline = (
+        _recovery_monotonic() + settings.crawl_sequential_recovery_max_seconds
+    )
 
     start_result = await _fetch_seed_page(
         start_url=start_url,
@@ -1378,6 +1384,7 @@ async def crawl_site(
                 cookies=cookies,
                 base_domain=base_domain,
                 recovery_budget=sequential_recovery_budget,
+                deadline=sequential_recovery_deadline,
             )
             sequential_recovery_budget -= recovery_attempted
         else:
@@ -1608,6 +1615,7 @@ async def _recover_bulk_5xx_batch(
     cookies: list[dict[str, Any]] | None,
     base_domain: str,
     recovery_budget: int,
+    deadline: float | None = None,
 ) -> tuple[list[CrawlResult], list[CrawlResult], list[FetchOutcome], int]:
     """Sequentially re-fetch a batch that failed WHOLESALE via bulk fetch.
 
@@ -1651,7 +1659,12 @@ async def _recover_bulk_5xx_batch(
     cooldown = settings.crawl_sequential_recovery_cooldown_seconds
     max_consecutive = settings.crawl_sequential_recovery_max_consecutive_failures
     time_budget = settings.crawl_sequential_recovery_max_seconds
+    # ``deadline`` is the crawl-job-wide clock passed by ``crawl_site`` so a
+    # many-batch crawl cannot spend the full allowance once per batch. Direct
+    # callers (tests) may omit it and get a fresh per-call budget.
     started_at = _recovery_monotonic()
+    if deadline is None:
+        deadline = started_at + time_budget
 
     logger.info(
         "crawl_sequential_recovery_started",
@@ -1704,13 +1717,13 @@ async def _recover_bulk_5xx_batch(
             )
             break
 
-        elapsed = _recovery_monotonic() - started_at
-        if elapsed >= time_budget:
+        now = _recovery_monotonic()
+        if now >= deadline:
             remaining = _abandon_remaining(i)
             still_failing += remaining
             logger.warning(
                 "crawl_sequential_recovery_time_budget_exhausted",
-                elapsed_seconds=round(elapsed, 1),
+                elapsed_seconds=round(now - started_at, 1),
                 recovered=recovered,
                 still_failing=still_failing,
                 remaining=remaining,

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1480,3 +1480,35 @@ async def test_recovery_stops_when_wall_clock_budget_is_exhausted(
     assert attempted == 2, "stopped once the elapsed clock passed the budget"
     assert len(outcomes) == len(urls)
     assert outcomes[-1]["reason_code"] == FetchReasonCode.HTTP_5XX.value
+
+
+@pytest.mark.asyncio
+async def test_recovery_deadline_is_job_wide_not_per_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A many-batch crawl must not spend the wall-clock allowance once per
+    batch. Passing an already-expired deadline means the batch abandons
+    immediately, even though its own elapsed time is zero."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_seconds", 1200.0)
+
+    slept: list[float] = []
+
+    async def _record_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    monkeypatch.setattr(crawl4ai_client, "_recovery_sleep", _record_sleep)
+    monkeypatch.setattr(crawl4ai_client, "_recovery_monotonic", lambda: 5_000.0)
+
+    urls = ["https://example.com/a", "https://example.com/b"]
+    _results, _links, outcomes, attempted = await crawl4ai_client._recover_bulk_5xx_batch(
+        urls,
+        crawler_config={},
+        cookies=None,
+        base_domain="example.com",
+        recovery_budget=60,
+        deadline=4_000.0,  # already spent by earlier batches of the same job
+    )
+
+    assert attempted == 0, "job-wide deadline already passed; no attempt may start"
+    assert slept == [], "and no cooldown may be burned either"
+    assert [o["reason_code"] for o in outcomes] == [FetchReasonCode.HTTP_5XX.value] * 2


### PR DESCRIPTION
## Waarom

In PR #976 beschreef ik de wall-clock-grens van 20 minuten als de bound die voorkomt dat één crawl-job langer dan een uur een worker-slot bezet houdt. Bij het teruglezen van mijn eigen code na de live-run bleek dat niet te kloppen: `started_at` werd *binnen* `_recover_bulk_5xx_batch` gezet, dus elke batch kreeg opnieuw 20 minuten. De echte worst case per job bleef 60 pogingen x 75s = 75 minuten.

## Fix

`crawl_site` berekent nu één deadline per job en geeft die door; de batch vergelijkt tegen die deadline in plaats van tegen zijn eigen verstreken tijd. Directe aanroepers (tests) mogen hem weglaten en krijgen dan een per-call budget.

Nieuwe test `test_recovery_deadline_is_job_wide_not_per_batch` pint het gedrag: een al verstreken deadline betekent nul pogingen en nul afkoelpauzes, ook al is de eigen verstreken tijd van die batch nul.

## Verificatie
- **1265 passed**, 4 skipped; ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
