### PR TITLE
feat(crawler): geblokkeerde batch verdient stealth in plaats van 20 minuten wachten

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -80,8 +80,14 @@ class Settings(BaseSettings):
         default=75.0,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_COOLDOWN_SECONDS"),
     )
+    # Only trips while nothing has been recovered yet (see the breaker in
+    # _recover_bulk_5xx_batch). 6 rather than 3: an intermittently-blocking
+    # site can easily open with a run of failures, and giving up there costs
+    # the whole crawl — measured on intermedia.com, 3 was the difference
+    # between recovering 7 pages and recovering none. Worst case on a truly
+    # dead site is 6 x 75s, comfortably inside the job deadline below.
     crawl_sequential_recovery_max_consecutive_failures: int = Field(
-        default=3,
+        default=6,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_MAX_CONSECUTIVE_FAILURES"),
     )
     crawl_sequential_recovery_max_seconds: float = Field(

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -1701,11 +1701,19 @@ async def _recover_bulk_5xx_batch(
             )
             break
 
-        # Circuit breaker: the cooldown below buys a fresh browser session
-        # per attempt, so a run of failures despite it means the site is not
-        # recoverable — every further attempt would burn another cooldown for
-        # nothing.
-        if consecutive_failures >= max_consecutive:
+        # Circuit breaker: a run of failures despite the fresh session the
+        # cooldown buys means the site is not recoverable, so stop burning a
+        # cooldown per remaining URL.
+        #
+        # It only applies while NOTHING has been recovered yet. One success
+        # proves the site IS reachable, and from then on failures are just the
+        # intermittency this whole path exists for. Measured on intermedia.com
+        # 2026-08-14: one run recovered 7 of 12 because early successes kept
+        # resetting the counter, while the next run lost all 17 because its
+        # first three attempts happened to fail. Same site, same code — only
+        # luck differed, and the breaker turned that luck into the outcome.
+        # Attempts and the job-wide deadline still bound the patient case.
+        if consecutive_failures >= max_consecutive and recovered == 0:
             remaining = _abandon_remaining(i)
             still_failing += remaining
             logger.warning(

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -780,9 +780,19 @@ def _extract_result(url: str, page: dict[str, Any]) -> CrawlResult:
 
 def _build_browser_config_with_cookies(
     cookies: list[dict[str, Any]] | None,
+    *,
+    stealth: bool = False,
 ) -> dict[str, Any] | None:
     """Build a BrowserConfig payload that injects cookies natively at browser
     context creation.
+
+    ``stealth=True`` additionally turns on crawl4ai's own ``enable_stealth``
+    and a randomised user agent. Both are shipped crawl4ai features and both
+    pass its untrusted-config boundary (``magic``, ``simulate_user`` and
+    ``override_navigator`` do NOT — the server rejects those with HTTP 400).
+    Reserved for the escalation path in ``crawl_site``: it is not the default
+    because a randomised UA can change what a site serves, and every crawl
+    that works today does so without it.
 
     Why not the ``on_page_context_created`` hook we used before? The hook
     pattern has known timing issues — Playwright #26786 (cookies added before
@@ -805,11 +815,17 @@ def _build_browser_config_with_cookies(
         if bc:
             payload["browser_config"] = bc
     """
-    if not cookies:
+    params: dict[str, Any] = {}
+    if cookies:
+        params["cookies"] = cookies
+    if stealth:
+        params["enable_stealth"] = True
+        params["user_agent_mode"] = "random"
+    if not params:
         return None
     return {
         "type": "BrowserConfig",
-        "params": {"cookies": cookies},
+        "params": params,
     }
 
 
@@ -863,12 +879,13 @@ async def _crawl_page_with_config(
     cookies: list[dict[str, Any]] | None,
     selector: str | None,
     relaxed: bool = False,
+    stealth: bool = False,
 ) -> CrawlResult:
     payload: dict[str, Any] = {
         "urls": [url],
         "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
     }
-    bc = _build_browser_config_with_cookies(cookies)
+    bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
     if bc:
         payload["browser_config"] = bc
 
@@ -1365,6 +1382,23 @@ async def crawl_site(
         fetched_count += len(batch)
 
         if transport_error is not None and _is_bulk_5xx_error(transport_error):
+            # Escalation step 1: retry the SAME batch once with crawl4ai's
+            # stealth mode + a randomised UA. Measured on intermedia.com
+            # 2026-08-15: the plain bulk request 500s wholesale, the identical
+            # batch with stealth returns 200 with 5 of 6 pages — seconds, not
+            # the ~20 minutes the sequential path costs. Stealth is not the
+            # default because a randomised UA can change what a site serves,
+            # and every crawl that works today works without it; earning it
+            # via a failure keeps healthy sites untouched.
+            logger.info("crawl_bulk_5xx_stealth_retry", urls=len(batch))
+            raw_results, transport_error = await _chunked_bulk_fetch(
+                urls=batch,
+                crawler_config=crawler_config,
+                cookies=cookies,
+                stealth=True,
+            )
+
+        if transport_error is not None and _is_bulk_5xx_error(transport_error):
             # crawl4ai's bulk endpoint failed the WHOLE batch with an
             # opaque 5xx (evidence + budget: see _MAX_SEQUENTIAL_RECOVERY,
             # _is_bulk_5xx_error). The client-side cause is unknowable from
@@ -1385,6 +1419,12 @@ async def crawl_site(
                 base_domain=base_domain,
                 recovery_budget=sequential_recovery_budget,
                 deadline=sequential_recovery_deadline,
+                # Stealth already earned by two consecutive bulk 5xx; the
+                # per-URL retries get it too. Measured: with stealth a failure
+                # no longer poisons the session (3 of 5 succeeded back-to-back
+                # with no cooldown at all), which is exactly what the cooldown
+                # was working around.
+                stealth=True,
             )
             sequential_recovery_budget -= recovery_attempted
         else:
@@ -1616,6 +1656,7 @@ async def _recover_bulk_5xx_batch(
     base_domain: str,
     recovery_budget: int,
     deadline: float | None = None,
+    stealth: bool = False,
 ) -> tuple[list[CrawlResult], list[CrawlResult], list[FetchOutcome], int]:
     """Sequentially re-fetch a batch that failed WHOLESALE via bulk fetch.
 
@@ -1744,7 +1785,7 @@ async def _recover_bulk_5xx_batch(
         await _recovery_sleep(cooldown)
 
         attempted += 1
-        result = await _crawl_page_with_config(url, crawler_config, cookies=cookies, selector=None)
+        result = await _crawl_page_with_config(url, crawler_config, cookies=cookies, selector=None, stealth=stealth)
         reason_code = _classify_fetch_outcome(
             {
                 "success": result.success,
@@ -2193,6 +2234,7 @@ async def _chunked_bulk_fetch(
     urls: list[str],
     crawler_config: dict[str, Any],
     cookies: list[dict[str, Any]] | None,
+    stealth: bool = False,
 ) -> tuple[list[dict[str, Any]], BaseException | None]:
     """Submit ``urls`` to crawl4ai's bulk ``/crawl`` endpoint in chunks of 100.
 
@@ -2211,7 +2253,7 @@ async def _chunked_bulk_fetch(
             "urls": chunk_urls,
             "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
         }
-        bc = _build_browser_config_with_cookies(cookies)
+        bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
         if bc:
             payload["browser_config"] = bc
         try:

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1552,3 +1552,102 @@ async def test_recovery_breaker_still_fires_when_nothing_was_recovered(
     assert attempted == 2
     assert len(slept) == 2
     assert len(outcomes) == len(urls)
+
+
+# ---------------------------------------------------------------------------
+# Stealth escalation: one retry of the same batch before the slow path
+#
+# Measured on intermedia.com 2026-08-15: the plain bulk request 500s
+# wholesale, the identical batch with crawl4ai's enable_stealth + random UA
+# returns 200 with 5 of 6 pages. Seconds instead of the ~20 minutes the
+# sequential path costs, so it is tried first — but only after a failure, so
+# sites that work today are untouched.
+# ---------------------------------------------------------------------------
+
+
+def _opaque_500() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+    response = httpx.Response(
+        500,
+        json={"error": "Internal server error", "correlation_id": "188834187d7d"},
+        request=request,
+    )
+    return httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+
+@pytest.mark.asyncio
+async def test_bulk_5xx_is_retried_with_stealth_before_the_sequential_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/page-a", "https://example.com/page-b"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+
+    seen: list[dict[str, Any]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        seen.append(payload)
+        browser = payload.get("browser_config") or {}
+        stealth = (browser.get("params") or {}).get("enable_stealth") is True
+        if len(payload["urls"]) > 1 and not stealth:
+            raise _opaque_500()  # plain bulk: blocked wholesale
+        return {
+            "results": [
+                {
+                    "url": u,
+                    "success": True,
+                    "status_code": 200,
+                    "html": "<html><body>Real page content, plenty of words here.</body></html>",
+                    "markdown": "Real page content, plenty of words here.",
+                    "links": {"internal": []},
+                    "media": {},
+                }
+                for u in payload["urls"]
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com", max_pages=10
+    )
+
+    bulk_payloads = [p for p in seen if len(p["urls"]) > 1]
+    assert len(bulk_payloads) == 2, "one plain attempt, then exactly one stealth retry"
+    assert bulk_payloads[0].get("browser_config") is None
+    stealth_params = bulk_payloads[1]["browser_config"]["params"]
+    assert stealth_params["enable_stealth"] is True
+    assert stealth_params["user_agent_mode"] == "random"
+
+    # The stealth retry succeeded, so the slow per-URL path never ran.
+    assert [p for p in seen if len(p["urls"]) == 1 and p["urls"][0] != "https://example.com"] == []
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/page-a"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/page-b"] == FetchReasonCode.SUCCESS.value
+    assert {r.url for r in results} >= {
+        "https://example.com/page-a",
+        "https://example.com/page-b",
+    }
+
+
+def test_browser_config_merges_cookies_and_stealth() -> None:
+    """Stealth must not drop an authenticated crawl's cookies."""
+    cookies = [{"name": "session", "value": "abc", "domain": "example.com", "path": "/"}]
+
+    plain = crawl4ai_client._build_browser_config_with_cookies(cookies)
+    assert plain is not None
+    assert plain["params"] == {"cookies": cookies}
+
+    both = crawl4ai_client._build_browser_config_with_cookies(cookies, stealth=True)
+    assert both is not None
+    assert both["params"]["cookies"] == cookies
+    assert both["params"]["enable_stealth"] is True
+
+    assert crawl4ai_client._build_browser_config_with_cookies(None) is None
+    stealth_only = crawl4ai_client._build_browser_config_with_cookies(None, stealth=True)
+    assert stealth_only is not None
+    assert "cookies" not in stealth_only["params"]

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1512,3 +1512,43 @@ async def test_recovery_deadline_is_job_wide_not_per_batch(
     assert attempted == 0, "job-wide deadline already passed; no attempt may start"
     assert slept == [], "and no cooldown may be burned either"
     assert [o["reason_code"] for o in outcomes] == [FetchReasonCode.HTTP_5XX.value] * 2
+
+
+@pytest.mark.asyncio
+async def test_recovery_breaker_does_not_fire_once_a_page_was_recovered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One success proves the site is reachable, so a later run of failures
+    is intermittency — not grounds to abandon the rest of the batch. The
+    attempt budget and job deadline still bound it."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 2)
+    urls = [f"https://example.com/p{i}" for i in range(6)]
+    scripted = {
+        urls[0]: _ok_result(urls[0]),  # proves reachability
+        urls[1]: _blocked_result(),
+        urls[2]: _blocked_result(),
+        urls[3]: _blocked_result(),
+        urls[4]: _blocked_result(),
+        urls[5]: _ok_result(urls[5]),  # only reached if the breaker held off
+    }
+
+    (results, _links, _outcomes, attempted), _slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 6, "breaker must stay closed after a recovered page"
+    assert {r.url for r in results} == {urls[0], urls[5]}
+
+
+@pytest.mark.asyncio
+async def test_recovery_breaker_still_fires_when_nothing_was_recovered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site that never answers must not cost a cooldown per URL."""
+    monkeypatch.setattr(settings, "crawl_sequential_recovery_max_consecutive_failures", 2)
+    urls = [f"https://example.com/p{i}" for i in range(8)]
+    scripted = {u: _blocked_result() for u in urls}
+
+    (_results, _links, outcomes, attempted), slept = await _recover(monkeypatch, urls, scripted)
+
+    assert attempted == 2
+    assert len(slept) == 2
+    assert len(outcomes) == len(urls)


### PR DESCRIPTION
## Waarom

Het antwoord van gisteren op een Cloudflare-geblokkeerde batch was geduld: elke URL apart, 75 seconden uit elkaar, zodat crawl4ai's browser-pool een gemarkeerde sessie kon recyclen. Dat werkte (één keer 7 van 12 pagina's), maar kostte ~20 minuten per batch en was overgeleverd aan toeval.

crawl4ai heeft een beter antwoord dat we niet gebruikten. Vandaag gemeten op intermedia.com:

| Aanpak | Resultaat |
|---|---|
| Bulk, normaal | HTTP 500, hele batch weg |
| **Bulk, met stealth** | **HTTP 200, 5 van 6 pagina's, in seconden** |
| Los, zonder stealth | 1e slaagt, 2e en 3e falen (sessie vergiftigd) |
| Los, met stealth | 3 van 5 slagen, zónder enige pauze |

Een mislukking vergiftigt de sessie dus niet meer — precies waar die 75 seconden voor bedoeld waren.

## Wat er nu gebeurt

Een bulk-5xx escaleert in plaats van te wachten:

1. **Normale bulk** — ongewijzigd; gezonde sites komen hier nooit voorbij
2. **Dezelfde batch één keer opnieuw met stealth** — seconden, haalt het meeste binnen
3. **Pas dan het sequentiële pad**, dat nu ook stealth krijgt

Stealth is bewust **niet** de standaard: een willekeurige user-agent kan veranderen wat een site serveert, en elke crawl die vandaag werkt doet dat zonder. Door het via een echte mislukking te laten "verdienen" blijft die garantie overeind.

## Ook gemeten, voor de volgende lezer

crawl4ai's untrusted-config-grens weigert `magic`, `simulate_user` en `override_navigator` met HTTP 400. `enable_stealth` en `user_agent_mode` komen er wél door. Cookies en stealth worden nu samengevoegd, zodat een geauthenticeerde crawl zijn sessie behoudt bij escalatie.

## Verificatie
- **1269 passed**, 4 skipped — incl. een test die bewijst dat er precies één stealth-retry gebeurt, dat de vlag in de payload belandt, en dat het trage pad dan wordt overgeslagen
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
