### PR TITLE
feat(obs): prove every Postgres alert can read its data + pin the cold-start threshold

### DIFF
--- a/.claude/rules/klai/infra/observability.md
+++ b/.claude/rules/klai/infra/observability.md
@@ -103,6 +103,43 @@ Useful queries:
 - Tenant activity: `SELECT * FROM product_events WHERE org_id = <id> ORDER BY created_at DESC`
 - Reconnect-funnel health: `SELECT properties->>'reason' AS reason, COUNT(*) FROM product_events WHERE event_type = 'connector.reconnect_failed' GROUP BY 1`
 
+## A provisioned alert must be proven able to read its data (HIGH)
+
+An alert that cannot read its datasource is worse than no alert: it reports
+healthy forever. On 2026-08-14, four of six Postgres-backed rules were blind.
+Nothing in Grafana showed it, because a query error under `execErrState: OK`
+looks exactly like "nothing wrong".
+
+Two distinct failure modes, and checking only the first is how the second hid
+for months:
+
+| Mode | Cause | Looks like |
+|---|---|---|
+| Permission | no `SELECT` grant, or `USAGE` on the schema missing | query error, swallowed by `execErrState: OK` |
+| RLS blackhole | grant exists, but the table's SELECT policy is scoped to another role or to a tenant GUC Grafana never sets | success, zero rows, forever |
+
+`deploy/scripts/verify-alert-datasource-access.py` checks both — `EXPLAIN` as
+`grafana_reader` for the first, and a superuser-vs-reader row-count comparison
+per relation for the second. It runs on core-01 from `deploy-compose.yml` after
+the provisioning sync, and fails the deploy on any blind rule that is not
+listed in the script's `KNOWN_BLIND` allowlist with a reason. The parser has its
+own self-test in CI, and a stale allowlist entry fails it.
+
+When wiring a new Postgres-backed alert:
+
+- `grafana_reader` needs `GRANT USAGE ON SCHEMA <s>` **and** `GRANT SELECT ON
+  <s>.<table>` — one without the other still denies.
+- `ALTER DEFAULT PRIVILEGES` in `deploy/grafana/sql/grafana-reader-setup.sql`
+  only covers tables created by the role that ran it. Alembic creates tables as
+  `portal_api`, so anything newer is invisible until granted explicitly.
+- For an RLS table, prefer a superuser-owned view exposing only the columns the
+  rule needs (see `portal_feedback_correlation_stats`). A view that is not
+  `security_invoker` evaluates the base table's RLS as its owner, so the rule
+  can read the aggregate without widening the base-table grant — which matters
+  when the table also holds user-written text.
+- Set `execErrState: Error`, not `OK`, on any rule whose purpose is catching
+  silence. Otherwise the rule can fail silently itself.
+
 ## When to use what
 | Scenario | Tool |
 |---|---|

--- a/.github/workflows/alerting-check.yml
+++ b/.github/workflows/alerting-check.yml
@@ -9,6 +9,8 @@ on:
       - 'scripts/audit-alert-uid-length.sh'
       - 'scripts/verify-alert-runbooks.sh'
       - 'scripts/test-alerting-guards.sh'
+      - 'deploy/scripts/verify-alert-datasource-access.py'
+      - 'deploy/scripts/tests/verify-alert-datasource-access.test.sh'
       - 'docs/runbooks/**'
       - 'docs/retros/**'
       - '.github/workflows/alerting-check.yml'
@@ -21,6 +23,8 @@ on:
       - 'scripts/audit-alert-uid-length.sh'
       - 'scripts/verify-alert-runbooks.sh'
       - 'scripts/test-alerting-guards.sh'
+      - 'deploy/scripts/verify-alert-datasource-access.py'
+      - 'deploy/scripts/tests/verify-alert-datasource-access.test.sh'
       - 'docs/runbooks/**'
       - 'docs/retros/**'
 
@@ -32,8 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install jq (required by audit-alert-uid-length.sh)
-        run: sudo apt-get update -y && sudo apt-get install -y jq
+      - name: Install jq + python3-yaml (required by the audit scripts)
+        run: sudo apt-get update -y && sudo apt-get install -y jq python3-yaml
 
       - name: Audit secrets in alerting provisioning
         run: bash scripts/audit-alert-secrets.sh
@@ -49,6 +53,14 @@ jobs:
       # pitfall `grafana-uid-40-char-limit (HIGH)` in process-rules.md.
       - name: Audit Grafana UID length (40-char limit)
         run: bash scripts/audit-alert-uid-length.sh
+
+      # The datasource-access checker itself runs at deploy time, on core-01,
+      # where a real database exists. What CI can prove is that its relation
+      # extraction is right: a rule whose relations are mis-parsed gets checked
+      # against the wrong table and passes while blind. Also fails on a stale
+      # KNOWN_BLIND entry, so the allowlist cannot outlive the rule it excuses.
+      - name: Self-test — alert datasource-access parser
+        run: bash deploy/scripts/tests/verify-alert-datasource-access.test.sh
 
       - name: Regression tests — both guards catch the CLASS of bug
         # Deliberately-bad fixtures must fail the audit/verify scripts;

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -170,6 +170,18 @@ jobs:
               docker compose --project-directory /opt/klai up -d grafana
             fi
 
+            # A provisioned alert that cannot read its datasource is worse than
+            # no alert: it reports healthy forever. On 2026-08-14 four of six
+            # Postgres-backed rules were blind -- two on a missing grant, one on
+            # an RLS policy scoped to another role, and the fourth had shipped
+            # broken that same afternoon. None of it was visible in Grafana,
+            # because a query error with execErrState: OK looks exactly like
+            # "nothing wrong". This runs after the sync so it judges what is
+            # actually on disk, and fails the deploy on any rule that is blind
+            # without a documented reason.
+            python3 deploy/scripts/verify-alert-datasource-access.py \
+              /opt/klai/grafana/provisioning/alerting
+
             # SPEC-INFRA-CONFIG-SYNC-001 R1 — bash helper for bind-mount
             # config sync. Replaces the inline Caddyfile block from
             # SPEC-INFRA-CADDY-CONFIG-DEPLOY-001 (which is now one of

--- a/deploy/grafana/sql/grafana-reader-setup.sql
+++ b/deploy/grafana/sql/grafana-reader-setup.sql
@@ -42,6 +42,22 @@ CREATE OR REPLACE VIEW portal_feedback_correlation_stats AS
 
 GRANT SELECT ON portal_feedback_correlation_stats TO grafana_reader;
 
+-- ── SPEC-RAG-EVAL — faithfulness + canary alerts ─────────────────────────
+--
+-- rag-eval-001-faithfulness-low and rag-eval-001-canary-dropped read
+-- knowledge.rag_eval_results and both failed with "permission denied for
+-- schema knowledge" on every evaluation since they were provisioned. USAGE on
+-- the schema is a separate privilege from SELECT on the table -- granting only
+-- one of the two still denies.
+--
+-- Granted at table level rather than schema-wide: a future table under
+-- knowledge may well hold customer content, and this role should not inherit
+-- access to it by accident. The table itself holds no user text -- scores,
+-- timings, chunk ids, a query_id, and a meta jsonb whose only keys are
+-- variant/error/errors (verified against production, 7264 rows). No RLS.
+GRANT USAGE ON SCHEMA knowledge TO grafana_reader;
+GRANT SELECT ON knowledge.rag_eval_results TO grafana_reader;
+
 -- Verify after running (must return a non-zero count, not an error and not 0):
 --   SET ROLE grafana_reader;
 --   SELECT count(*) FROM portal_feedback_correlation_stats;

--- a/deploy/scripts/tests/verify-alert-datasource-access.test.sh
+++ b/deploy/scripts/tests/verify-alert-datasource-access.test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Self-test for verify-alert-datasource-access.py's parser.
+#
+# The DB half of that script cannot run here (no postgres, by design -- an
+# earlier guard in this repo shipped with a mockable target and passed against
+# an image that did not exist). What IS testable offline is the fragile half:
+# which relations a rule really reads. Get that wrong and the checker silently
+# skips the relation that is actually broken, which is the same failure mode it
+# exists to prevent.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/deploy/scripts/verify-alert-datasource-access.py"
+PYTHON="${PYTHON:-python3}"
+
+if ! "$PYTHON" -c 'import yaml' 2>/dev/null; then
+  echo "FAIL: $PYTHON cannot import yaml -- install python3-yaml (the checker needs it on core-01 too)" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+ok() { echo "  ok: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1" >&2; fail=$((fail + 1)); }
+
+plan() { "$PYTHON" "$SCRIPT" --plan "$1" 2>&1; }
+
+# ── 1. The repo's own rules parse, and CTEs are not mistaken for relations ──
+echo "1. real alerting directory"
+if out="$(plan "$REPO_ROOT/deploy/grafana/provisioning/alerting")"; then
+  ok "exits 0"
+else
+  bad "exits non-zero: $out"
+fi
+for expected in \
+  "spec-kb-015-feedback-correlation-low	portal_feedback_correlation_stats" \
+  "spec-kb-015-feedback-correlation-low	portal_orgs" \
+  "spec-priv-001-tenant-stuck-full	portal_audit_log" \
+  "rag-eval-001-faithfulness-low	knowledge.rag_eval_results"; do
+  if printf '%s\n' "$out" | grep -qF "$expected"; then
+    ok "finds ${expected//	/ -> }"
+  else
+    bad "missing ${expected//	/ -> }"
+  fi
+done
+# rag-eval wraps its query in `WITH last_two AS (...), ranked AS (...)`. A CTE
+# name appears after FROM exactly like a table does, but has no grants -- a
+# count on one would error and be reported as a finding that does not exist.
+for cte in last_two ranked; do
+  if printf '%s\n' "$out" | grep -qE "[[:space:]]$cte$"; then
+    bad "CTE '$cte' leaked into the relation list"
+  else
+    ok "CTE '$cte' excluded"
+  fi
+done
+
+# ── 2. A directory with no Postgres rules must refuse, not report success ──
+echo "2. no Postgres-datasource rules"
+mkdir -p "$TMP/empty"
+cat >"$TMP/empty/only-logs.yaml" <<'YAML'
+apiVersion: 1
+groups:
+  - name: logs-only
+    rules:
+      - uid: some-victorialogs-rule
+        data:
+          - refId: query
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:portal-api'
+YAML
+set +e
+plan "$TMP/empty" >"$TMP/out2" 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 2 ]; then
+  ok "exits 2 rather than claiming success on an empty check"
+else
+  bad "expected exit 2, got $rc: $(cat "$TMP/out2")"
+fi
+
+# ── 3. A stale allowlist entry must fail ──────────────────────────────────
+# KNOWN_BLIND records rules we know are blind. If a uid in there no longer
+# exists, the entry is a lie that makes a future reader think a rule is
+# accounted for. This fixture has a Postgres rule but not the allowlisted uid.
+echo "3. stale KNOWN_BLIND entry"
+mkdir -p "$TMP/stale"
+cat >"$TMP/stale/rules.yaml" <<'YAML'
+apiVersion: 1
+groups:
+  - name: pg-only
+    rules:
+      - uid: some-other-rule
+        data:
+          - refId: query
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                SELECT count(*) AS value FROM portal_orgs
+YAML
+set +e
+plan "$TMP/stale" >"$TMP/out3" 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 1 ] && grep -q "no longer exist" "$TMP/out3"; then
+  ok "exits 1 and names the stale uid"
+else
+  bad "expected exit 1 naming the stale uid, got $rc: $(cat "$TMP/out3")"
+fi
+
+# ── 4. Schema-qualified names and aliases survive extraction ──────────────
+echo "4. schema qualification and aliases"
+mkdir -p "$TMP/shapes"
+cat >"$TMP/shapes/rules.yaml" <<'YAML'
+apiVersion: 1
+groups:
+  - name: shapes
+    rules:
+      - uid: spec-priv-001-tenant-stuck-full
+        data:
+          - refId: query
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                WITH recent AS (
+                  SELECT id FROM some_schema.some_table WHERE x > 1
+                )
+                SELECT count(*) AS value
+                  FROM portal_orgs o
+                  JOIN recent r ON r.id = o.id
+                 WHERE o.id IN (SELECT org_id FROM nested_table)
+YAML
+out4="$(plan "$TMP/shapes")"
+for expected in some_schema.some_table portal_orgs nested_table; do
+  if printf '%s\n' "$out4" | grep -qE "[[:space:]]$expected$"; then
+    ok "extracts $expected"
+  else
+    bad "missed $expected"
+  fi
+done
+if printf '%s\n' "$out4" | grep -qE "[[:space:]]recent$"; then
+  bad "CTE 'recent' leaked (aliased JOIN onto a CTE)"
+else
+  ok "aliased CTE 'recent' excluded"
+fi
+
+echo
+echo "passed=$pass failed=$fail"
+[ "$fail" -eq 0 ]

--- a/deploy/scripts/verify-alert-datasource-access.py
+++ b/deploy/scripts/verify-alert-datasource-access.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Prove that every Postgres-backed Grafana alert can actually read its data.
+
+Why this exists
+---------------
+
+On 2026-08-14 a freshly provisioned alert (spec-kb-015-feedback-correlation-low)
+queried portal_feedback_events directly. grafana_reader has no SELECT grant on
+that table, so every evaluation threw "permission denied" -- and because the
+rule copied execErrState: OK from a neighbour, that failure was
+indistinguishable from a healthy system. An alert built to catch silence was
+itself silent. Nobody would have noticed until the thing it watches broke.
+
+There are TWO distinct ways a rule can be blind, and only checking the first is
+how the second one hid for months:
+
+  1. PERMISSION -- no SELECT grant. Loud at the datasource, invisible in
+     Grafana when execErrState is OK. Caught here by EXPLAIN.
+
+  2. RLS BLACKHOLE -- the grant exists, the query succeeds, and it returns zero
+     rows forever because the table's SELECT policy is scoped to another role
+     (or to a tenant GUC that Grafana never sets). Nothing errors. From Grafana
+     this is identical to "no data", which is identical to "all healthy".
+     Caught here by comparing what the superuser sees against what
+     grafana_reader sees on the same relation.
+
+Class 2 is why this script compares row counts instead of just running EXPLAIN.
+
+Usage
+-----
+
+    verify-alert-datasource-access.py --plan [DIR]
+        Parse only. Prints "uid<TAB>relation" per referenced relation. No DB
+        access, so it runs anywhere -- this is the mode the self-test drives.
+
+    verify-alert-datasource-access.py [DIR]
+        Full check. Requires docker + the postgres container on this host.
+        Exits non-zero on any unexplained failure.
+
+The DB half is deliberately NOT mockable. An earlier guard in this repo shipped
+with an env-var that could redirect its check away from the real target, which
+made it pass against a nonexistent image. Only the parser -- the fragile part --
+is exercised offline.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+DEFAULT_DIR = Path("deploy/grafana/provisioning/alerting")
+
+# The role Grafana authenticates as. Must match the `user:` field in
+# deploy/grafana/provisioning/datasources/portal-postgres.yaml.
+READER_ROLE = "grafana_reader"
+
+POSTGRES_CONTAINER = "klai-core-postgres-1"
+
+# Rules known to be blind, with the reason. An entry here does NOT make the
+# rule work -- it records that we looked, understood, and chose not to fix it
+# in that change. Same contract as a .trivyignore.yaml entry: a reason, not a
+# shrug. Remove the entry when the rule is fixed; a stale entry fails the
+# self-test, so this cannot rot quietly.
+KNOWN_BLIND: dict[str, str] = {
+    "spec-priv-001-tenant-stuck-full": (
+        "portal_audit_log returns 0 rows for grafana_reader: its "
+        "tenant_isolation_read policy is scoped on org_id = current_setting("
+        "'app.current_org_id'), which Grafana never sets, so the rule's "
+        "id IN (SELECT org_id FROM portal_audit_log ...) subquery is always "
+        "empty and the alert can never fire. Found 2026-08-14 while verifying "
+        "SPEC-KB-015's rule. Belongs to SPEC-PRIVACY-QUERY-SHADOW-001 -- "
+        "flagged rather than silently redesigned, because the fix is a "
+        "decision about exposing audit detail to a dashboard role."
+    ),
+}
+
+
+def _postgres_rules(directory: Path) -> list[tuple[str, str, str]]:
+    """Return (source_file, uid, rawSql) for every Postgres-datasource query."""
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(directory.glob("*.yaml")):
+        doc = yaml.safe_load(path.read_text()) or {}
+        for group in doc.get("groups") or []:
+            for rule in group.get("rules") or []:
+                uid = rule.get("uid", "<no-uid>")
+                for query in rule.get("data") or []:
+                    model = query.get("model") or {}
+                    raw_sql = model.get("rawSql")
+                    if not raw_sql:
+                        continue
+                    ds_type = (model.get("datasource") or {}).get("type", "")
+                    if "postgres" not in ds_type:
+                        continue
+                    found.append((path.name, uid, raw_sql))
+    return found
+
+
+_CTE_RE = re.compile(r"(?:\bWITH\b|,)\s*([a-zA-Z_][\w]*)\s+AS\s*\(", re.IGNORECASE)
+_REL_RE = re.compile(r"\b(?:FROM|JOIN)\s+([a-zA-Z_][\w]*(?:\.[a-zA-Z_][\w]*)?)", re.IGNORECASE)
+
+
+def referenced_relations(raw_sql: str) -> list[str]:
+    """Relations a query really reads, with CTE names removed.
+
+    CTE names appear after FROM exactly like tables do, but they are not
+    relations and have no grants -- counting rows on one would error and look
+    like a finding. Subqueries need no special handling: their FROM clauses are
+    matched on their own.
+    """
+    ctes = {m.lower() for m in _CTE_RE.findall(raw_sql)}
+    seen: list[str] = []
+    for rel in _REL_RE.findall(raw_sql):
+        if rel.lower() in ctes or rel.lower() in seen:
+            continue
+        seen.append(rel.lower())
+    return seen
+
+
+def _psql(sql: str) -> tuple[int, str, str]:
+    """Run SQL in the postgres container as the superuser.
+
+    Returns (rc, stdout, stderr). Keep the two streams apart: psql writes
+    errors to stderr and command tags like "SET" to stdout, so merging them
+    both truncates error messages to a stray caret AND makes a scalar result
+    unparseable the moment the statement is preceded by SET ROLE.
+    """
+    proc = subprocess.run(  # noqa: S603
+        [
+            "docker",
+            "exec",
+            POSTGRES_CONTAINER,
+            "sh",
+            "-c",
+            'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tA -v ON_ERROR_STOP=1 -c '
+            + _shell_quote(sql),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def _first_error(stderr: str) -> str:
+    """The actionable line of a psql error, not the caret that follows it."""
+    for line in stderr.splitlines():
+        if line.startswith(("ERROR:", "FATAL:")):
+            return line
+    return stderr.splitlines()[0] if stderr.splitlines() else "unknown error"
+
+
+def _scalar(stdout: str) -> str:
+    """Last non-empty stdout line -- skips the "SET" tag from SET ROLE."""
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    return lines[-1] if lines else ""
+
+
+def _shell_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _check_rule(uid: str, raw_sql: str) -> list[str]:
+    """Return a list of failure descriptions for one rule (empty = healthy)."""
+    failures: list[str] = []
+
+    # Class 1: can the role execute the query at all? EXPLAIN plans it without
+    # running it, which is enough to surface a missing grant.
+    rc, _out, err = _psql(f"SET ROLE {READER_ROLE}; EXPLAIN {raw_sql.rstrip().rstrip(';')}")
+    if rc != 0:
+        failures.append(f"cannot execute as {READER_ROLE}: {_first_error(err)}")
+        return failures  # No point counting rows on a query that cannot run.
+
+    # Class 2: the query runs but a relation is silently empty for this role.
+    for rel in referenced_relations(raw_sql):
+        rc_super, super_out, super_err = _psql(f"SELECT count(*) FROM {rel}")
+        if rc_super != 0:
+            failures.append(f"relation {rel} unreadable even as superuser: {_first_error(super_err)}")
+            continue
+        rc_reader, reader_out, reader_err = _psql(
+            f"SET ROLE {READER_ROLE}; SELECT count(*) FROM {rel}"
+        )
+        if rc_reader != 0:
+            failures.append(f"relation {rel} unreadable as {READER_ROLE}: {_first_error(reader_err)}")
+            continue
+        try:
+            super_n, reader_n = int(_scalar(super_out)), int(_scalar(reader_out))
+        except ValueError:
+            failures.append(
+                f"relation {rel}: unparseable counts ({_scalar(super_out)!r} / {_scalar(reader_out)!r})"
+            )
+            continue
+        if super_n > 0 and reader_n == 0:
+            failures.append(
+                f"relation {rel} is an RLS blackhole: superuser sees {super_n} rows, "
+                f"{READER_ROLE} sees 0. The query will never return data and the "
+                f"alert can never fire."
+            )
+    return failures
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv[1:] if a != "--plan"]
+    plan_only = "--plan" in argv[1:]
+    directory = Path(args[0]) if args else DEFAULT_DIR
+
+    if not directory.is_dir():
+        print(f"ERROR: {directory} is not a directory", file=sys.stderr)
+        return 2
+
+    rules = _postgres_rules(directory)
+    if not rules:
+        print(f"ERROR: no Postgres-datasource alert rules found under {directory}.")
+        print("Either the path is wrong or the rule shape changed -- refusing to")
+        print("report success on an empty check.")
+        return 2
+
+    if plan_only:
+        for _file, uid, raw_sql in rules:
+            for rel in referenced_relations(raw_sql):
+                print(f"{uid}\t{rel}")
+        # A stale allowlist is a silent lie: it suggests a rule is known-broken
+        # when that rule may no longer exist under that uid.
+        uids = {uid for _f, uid, _s in rules}
+        stale = sorted(set(KNOWN_BLIND) - uids)
+        if stale:
+            print(f"ERROR: KNOWN_BLIND lists uids that no longer exist: {stale}", file=sys.stderr)
+            return 1
+        return 0
+
+    exit_code = 0
+    for source, uid, raw_sql in rules:
+        failures = _check_rule(uid, raw_sql)
+        if not failures:
+            print(f"OK       {uid} ({source})")
+            continue
+        excuse = KNOWN_BLIND.get(uid)
+        label = "KNOWN" if excuse else "BLIND"
+        print(f"{label}    {uid} ({source})")
+        for failure in failures:
+            print(f"         - {failure}")
+        if excuse:
+            print(f"         allowlisted: {excuse.splitlines()[0]}")
+        else:
+            exit_code = 1
+
+    if exit_code:
+        print()
+        print("At least one alert cannot read its own data. It will never fire, and")
+        print("with execErrState: OK it will look healthy while doing nothing.")
+        print("Fix the grant, or expose a superuser-owned view for the columns the")
+        print("rule needs -- see deploy/grafana/sql/grafana-reader-setup.sql.")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/klai-retrieval-api/tests/test_quality_floor.py
+++ b/klai-retrieval-api/tests/test_quality_floor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import pytest
 
+from retrieval_api import quality_boost, quality_floor
 from retrieval_api.quality_floor import filter_quality_floor
 
 
@@ -161,6 +162,34 @@ class TestFeedbackColdStartExemption:
         out, n_filtered = filter_quality_floor(chunks, floor=0.6)
         assert n_filtered == 1
         assert out == []
+
+
+class TestColdStartThresholdIsShared:
+    """The floor and the boost must agree on what counts as a signal.
+
+    Both modules define _COLD_START_MIN_VOTES and a comment in each says they
+    have to stay equal. A comment is not a guard, and "two files, two
+    assumptions" is exactly the shape of the defect this exemption fixes: the
+    floor and the scorer each held a defensible view of what 0.0 meant, and
+    nothing forced them to meet.
+
+    Raise the boost's threshold without raising the floor's and chunks become
+    filterable while still too cold to be boosted -- the original bug, back.
+    Lower it in one place only and a single vote regains the power to remove a
+    chunk. Either direction, this test fails first.
+    """
+
+    def test_floor_and_boost_use_the_same_threshold(self) -> None:
+        assert quality_floor._COLD_START_MIN_VOTES == quality_boost._COLD_START_MIN_VOTES, (
+            "quality_floor and quality_boost disagree about the cold-start "
+            f"threshold ({quality_floor._COLD_START_MIN_VOTES} vs "
+            f"{quality_boost._COLD_START_MIN_VOTES}). SPEC-KB-015 r.182 defines one "
+            "guard, not two. Change both or neither."
+        )
+
+    def test_threshold_matches_the_spec(self) -> None:
+        """SPEC-KB-015 r.112/118 fixes the value at 3 votes."""
+        assert quality_floor._COLD_START_MIN_VOTES == 3
 
 
 class TestFloorPerformance:


### PR DESCRIPTION
Two of the four improvements from the post-review triage. Both close a "two files, one assumption" gap — the shape of the defect that started this.

## 1. Four of six Postgres alerts were blind

Generalising yesterday's bug produced a checker, and running it against production produced this:

| Rule | Verdict |
|---|---|
| `spec-kb-015-feedback-correlation-low` | OK — fixed yesterday, confirmed here |
| `rag-eval-001-faithfulness-low` | **BLIND** — `permission denied for schema knowledge` |
| `rag-eval-001-canary-dropped` | **BLIND** — same |
| `spec-priv-001-tenant-stuck-full` | **BLIND** — RLS blackhole, 16441 rows vs 0 |

None of it was visible in Grafana. A query error under `execErrState: OK` is indistinguishable from a healthy system, which is exactly how this hid.

The two rag-eval rules now pass: a faithfulness-regression alert and a canary alert that could never fire, can. Granted per-table rather than schema-wide — a future table under `knowledge` may hold customer content and this role should not inherit it by accident. `rag_eval_results` itself holds scores, timings, chunk ids, a `query_id`, and a `meta` jsonb whose only keys are `variant`/`error`/`errors` (verified against production, 7264 rows, no RLS).

`spec-priv-001-tenant-stuck-full` is allowlisted **with its reason**, not silently redesigned: its `portal_audit_log` read is blocked by a tenant-scoped policy Grafana never satisfies, and fixing it is a decision about exposing audit detail to a dashboard role. It belongs to SPEC-PRIVACY-QUERY-SHADOW-001. A stale allowlist entry fails the self-test, so the excuse cannot outlive the rule.

### Why it checks two things

Checking only the first is how the second stayed hidden:

- **Permission** — `EXPLAIN` as `grafana_reader`. Catches a missing grant.
- **RLS blackhole** — superuser row count vs reader row count, per relation. Catches a policy scoped to another role: nothing errors, zero rows, forever.

The DB half is deliberately not mockable. An earlier guard in this repo shipped with a redirectable target and passed against an image that did not exist. Only the relation parser runs offline — 13 assertions in CI covering CTE exclusion (a CTE name follows `FROM` exactly like a table and has no grants, so counting rows on one would invent a finding), schema qualification, aliases, refusal on an empty check, and stale allowlists.

Wired into `deploy-compose.yml` after the provisioning sync, so it judges what is actually on disk and fails the deploy on any undocumented blind rule.

## 2. The cold-start threshold could still drift

`quality_floor` and `quality_boost` each define `_COLD_START_MIN_VOTES`, and each carries a comment saying they must stay equal. I wrote one of those comments yesterday and did not enforce it — while fixing a bug whose whole shape was two files holding two defensible views of the same value.

Raise the boost's threshold without the floor's and chunks become filterable while still too cold to be boosted: the original bug, back. Lower one only and a single vote regains the power to remove a chunk. Either direction now fails a test first. A second test pins the value to the 3 that SPEC-KB-015 r.112/118 fixes.

## Verification

- Checker run against production: exit 0 after the grants, with the one allowlisted rule reported by name. Re-ran before and after to confirm it flips.
- Parser self-test: 13 passed, 0 failed.
- Drift test proven red: flipping the boost constant to 5 fails only the equality test.
- `587 passed, 1 skipped` in klai-retrieval-api via the exact CI invocation (`uv run --extra dev pytest`).
- Workflow YAML parses; both scripts syntax-check.

## Note on the grants

`GRANT USAGE ON SCHEMA` + `GRANT SELECT` were applied to production before this merge, since the rules cannot evaluate without them. Both are recorded in `deploy/grafana/sql/grafana-reader-setup.sql`, which now also documents why `ALTER DEFAULT PRIVILEGES` never covered these tables: it only applies to tables created by the role that ran it, and alembic creates tables as `portal_api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)