### PR TITLE
fix(obs): the orphan-audit runbooks sent operators to two paths that do not exist

### DIFF
--- a/.claude/rules/klai/infra/container-hygiene.md
+++ b/.claude/rules/klai/infra/container-hygiene.md
@@ -102,8 +102,12 @@ runs checks and `exit 2` blocks the tool-call:
 3. **Compose git-history grep:** if `klai-infra` checkout reachable,
    search `deploy/docker-compose*.yml` history for the target. Match
    means it was a declared service at some point — needs review.
-4. **Caddy upstream check:** target reachable via `/opt/klai/Caddyfile`
-   (best-effort, only when core-01 reachable — fail-open on dev).
+4. **Caddy upstream check:** target reachable in the live Caddy config
+   (best-effort, only when core-01 reachable — fail-open on dev). Read it from
+   inside the container — `docker exec klai-core-caddy-1 grep -r <name>
+   /etc/caddy/Caddyfile /etc/caddy/tenants/` — never from a host path. Two host
+   files answer to the name Caddyfile and the tenant configs live in a volume,
+   so every host-path form of this check has been wrong.
 5. **VictoriaLogs traffic check:** target had log-events in last 30d
    (best-effort — fail-open on dev).
 

--- a/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
@@ -126,7 +126,7 @@ groups:
                  legitimate tenant container — its tenant_slug label tells you
                  which tenant.
               3. Check why Caddy lost the upstream:
-                   ssh core-01 "grep -n {NAME} /opt/klai/Caddyfile /opt/klai/caddy/tenants/*.caddyfile"
+                   ssh core-01 "docker exec klai-core-caddy-1 grep -rn {NAME} /etc/caddy/Caddyfile /etc/caddy/tenants/"
                  If absent, the per-tenant Caddyfile was lost — recreate via
                  the portal-api provisioning re-run flow (see provisioning-retry.md
                  runbook).
@@ -203,7 +203,7 @@ groups:
                  The `container_name` field names the upstream Caddy could
                  not resolve.
               2. Verify Caddyfile state:
-                   ssh core-01 "grep -nE '(^|[[:space:]]){NAME}([[:space:]]|:|$)' /opt/klai/Caddyfile /opt/klai/caddy/tenants/*.caddyfile"
+                   ssh core-01 "docker exec klai-core-caddy-1 grep -rnE '(^|[[:space:]]){NAME}([[:space:]]|:|$)' /etc/caddy/Caddyfile /etc/caddy/tenants/"
               3. Decide: is this a stale Caddyfile entry (service was
                  intentionally removed) or a missing container (service
                  should exist)?

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -24,8 +24,8 @@
 #      timestamp > 7 days. May contain klantdata; never auto-prune.
 #
 #   5. caddy_upstream_missing
-#      Caddy upstream in /opt/klai/Caddyfile that does NOT match any
-#      running container — broken routing-rule.
+#      Caddy upstream in the live config that does NOT match any running
+#      container — broken routing-rule.
 #
 #   6. tenant_container_no_route
 #      Container with klasse-B label OR tenant-pattern-name (`librechat-*`)
@@ -74,7 +74,7 @@ echo 0 > "$EVENT_TMP"
 
 # ─── Assemble the full Caddy config ──────────────────────────────────────────
 #
-# /opt/klai/Caddyfile ends in `import /etc/caddy/tenants/*.caddyfile`, and every
+# The live Caddyfile ends in `import /etc/caddy/tenants/*.caddyfile`, and every
 # tenant route lives in there — written by portal-api at provisioning time,
 # stored in a Docker volume, so the path in that import is container-internal and
 # does not exist on the host.


### PR DESCRIPTION
Both alert descriptions told the operator to run:

```
grep -n <name> /opt/klai/Caddyfile /opt/klai/caddy/tenants/*.caddyfile
```

Neither path is right. `/opt/klai/Caddyfile` is a 256-line leftover from 2026-04-21 — the live file is `/opt/klai/caddy/Caddyfile`. And the tenant configs are not on the host at all: they live in the `klai-core_caddy-tenants` volume, mounted at `/etc/caddy/tenants` inside the container.

So **the runbook attached to an alert about missing routes would itself find no routes.** Someone following it would conclude the upstream really is orphaned — which is exactly the librechat-voys reasoning the alert exists to prevent.

## Fix

Read it from inside the container:

```
docker exec klai-core-caddy-1 grep -rn <name> /etc/caddy/Caddyfile /etc/caddy/tenants/
```

Stable regardless of which host path is current or where the volume is mounted. Verified on core-01 — it finds `/etc/caddy/tenants/voys.caddyfile:23` for `librechat-voys`, where both host-path forms returned nothing.

Same correction applied to two stale header comments in `docker-orphan-audit.sh` and to the hook's check-4 description in `container-hygiene.md`, which named the same dead host path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)