### PR TITLE
ci: put the deploy verdict on the run summary, not only in the log body

### DIFF
--- a/deploy/scripts/compose-up.sh
+++ b/deploy/scripts/compose-up.sh
@@ -254,7 +254,7 @@ verify_service_running() {
     cid="$(service_container_id "$service")"
     VERIFIED_CID="$cid"
     if [[ -z "$cid" ]]; then
-        echo "ERROR: no container for $service after recreate" >&2
+        echo "::error::no container for $service after recreate"
         return 1
     fi
 
@@ -268,16 +268,16 @@ verify_service_running() {
         restarts="$(inspect_field "$cid" '{{.RestartCount}}')"
 
         if [[ -z "$status" ]]; then
-            echo "ERROR: cannot inspect $service's container ($cid) — daemon unreachable or container gone" >&2
+            echo "::error::cannot inspect $service's container ($cid) — daemon unreachable or container gone"
             return 1
         fi
         if [[ "$status" != "running" ]]; then
-            echo "ERROR: $service is '$status' after recreate (expected running)" >&2
+            echo "::error::$service is '$status' after recreate (expected running)"
             "$DOCKER" logs --tail 30 "$cid" 2>&1 | sed 's/^/    /' >&2 || true
             return 1
         fi
         if [[ -n "$prev_restarts" && -n "$restarts" && "$restarts" != "$prev_restarts" ]]; then
-            echo "ERROR: $service restarted during verification ($prev_restarts -> $restarts) — crash loop" >&2
+            echo "::error::$service restarted during verification ($prev_restarts -> $restarts) — crash loop"
             "$DOCKER" logs --tail 30 "$cid" 2>&1 | sed 's/^/    /' >&2 || true
             return 1
         fi
@@ -288,7 +288,7 @@ verify_service_running() {
     health="$(inspect_field "$cid" '{{if .State.Health}}{{.State.Health.Status}}{{end}}')"
     case "$health" in
         unhealthy)
-            echo "ERROR: $service is running but its healthcheck reports unhealthy" >&2
+            echo "::error::$service is running but its healthcheck reports unhealthy"
             "$DOCKER" logs --tail 30 "$cid" 2>&1 | sed 's/^/    /' >&2 || true
             return 1
             ;;
@@ -392,11 +392,14 @@ if [[ -n "$SERVICE" ]]; then
     if verify_service_running "$SERVICE"; then
         if (( COMPOSE_RC != 0 )); then
             if [[ -n "$PRE_CID" && "$VERIFIED_CID" == "$PRE_CID" ]]; then
-                echo "ERROR: docker compose exited $COMPOSE_RC and $SERVICE was never replaced —" >&2
-                echo "       container ${PRE_CID:0:12} is the one that was already running, so this deploy shipped nothing." >&2
+                echo "::error::$SERVICE was never replaced: docker compose exited $COMPOSE_RC and container ${PRE_CID:0:12} is the one that was already running, so this deploy shipped nothing"
                 exit 1
             fi
-            echo "WARN: docker compose exited $COMPOSE_RC, but $SERVICE was replaced (${PRE_CID:0:12} -> ${VERIFIED_CID:0:12}) and verified running — treating the deploy as successful" >&2
+            # ::warning:: puts this on the GitHub Actions run summary. Without
+            # it the run is green and the only trace is a line in a log nobody
+            # opens, so the one case where we ship THROUGH a compose failure
+            # would be the least visible thing the deploy does.
+            echo "::warning::$SERVICE deployed despite docker compose exiting $COMPOSE_RC — container was replaced (${PRE_CID:0:12} -> ${VERIFIED_CID:0:12}) and verified running"
         fi
     else
         if (( COMPOSE_RC != 0 )); then

--- a/deploy/scripts/tests/compose-up-verify.test.sh
+++ b/deploy/scripts/tests/compose-up-verify.test.sh
@@ -163,6 +163,10 @@ echo "2026-08-14T11:00:00Z" > "$case_dir/fixtures/created_new456"
 run_target demo
 check "compose exit 1 + container REPLACED -> 0" 0 "$rc"
 check_output "  names both container ids" "cid123 -> new456"
+# The run is GREEN in this case, so the only thing that makes shipping through
+# a compose failure visible is the annotation on the run summary. Drop the
+# prefix and it becomes a line in a log nobody opens.
+check_output "  surfaces as a workflow annotation" "::warning::"
 
 # The dangerous twin, and the reason the override is narrow. An unresolvable
 # image tag or a dependency that will not start makes compose abort BEFORE
@@ -174,6 +178,7 @@ fx up_stderr "Error failed to resolve reference ghcr.io/getklai/nope:bad"
 run_target demo
 check "compose exit 1 + same container -> 1" 1 "$rc"
 check_output "  says the deploy shipped nothing" "shipped nothing"
+check_output "  surfaces as a workflow annotation" "::error::"
 
 new_case compose_fails_no_container
 fx up_rc 1
@@ -189,12 +194,14 @@ fx status_cid123 "exited"
 run_target demo
 check "compose exit 0 + container exited -> 1" 1 "$rc"
 check_output "  dumps container logs" "stub container log line"
+check_output "  puts the reason on the run summary" "::error::demo is 'exited'"
 
 new_case crash_loop
 printf '0\n1\n' > "$case_dir/fixtures/restarts"
 run_target demo
 check "restart count rising -> 1" 1 "$rc"
 check_output "  calls it a crash loop" "crash loop"
+check_output "  puts the reason on the run summary" "::error::"
 
 new_case unhealthy
 fx health "unhealthy"


### PR DESCRIPTION
`compose-up.sh` decides whether a deploy succeeded, and until now it said so only in a line of SSH output.

That is fine when the run goes red — someone opens the log. It is exactly wrong for the one case that goes **green** through a compose failure: the override fires, the workflow passes, and the only trace that we shipped despite `docker compose` exiting non-zero is a `WARN` nobody will ever scroll to.

## What changed

The verdict lines are workflow annotations now. GitHub parses `::warning::` / `::error::` out of the relayed stdout and puts them on the run summary; the repo already relies on that from inside `appleboy/ssh-action` scripts (`portal-api.yml`, `deploy-compose.yml`).

| level | case |
|---|---|
| `::warning::` | shipped despite a compose failure, container **was** replaced |
| `::error::` | never replaced — this deploy shipped nothing |
| `::error::` | not running / crash loop / unhealthy / cannot inspect / no container |

The four failure reasons matter for a different reason than the warning: a red deploy used to put *"the workflow failed"* on the summary and the actual cause 30 lines down. Now the summary says which of crash-loop, exited-on-boot, unhealthy or daemon-unreachable it was.

## Tests

The prefixes are asserted, so a future edit cannot quietly drop them — the same silent-drift class this whole thread has been closing. Stripping `::warning::`/`::error::` from the script fails **4** cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)