### PR TITLE
fix(security): patch base-image OS packages everywhere, and guard that it stays that way

### DIFF
--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -19,6 +19,8 @@ on:
     paths:
       - 'deploy/scripts/**'
       - 'deploy/librechat/tests/**'
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
       - '.claude/hooks/klai/container-hygiene-preflight.sh'
       - '.claude/hooks/klai/tests/**'
       - '.github/workflows/deploy-scripts-tests.yml'
@@ -27,6 +29,8 @@ on:
     paths:
       - 'deploy/scripts/**'
       - 'deploy/librechat/tests/**'
+      - '**/Dockerfile'
+      - '**/Dockerfile.*'
       - '.claude/hooks/klai/container-hygiene-preflight.sh'
       - '.claude/hooks/klai/tests/**'
       - '.github/workflows/deploy-scripts-tests.yml'
@@ -51,6 +55,12 @@ jobs:
 
       - name: compose-up.sh verification suite
         run: bash deploy/scripts/tests/compose-up-verify.test.sh
+
+      # A shipped image that does not patch its base OS is a deploy the Trivy
+      # gate will block — for whoever happens to touch that service next, not
+      # for whoever left it unpatched.
+      - name: base-image security-update guard suite
+        run: bash deploy/scripts/tests/check-dockerfile-security-updates.test.sh
 
       - name: assert-safe-to-prune guard suite
         run: sh deploy/scripts/tests/assert-safe-to-prune.test.sh

--- a/deploy/bge-m3-sparse/Dockerfile
+++ b/deploy/bge-m3-sparse/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 
+# Apply security patches to base image OS packages. Built on gpu-01 rather
+# than in CI, so nothing else would ever catch a stale OS package here.
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+
 # SEC-018 F-029: create non-root user + writable model cache before runtime.
 RUN useradd --create-home --uid 1000 --shell /bin/bash app && \
     mkdir -p /models && chown -R app:app /models

--- a/deploy/scripts/check-dockerfile-security-updates.sh
+++ b/deploy/scripts/check-dockerfile-security-updates.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Every image we build and ship must patch its base OS packages.
+#
+# Why this guard exists: on 2026-08-17 the Trivy gate blocked the retrieval-api
+# deploy on CVE-2026-53615 (util-linux, 9 packages, fix available). It was not
+# a retrieval-api problem — it came from the shared python:3.12-slim base, so
+# every service on that base was one rebuild away from a blocked deploy.
+# klai-portal/backend had carried the fix for months; nobody else had it, and
+# nothing said so.
+#
+# Seven Dockerfiles then got the same three lines. Seven copies of anything
+# drift (see `url-shape-multi-file-drift` in the process pitfalls), and the
+# drift here is invisible until a deploy is already blocked. This turns "did
+# somebody remember" into a check.
+#
+# What it enforces: the FINAL stage of each Dockerfile — the one that produces
+# the shipped filesystem, which is what Trivy scans — runs an OS package
+# upgrade. Builder stages are irrelevant; their layers do not ship.
+#
+# Usage:  bash deploy/scripts/check-dockerfile-security-updates.sh [file...]
+#         (no arguments = every tracked Dockerfile)
+
+set -euo pipefail
+
+# Images whose base OS we do not own. Adding an apt/apk upgrade to these means
+# patching somebody else's image on top of their pinned dependency set, which
+# is how you get a build that works until upstream moves. Each line needs a
+# reason, not just a path.
+is_allowlisted() {
+    case "$1" in
+        deploy/crawl4ai/Dockerfile)
+            # Thin re-tag of unclecode/crawl4ai. Upstream owns the OS layer and
+            # pins a Playwright/Chromium combination that an OS upgrade can
+            # break; it is scanned WARN-tier, not STRICT.
+            return 0 ;;
+        deploy/librechat/Dockerfile.klai)
+            # Source-level patches on top of ghcr.io/danny-avila/librechat.
+            # Same reasoning, plus the image is digest-pinned downstream, so an
+            # upgrade here would move a digest a canary can be rolled back to.
+            return 0 ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+# Resolve the final stage's real base, following `FROM <earlier-stage>` links.
+# klai-docs is the reason this is not a one-liner: its runtime stage is
+# `FROM base AS runner`, where `base` is defined earlier as node:22-alpine.
+resolve_base() {
+    local file="$1" target="$2" depth=0 line base alias
+    while (( depth++ < 10 )); do
+        line=""
+        while IFS= read -r candidate; do
+            base="$(sed -E 's/^FROM +//; s/ +AS +.*$//I' <<< "$candidate")"
+            alias="$(sed -nE 's/^FROM +.* +AS +(.*)$/\1/Ip' <<< "$candidate")"
+            if [[ -z "$target" || "$alias" == "$target" ]]; then
+                line="$base"
+                [[ -z "$target" ]] && break
+            fi
+        done < <(grep -E '^FROM ' "$file")
+        [[ -n "$line" ]] || { printf '%s' "$target"; return; }
+        # Another local stage? follow it. Otherwise this is the real base.
+        if grep -qiE "^FROM +.* +AS +${line}$" "$file" 2>/dev/null; then
+            target="$line"; continue
+        fi
+        printf '%s' "$line"; return
+    done
+    printf '%s' "$target"
+}
+
+final_stage_body() {
+    # Everything after the last FROM — the shipped stage.
+    local file="$1" last
+    last="$(grep -nE '^FROM ' "$file" | tail -1 | cut -d: -f1)"
+    tail -n "+$last" "$file"
+}
+
+failures=0
+checked=0
+skipped=0
+
+files=("$@")
+if (( ${#files[@]} == 0 )); then
+    mapfile -t files < <(git ls-files | grep -E '(^|/)Dockerfile[^/]*$')
+fi
+
+for file in "${files[@]}"; do
+    [[ -f "$file" ]] || continue
+
+    if is_allowlisted "$file"; then
+        echo "  skip  $file (upstream-owned base, see allow-list)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    final_from="$(grep -E '^FROM ' "$file" | tail -1 | sed -E 's/^FROM +//; s/ +AS +.*$//I')"
+    if grep -qiE "^FROM +.* +AS +${final_from}$" "$file" 2>/dev/null; then
+        base="$(resolve_base "$file" "$final_from")"
+    else
+        base="$final_from"
+    fi
+
+    body="$(final_stage_body "$file")"
+
+    case "$base" in
+        *alpine*)
+            want='apk upgrade'
+            ;;
+        *slim*|*debian*|*ubuntu*|*bookworm*|*trixie*|*bullseye*)
+            want='apt-get upgrade'
+            ;;
+        *)
+            echo "  skip  $file (base '$base' is neither Debian- nor Alpine-based)"
+            skipped=$((skipped + 1))
+            continue
+            ;;
+    esac
+
+    checked=$((checked + 1))
+    if grep -qF "$want" <<< "$body"; then
+        echo "  ok    $file (final stage: $base)"
+    else
+        echo "  FAIL  $file — final stage is '$base' but never runs '$want'" >&2
+        failures=$((failures + 1))
+    fi
+done
+
+echo
+echo "checked=$checked  skipped=$skipped  failures=$failures"
+
+if (( failures > 0 )); then
+    cat >&2 <<'EOF'
+
+A shipped image is not patching its base OS packages. Trivy gates the deploy on
+exactly those findings, so this becomes a blocked deploy the next time that
+service builds — usually for somebody who did not touch the Dockerfile.
+
+Add to the FINAL stage (the pattern klai-portal/backend/Dockerfile has used
+since before this guard existed):
+
+    # Apply security patches to base image OS packages
+    RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+        && rm -rf /var/lib/apt/lists/*
+
+Alpine equivalent: `apk update && apk upgrade --no-cache`.
+
+If the base genuinely is not ours to patch, add it to is_allowlisted() with the
+reason — not a bare path.
+EOF
+    exit 1
+fi

--- a/deploy/scripts/tests/check-dockerfile-security-updates.test.sh
+++ b/deploy/scripts/tests/check-dockerfile-security-updates.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Tests for check-dockerfile-security-updates.sh.
+#
+# The guard takes file arguments, so every case is a fixture Dockerfile in a
+# temp dir — no Docker, no network.
+#
+# Run: bash deploy/scripts/tests/check-dockerfile-security-updates.test.sh
+
+set -euo pipefail
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../../.." && pwd)
+guard="$repo_root/deploy/scripts/check-dockerfile-security-updates.sh"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+run_guard() {
+    set +e
+    ( cd "$repo_root" && bash "$guard" "$@" ) > "$work/out" 2>&1
+    rc=$?
+    set -e
+}
+
+check() {
+    if [[ "$2" == "$3" ]]; then
+        echo "  ok   $1"
+    else
+        echo "  FAIL $1 (expected exit $2, got $3)"
+        sed 's/^/       /' "$work/out"
+        failures=$((failures + 1))
+    fi
+}
+
+fixture() {
+    local name="$1"; shift
+    printf '%s\n' "$@" > "$work/$name"
+    printf '%s' "$work/$name"
+}
+
+echo "check-dockerfile-security-updates.sh"
+
+f=$(fixture Dockerfile.debian_ok \
+    'FROM python:3.12-slim' \
+    'RUN apt-get update && apt-get upgrade -y --no-install-recommends \' \
+    '    && rm -rf /var/lib/apt/lists/*' \
+    'COPY app app')
+run_guard "$f"; check "debian base with the upgrade -> pass" 0 "$rc"
+
+f=$(fixture Dockerfile.debian_missing \
+    'FROM python:3.12-slim' \
+    'RUN apt-get update && apt-get install -y curl' \
+    'COPY app app')
+run_guard "$f"; check "debian base without the upgrade -> fail" 1 "$rc"
+
+f=$(fixture Dockerfile.alpine_ok \
+    'FROM node:22-alpine' \
+    'RUN apk update && apk upgrade --no-cache')
+run_guard "$f"; check "alpine base with apk upgrade -> pass" 0 "$rc"
+
+f=$(fixture Dockerfile.alpine_missing \
+    'FROM node:22-alpine' \
+    'RUN apk add --no-cache tini')
+run_guard "$f"; check "alpine base without apk upgrade -> fail" 1 "$rc"
+
+# The mistake worth guarding hardest: patching a stage whose layers never ship.
+# Trivy scans the final filesystem, so an upgrade in the builder buys nothing
+# while looking exactly like a fix in review.
+f=$(fixture Dockerfile.builder_only \
+    'FROM python:3.12-slim AS builder' \
+    'RUN apt-get update && apt-get upgrade -y' \
+    'RUN pip install .' \
+    '' \
+    'FROM python:3.12-slim' \
+    'COPY --from=builder /usr/local /usr/local')
+run_guard "$f"; check "upgrade only in the builder stage -> fail" 1 "$rc"
+
+f=$(fixture Dockerfile.builder_and_final \
+    'FROM python:3.12-slim AS builder' \
+    'RUN pip install .' \
+    '' \
+    'FROM python:3.12-slim' \
+    'RUN apt-get update && apt-get upgrade -y --no-install-recommends' \
+    'COPY --from=builder /usr/local /usr/local')
+run_guard "$f"; check "upgrade in the final stage of a multi-stage -> pass" 0 "$rc"
+
+# klai-docs is why base resolution exists: its runtime stage inherits from a
+# named local stage, so the literal FROM line says nothing about the OS.
+f=$(fixture Dockerfile.named_stage \
+    'FROM node:22-alpine AS base' \
+    'FROM base AS deps' \
+    'RUN npm ci' \
+    'FROM base AS runner' \
+    'RUN apk update && apk upgrade --no-cache')
+run_guard "$f"; check "final stage inherits a named stage -> resolves the base" 0 "$rc"
+
+f=$(fixture Dockerfile.named_stage_missing \
+    'FROM node:22-alpine AS base' \
+    'FROM base AS runner' \
+    'COPY dist dist')
+run_guard "$f"; check "named-stage inheritance without the upgrade -> fail" 1 "$rc"
+
+# Nothing to patch, and no package manager to do it with.
+f=$(fixture Dockerfile.scratch \
+    'FROM scratch' \
+    'COPY server /server')
+run_guard "$f"; check "scratch base -> skipped, not failed" 0 "$rc"
+if grep -q "skip" "$work/out"; then
+    echo "  ok     says it skipped rather than passing silently"
+else
+    echo "  FAIL   skipped without saying so"
+    failures=$((failures + 1))
+fi
+
+# The allow-list is keyed on real repo paths, so this case uses one.
+run_guard deploy/crawl4ai/Dockerfile
+check "allow-listed upstream image -> skipped" 0 "$rc"
+if grep -q "allow-list" "$work/out"; then
+    echo "  ok     points at the allow-list for the reason"
+else
+    echo "  FAIL   skipped an allow-listed file without saying why"
+    failures=$((failures + 1))
+fi
+
+# The whole repo has to be clean, or the guard is decoration.
+run_guard
+check "every tracked Dockerfile in the repo -> pass" 0 "$rc"
+
+echo
+if [[ "$failures" -eq 0 ]]; then
+    echo "check-dockerfile-security-updates: all cases passed"
+else
+    echo "check-dockerfile-security-updates: $failures case(s) failed"
+    exit 1
+fi

--- a/klai-connector/Dockerfile
+++ b/klai-connector/Dockerfile
@@ -40,6 +40,11 @@ FROM python:3.12-slim
 
 WORKDIR /repo/klai-connector
 
+# Apply security patches to base image OS packages (Trivy blocks the deploy
+# on unfixed CVEs shipped by python:3.12-slim, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # Venv (has editable klai-connector-credentials pointer) + the shared-lib
 # source the editable install points at.
 COPY --from=deps /repo/klai-connector/.venv /repo/klai-connector/.venv

--- a/klai-docker-authz/Dockerfile
+++ b/klai-docker-authz/Dockerfile
@@ -15,6 +15,11 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.12-slim AS runtime
 
+# Apply security patches to base image OS packages (Trivy blocks the deploy
+# on unfixed CVEs shipped by python:3.12-slim, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=deps /repo /repo
 WORKDIR /repo/klai-docker-authz
 COPY klai-docker-authz/app app

--- a/klai-docs/Dockerfile
+++ b/klai-docs/Dockerfile
@@ -18,6 +18,11 @@ RUN npm run build
 
 # Production image
 FROM base AS runner
+
+# Apply security patches to base image OS packages. node:22-alpine ships
+# apk packages with fixed CVEs and the Trivy gate blocks the deploy on them.
+RUN apk update && apk upgrade --no-cache
+
 WORKDIR /app
 ENV NODE_ENV=production
 

--- a/klai-knowledge-mcp/Dockerfile
+++ b/klai-knowledge-mcp/Dockerfile
@@ -5,6 +5,11 @@
 
 FROM python:3.12-slim
 
+# Apply security patches to base image OS packages (Trivy blocks the deploy
+# on unfixed CVEs shipped by python:3.12-slim, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # uv from the official distroless image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 

--- a/klai-mailer/Dockerfile
+++ b/klai-mailer/Dockerfile
@@ -34,6 +34,11 @@ FROM python:3.12-slim
 
 WORKDIR /repo/klai-mailer
 
+# Apply security patches to base image OS packages (Trivy blocks the deploy
+# on unfixed CVEs shipped by python:3.12-slim, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # Venv (has editable klai-log-utils + klai-webhook-replay pointers) + the
 # shared-lib sources the editable installs point at.
 COPY --from=deps /repo/klai-mailer/.venv /repo/klai-mailer/.venv

--- a/klai-retrieval-api/Dockerfile
+++ b/klai-retrieval-api/Dockerfile
@@ -5,6 +5,11 @@
 
 FROM python:3.12-slim
 
+# Apply security patches to base image OS packages (Trivy blocks the deploy
+# on unfixed CVEs shipped by python:3.12-slim, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # uv from the official distroless image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 

--- a/klai-scribe/scribe-api/Dockerfile
+++ b/klai-scribe/scribe-api/Dockerfile
@@ -34,7 +34,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 # Stage 2: Application
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Apply security patches to base image OS packages before installing
+# runtime deps (Trivy blocks the deploy on unfixed CVEs, e.g. CVE-2026-53615)
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     ffmpeg \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*

--- a/klai-scribe/whisper-server/Dockerfile
+++ b/klai-scribe/whisper-server/Dockerfile
@@ -18,7 +18,8 @@ FROM nvidia/cuda:12.9.1-cudnn-runtime-ubuntu24.04
 # the binary has no purpose in the runtime container, so we remove the
 # entire family. Combined with the 12.9.1 base bump this defends against
 # CVE-2025-68973 by both patching AND removing the affected binaries.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv \
     ffmpeg \
     libsndfile1 \


### PR DESCRIPTION
The Trivy gate blocked the retrieval-api deploy this morning on `CVE-2026-53615` (util-linux 2.41-5, fix available, 9 packages).

It was not a retrieval-api problem. The finding comes from the shared `python:3.12-slim` base, and the same one sits in the published knowledge-ingest image. **Every service on that base was one rebuild away from a blocked deploy.**

## The fix

`klai-portal/backend` has carried it for months — a generic `apt-get upgrade` in its runtime stage. Nobody else had it, and nothing said so. Seven Dockerfiles now carry the same block, in their **final stage only**: builder layers do not ship, and Trivy scans the shipped filesystem.

Generic upgrade, not a pinned package list, deliberately. A pinned list needs an edit for every future base CVE; a generic upgrade fixes the next one on the next rebuild. That is portal-api's existing shape and it is why it never had this problem.

**Verified, not assumed:** retrieval-api built locally with the change and scanned with CI's exact flags (`--severity CRITICAL,HIGH --ignore-unfixed --scanners vuln`) goes from **9 findings to 0**.

## The guard, because seven copies drift

`deploy/scripts/check-dockerfile-security-updates.sh`: for every tracked Dockerfile, the final stage of a Debian- or Alpine-based image must run the upgrade. It resolves `FROM <named-stage>` chains (klai-docs inherits `node:22-alpine` through two of them), skips bases that are neither, and allow-lists the two images whose OS layer belongs to upstream — crawl4ai and the LibreChat patch image — with the reason, not just the path.

It immediately found three more gaps nobody had noticed:

| file | gap |
|---|---|
| `klai-docs/Dockerfile` | `node:22-alpine`, no `apk upgrade` |
| `deploy/bge-m3-sparse/Dockerfile` | `python:3.11-slim`, built on gpu-01 so **no CI scan would ever have caught it** |
| `klai-scribe/whisper-server/Dockerfile` | `nvidia/cuda` ubuntu24.04 |

All three fixed.

> ⚠️ **whisper-server needs a GPU smoke test before rollout.** It is rolled out by hand on gpu-01, so this PR ships no image for it by itself — see the manual-rollout note in `VERSIONS.md`.

## Tests

13 cases, no Docker needed. The one that matters most is **"upgrade in the builder stage only" → fail**, because that mistake looks exactly like a fix in review and buys nothing.

Mutation-tested: making the guard read the whole file instead of the final stage, or dropping named-stage resolution, each fails a case.

Wired into the pre-merge job, with `**/Dockerfile` added to its paths so any Dockerfile change is gated.

## Not in this PR

The `klai-docs` deploy is also red, but on 8 **npm** findings (`next` 16.2.10 → 16.2.11, `sharp`, plus two transitives) — a different subsystem, handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)