### PR TITLE
fix(feedback): count every vote, and test the correlation step for real

### DIFF
--- a/klai-portal/backend/app/services/quality_scorer.py
+++ b/klai-portal/backend/app/services/quality_scorer.py
@@ -8,6 +8,7 @@ Uses httpx REST calls to Qdrant (NOT qdrant-client).
 """
 
 import asyncio
+import weakref
 
 import httpx
 import structlog
@@ -15,6 +16,43 @@ import structlog
 from app.core.config import settings
 
 logger = structlog.get_logger()
+
+# Qdrant has no atomic increment for payload fields, so the read-compute-write
+# below is a read-modify-write: two feedback events interleaving on the same
+# chunk both read feedback_count = N and both write N + 1, and one vote vanishes
+# with no error anywhere. That is worse than a rounding error, because the count
+# IS the cold-start gate quality_boost opens at 3 (SPEC-KB-015 r.118) -- the lost
+# vote can be the one that would have crossed it.
+#
+# One lock for all updates rather than one per chunk: two feedback events can
+# share part of their chunk sets, and per-chunk locks would then need a global
+# acquisition order to stay deadlock-free. Real feedback volume is single digits
+# per month, so serialising costs nothing measurable and cannot deadlock.
+#
+# This closes the race completely as long as portal-api runs ONE process:
+# scripts/uvicorn-launch.sh passes no --workers and entrypoint.sh adds only
+# host/port, so uvicorn's default of 1 applies. Add workers or a second replica
+# and this narrows the window instead of closing it -- at that point the lock
+# has to move to Redis, which the feedback path already uses.
+#
+# Per running loop, NOT a single module-level Lock. A Lock binds to the loop
+# that first awaits it and raises "bound to a different event loop" everywhere
+# else -- and since this function swallows exceptions by contract
+# (REQ-KB-015-18), that would turn into the feedback loop silently doing nothing
+# for any caller on another loop (an operator script, a future worker, every
+# test after the first). Weak keys so a finished loop does not pin itself in
+# memory.
+_UPDATE_LOCKS: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = weakref.WeakKeyDictionary()
+
+
+def _update_lock() -> asyncio.Lock:
+    """The update lock for the currently running loop, created on first use."""
+    loop = asyncio.get_running_loop()
+    lock = _UPDATE_LOCKS.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _UPDATE_LOCKS[loop] = lock
+    return lock
 
 
 async def apply_quality_score(
@@ -37,7 +75,9 @@ async def apply_quality_score(
     headers = {"api-key": settings.qdrant_api_key} if settings.qdrant_api_key else {}
 
     try:
-        async with httpx.AsyncClient(timeout=5.0, headers=headers) as client:
+        # The lock spans read AND write; holding it only around either half
+        # would leave exactly the gap it exists to close.
+        async with _update_lock(), httpx.AsyncClient(timeout=5.0, headers=headers) as client:
             # Batch fetch current payloads
             resp = await client.post(
                 f"{base_url}/collections/{collection}/points",

--- a/klai-portal/backend/tests/test_kb_feedback_correlation.py
+++ b/klai-portal/backend/tests/test_kb_feedback_correlation.py
@@ -1,0 +1,215 @@
+"""The correlation step itself, unmocked, against a real Redis.
+
+Why this file exists next to test_kb_feedback_endpoint.py
+---------------------------------------------------------
+
+That file patches ``find_correlated_log`` and asserts what the endpoint does
+with its answer. Necessary, but it means the correlation step -- Redis key
+construction, which identity the key is built from, and the timestamp window --
+was never executed by any test. Both causes of the four-month outage lived
+exactly there:
+
+  1. The endpoint looked the log up under LibreChat's Mongo ObjectId while
+     retrieval had written it under the Zitadel subject. Two namespaces, so the
+     key never matched. 55 of 58 events came back uncorrelated.
+  2. The forward sent the moment of the click instead of the message's own
+     createdAt, which falls outside the SPEC's [-60s, +10s] window as soon as
+     someone rates a message that is not brand new.
+
+Neither is visible to a test that patches the function they live in. Both fail
+here.
+
+These tests write through the real ``write_retrieval_log`` and read through the
+real ``find_correlated_log``, on the shared fakeredis fixture. Only the layers
+that are genuinely not under test are patched: auth, the DB, and the two
+fire-and-forget side effects.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# The retrieval log is keyed by the Zitadel subject, because that is the
+# identity the retrieval path knows. LibreChat's own user id is a Mongo
+# ObjectId from an unrelated namespace -- the two must never be confused,
+# which is the whole point of these tests.
+ZITADEL_SUBJECT = "319481925918031876"
+LIBRECHAT_OBJECT_ID = "68b1f0c2e4b0a1d2c3f4a5b6"
+ORG_ID = 42
+CHUNK_IDS = ["chunk-a", "chunk-b", "chunk-c"]
+
+
+@pytest.fixture
+def mock_org():
+    org = MagicMock()
+    org.id = ORG_ID
+    org.zitadel_org_id = "zit-org-1"
+    org.librechat_container = "tenant-abc"
+    return org
+
+
+def _mock_result(value):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+async def _seed_retrieval_log(*, user_id: str, retrieved_at: datetime) -> None:
+    """Write a log entry through the production writer, not a hand-built key.
+
+    Building the Redis key by hand in the test would let the writer and the
+    reader drift apart while both tests stayed green -- the same two-sided
+    mistake this file exists to catch.
+    """
+    from app.services.retrieval_log import write_retrieval_log
+
+    await write_retrieval_log(
+        org_id=ORG_ID,
+        user_id=user_id,
+        chunk_ids=CHUNK_IDS,
+        reranker_scores=[0.91, 0.84, 0.72],
+        query_resolved="hoe vraag ik verlof aan",
+        embedding_model_version="bge-m3-v1",
+        retrieved_at=retrieved_at,
+    )
+
+
+async def _post_feedback(body, mock_org):
+    """Call the endpoint with correlation live. Returns (schedule_mock, emit_mock)."""
+    from app.api.internal import post_kb_feedback
+
+    mock_request = MagicMock()
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=_mock_result(mock_org))
+    mock_db.commit = AsyncMock()
+
+    # The idempotency check and the retrieval log share the same pool in
+    # production, so the fake is handed to both -- a GET on an unset
+    # idempotency key returns None, which is exactly "not seen before".
+    from app.services import redis_client
+
+    with (
+        patch("app.api.internal._require_internal_token"),
+        patch("app.api.internal.get_redis_pool", side_effect=redis_client.get_redis_pool),
+        patch("app.api.internal.set_tenant"),
+        patch("app.api.internal.emit_event") as mock_emit,
+        patch("app.api.internal.schedule_quality_update") as mock_schedule,
+    ):
+        await post_kb_feedback(body=body, request=mock_request, db=mock_db)
+    return mock_schedule, mock_emit
+
+
+def _body(**overrides):
+    from app.api.internal import KbFeedbackIn
+
+    defaults = {
+        "conversation_id": "conv-1",
+        "message_id": "msg-1",
+        "message_created_at": datetime.now(UTC),
+        "rating": "thumbsUp",
+        "librechat_user_id": LIBRECHAT_OBJECT_ID,
+        "librechat_tenant_id": "tenant-abc",
+        "identity_user_id": ZITADEL_SUBJECT,
+    }
+    defaults.update(overrides)
+    return KbFeedbackIn(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_identity_id_correlates_against_the_log_retrieval_wrote(fake_redis, mock_org):
+    """The whole chain: retrieval writes, feedback finds it, Qdrant gets scheduled."""
+    now = datetime.now(UTC)
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=now - timedelta(seconds=5))
+
+    schedule, emit = await _post_feedback(_body(message_created_at=now), mock_org)
+
+    schedule.assert_called_once_with(CHUNK_IDS, "thumbsUp", ORG_ID)
+    assert emit.call_args[1]["properties"]["correlated"] is True
+    assert emit.call_args[1]["properties"]["chunk_count"] == len(CHUNK_IDS)
+
+
+@pytest.mark.asyncio
+async def test_librechat_object_id_alone_finds_nothing(fake_redis, mock_org):
+    """The original bug, pinned.
+
+    Retrieval writes under the Zitadel subject. A forward that only knows
+    LibreChat's ObjectId looks under a key that was never written, gets no
+    error, and stores the feedback as uncorrelated. That is what ran for four
+    months. If someone drops identity_user_id from the forward again, this test
+    keeps passing (correctly -- it asserts the fallback is inert) while the test
+    above starts failing.
+    """
+    now = datetime.now(UTC)
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=now - timedelta(seconds=5))
+
+    schedule, emit = await _post_feedback(_body(message_created_at=now, identity_user_id=None), mock_org)
+
+    schedule.assert_not_called()
+    assert emit.call_args[1]["properties"]["correlated"] is False
+    assert emit.call_args[1]["properties"]["chunk_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_click_time_on_an_older_message_falls_outside_the_window(fake_redis, mock_org):
+    """The second cause, pinned.
+
+    SPEC-KB-015 r.71 correlates on the MESSAGE's createdAt, within
+    [-60s, +10s] of the retrieval. Sending the click time instead works for a
+    message rated immediately and silently stops working the moment a user
+    scrolls up and rates an older answer -- the retrieval is then further back
+    than the window allows.
+    """
+    now = datetime.now(UTC)
+    message_created_at = now - timedelta(minutes=10)
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=message_created_at - timedelta(seconds=3))
+
+    # Correct: the message's own timestamp still correlates ten minutes later.
+    schedule, emit = await _post_feedback(_body(message_created_at=message_created_at), mock_org)
+    schedule.assert_called_once_with(CHUNK_IDS, "thumbsUp", ORG_ID)
+    assert emit.call_args[1]["properties"]["correlated"] is True
+
+    # Wrong: the click time is 10 minutes past the retrieval, far outside the
+    # 60-second window.
+    schedule, emit = await _post_feedback(_body(message_id="msg-2", message_created_at=now), mock_org)
+    schedule.assert_not_called()
+    assert emit.call_args[1]["properties"]["correlated"] is False
+
+
+@pytest.mark.asyncio
+async def test_window_boundaries(fake_redis, mock_org):
+    """r.71 defines [message_created_at - 60s, +10s]. Pin both edges."""
+    now = datetime.now(UTC)
+
+    # 59s before the message: inside.
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=now - timedelta(seconds=59))
+    schedule, _ = await _post_feedback(_body(message_created_at=now), mock_org)
+    schedule.assert_called_once()
+
+    # 61s before: outside. A fresh key keeps the two cases independent.
+    await fake_redis.delete(f"rl:{ORG_ID}:{ZITADEL_SUBJECT}")
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=now - timedelta(seconds=61))
+    schedule, _ = await _post_feedback(_body(message_id="msg-3", message_created_at=now), mock_org)
+    schedule.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_different_tenant_cannot_correlate_against_our_log(fake_redis, mock_org):
+    """The key is org-scoped. Same subject, other org, must not match.
+
+    Cheap to assert and worth pinning: the retrieval log holds chunk ids, and
+    correlating across orgs would attach one tenant's feedback to another
+    tenant's chunks.
+    """
+    now = datetime.now(UTC)
+    await _seed_retrieval_log(user_id=ZITADEL_SUBJECT, retrieved_at=now - timedelta(seconds=5))
+
+    other_org = MagicMock()
+    other_org.id = 99
+    other_org.zitadel_org_id = "zit-org-2"
+    other_org.librechat_container = "tenant-other"
+
+    schedule, emit = await _post_feedback(_body(message_created_at=now), other_org)
+
+    schedule.assert_not_called()
+    assert emit.call_args[1]["properties"]["correlated"] is False

--- a/klai-portal/backend/tests/test_quality_scorer_race.py
+++ b/klai-portal/backend/tests/test_quality_scorer_race.py
@@ -1,0 +1,157 @@
+"""Two thumbs on the same chunk must count as two.
+
+``apply_quality_score`` reads a chunk's payload, computes the new running
+average, and writes it back. Qdrant has no atomic increment for payload fields,
+so those three steps are a classic read-modify-write: two feedback events
+interleaving on the same chunk both read ``feedback_count = N`` and both write
+``N + 1``. One vote disappears with no error anywhere.
+
+That matters more than the raw probability suggests. The count is not just a
+statistic -- it is the cold-start gate (SPEC-KB-015 r.118). A chunk stuck one
+vote short of three stays unboosted, and the vote that would have crossed the
+threshold is the one that got lost.
+
+The fake below awaits between read and write, which is what makes the
+interleaving deterministic instead of a coin flip. Without the lock in
+apply_quality_score, ``test_two_concurrent_ratings_both_count`` fails with
+count 1.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+CHUNK = "chunk-shared"
+
+
+class _FakeQdrant:
+    """Minimal stand-in for the two Qdrant REST calls, with a shared store.
+
+    Deliberately yields the event loop inside the read. A real HTTP round-trip
+    yields too, so this reproduces the production interleaving rather than
+    inventing one.
+    """
+
+    def __init__(self, *, quality_score: float = 0.5, feedback_count: int = 0) -> None:
+        self.store = {"quality_score": quality_score, "feedback_count": feedback_count}
+        self.writes: list[dict] = []
+
+    async def post(self, url: str, json: dict):  # `json` mirrors httpx.posts kwarg name
+        if url.endswith("/points"):
+            # Snapshot BEFORE yielding, then yield. That is the real shape: a
+            # read returns the value as of the moment the server answered, and
+            # the caller does its arithmetic after a network delay during which
+            # another writer can land. Snapshotting after the yield would let
+            # the second reader see the first writer's result and the race
+            # would quietly fail to reproduce.
+            snapshot = dict(self.store)
+            await asyncio.sleep(0)
+            return _FakeResponse({"result": [{"id": CHUNK, "payload": snapshot}]})
+        if url.endswith("/points/payload"):
+            payload = json["payload"]
+            self.store.update(payload)
+            self.writes.append(dict(payload))
+            return _FakeResponse({"result": {}})
+        raise AssertionError(f"unexpected Qdrant call: {url}")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+class _FakeResponse:
+    def __init__(self, body: dict) -> None:
+        self._body = body
+
+    def json(self) -> dict:
+        return self._body
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_ratings_both_count():
+    """The race, pinned. Two thumbsUp on one chunk -> feedback_count 2."""
+    from app.services import quality_scorer
+
+    fake = _FakeQdrant()
+
+    with patch.object(quality_scorer.httpx, "AsyncClient", lambda **_kw: fake):
+        await asyncio.gather(
+            quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42),
+            quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42),
+        )
+
+    assert fake.store["feedback_count"] == 2, (
+        "a concurrent vote was lost: both calls read the same count and wrote "
+        f"the same increment (writes: {fake.writes})"
+    )
+    assert fake.store["quality_score"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_mixed_ratings_average_over_both_votes():
+    """One up, one down, from count 0 -> 0.5 over two votes, not one.
+
+    Order does not matter here: (0*0+1)/1 then (1*1+0)/2 = 0.5, and the reverse
+    gives (0*0+0)/1 then (0*1+1)/2 = 0.5.
+    """
+    from app.services import quality_scorer
+
+    fake = _FakeQdrant()
+
+    with patch.object(quality_scorer.httpx, "AsyncClient", lambda **_kw: fake):
+        await asyncio.gather(
+            quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42),
+            quality_scorer.apply_quality_score([CHUNK], "thumbsDown", 42),
+        )
+
+    assert fake.store["feedback_count"] == 2
+    assert fake.store["quality_score"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_serialisation_does_not_swallow_the_second_vote_on_a_cold_chunk():
+    """Three votes must reach the cold-start threshold, not stall at two.
+
+    This is the consequence that makes the race worth fixing: feedback_count is
+    the gate quality_boost opens at 3 (SPEC-KB-015 r.118). A lost vote is not a
+    rounding error, it is a chunk that never starts being ranked on its
+    feedback.
+    """
+    from app.services import quality_scorer
+
+    fake = _FakeQdrant()
+
+    with patch.object(quality_scorer.httpx, "AsyncClient", lambda **_kw: fake):
+        await asyncio.gather(*(quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42) for _ in range(3)))
+
+    assert fake.store["feedback_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_a_qdrant_failure_still_releases_the_lock():
+    """A raising update must not wedge every later update behind a held lock.
+
+    apply_quality_score swallows errors by contract (REQ-KB-015-18); the danger
+    is the lock, not the exception. If the first call leaves it held, the
+    feedback loop stops silently for the lifetime of the process.
+    """
+    from app.services import quality_scorer
+
+    class _Exploding(_FakeQdrant):
+        async def post(self, url: str, json: dict):
+            raise RuntimeError("qdrant unreachable")
+
+    with patch.object(quality_scorer.httpx, "AsyncClient", lambda **_kw: _Exploding()):
+        await quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42)
+
+    fake = _FakeQdrant()
+    with patch.object(quality_scorer.httpx, "AsyncClient", lambda **_kw: fake):
+        await asyncio.wait_for(quality_scorer.apply_quality_score([CHUNK], "thumbsUp", 42), timeout=2)
+
+    assert fake.store["feedback_count"] == 1

--- a/klai-portal/frontend/e2e/prod-tenant/J04-chat-feedback.spec.ts
+++ b/klai-portal/frontend/e2e/prod-tenant/J04-chat-feedback.spec.ts
@@ -27,6 +27,16 @@
  * response body reflects rating "thumbsUp" -> assert the button's
  * aria-pressed flips to "true" so a silently-failing handler is caught.
  *
+ * The SECOND half -- whether the forwarded feedback actually correlates with a
+ * retrieval log, so Qdrant learns anything -- cannot be asserted from a browser
+ * at all: it happens server-side and no client-visible response reflects it.
+ * That is deliberately covered instead by
+ * klai-portal/backend/tests/test_kb_feedback_correlation.py, which runs the real
+ * correlation against a real Redis and pins both causes of the four-month
+ * outage (identity namespace, and message-createdAt vs click time). Do not add
+ * a correlation assertion here; it would need the internal secret in the
+ * browser's environment to read that state.
+ *
  * docs/testing/test-suite-plan.md §6 (J04).
  */
 import { test, expect } from '@playwright/test'


### PR DESCRIPTION
The last two of the four improvements from the post-review triage.

## 1. The correlation step was never executed by a test

`test_kb_feedback_endpoint.py` patches `find_correlated_log` and asserts what the endpoint does with its answer. Necessary — but it means the correlation step itself (Redis key construction, which identity the key is built from, the timestamp window) had no coverage at all. Both causes of the four-month outage lived exactly there:

1. The lookup used LibreChat's Mongo ObjectId while retrieval had written the log under the Zitadel subject. Two namespaces, so the key never matched.
2. The forward sent the moment of the click rather than the message's own `createdAt`, which leaves the SPEC's `[-60s, +10s]` window as soon as someone rates an answer that is not brand new.

Neither is visible to a test that patches the function they live in.

Five tests now write through the real `write_retrieval_log` and read through the real `find_correlated_log` on the shared fakeredis fixture — pinning both causes, both window edges, and org-scoping (same subject, other org, must not match; correlating across tenants would attach one tenant's feedback to another tenant's chunks).

**Proven red:** reverting `_correlation_user_id` to the LibreChat id alone fails 3 of the 5. The other two assert the *absence* of correlation and correctly stay green.

### Why not an e2e test

The original triage framed this as e2e. It cannot be: whether feedback correlates is server-side state that no client-visible response reflects, so asserting it from a browser would require the internal secret in the browser's environment. J04 keeps covering the first half and now says so explicitly, to stop a future reader concluding the second half is simply unproven.

## 2. Two thumbs on one chunk counted as one

`apply_quality_score` does read → compute → write, and Qdrant has no atomic increment for payload fields. Two feedback events interleaving on the same chunk both read `feedback_count = N` and both write `N + 1`. One vote vanishes, silently.

Worth fixing despite low collision odds, because the count is not a statistic — it is the cold-start gate `quality_boost` opens at 3 (r.118). The lost vote can be exactly the one that would have crossed it, and the chunk then never starts being ranked on its feedback at all.

One lock for all updates rather than one per chunk: two events can share part of their chunk sets, so per-chunk locks would need a global acquisition order to stay deadlock-free, for no measurable gain at single-digit monthly volume.

### The bug inside the fix

My first version used a single module-level `asyncio.Lock`. A Lock binds to the loop that first awaits it and raises `bound to a different event loop` everywhere else — and since this function swallows exceptions by contract (REQ-KB-015-18), that turns into **the feedback loop silently doing nothing** for any caller on another loop. The tests caught it: two failed with count 1 and a RuntimeError buried in a swallowed traceback. Now held per running loop, in a `WeakKeyDictionary`.

There was a second self-inflicted trap worth recording: the first version of the fake snapshotted the payload *after* yielding, which let the second reader see the first writer's result. The race quietly failed to reproduce and all four tests passed against unfixed code. Snapshotting before the yield is the real shape — a read returns the value as of the server's answer, and the caller computes after a network delay.

### Scope of the fix

This closes the race completely while portal-api runs one process: `scripts/uvicorn-launch.sh` passes no `--workers` and `entrypoint.sh` adds only host/port, so uvicorn's default of 1 applies (verified, not assumed). Add workers or a second replica and it narrows the window instead of closing it — at which point the lock has to move to Redis, which this path already uses. Stated in the code so the assumption is visible rather than implicit.

## Verification

- Correlation: 5 passed; 3 fail against the pre-fix identity behaviour.
- Race: 4 passed; 3 fail without the lock; one covers the lock being released when Qdrant raises, since a wedged lock would stop the loop for the process lifetime.
- `3587 passed, 9 deselected, 1 xfailed` in portal-api.
- ruff check + format clean; pyright `0 errors` on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)