### PR TITLE
fix(obs): give the last blind alert its data, and make exemptions expire

### DIFF
--- a/deploy/grafana/provisioning/alerting/privacy-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/privacy-rules.yaml
@@ -51,15 +51,25 @@ groups:
                 uid: portal-postgres
               format: table
               rawSql: |
+                -- portal_telemetry_mode_changes, not portal_audit_log: the
+                -- audit table is category-C RLS with a SELECT policy scoped to
+                -- a tenant GUC that Grafana never sets, so this subquery
+                -- returned zero rows and the rule could never fire -- silently,
+                -- from the day it was provisioned until 2026-08-17. The view is
+                -- superuser-owned and exposes only telemetry transitions
+                -- (org_id, created_at, new_level). Defined in
+                -- deploy/grafana/sql/grafana-reader-setup.sql; the action filter
+                -- lives inside it. Verified by
+                -- deploy/scripts/verify-alert-datasource-access.py, which fails
+                -- the deploy if this ever goes blind again.
                 SELECT count(*) AS value
                   FROM portal_orgs
                  WHERE telemetry_level = 'full'
                    AND deleted_at IS NULL
                    AND id IN (
                      SELECT org_id
-                       FROM portal_audit_log
-                      WHERE action = 'telemetry_level_changed'
-                        AND (details->>'new_level') = 'full'
+                       FROM portal_telemetry_mode_changes
+                      WHERE new_level = 'full'
                         AND created_at < now() - interval '14 days'
                    )
           - refId: reduce
@@ -87,7 +97,12 @@ groups:
                   reducer: { params: [], type: last }
                   type: query
         noDataState: OK
-        execErrState: OK
+        # Error, not OK. This rule spent its whole life returning zero rows
+        # because it could not read its own data, and execErrState: OK is what
+        # made that indistinguishable from "no tenant is stuck". Now that the
+        # read works, a future permission or policy change must page rather
+        # than restore the silence.
+        execErrState: Error
         for: 0s
         keepFiringFor: 1d
         isPaused: false

--- a/deploy/grafana/sql/grafana-reader-setup.sql
+++ b/deploy/grafana/sql/grafana-reader-setup.sql
@@ -58,6 +58,31 @@ GRANT SELECT ON portal_feedback_correlation_stats TO grafana_reader;
 GRANT USAGE ON SCHEMA knowledge TO grafana_reader;
 GRANT SELECT ON knowledge.rag_eval_results TO grafana_reader;
 
+-- ── SPEC-PRIVACY-QUERY-SHADOW-001 — tenant-stuck-in-full alert ───────────
+--
+-- spec-priv-001-tenant-stuck-full asks "which orgs have been in full telemetry
+-- mode for more than 14 days", which needs the moment the mode was switched.
+-- That lives in portal_audit_log, a category-C RLS table whose
+-- tenant_isolation_read policy is scoped to
+-- org_id = current_setting('app.current_org_id') -- a GUC Grafana never sets.
+-- The grant exists, so nothing errors: the read just returns zero rows, the
+-- rule's IN-subquery is always empty, and the alert has never been able to
+-- fire. Found 2026-08-14 by verify-alert-datasource-access.py.
+--
+-- Narrower than the feedback view on purpose. portal_audit_log spans every
+-- audited action and its details jsonb can carry operational specifics, so this
+-- exposes ONLY telemetry-mode transitions, and only three fields of them: which
+-- org, when, and which level it moved to. Nothing about any other action is
+-- reachable through it.
+CREATE OR REPLACE VIEW portal_telemetry_mode_changes AS
+    SELECT org_id,
+           created_at,
+           details ->> 'new_level' AS new_level
+      FROM portal_audit_log
+     WHERE action = 'telemetry_level_changed';
+
+GRANT SELECT ON portal_telemetry_mode_changes TO grafana_reader;
+
 -- Verify after running (must return a non-zero count, not an error and not 0):
 --   SET ROLE grafana_reader;
 --   SELECT count(*) FROM portal_feedback_correlation_stats;

--- a/deploy/scripts/tests/verify-alert-datasource-access.test.sh
+++ b/deploy/scripts/tests/verify-alert-datasource-access.test.sh
@@ -39,7 +39,7 @@ fi
 for expected in \
   "spec-kb-015-feedback-correlation-low	portal_feedback_correlation_stats" \
   "spec-kb-015-feedback-correlation-low	portal_orgs" \
-  "spec-priv-001-tenant-stuck-full	portal_audit_log" \
+  "spec-priv-001-tenant-stuck-full	portal_telemetry_mode_changes" \
   "rag-eval-001-faithfulness-low	knowledge.rag_eval_results"; do
   if printf '%s\n' "$out" | grep -qF "$expected"; then
     ok "finds ${expected//	/ -> }"
@@ -86,37 +86,74 @@ else
   bad "expected exit 2, got $rc: $(cat "$TMP/out2")"
 fi
 
-# ── 3. A stale allowlist entry must fail ──────────────────────────────────
-# KNOWN_BLIND records rules we know are blind. If a uid in there no longer
-# exists, the entry is a lie that makes a future reader think a rule is
-# accounted for. This fixture has a Postgres rule but not the allowlisted uid.
-echo "3. stale KNOWN_BLIND entry"
-mkdir -p "$TMP/stale"
-cat >"$TMP/stale/rules.yaml" <<'YAML'
-apiVersion: 1
-groups:
-  - name: pg-only
-    rules:
-      - uid: some-other-rule
-        data:
-          - refId: query
-            model:
-              refId: query
-              datasource:
-                type: postgres
-                uid: portal-postgres
-              format: table
-              rawSql: |
-                SELECT count(*) AS value FROM portal_orgs
-YAML
+# ── 3. The allowlist is empty, and its validator rejects rot ──────────────
+# KNOWN_BLIND records rules we know are blind. Two ways it goes bad: an entry
+# whose rule no longer exists (a lie), and an entry nobody ever revisits (a
+# permanent exception wearing a reason). Both must fail CI.
+echo "3. KNOWN_BLIND hygiene"
+if "$PYTHON" -c "
+import pathlib, sys
+src = pathlib.Path('$SCRIPT').read_text()
+ns = {}
+exec(compile(src.split('def _validate_allowlist')[0], 'chk', 'exec'), ns)
+sys.exit(0 if ns['KNOWN_BLIND'] == {} else 1)
+" 2>/dev/null; then
+  ok "allowlist is empty (every rule reads its own data)"
+else
+  bad "allowlist is non-empty -- each entry needs a live uid, a >=40-char statement and a future expired_at"
+fi
+
+# Drive the validator directly with hostile entries; building fixture YAML for
+# each case would exercise the parser, not the rot rules.
+cat >"$TMP/val.py" <<'PY'
+import json, pathlib, sys
+src = pathlib.Path(sys.argv[1]).read_text()
+ns = {}
+exec(compile(src, "chk", "exec"), ns)
+ns["KNOWN_BLIND"].clear()
+ns["KNOWN_BLIND"].update(json.loads(sys.argv[2]))
+problems = ns["_validate_allowlist"]({"live-rule"})
+print("\n".join(problems))
+sys.exit(1 if problems else 0)
+PY
+
+check_rejected() {
+  local label="$1" entries="$2" expect="$3"
+  set +e
+  out="$("$PYTHON" "$TMP/val.py" "$SCRIPT" "$entries" 2>&1)"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi "$expect"; then
+    ok "rejects $label"
+  else
+    bad "should reject $label (rc=$rc): $out"
+  fi
+}
+
+FUTURE="$("$PYTHON" -c 'import datetime;print(datetime.date.today()+datetime.timedelta(days=30))')"
+PAST="$("$PYTHON" -c 'import datetime;print(datetime.date.today()-datetime.timedelta(days=1))')"
+FAR="$("$PYTHON" -c 'import datetime;print(datetime.date.today()+datetime.timedelta(days=400))')"
+LONG="a reason long enough to clear the forty character minimum"
+
+check_rejected "a uid that no longer exists" \
+  "{\"ghost-rule\": {\"statement\": \"$LONG\", \"expired_at\": \"$FUTURE\"}}" "no longer excuses"
+check_rejected "a too-short statement" \
+  "{\"live-rule\": {\"statement\": \"known issue\", \"expired_at\": \"$FUTURE\"}}" "at least 40"
+check_rejected "a missing expiry" \
+  "{\"live-rule\": {\"statement\": \"$LONG\"}}" "expired_at"
+check_rejected "an expiry already past" \
+  "{\"live-rule\": {\"statement\": \"$LONG\", \"expired_at\": \"$PAST\"}}" "expired on"
+check_rejected "an expiry indistinguishable from permanent" \
+  "{\"live-rule\": {\"statement\": \"$LONG\", \"expired_at\": \"$FAR\"}}" "permanent"
+
 set +e
-plan "$TMP/stale" >"$TMP/out3" 2>&1
+"$PYTHON" "$TMP/val.py" "$SCRIPT" "{\"live-rule\": {\"statement\": \"$LONG\", \"expired_at\": \"$FUTURE\"}}" >/dev/null 2>&1
 rc=$?
 set -e
-if [ "$rc" -eq 1 ] && grep -q "no longer exist" "$TMP/out3"; then
-  ok "exits 1 and names the stale uid"
+if [ "$rc" -eq 0 ]; then
+  ok "accepts a well-formed exemption"
 else
-  bad "expected exit 1 naming the stale uid, got $rc: $(cat "$TMP/out3")"
+  bad "a live uid with a long statement and a near-future expiry should pass"
 fi
 
 # ── 4. Schema-qualified names and aliases survive extraction ──────────────
@@ -158,6 +195,46 @@ if printf '%s\n' "$out4" | grep -qE "[[:space:]]recent$"; then
 else
   ok "aliased CTE 'recent' excluded"
 fi
+
+# ── 5. Prose in SQL comments is not a relation ────────────────────────────
+# The regex matches FROM/JOIN anywhere, and English is full of both words. A
+# comment reading "from the day it was provisioned" made the checker look for a
+# table called "the", fail, and report a working rule as blind.
+echo "5. comments are stripped before matching"
+mkdir -p "$TMP/comments"
+cat >"$TMP/comments/rules.yaml" <<'YAML'
+apiVersion: 1
+groups:
+  - name: commented
+    rules:
+      - uid: commented-rule
+        data:
+          - refId: query
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                -- Reads the view, not the base table: blind from the day it
+                -- shipped, and join us in never doing that again.
+                /* block comment: select from nowhere, join nothing */
+                SELECT count(*) AS value FROM real_view
+YAML
+out5="$(plan "$TMP/comments")"
+if printf '%s\n' "$out5" | grep -qE "[[:space:]]real_view$"; then
+  ok "extracts the real relation"
+else
+  bad "missed real_view: $out5"
+fi
+for ghost in the us nowhere nothing; do
+  if printf '%s\n' "$out5" | grep -qE "[[:space:]]$ghost$"; then
+    bad "prose word '$ghost' extracted as a relation"
+  else
+    ok "prose word '$ghost' ignored"
+  fi
+done
 
 echo
 echo "passed=$pass failed=$fail"

--- a/deploy/scripts/verify-alert-datasource-access.py
+++ b/deploy/scripts/verify-alert-datasource-access.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+from datetime import date
 from pathlib import Path
 
 import yaml
@@ -60,23 +61,79 @@ READER_ROLE = "grafana_reader"
 
 POSTGRES_CONTAINER = "klai-core-postgres-1"
 
-# Rules known to be blind, with the reason. An entry here does NOT make the
-# rule work -- it records that we looked, understood, and chose not to fix it
-# in that change. Same contract as a .trivyignore.yaml entry: a reason, not a
-# shrug. Remove the entry when the rule is fixed; a stale entry fails the
-# self-test, so this cannot rot quietly.
-KNOWN_BLIND: dict[str, str] = {
-    "spec-priv-001-tenant-stuck-full": (
-        "portal_audit_log returns 0 rows for grafana_reader: its "
-        "tenant_isolation_read policy is scoped on org_id = current_setting("
-        "'app.current_org_id'), which Grafana never sets, so the rule's "
-        "id IN (SELECT org_id FROM portal_audit_log ...) subquery is always "
-        "empty and the alert can never fire. Found 2026-08-14 while verifying "
-        "SPEC-KB-015's rule. Belongs to SPEC-PRIVACY-QUERY-SHADOW-001 -- "
-        "flagged rather than silently redesigned, because the fix is a "
-        "decision about exposing audit detail to a dashboard role."
-    ),
-}
+# Rules known to be blind, keyed by uid. An entry does NOT make a rule work --
+# it records that we looked, understood, and chose not to fix it in that change.
+#
+# Empty, and worth keeping that way. The one entry this started with
+# (spec-priv-001-tenant-stuck-full) was retired on 2026-08-17 by giving the rule
+# a superuser-owned view over the telemetry transitions it needs, rather than by
+# writing a better excuse.
+#
+# The shape mirrors .trivyignore.yaml deliberately, because that file solved the
+# harder half of this problem: an exception with only a reason lives forever, so
+# every entry also needs a date on which someone must look again. Enforced by
+# _validate_allowlist below -- a reason under 40 characters, a missing or
+# malformed date, a date already past, or a date more than a year out all fail
+# CI. So does a uid that no longer exists, which is how the list cannot outlive
+# the rules it excuses.
+#
+#   "some-rule-uid": {
+#       "statement": "Why it is blind, what it costs, and who owns the fix.",
+#       "expired_at": "2027-01-31",
+#   },
+KNOWN_BLIND: dict[str, dict[str, str]] = {}
+
+_MIN_STATEMENT_CHARS = 40
+_MAX_EXEMPTION_DAYS = 365
+
+
+def _validate_allowlist(known_uids: set[str]) -> list[str]:
+    """Return the reasons KNOWN_BLIND is itself invalid (empty = fine).
+
+    An allowlist that is never checked becomes the place findings go to die. The
+    two failure modes are a stale entry (the rule is gone, so the excuse is
+    fiction) and a permanent entry (nobody ever looks again).
+    """
+    problems: list[str] = []
+    today = date.today()
+
+    for uid in sorted(set(KNOWN_BLIND) - known_uids):
+        problems.append(
+            f"{uid}: listed in KNOWN_BLIND but no rule with that uid exists -- "
+            "the exemption no longer excuses anything. Remove it."
+        )
+
+    for uid, entry in sorted(KNOWN_BLIND.items()):
+        statement = (entry.get("statement") or "").strip()
+        if len(statement) < _MIN_STATEMENT_CHARS:
+            problems.append(
+                f"{uid}: statement is {len(statement)} chars, needs at least "
+                f"{_MIN_STATEMENT_CHARS}. Say why it is blind, what it costs, "
+                "and who owns the fix -- 'known issue' is not a reason."
+            )
+
+        raw_expiry = (entry.get("expired_at") or "").strip()
+        if not raw_expiry:
+            problems.append(f"{uid}: no expired_at. Every exemption needs a date to look again.")
+            continue
+        try:
+            expires = date.fromisoformat(raw_expiry)
+        except ValueError:
+            problems.append(f"{uid}: expired_at {raw_expiry!r} is not YYYY-MM-DD.")
+            continue
+        if expires < today:
+            problems.append(
+                f"{uid}: exemption expired on {expires}. Fix the rule, or renew "
+                "the date deliberately with a statement that still holds."
+            )
+        elif (expires - today).days > _MAX_EXEMPTION_DAYS:
+            problems.append(
+                f"{uid}: expired_at {expires} is more than "
+                f"{_MAX_EXEMPTION_DAYS} days out, which is indistinguishable "
+                "from permanent."
+            )
+
+    return problems
 
 
 def _postgres_rules(directory: Path) -> list[tuple[str, str, str]]:
@@ -101,19 +158,35 @@ def _postgres_rules(directory: Path) -> list[tuple[str, str, str]]:
 
 _CTE_RE = re.compile(r"(?:\bWITH\b|,)\s*([a-zA-Z_][\w]*)\s+AS\s*\(", re.IGNORECASE)
 _REL_RE = re.compile(r"\b(?:FROM|JOIN)\s+([a-zA-Z_][\w]*(?:\.[a-zA-Z_][\w]*)?)", re.IGNORECASE)
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _strip_comments(raw_sql: str) -> str:
+    """Remove SQL comments before any pattern matching.
+
+    Prose is full of "from" and "join". A rule whose rawSql carries a comment
+    explaining WHY it reads a particular view -- exactly the kind of comment
+    worth writing -- would otherwise have words from that sentence extracted as
+    relation names. Caught by the phrase "from the day it was provisioned",
+    which produced `relation "the" does not exist` and reported a healthy rule
+    as blind.
+    """
+    return _BLOCK_COMMENT_RE.sub(" ", _LINE_COMMENT_RE.sub(" ", raw_sql))
 
 
 def referenced_relations(raw_sql: str) -> list[str]:
-    """Relations a query really reads, with CTE names removed.
+    """Relations a query really reads, with comments and CTE names removed.
 
     CTE names appear after FROM exactly like tables do, but they are not
     relations and have no grants -- counting rows on one would error and look
     like a finding. Subqueries need no special handling: their FROM clauses are
     matched on their own.
     """
-    ctes = {m.lower() for m in _CTE_RE.findall(raw_sql)}
+    sql = _strip_comments(raw_sql)
+    ctes = {m.lower() for m in _CTE_RE.findall(sql)}
     seen: list[str] = []
-    for rel in _REL_RE.findall(raw_sql):
+    for rel in _REL_RE.findall(sql):
         if rel.lower() in ctes or rel.lower() in seen:
             continue
         seen.append(rel.lower())
@@ -222,12 +295,11 @@ def main(argv: list[str]) -> int:
         for _file, uid, raw_sql in rules:
             for rel in referenced_relations(raw_sql):
                 print(f"{uid}\t{rel}")
-        # A stale allowlist is a silent lie: it suggests a rule is known-broken
-        # when that rule may no longer exist under that uid.
-        uids = {uid for _f, uid, _s in rules}
-        stale = sorted(set(KNOWN_BLIND) - uids)
-        if stale:
-            print(f"ERROR: KNOWN_BLIND lists uids that no longer exist: {stale}", file=sys.stderr)
+        problems = _validate_allowlist({uid for _f, uid, _s in rules})
+        if problems:
+            print("ERROR: KNOWN_BLIND is not valid:", file=sys.stderr)
+            for problem in problems:
+                print(f"  - {problem}", file=sys.stderr)
             return 1
         return 0
 
@@ -237,13 +309,14 @@ def main(argv: list[str]) -> int:
         if not failures:
             print(f"OK       {uid} ({source})")
             continue
-        excuse = KNOWN_BLIND.get(uid)
-        label = "KNOWN" if excuse else "BLIND"
+        entry = KNOWN_BLIND.get(uid)
+        excuse = (entry or {}).get("statement", "")
+        label = "KNOWN" if entry else "BLIND"
         print(f"{label}    {uid} ({source})")
         for failure in failures:
             print(f"         - {failure}")
-        if excuse:
-            print(f"         allowlisted: {excuse.splitlines()[0]}")
+        if entry:
+            print(f"         allowlisted until {entry.get('expired_at', '?')}: {excuse[:110]}")
         else:
             exit_code = 1
 


### PR DESCRIPTION
The allowlist had exactly one entry. Retiring it beats writing a better excuse for it, so the counter now reads zero.

## The last blind rule

`spec-priv-001-tenant-stuck-full` needs to know *when* an org switched to full telemetry. That lives in `portal_audit_log` — category-C RLS with a SELECT policy scoped to a tenant GUC Grafana never sets. The grant exists, so nothing ever errored: the subquery returned zero rows, and a privacy-compliance alert about raw queries lingering in `full` mode has never been able to fire.

It now reads `portal_telemetry_mode_changes`, a superuser-owned view exposing **only** `org_id`, `created_at` and `new_level`, filtered to `action = 'telemetry_level_changed'`. Deliberately narrower than the feedback view: `portal_audit_log` spans every audited action and its `details` jsonb carries operational specifics, so nothing about any other action is reachable through this one.

`execErrState` also moves `OK` → `Error`. This rule's entire history is the argument for it: silence must not read as health.

## The mechanism stays, and now rots loudly

An exemption with only a reason lives forever. The shape mirrors `.trivyignore.yaml`, which already solved this: a `statement` of at least 40 characters **and** an `expired_at`. All of these now fail CI:

| Case | Why |
|---|---|
| uid no longer exists | the excuse is fiction |
| statement under 40 chars | "known issue" is not a reason |
| missing / malformed `expired_at` | no date means nobody looks again |
| `expired_at` already past | fix it, or renew deliberately |
| `expired_at` > 365 days out | indistinguishable from permanent |

Six self-test cases drive the validator directly, plus one asserting the list is empty.

## A parser bug this change exposed

Not found by review — found by running it. The `FROM`/`JOIN` regex ran over SQL comments, so the phrase *"from the day it was provisioned"* in the new rule comment made the checker look for a table named `the`:

```
BLIND    spec-priv-001-tenant-stuck-full
         - relation the unreadable even as superuser: ERROR: relation "the" does not exist
```

A working rule reported as blind. Comments are stripped before matching now, with a fixture whose comments read "from the day", "join us", "select from nowhere" and "join nothing" — none of which may surface as relations. Prose is full of both keywords, and a rule explaining *why* it reads a particular view is exactly the comment worth having; the parser had to stop punishing it.

Rewording my comment would have hidden the defect for the next person to write one.

## Verification

Against production, before and after:

```
before:  OK / BLIND (relation "the") / OK / OK          exit 1
after:   OK / OK / OK / OK                              exit 0
```

`portal_telemetry_mode_changes` returns 9 rows to `grafana_reader` where `portal_audit_log` returned 0. Self-test: 24 passed, 0 failed. Started this session at four of six rules blind.

## Note on the view

Created on production before this merge, since the rewritten rule cannot evaluate without it. Recorded in `deploy/grafana/sql/grafana-reader-setup.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)