### PR TITLE
feat(hygiene): notice when someone edits the deployed compose file by hand

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -63,6 +63,7 @@ jobs:
           # incident. This job also installs it, so its tests belong here.
           bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
           bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
+          bash deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -67,5 +67,8 @@ jobs:
       - name: orphan-audit caddy-route suite
         run: bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
 
+      - name: orphan-audit hand-edit suite
+        run: bash deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
+
       - name: container-hygiene preflight suite
         run: bash .claude/hooks/klai/tests/container-hygiene-preflight.test.sh

--- a/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
@@ -210,3 +210,84 @@ groups:
                  - Stale entry: edit Caddyfile, remove the route, redeploy.
                  - Missing container: investigate why it's down via
                    container_down runbook + recreate via compose-up.sh.
+
+      - uid: spec-hyg-001-compose-hand-edit
+        title: compose_hand_edit_artifact
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:klai-orphan-audit AND event:compose_hand_edit_artifact'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 1h
+        isPaused: false
+        labels:
+          # warning, not critical, unlike the two rules above. Those describe a
+          # route or a container that is wrong right now; this describes a file
+          # that should not exist. It wants cleaning up, not waking anyone. The
+          # emitted event carries the same level, so the two agree.
+          severity: warning
+          spec: SPEC-INFRA-CONTAINER-HYGIENE-001
+          service_group: hygiene-orphan-audit
+        annotations:
+          summary: 'a file was edited beside the deployed docker-compose.yml — someone bypassed the deploy pipeline'
+          runbook_url: 'docs/runbooks/container-hygiene-systemd-install.md'
+          description: |
+            A sibling of /opt/klai/docker-compose.yml exists (.bak, .orig,
+            .pre-*, .before-*). The deploy pipeline writes that file from the
+            repo and never creates a sibling, so this marks an edit made by
+            hand on the server — which the repo forbids as CRIT
+            (infra/deploy.md, "No manual server edits").
+
+            The edit itself is the problem, not the leftover: deploy-compose.yml
+            overwrites the deployed file on the next push, so whatever was
+            changed by hand is silently lost, and the backup is the only record
+            that it ever happened.
+
+            What to do:
+              1. Diff the leftover against the deployed file to see what was
+                 changed:  diff /opt/klai/docker-compose.yml <leftover>
+              2. If the change is still wanted, put it in deploy/docker-compose.yml
+                 and push. If not, delete the leftover.
+              3. Either way the leftover goes; it is not a backup worth keeping,
+                 because deploy/docker-compose.yml is in git.
+
+            26 of these accumulated between April and May 2026 before anything
+            watched for them. None held a service absent from git, so nothing
+            was lost that time.

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -2,7 +2,7 @@
 # /opt/klai/scripts/docker-orphan-audit.sh
 #
 # Weekly orphan audit emitting structlog-events to stdout (Alloy →
-# VictoriaLogs). Detects six categories of "wees" state:
+# VictoriaLogs). Detects seven categories of "wees" state:
 #
 #   1. orphan_no_managed_label
 #      Running container without klasse-A (compose-project=klai-core)
@@ -26,6 +26,10 @@
 #   5. caddy_upstream_missing
 #      Caddy upstream in the live config that does NOT match any running
 #      container — broken routing-rule.
+#
+#   7. compose_hand_edit_artifact
+#      A sibling of the deployed compose file (.bak / .orig / .pre-* / …).
+#      The deploy pipeline never creates one, so it marks a hand-edit.
 #
 #   6. tenant_container_no_route
 #      Container with klasse-B label OR tenant-pattern-name (`librechat-*`)
@@ -299,6 +303,28 @@ if [[ -n "$CADDY_TENANTS_OK" ]]; then
             emit_event "caddy_upstream_missing" "critical" "$host" \
                 "{\"upstream_in_caddyfile\":\"$host\"}"
         done
+fi
+
+# ─── Detection 7: hand-edit artifacts beside the deployed compose file ───────
+#
+# /opt/klai/docker-compose.yml is written by deploy-compose.yml from the repo.
+# Nothing in that pipeline ever creates a sibling — so a docker-compose.yml.bak,
+# .orig, .pre-*, or .before-* is the fingerprint of somebody editing the
+# deployed file by hand, which the repo forbids as CRIT.
+#
+# By 2026-08-17 there were 26 of them, spanning April to May, 1.7 MB. None was
+# mounted and none held a service absent from git, so nothing was lost — but
+# every one marked an edit made outside the pipeline, and the pile grew for four
+# months with nothing watching. The audit is the only layer that sees a human on
+# the server, so it is the layer that has to notice.
+COMPOSE_DIR="$(dirname "$COMPOSE_FILE")"
+COMPOSE_BASE="$(basename "$COMPOSE_FILE")"
+if [[ -d "$COMPOSE_DIR" ]]; then
+    while IFS= read -r artifact; do
+        [[ -z "$artifact" ]] && continue
+        emit_event "compose_hand_edit_artifact" "warning" "$(basename "$artifact")" \
+            "{\"path\":\"$artifact\",\"detail\":\"sibling of the deployed compose file; the deploy pipeline never creates one, so this marks an edit made outside it\"}"
+    done < <(find "$COMPOSE_DIR" -maxdepth 1 -type f -name "${COMPOSE_BASE}.*" 2>/dev/null | sort)
 fi
 
 # ─── Always emit run-completed marker ────────────────────────────────────────

--- a/deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
+++ b/deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# SPEC-INFRA-CONTAINER-HYGIENE-001 REQ-5 — notice edits made outside the pipeline.
+#
+# /opt/klai/docker-compose.yml is written by deploy-compose.yml from the repo, and
+# nothing in that pipeline creates a sibling file. So a docker-compose.yml.bak,
+# .orig, .pre-victorialogs or .before-cadvisor-flags is the fingerprint of someone
+# editing the deployed file by hand — which the repo forbids as CRIT.
+#
+# On 2026-08-17 there were 26 of them, April through May, 1.7 MB. Nothing was
+# lost: none was mounted, and every service in them also existed somewhere in the
+# 6773 commits touching deploy/docker-compose.yml. But each one marked an edit
+# made outside the pipeline, and the pile grew for four months with nothing
+# watching it. The audit is the only layer that sees a human on the server.
+#
+# The risk in a detection like this is the opposite of the last one: it must not
+# fire on the compose files the deploy legitimately places next to each other.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+AUDIT="$REPO_ROOT/deploy/scripts/docker-orphan-audit.sh"
+FAIL=0
+
+run_with() {
+    # $@ = filenames to create next to the compose file
+    local tmp; tmp="$(mktemp -d)"
+    printf 'services:\n  portal-api:\n' > "$tmp/docker-compose.yml"
+    for f in "$@"; do printf 'services:\n' > "$tmp/$f"; done
+
+    cat > "$tmp/docker" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  ps)
+    for a in "$@"; do [[ "$a" == "-a" ]] && exit 0; done
+    case "$*" in
+      *'{{.Names}}'*) echo "klai-core-portal-api-1" ;;
+      *com.docker.compose.service*) echo "portal-api" ;;
+      *) : ;;
+    esac
+    ;;
+  inspect)
+    case "$4" in
+      *com.docker.compose.project*) echo "klai-core" ;;
+      *com.docker.compose.service*) echo "portal-api" ;;
+      *) : ;;
+    esac
+    ;;
+  *) : ;;
+esac
+exit 0
+STUB
+    chmod +x "$tmp/docker"
+
+    PATH="$tmp:$PATH" COMPOSE_FILE="$tmp/docker-compose.yml" \
+        OVERRIDE_FILE="$tmp/none.yml" DEV_FILE="$tmp/none.yml" \
+        CADDYFILE="$tmp/no-caddyfile" \
+        bash "$AUDIT" 2>/dev/null
+    rm -rf "$tmp"
+}
+
+flagged() { echo "$1" | grep -c "\"event\":\"compose_hand_edit_artifact\"" | tr -d ' '; }
+
+expect_count() {
+    want="$1"; got="$2"; why="$3"
+    if [ "$got" = "$want" ]; then echo "OK:   $got flagged — $why"
+    else echo "FAIL: expected $want flagged, got $got — $why" >&2; FAIL=1; fi
+}
+
+echo "── compose hand-edit detection ──"
+
+OUT=$(run_with)
+expect_count 0 "$(flagged "$OUT")" "a clean deploy leaves no siblings"
+
+# The exact names found on core-01.
+OUT=$(run_with docker-compose.yml.bak docker-compose.yml.orig \
+               docker-compose.yml.pre-victorialogs.bak \
+               docker-compose.yml.before-cadvisor-flags-20260606141107)
+expect_count 4 "$(flagged "$OUT")" "every real leftover shape is caught"
+
+# Must NOT fire on legitimate compose files that share the directory. These are
+# separate files, not siblings of docker-compose.yml, and the deploy places them
+# there on purpose.
+OUT=$(run_with docker-compose.override.yml docker-compose.dev.yml)
+expect_count 0 "$(flagged "$OUT")" "override/dev compose files are not hand-edit marks"
+
+if echo "$OUT" | grep -q '"event":"audit_run_completed"'; then
+    echo "OK:   audit ran to completion"
+else
+    echo "FAIL: audit aborted before its final event" >&2; FAIL=1
+fi
+
+echo "─────────────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+    echo "compose hand-edit guard: OK"
+else
+    echo "compose hand-edit guard: FAILED" >&2
+fi
+exit "$FAIL"

--- a/scripts/audit-compose-orphans.sh
+++ b/scripts/audit-compose-orphans.sh
@@ -71,9 +71,10 @@ CADDY_WHITELIST=(
     # SPEC-VEXA-004: the 0.10 names (api-gateway, admin-api, meeting-api,
     # runtime-api) are deliberately NOT whitelisted — they no longer exist, so a
     # Caddy upstream naming one is a resurrected orphan the audit must surface.
-    '^vexa12-meeting-api$'       # Vexa internal — managed by the Vexa stack
-    '^vexa12-admin-api$'         # Vexa internal
-    '^vexa12-runtime$'           # Vexa internal
+    # vexa12-meeting-api / -admin-api / -runtime used to be listed here as
+    # "Vexa internal". They are declared services in deploy/docker-compose.yml,
+    # so the normal check already resolves them and the entries only widened the
+    # exemption for names nobody was exempting. Removed 2026-08-17.
 )
 
 is_whitelisted() {


### PR DESCRIPTION
`/opt/klai/docker-compose.yml` is written by `deploy-compose.yml` from the repo, and nothing in that pipeline creates a sibling. So a `docker-compose.yml.bak`, `.orig`, `.pre-victorialogs` or `.before-cadvisor-flags-20260606141107` is the fingerprint of an edit made on the server — which the repo forbids as CRIT.

There were **26 of them**, April through May, 1.7 MB. Removed today after checking they held nothing unique:

- none was mounted by any container
- all 53 services they name appear somewhere in the **6773** commits touching `deploy/docker-compose.yml`

A 400-commit sample said 7 services were unique. Widening to the full history dropped that to zero — which is the whole argument for not trusting a sample.

## The leftover is not the problem — the edit is

`deploy-compose.yml` overwrites the deployed file on the next push, so a hand change is silently discarded and the backup beside it is the only trace it ever existed. The pile grew for four months with nothing watching, because the audit looked at containers, images, volumes and routes — never at the file the whole deploy pipeline is built around.

## Detection 7

Emits `compose_hand_edit_artifact` per sibling, alert routed to ops via `spec=SPEC-INFRA-CONTAINER-HYGIENE-001`.

**Warning, not critical**, unlike the two rules beside it: those describe something that is wrong right now, this describes a file that should not exist. The runbook says to diff it first — if the change was wanted it belongs in the repo; if not, the leftover simply goes.

## The guard's own risk

It is the opposite of the last detection's: firing on compose files the deploy legitimately places in the same directory. The suite pins that.

| scenario | expected |
|---|---|
| clean deploy | 0 flagged |
| `.bak` / `.orig` / `.pre-*` / `.before-*` | 4 flagged |
| `docker-compose.override.yml`, `docker-compose.dev.yml` | **0 flagged** |
| every run | reaches `audit_run_completed` |

Verified by mutation: widening the glob to `docker-compose*` turns three assertions red; disabling the detection turns one red.

## Also

Removed the `'^vexa12-*$'` entries from `CADDY_WHITELIST`. They were listed as "Vexa internal", but all three are declared services in `deploy/docker-compose.yml`, so the normal check already resolved them — the entries only widened an exemption for names nobody needed exempting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)