### PR TITLE
feat(sec): stop meeting bots reaching the host — SPEC-SEC-022 REQ-2

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -64,6 +64,7 @@ jobs:
           bash deploy/scripts/tests/docker-orphan-audit-klasse-c.test.sh
           bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
           bash deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
+          bash deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -80,5 +80,8 @@ jobs:
       - name: orphan-audit hand-edit suite
         run: bash deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
 
+      - name: bot host-isolation suite (SPEC-SEC-022)
+        run: bash deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+
       - name: container-hygiene preflight suite
         run: bash .claude/hooks/klai/tests/container-hygiene-preflight.test.sh

--- a/.moai/specs/SPEC-SEC-022/spec.md
+++ b/.moai/specs/SPEC-SEC-022/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-SEC-022
-version: 0.2.0
-status: in_progress
+version: 0.3.0
+status: partially_implemented
 created: 2026-04-19
-updated: 2026-04-22
+updated: 2026-08-17
 author: Mark Vletter
 priority: medium
 ---
@@ -11,6 +11,69 @@ priority: medium
 # SPEC-SEC-022: vexa-bots network egress allowlist
 
 ## HISTORY
+
+### v0.3.0 (2026-08-17)
+
+**REQ-2 implemented and verified. REQ-1 deliberately dropped. The rest of this
+document was written against a stack that no longer exists — read the notes
+below before acting on anything above them.**
+
+The April premise was measured on Vexa 0.10: `vexa-bots`, subnet 172.27.0.0/16,
+`Internal=false`, bots with "arbitrary internet + full access to our internal
+network". Vexa 0.12.22 replaced that stack in August. What is true now:
+
+- The bot network is `vexa12-bots`, subnet **172.29.0.0/16**. The SPEC's
+  172.27.0.0/16 is now `vexa12-portal`, an `Internal=true` network — applying
+  the Phase 3 rules verbatim would have filtered the wrong containers and left
+  the bots untouched.
+- Bots **cannot** reach klai-net containers. Docker's `DOCKER-FORWARD` isolation
+  handles it; verified by probing container IPs directly, not names, so the
+  result is a packet drop and not a DNS failure.
+- Bots **could** reach the host: SSH on 22, and all five GPU tunnel forwards
+  (ollama 11434, vLLM 8000/8001, embeddings 7997, reranker 7998), every one
+  unauthenticated. `DOCKER-USER` is inbound-only (`-i $EXT_IF`) and never saw
+  this traffic; it lands in INPUT, whose policy is ACCEPT and which nothing
+  filters — ufw is not even installed here, only its empty chains remain.
+
+**REQ-2 — done.** `deploy/scripts/harden-docker-user.sh` installs a default-deny
+from the bot subnet to the host with one exception, applied by the existing
+`klai-harden-firewall.service` and persisted through `netfilter-persistent`.
+Verified from a container on `vexa12-bots`: SSH and four GPU endpoints closed,
+transcription + redis + internet still open. `retrieval-api` on klai-net still
+reaches all four GPU endpoints — that path was never in scope and is untouched.
+
+The exception is tcp/8000, the transcription endpoint. `vexa12-meeting-api`
+carries `TRANSCRIPTION_SERVICE_URL` pointing at it and sits on the same subnet.
+With no bot running there was no way to prove which process actually opens that
+connection, and transcription demonstrably works — so it stays open rather than
+being closed on a guess. Narrowing it needs REQ-1's capture during a real
+meeting. This is a documented hole, not an oversight.
+
+`172.18.0.1:443` also remains reachable, and stays that way: DNAT rewrites it to
+the Caddy container before INPUT sees it, so it is FORWARD traffic. Confirmed by
+counters — the DROP counter moved by exactly the blocked probes and not by that
+one. A bot reaching Caddy has the same access as any host on the internet.
+
+**REQ-1 — dropped, not deferred.** The full-internet allowlist was never built
+because Phase 1 needs a ≥4-hour capture across ≥15 meetings on three providers,
+and that window never happened in four months. The SPEC's own risk section
+explains why: Google, Microsoft and Zoom rotate CDN IPs continuously, so the
+allowlist needs a 6-hourly refresh and breaks meetings when it drifts. That is a
+permanent maintenance cost against a browser whose job is to visit URLs we do
+not control — and the lateral-movement risk it was meant to contain is now
+covered by REQ-2 plus Docker's network isolation. Egress to the internet on
+443 stays open. If this is revisited, start by measuring, not by enforcing.
+
+REQ-3, REQ-4 and REQ-5 belonged to REQ-1's allowlist and go with it. REQ-5's
+conntrack concern does not arise: the rules are subnet-scoped, not per-IP, so a
+recycled bot IP is evaluated against the same rule.
+
+**Guard:** `deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh` pins
+the shape — subnet read from Docker rather than hardcoded, exception ordered
+above the deny, re-runs that do not stack rules, and a loud warning if the
+network is missing instead of a silent skip. Verified by mutation: hardcoding
+the SPEC's old CIDR fails six assertions, swapping the rule order fails one, and
+downgrading the warning fails one.
 
 ### v0.2.0 (2026-04-22)
 - **Phase 1 infrastructure ready.** `scripts/vexa-egress-capture.sh` wraps

--- a/deploy/scripts/harden-docker-user.sh
+++ b/deploy/scripts/harden-docker-user.sh
@@ -40,6 +40,65 @@ iptables -A DOCKER-USER -i "$EXT_IF" -j DROP
 echo "Done. Current DOCKER-USER chain:"
 iptables -L DOCKER-USER -n --line-numbers
 
+# ── Meeting bots must not reach the host (SPEC-SEC-022 REQ-2) ────────────────
+#
+# DOCKER-USER above is inbound-only (-i $EXT_IF): it governs internet → container.
+# Container → container is handled by Docker's own DOCKER-FORWARD isolation, and
+# measurement confirms a bot cannot reach any klai-net container.
+#
+# Container → the HOST is neither. That traffic lands in INPUT, whose policy is
+# ACCEPT and which nothing else filters — ufw is uninstalled here, only its empty
+# chains remain. So on 2026-08-17 a container on vexa12-bots could reach every
+# service the host binds on its bridge addresses:
+#
+#   172.18.0.1:22     SSH
+#   172.18.0.1:11434  ollama          172.18.0.1:7997  embeddings
+#   172.18.0.1:8000   transcription   172.18.0.1:7998  reranker
+#   172.18.0.1:8001   vLLM
+#
+# Those are the GPU tunnel forwards, unauthenticated, plus the host's SSH port.
+# The bots run Chromium against meeting pages we do not control, which is the
+# whole reason SPEC-SEC-022 exists.
+#
+# Default-deny with one exception rather than a blocklist, so a service bound to
+# a new host port later is covered without anyone remembering to add it.
+#
+# The exception is 8000: vexa12-meeting-api carries
+# TRANSCRIPTION_SERVICE_URL=http://172.18.0.1:8000/... and sits on this same
+# subnet. Transcription demonstrably works, and with no bot running there was no
+# way to prove which process actually opens that connection — so it stays open
+# rather than being closed on a guess. Narrowing it needs a capture during a real
+# meeting (SPEC-SEC-022 Phase 1); until then this is a deliberate, documented
+# hole and not an oversight.
+#
+# The subnet is read from Docker rather than hardcoded: 172.29.0.0/16 today, but
+# the SPEC was written against 172.27.0.0/16 and that range now belongs to a
+# different network entirely. A hardcoded CIDR here would have silently filtered
+# the wrong containers.
+BOTS_NET="${BOTS_NET:-vexa12-bots}"
+BOTS_CIDR="$(docker network inspect "$BOTS_NET" \
+    --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
+
+if [ -n "$BOTS_CIDR" ]; then
+    echo ""
+    echo "Restricting $BOTS_NET ($BOTS_CIDR) → host ..."
+
+    # Idempotent: the unit re-runs on every boot and after every deploy.
+    while iptables -D INPUT -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
+    while iptables -D INPUT -s "$BOTS_CIDR" -j DROP 2>/dev/null; do :; done
+
+    # Order matters: the exception has to sit above the deny.
+    iptables -I INPUT 1 -s "$BOTS_CIDR" -j DROP
+    iptables -I INPUT 1 -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT
+
+    echo "Done. INPUT rules for $BOTS_CIDR:"
+    iptables -L INPUT -n --line-numbers | grep -E "^(num|[0-9]+ .*${BOTS_CIDR//./\\.})" || true
+else
+    echo ""
+    echo "WARNING: docker network '$BOTS_NET' not found — host-isolation rules NOT applied." >&2
+    echo "         Bots can reach every host-bound port until this is resolved." >&2
+fi
+
 echo ""
 echo "Persisting rules to /etc/iptables/rules.v4 ..."
 iptables-save > /etc/iptables/rules.v4

--- a/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+++ b/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPEC-SEC-022 REQ-2 — meeting bots must not reach the host.
+#
+# DOCKER-USER is inbound-only (-i $EXT_IF) and Docker's DOCKER-FORWARD handles
+# container → container. Container → HOST is neither: it lands in INPUT, whose
+# policy is ACCEPT here and which nothing filters, since ufw is uninstalled and
+# only its empty chains remain.
+#
+# Measured on 2026-08-17: a container on vexa12-bots could reach the host's SSH
+# port and all five GPU tunnel forwards — ollama, vLLM ×2, embeddings, reranker,
+# all unauthenticated. The bots run Chromium against meeting pages we do not
+# control, which is the entire premise of SPEC-SEC-022.
+#
+# This pins the shape of the fix, because each part of it was a trap:
+#   - the subnet must come from Docker, not a literal. The SPEC was written
+#     against 172.27.0.0/16; that range now belongs to vexa12-portal, so a
+#     hardcoded CIDR would filter the wrong containers entirely.
+#   - the ACCEPT for transcription must sit ABOVE the DROP, or it does nothing.
+#   - the script re-runs on every boot and deploy, so it must not stack rules.
+#   - a missing network must be loud. Silently skipping leaves bots wide open
+#     while the script still reports success.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/deploy/scripts/harden-docker-user.sh"
+FAIL=0
+
+run_script() {
+    # $1 = subnet the docker stub reports ("" = network not found)
+    local subnet="$1"
+    local tmp; tmp="$(mktemp -d)"
+
+    cat > "$tmp/docker" <<STUB
+#!/usr/bin/env bash
+[ -n "$subnet" ] && echo "$subnet"
+exit 0
+STUB
+    cat > "$tmp/iptables" <<STUB
+#!/usr/bin/env bash
+echo "iptables \$*" >> "$tmp/calls.log"
+# -D probes must fail once nothing is left to delete, or the cleanup loops forever.
+if [ "\$1" = "-D" ]; then
+    grep -q "DELETED \$*" "$tmp/state" 2>/dev/null && exit 1
+    echo "DELETED \$*" >> "$tmp/state"
+    exit 1
+fi
+exit 0
+STUB
+    cat > "$tmp/iptables-save" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$tmp/docker" "$tmp/iptables" "$tmp/iptables-save"
+
+    PATH="$tmp:$PATH" bash "$SCRIPT" eth0 >"$tmp/out" 2>"$tmp/err" || true
+    cat "$tmp/calls.log" 2>/dev/null > "$tmp/calls.final"
+    LAST_OUT="$(cat "$tmp/out" "$tmp/err" 2>/dev/null)"
+    LAST_CALLS="$(cat "$tmp/calls.final" 2>/dev/null)"
+    rm -rf "$tmp"
+}
+
+check() {
+    desc="$1"; shift
+    if "$@"; then echo "OK:   $desc"; else echo "FAIL: $desc" >&2; FAIL=1; fi
+}
+
+echo "── bot host-isolation guard ──"
+
+run_script "172.29.0.0/16"
+
+check "subnet comes from Docker, not a literal" \
+    bash -c 'echo "$0" | grep -q -- "-s 172.29.0.0/16"' "$LAST_CALLS"
+
+check "the SPEC's stale 172.27.0.0/16 is not used" \
+    bash -c '! echo "$0" | grep -q -- "172.27.0.0/16"' "$LAST_CALLS"
+
+check "a default DROP is installed for the bot subnet" \
+    bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
+
+check "transcription (8000) is excepted" \
+    bash -c 'echo "$0" | grep -q -- "-s 172.29.0.0/16 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
+
+# Both are inserted at position 1, so the LAST insert ends up on top. The ACCEPT
+# has to be the last one written or the DROP shadows it and transcription dies.
+check "the exception is inserted after the DROP, so it lands above it" \
+    bash -c '
+      drop=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP" | tail -1 | cut -d: -f1)
+      acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
+      [ -n "$drop" ] && [ -n "$acc" ] && [ "$acc" -gt "$drop" ]' "$LAST_CALLS"
+
+check "existing rules are cleared first, so re-runs do not stack" \
+    bash -c 'echo "$0" | grep -q -- "-D INPUT -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
+
+# Network gone: the script must say so rather than quietly leaving bots exposed.
+run_script ""
+
+check "a missing bot network produces no INPUT rules" \
+    bash -c '! echo "$0" | grep -q -- "-I INPUT"' "$LAST_CALLS"
+
+check "a missing bot network warns loudly" \
+    bash -c 'echo "$0" | grep -qi "WARNING.*not found"' "$LAST_OUT"
+
+echo "──────────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+    echo "bot host-isolation guard: OK"
+else
+    echo "bot host-isolation guard: FAILED" >&2
+fi
+exit "$FAIL"


### PR DESCRIPTION
A container on `vexa12-bots` could reach the host's SSH port and **all five GPU tunnel forwards** — ollama 11434, vLLM 8000/8001, embeddings 7997, reranker 7998 — every one unauthenticated. The bots run Chromium against meeting pages we do not control, which is the premise SPEC-SEC-022 was written on in April.

## Why nothing caught it

The gap is structural, not a missing rule:

| path | governed by | result |
|---|---|---|
| internet → container | `DOCKER-USER` (`-i $EXT_IF`) | filtered |
| container → container | Docker's `DOCKER-FORWARD` | **blocked** — verified by probing container IPs, not names, so it is a packet drop and not a DNS failure |
| container → **host** | nothing | INPUT policy is ACCEPT; ufw is not installed, only its empty chains remain |

## The fix

Default-deny from the bot subnet to the host, one exception, applied by the existing `klai-harden-firewall.service` and persisted through `netfilter-persistent`.

Verified from a container on the bot network:

```
--- closed ---            --- still open ---
ssh          blocked      transcription (8000)  reachable
ollama       blocked      redis                 reachable
embeddings   blocked      internet              reachable
reranker     blocked
vllm-2       blocked
```

`retrieval-api` on klai-net still reaches all four GPU endpoints — that path was never in scope and is untouched.

## Three traps in the shape

**The subnet is read from Docker, not written down.** The SPEC targets `172.27.0.0/16` — the 0.10 network. That range now belongs to `vexa12-portal`, so the rules as specified would have filtered the wrong containers and left the bots untouched.

**tcp/8000 stays open.** `vexa12-meeting-api` carries `TRANSCRIPTION_SERVICE_URL` pointing there and sits on the same subnet. With no bot running there was no way to prove which process opens that connection, and transcription demonstrably works — closing it on a guess would have broken meetings. Documented hole, not an oversight.

**`172.18.0.1:443` stays reachable, correctly.** DNAT rewrites it to the Caddy container before INPUT sees it, so it is FORWARD traffic. Confirmed by counters: the DROP counter moved by exactly the blocked probes and not by that one. A bot reaching Caddy has the same access as any host on the internet.

## REQ-1 dropped, not deferred

The full-internet allowlist needs a ≥4-hour capture across ≥15 meetings that never happened in four months; the providers rotate CDN IPs continuously so it breaks meetings when it drifts; and the lateral-movement risk it was meant to contain is what REQ-2 just closed. Reasoning recorded in the SPEC rather than left as a permanently open phase.

## Guard

Pins subnet-from-Docker, exception ordered above the deny, no rule stacking on re-run, and a loud warning if the network is missing instead of a silent skip. Verified by mutation — hardcoding the old CIDR fails six assertions, swapping the order fails one, downgrading the warning fails one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)