### PR TITLE
fix(hygiene): the audit was reading a Caddyfile from April

### DIFF
--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -44,7 +44,27 @@ TIMESTAMP="$(date -Iseconds)"
 COMPOSE_FILE="${COMPOSE_FILE:-/opt/klai/docker-compose.yml}"
 OVERRIDE_FILE="${OVERRIDE_FILE:-/opt/klai/docker-compose.override.yml}"
 DEV_FILE="${DEV_FILE:-/opt/klai/docker-compose.dev.yml}"
-CADDYFILE="${CADDYFILE:-/opt/klai/Caddyfile}"
+# Which Caddyfile is the real one? Two files on this host answer to that name:
+#
+#   /opt/klai/caddy/Caddyfile   592 lines, bind-mounted into the container — LIVE
+#   /opt/klai/Caddyfile         256 lines, last touched 2026-04-21 — a leftover
+#
+# The second predates SPEC-INFRA-CADDY-CONFIG-DEPLOY-001, which moved the synced
+# path under caddy/. Nothing reads it, but it still looks authoritative, and this
+# audit defaulted to it — so detection 5 compared live upstreams against a route
+# set four months old. It also carries a comment claiming basic_auth was removed
+# from the dev host, while the live config still has it, which is how the decoy
+# produces confident wrong answers rather than obvious ones.
+#
+# Do not pick a path. Ask the container which file it actually mounted, the same
+# way the tenant directory is resolved below. The literal is only a fallback for
+# when there is no container to ask, and it now names the correct file.
+if [[ -z "${CADDYFILE:-}" ]]; then
+    CADDYFILE=$(docker inspect klai-core-caddy-1 \
+        --format '{{range .Mounts}}{{if eq .Destination "/etc/caddy/Caddyfile"}}{{.Source}}{{end}}{{end}}' \
+        2>/dev/null || echo "")
+    [[ -n "$CADDYFILE" ]] || CADDYFILE="/opt/klai/caddy/Caddyfile"
+fi
 
 # Use a tempfile to count events across subshells (while|read pipelines)
 EVENT_TMP="$(mktemp)"

--- a/deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
+++ b/deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
@@ -19,14 +19,19 @@ AUDIT="$REPO_ROOT/deploy/scripts/docker-orphan-audit.sh"
 FAIL=0
 
 scenario() {
-    # $1 = tenant dir readable? (yes|no)   $2 = include a route for librechat-beta?
-    local readable="$1" beta_route="$2"
+    # $1 = tenant dir readable? (yes|no)
+    # $2 = include a route for librechat-beta?
+    # $3 = ask the container for the main config instead of passing CADDYFILE? (yes|no)
+    local readable="$1" beta_route="$2" resolve="${3:-no}"
     local tmp; tmp="$(mktemp -d)"
 
     mkdir -p "$tmp/tenants"
     cat > "$tmp/Caddyfile" <<'EOF'
 example.getklai.com {
     reverse_proxy portal-api:8000
+}
+dev.getklai.com {
+    reverse_proxy portal-api-dev:8010
 }
 import /etc/caddy/tenants/*.caddyfile
 EOF
@@ -44,13 +49,33 @@ EOF
     fi
 
     # Two provisioned tenants; only alpha is guaranteed a route.
+    # Field 7 is the compose-service label. At least one container must carry
+    # one: the audit builds its service set with `... | grep -v '^$' | sort -u`,
+    # and grep exits 1 on empty input, which under `set -euo pipefail` kills the
+    # script mid-run. A fixture of only provisioning-managed containers made it
+    # abort before detection 5 — silently, since set -e prints nothing — so that
+    # detection was never exercised at all.
     cat > "$tmp/containers.txt" <<'EOF'
-librechat-alpha||portal-api-provisioning||false|1b8fa0a19a2c
-librechat-beta||portal-api-provisioning||false|1b8fa0a19a2c
+klai-core-portal-api-1|klai-core|||false|ghcr.io/getklai/portal-api:latest|portal-api
+librechat-alpha||portal-api-provisioning||false|1b8fa0a19a2c|
+librechat-beta||portal-api-provisioning||false|1b8fa0a19a2c|
 EOF
 
     local tenants_src="$tmp/tenants"
     [ "$readable" = "no" ] && tenants_src="$tmp/does-not-exist"
+
+    # A decoy beside the live file: same name, older, missing the tenant import
+    # and routing librechat-alpha nowhere. Reading it looks like success and
+    # produces confidently wrong findings — which is exactly what happened on
+    # core-01, where /opt/klai/Caddyfile sat four months stale next to the real
+    # /opt/klai/caddy/Caddyfile.
+    mkdir -p "$tmp/stale"
+    cat > "$tmp/stale/Caddyfile" <<'EOF'
+old.getklai.com {
+    reverse_proxy portal-api:8000
+}
+EOF
+    local live_caddyfile="$tmp/Caddyfile"
 
     cat > "$tmp/docker" <<STUB
 #!/usr/bin/env bash
@@ -61,11 +86,18 @@ case "\$1" in
     for a in "\$@"; do [[ "\$a" == "-a" ]] && exit 0; done
     case "\$*" in
       *'{{.Names}}'*) cut -d'|' -f1 "\$FIX" ;;
+      *com.docker.compose.service*) cut -d'|' -f7 "\$FIX" ;;
       *) : ;;
     esac
     ;;
   inspect)
-    if [[ "\$2" == "klai-core-caddy-1" ]]; then echo "$tenants_src"; exit 0; fi
+    if [[ "\$2" == "klai-core-caddy-1" ]]; then
+      case "\$*" in
+        */etc/caddy/tenants*)  echo "$tenants_src" ;;
+        */etc/caddy/Caddyfile*) echo "$live_caddyfile" ;;
+      esac
+      exit 0
+    fi
     name="\$2"; tpl="\$4"
     case "\$tpl" in
       *com.docker.compose.project*) field "\$name" 2 ;;
@@ -82,9 +114,17 @@ exit 0
 STUB
     chmod +x "$tmp/docker"
 
-    PATH="$tmp:$PATH" CADDYFILE="$tmp/Caddyfile" \
-        COMPOSE_FILE="$tmp/none.yml" OVERRIDE_FILE="$tmp/none.yml" DEV_FILE="$tmp/none.yml" \
-        bash "$AUDIT" 2>/dev/null
+    if [ "$resolve" = "yes" ]; then
+        # CADDYFILE unset: the audit must ask the container, not fall back to a
+        # path someone guessed.
+        PATH="$tmp:$PATH" \
+            COMPOSE_FILE="$tmp/none.yml" OVERRIDE_FILE="$tmp/none.yml" DEV_FILE="$tmp/none.yml" \
+            bash "$AUDIT" 2>/dev/null
+    else
+        PATH="$tmp:$PATH" CADDYFILE="$tmp/Caddyfile" \
+            COMPOSE_FILE="$tmp/none.yml" OVERRIDE_FILE="$tmp/none.yml" DEV_FILE="$tmp/none.yml" \
+            bash "$AUDIT" 2>/dev/null
+    fi
     rm -rf "$tmp"
 }
 
@@ -101,10 +141,22 @@ expect() {
     fi
 }
 
+completed() {
+    # Same reason as in the klasse-C suite: set -e aborts without a word, and
+    # every assertion below is about a detection that could simply never have run.
+    if echo "$1" | grep -q '"event":"audit_run_completed"'; then
+        echo "OK:   audit ran to completion"
+    else
+        echo "FAIL: audit aborted before its final event — later detections never ran" >&2
+        FAIL=1
+    fi
+}
+
 echo "── caddy route detection ──"
 
 echo "-- tenant config readable, both tenants routed --"
 OUT=$(scenario yes yes)
+completed "$OUT"
 expect absent "$OUT" tenant_container_no_route librechat-alpha "route lives behind the import"
 expect absent "$OUT" tenant_container_no_route librechat-beta  "route lives behind the import"
 expect absent "$OUT" caddy_config_unreadable   klai-core-caddy-1 "config was fully readable"
@@ -119,6 +171,17 @@ OUT=$(scenario no yes)
 expect present "$OUT" caddy_config_unreadable   klai-core-caddy-1 "say it once"
 expect absent  "$OUT" tenant_container_no_route librechat-alpha "do not blame tenants for a config we cannot read"
 expect absent  "$OUT" tenant_container_no_route librechat-beta  "do not blame tenants for a config we cannot read"
+
+echo "-- main config resolved from the container, decoy present --"
+OUT=$(scenario yes yes yes)
+completed "$OUT"
+# portal-api-dev appears only in the live file and has no container. Its absence
+# from the findings would mean the audit read the decoy, or read nothing at all
+# and skipped the detection — the two failure modes that look identical from a
+# negative assertion.
+expect present "$OUT" caddy_upstream_missing    portal-api-dev  "only the mounted file names this upstream"
+expect absent  "$OUT" tenant_container_no_route librechat-alpha "tenant routes still resolved"
+expect absent  "$OUT" tenant_container_no_route librechat-beta  "tenant routes still resolved"
 
 echo "───────────────────────────"
 if [ "$FAIL" -eq 0 ]; then

--- a/deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
+++ b/deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
@@ -22,13 +22,18 @@ AUDIT="$REPO_ROOT/deploy/scripts/docker-orphan-audit.sh"
 STUB_DIR="$(mktemp -d)"
 trap 'rm -rf "$STUB_DIR"' EXIT
 
-# Fixture: name|compose-project|klai.managed_by|klai.adhoc|runtime.managed|image
+# Fixture: name|compose-project|klai.managed_by|klai.adhoc|runtime.managed|image|compose-service
+#
+# This suite exercises detection 1 only: with no readable main Caddy config the
+# route detections are skipped, so the script never reaches the pipeline that
+# aborts on an empty service set. The compose-service column is here for parity
+# with the caddy-routes fixture, where it IS load-bearing — see the note there.
 cat > "$STUB_DIR/containers.txt" <<'EOF'
-klai-core-portal-api-1|klai-core|||false|ghcr.io/getklai/portal-api:latest
-librechat-voys||portal-api-provisioning||false|1b8fa0a19a2c
-vexa-mtg-5-9a935aa1||||true|vexaai/vexa-bot:v0.12.22
-debug-shell||||false|alpine:3.22
-impostor-bot||||true|alpine:3.22
+klai-core-portal-api-1|klai-core|||false|ghcr.io/getklai/portal-api:latest|portal-api
+librechat-voys||portal-api-provisioning||false|1b8fa0a19a2c|
+vexa-mtg-5-9a935aa1||||true|vexaai/vexa-bot:v0.12.22|
+debug-shell||||false|alpine:3.22|
+impostor-bot||||true|alpine:3.22|
 EOF
 
 cat > "$STUB_DIR/docker" <<'STUB'
@@ -45,6 +50,7 @@ case "$1" in
     for a in "$@"; do [[ "$a" == "-a" ]] && exit 0; done
     case "$*" in
       *'{{.Names}}'*) cut -d'|' -f1 "$FIX" ;;
+      *com.docker.compose.service*) cut -d'|' -f7 "$FIX" ;;
       *) : ;;
     esac
     ;;
@@ -52,7 +58,7 @@ case "$1" in
     name="$2"; tpl="$4"
     case "$tpl" in
       *com.docker.compose.project*) field "$name" 2 ;;
-      *com.docker.compose.service*) : ;;
+      *com.docker.compose.service*) field "$name" 7 ;;
       *klai.managed_by*)            field "$name" 3 ;;
       *klai.tenant_slug*)           : ;;
       *klai.adhoc*)                 field "$name" 4 ;;
@@ -84,6 +90,17 @@ expect() {
 }
 
 echo "── orphan-audit managed-class guard ──"
+
+# The run must reach its own last line. `set -euo pipefail` aborts silently, so a
+# suite that only asserts on early detections stays green against a script that
+# died halfway — which is exactly what happened here before the compose-service
+# column existed.
+if echo "$OUT" | grep -q '"event":"audit_run_completed"'; then
+    echo "OK:   audit ran to completion"
+else
+    echo "FAIL: audit aborted before its final event — later detections never ran" >&2
+    FAIL=1
+fi
 expect exempt  klai-core-portal-api-1 "klasse A — compose-project=klai-core"
 expect exempt  librechat-voys         "klasse B — klai.managed_by=portal-api-provisioning"
 expect exempt  vexa-mtg-5-9a935aa1    "klasse C — runtime.managed=true on a vexaai/* image"


### PR DESCRIPTION
Two files on core-01 answer to the name Caddyfile:

| path | lines | last touched | |
|---|---|---|---|
| `/opt/klai/caddy/Caddyfile` | 592 | 14 Aug | bind-mounted into the container — **live** |
| `/opt/klai/Caddyfile` | 256 | **21 Apr** | leftover; nothing reads it |

The second predates SPEC-INFRA-CADDY-CONFIG-DEPLOY-001, which moved the synced path under `caddy/`. The audit defaulted to it, so **detection 5 has been comparing live upstreams against a route set four months old** — every route added since April was invisible.

Yesterday's #983 resolved the tenant directory from the container mount but left the main file as a guessed path: it fixed half the problem and left the more misleading half. The decoy also carries a comment claiming `basic_auth` was removed from the dev host while the live config still has it — that is how a stale file produces *confident* wrong answers rather than obviously wrong ones.

**Fix:** don't pick a path. Ask the container which file it mounted, exactly as the tenant directory is already resolved. The literal stays only as a fallback for when there is no container to ask, and now names the correct file.

## The test harness was hiding worse

The audit builds its compose-service set with `... | grep -v '^$' | sort -u`. `grep` exits 1 on empty input, and under `set -euo pipefail` that killed the run mid-way **without printing anything**. The fixture had no compose-managed container, so every run aborted before detection 5 ever executed.

The suite was green because its assertions were all negative — and absence is also what a detection that never ran looks like. That is why the first mutation I tried against this fix reported zero failures.

Fixed three ways:
1. the fixture carries a compose service, so the run completes;
2. the resolve scenario asserts a **positive** signal — an upstream only the mounted file names;
3. both suites assert the run reached its own final event.

A test that cannot tell "no findings" from "never ran" is not a test.

Verified by mutation: hardcoding the stale path, breaking the mount lookup, or removing the compose service each turn the suite red. The first two were silent before this change.

SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)