### PR TITLE
chore(caddy): remove dev.getklai.com — the route outlived its backend by four months

### DIFF
--- a/.github/workflows/caddy-validate.yml
+++ b/.github/workflows/caddy-validate.yml
@@ -42,27 +42,21 @@ jobs:
 
       - name: Validate Caddyfile syntax
         run: |
-          # Dummy env vars cover all six {$VAR} placeholders in
-          # deploy/caddy/Caddyfile. Use `--env-file` with a quoted
-          # heredoc so the bcrypt-shaped CADDY_DEV_PASSWORD_HASH (which
-          # contains literal `$` chars) is not subject to shell
-          # expansion. Empty tenants dir is mounted to resolve the
-          # `import /etc/caddy/tenants/*.caddyfile` glob to zero
-          # matches (Caddy 2 silently OK on no-match).
+          # Dummy env vars cover all four {$VAR} placeholders in
+          # deploy/caddy/Caddyfile. Empty tenants dir is mounted to
+          # resolve the `import /etc/caddy/tenants/*.caddyfile` glob to
+          # zero matches (Caddy 2 silently OK on no-match).
           #
-          # CADDY_DEV_PASSWORD_HASH must be bcrypt-shaped — Caddy's
-          # basic_auth directive parses the hash format at validate
-          # time. The value below is a real bcrypt hash with cost 14
-          # (it never matches any password we care about; this is a
-          # validate-only credential).
+          # The quoted heredoc is kept: it costs nothing and keeps any
+          # future value containing literal `$` safe from shell expansion.
+          # It was originally required for the bcrypt CADDY_DEV_PASSWORD_HASH,
+          # dropped with dev.getklai.com on 2026-08-17.
           mkdir -p /tmp/empty-tenants
           cat > /tmp/caddy-validate.env <<'EOF'
           ADMIN_EMAIL=ci@example.com
           DOMAIN=example.com
           HETZNER_AUTH_API_TOKEN=validate-only-dummy-token
           VICTORIALOGS_INGEST_TOKEN=validate-only-dummy-token
-          CADDY_DEV_USERNAME=ci-validate
-          CADDY_DEV_PASSWORD_HASH=$2a$14$8K1p/a0dqbPzNDIJKMlj3eLvhR0DWNmgKnHr0gZxhkNH88nF.gzqK
           EOF
           docker run --rm \
             --env-file /tmp/caddy-validate.env \

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -349,39 +349,15 @@
         }
     }
 
-    # Dev environment — dev.getklai.com routes to portal-api-dev + /srv/portal-dev
-    # Must come BEFORE the general /api/* handler below.
-    # Uses `route` to preserve directive order.
-    #
-    # SPEC-SEC-008 F-018 — protected by basic_auth to gate public internet access.
-    # Credentials stored in SOPS (CADDY_DEV_USERNAME / CADDY_DEV_PASSWORD_HASH).
-    @dev-host host dev.{$DOMAIN}
-    handle @dev-host {
-        basic_auth {
-            {$CADDY_DEV_USERNAME} {$CADDY_DEV_PASSWORD_HASH}
-        }
-        route {
-            @dev-api path /api/*
-            reverse_proxy @dev-api portal-api-dev:8010 {
-                header_up -X-Internal-Secret
-                header_up -X-Caller-Service
-                header_up -X-Org-ID
-                header_up -X-Org-Slug
-                header_up -X-User-ID
-            }
-
-            root * /srv/portal-dev
-
-            @dev-spa-assets path /assets/*
-            header @dev-spa-assets Cache-Control "public, max-age=31536000, immutable"
-
-            @dev-spa-html not path /assets/*
-            header @dev-spa-html Cache-Control "no-cache"
-
-            try_files {path} /index.html
-            file_server
-        }
-    }
+    # dev.getklai.com was removed 2026-08-17. It routed to portal-api-dev +
+    # /srv/portal-dev, a parallel review environment from PR #103
+    # (feat/chat-first-redesign, April 2026) where every feat/* push auto-deployed.
+    # That PR was closed, taking its compose file and both deploy workflows with
+    # it; the route reached main separately via 53d31aa4f, which brought the
+    # server's Caddyfile under version control three days earlier. So the route
+    # outlived the thing it pointed at by four months: no CI deployed to it, no
+    # container backed it, and 30 days of logs held 932 basic-auth rejections,
+    # a handful of crawlers, and no human request at all.
 
     # SPEC-KB-FILE-UPLOAD-001 REQ-2: scoped multipart-body cap on the
     # KB file-upload endpoint. 200 MB matches the binary path's

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -123,9 +123,6 @@ services:
       GRAFANA_CADDY_HASH: ${GRAFANA_CADDY_HASH}
       VICTORIALOGS_INGEST_TOKEN: ${VICTORIALOGS_INGEST_TOKEN}
       VICTORIALOGS_BASIC_AUTH_B64: ${VICTORIALOGS_BASIC_AUTH_B64}
-      # SPEC-SEC-008 F-018 — dev.getklai.com basic-auth credentials
-      CADDY_DEV_USERNAME: ${CADDY_DEV_USERNAME:-}
-      CADDY_DEV_PASSWORD_HASH: ${CADDY_DEV_PASSWORD_HASH:-}
     networks:
       - klai-net
       - monitoring

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -74,7 +74,6 @@ CADDY_WHITELIST=(
     '^vexa12-meeting-api$'       # Vexa internal — managed by the Vexa stack
     '^vexa12-admin-api$'         # Vexa internal
     '^vexa12-runtime$'           # Vexa internal
-    '^portal-api-dev$'           # protected dev environment outside prod compose
 )
 
 is_whitelisted() {


### PR DESCRIPTION
`dev.getklai.com` was a parallel review environment: every `feat/*` push built a `:dev` image and deployed there — isolated container, own database `klai_dev`, own `PORTAL_API_DEV_*` secrets. It came from **PR #103** (`feat/chat-first-redesign`, 16–17 April 2026) together with `docker-compose.dev.yml`, two deploy workflows and a `dev.md` operating guide.

**PR #103 was closed, not merged.** The compose file, both workflows and the docs went with it. The route did not: `53d31aa4f` had brought the server's Caddyfile under version control three days earlier, explicitly noting the dev-host block *"was server-only, now in repo"* and adding the SEC-008 basic_auth gate. A correct config-sync commit adopted a route whose backend was about to be abandoned, and nothing connected the two events.

Four months later:

| | |
|---|---|
| CI deploying to it | none — both workflows died with the PR |
| containers backing it | none of `portal-api-dev`, `litellm-dev`, `librechat-dev` exists |
| 30 days of traffic | 932 × `401`, ~20 crawler requests, **0 human** |

## Removed

- the `@dev-host` block in `deploy/caddy/Caddyfile`
- `CADDY_DEV_USERNAME` / `CADDY_DEV_PASSWORD_HASH` from the caddy service — no reader left
- their stub values in `caddy-validate.yml` (four placeholders remain, not six)
- the `'^portal-api-dev$'` exemption in `audit-compose-orphans.sh`, which called it a *"protected dev environment"* and had outlived the thing it protected

The SOPS keys and the server-side leftovers (`/opt/klai/docker-compose.dev.yml`, `/opt/klai/portal-dev`) follow separately, after this deploys — the route must go before the credentials it reads.

Caddyfile validated with the real binary: `Valid configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)