### PR TITLE
fix(crawler): circuit-breaker mag geen pech tot uitkomst maken

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -80,8 +80,14 @@ class Settings(BaseSettings):
         default=75.0,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_COOLDOWN_SECONDS"),
     )
+    # Only trips while nothing has been recovered yet (see the breaker in
+    # _recover_bulk_5xx_batch). 6 rather than 3: an intermittently-blocking
+    # site can easily open with a run of failures, and giving up there costs
+    # the whole crawl — measured on intermedia.com, 3 was the difference
+    # between recovering 7 pages and recovering none. Worst case on a truly
+    # dead site is 6 x 75s, comfortably inside the job deadline below.
     crawl_sequential_recovery_max_consecutive_failures: int = Field(
-        default=3,
+        default=6,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_MAX_CONSECUTIVE_FAILURES"),
     )
     crawl_sequential_recovery_max_seconds: float = Field(

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -1701,11 +1701,19 @@ async def _recover_bulk_5xx_batch(
             )
             break
 
-        # Circuit breaker: the cooldown below buys a fresh browser session
-        # per attempt, so a run of failures despite it means the site is not
-        # recoverable — every further attempt would burn another cooldown for
-        # nothing.
-        if consecutive_failures >= max_consecutive:
+        # Circuit breaker: a run of failures despite the fresh session the
+        # cooldown buys means the site is not recoverable, so stop burning a
+        # cooldown per remaining URL.
+        #
+        # It only applies while NOTHING has been recovered yet. One success
+        # proves the site IS reachable, and from then on failures are just the
+        # intermittency this whole path exists for. Measured on intermedia.com
+        # 2026-08-14: one run recovered 7 of 12 because early successes kept
+        # resetting the counter, while the next run lost all 17 because its
+        # first three attempts happened to fail. Same site, same code — only
+        # luck differed, and the breaker turned that luck into the outcome.
+        # Attempts and the job-wide deadline still bound the patient case.
+        if consecutive_failures >= max_consecutive and recovered == 0:
             remaining = _abandon_remaining(i)
             still_failing += remaining
             logger.warning(

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1512,3 +1512,43 @@ async def test_recovery_deadline_is_job_wide_not_per_batch(
     assert attempted == 0, "job-wide deadline already passed; no attempt may start"
     assert slept == [], "and no cooldown may be burned either"
     assert [o["reason_code"] for o in outcomes] == [FetchReasonCode.HTTP_5XX.value] * 2
+
+
+@pytest.mark.asyncio
+async def test_recovery_breaker_does_not_fire_once_a_page_was_recovered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One success proves the site is reachable, so a later run of failures
+    is intermittency — not grounds to abandon the rest of the batch. The
+    attempt budget and job deadline still bound it."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 2)
+    urls = [f"https://example.com/p{i}" for i in range(6)]
+    scripted = {
+        urls[0]: _ok_result(urls[0]),  # proves reachability
+        urls[1]: _blocked_result(),
+        urls[2]: _blocked_result(),
+        urls[3]: _blocked_result(),
+        urls[4]: _blocked_result(),
+        urls[5]: _ok_result(urls[5]),  # only reached if the breaker held off
+    }
+
+    (results, _links, _outcomes, attempted), _slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 6, "breaker must stay closed after a recovered page"
+    assert {r.url for r in results} == {urls[0], urls[5]}
+
+
+@pytest.mark.asyncio
+async def test_recovery_breaker_still_fires_when_nothing_was_recovered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site that never answers must not cost a cooldown per URL."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 2)
+    urls = [f"https://example.com/p{i}" for i in range(8)]
+    scripted = {u: _blocked_result() for u in urls}
+
+    (_results, _links, outcomes, attempted), slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 2
+    assert len(slept) == 2
+    assert len(outcomes) == len(urls)


### PR DESCRIPTION
## Waarom

Twee volledige crawls van dezelfde site, met dezelfde code, gaven **7 herstelde pagina's** en **0**. Het enige verschil was volgorde: in de eerste run slaagden de eerste pogingen, wat de teller voor opeenvolgende mislukkingen telkens resette. In de tweede run faalden de eerste drie toevallig, sloeg de breaker dicht en werden de resterende 14 URLs ongeprobeerd afgeschreven.

## Fix

De breaker bestaat om te detecteren dat een site *helemaal* niet herstelbaar is. Eén succes weerlegt precies dat. Hij geldt daarom nu alleen zolang er nog niets hersteld is; daarna zijn mislukkingen de grilligheid waarvoor dit pad juist bestaat. Het pogingenbudget (60) en de job-brede deadline (20 min) begrenzen het geduldige geval nog steeds.

Drempel ook van 3 naar 6: een intermitterende site kan plausibel met een reeks mislukkingen openen. Worst case op een écht dode site is 6 x 75s, ruim binnen de deadline.

## Verificatie
- **1267 passed**, 4 skipped — twee nieuwe tests: breaker blijft dicht ná een herstelde pagina, en vuurt nog steeds als er niets herstelde
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
