### PR TITLE
docs: three more places that still described whisper-server as the running STT

### DIFF
--- a/.serena/memories/services-overview.md
+++ b/.serena/memories/services-overview.md
@@ -7,7 +7,9 @@
 ## klai-scribe (`klai-scribe/`)
 - **Purpose:** Meeting/audio transcription
 - **Components:**
-  - `whisper-server/` — Whisper ASR server image/runtime
+  - `whisper-server/` — reference ASR image for self-hosters. NOT what Klai
+    production runs: SPEC-VEXA-003 replaced it with the Vexa transcription
+    workers on the same port and the same OpenAI-compatible path.
   - `scribe-api/` — FastAPI, stores transcriptions, integrates with portal
 
 ## klai-website (`klai-website/`)
@@ -39,7 +41,7 @@ Inference endpoints are environment-specific. The public product contracts are:
 | embedding runtime | BGE-M3-compatible | Dense embeddings for knowledge-ingest and retrieval-api |
 | reranker runtime | cross-encoder reranker | Reranking for retrieval-api |
 | sparse embedding runtime | BGE-M3-compatible sparse encoder | Sparse embeddings for knowledge-ingest |
-| whisper-server | Whisper-compatible ASR | STT for scribe-api |
+| whisper-server | Whisper-compatible ASR | Self-host reference image. Klai production serves STT from the Vexa transcription workers (SPEC-VEXA-003), reached through the same `WHISPER_SERVER_URL`. |
 
 ## External Platform Services
 | Service | Role | URL |

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -197,7 +197,7 @@ Usage reporting (token usage per user/company) does not exist natively in LibreC
 
 Added early, already working in another stack. UI likely custom-built. Architecture principle: voice data is per user, not per company. No sharing between users.
 
-**Deployment (updated 2026-03):** `scribe-api` runs on core-01 and calls `whisper-server` on gpu-01 via SSH tunnel (`http://172.18.0.1:8000`). GPU migration completed with SPEC-GPU-001/SPEC-DEVOPS-002. No env change needed when scaling to a larger GPU — just update the tunnel config.
+**Deployment (updated 2026-08-17):** `scribe-api` runs on core-01 and reaches speech-to-text over the GPU SSH tunnel (`http://172.18.0.1:8000`). What answers there is the Vexa transcription stack — an nginx load balancer in front of two faster-whisper CUDA workers — not a `whisper-server` container: SPEC-VEXA-003 replaced it deliberately on the same port and the same OpenAI-compatible path, which is why `WHISPER_SERVER_URL` never had to change. GPU migration completed with SPEC-GPU-001/SPEC-DEVOPS-002. No env change needed when scaling to a larger GPU — just update the tunnel config.
 
 **Whisper model (Phase 3+):** faster-whisper large-v3-turbo, INT8 quantization. ~2-2.5 GB weights, ~4-6 GB VRAM total. 6x faster than large-v3, multilingual (NL/DE/EN), less than 1-2% quality loss. Deployed on ai-01 alongside vLLM — ~34 GB VRAM free, no conflict. NVIDIA MPS with `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=20` prevents SM contention.
 


### PR DESCRIPTION
Correcting `VERSIONS.md` in #1026 fixed the sentence **I** had written. It did not fix the ones that were already there.

A grep across docs, rules and Serena memories found three that still describe `whisper-server` as the thing serving speech-to-text:

| file | claim |
|---|---|
| `.serena/memories/services-overview.md` | *"Whisper ASR server image/runtime"* |
| `.serena/memories/services-overview.md` | *"\| whisper-server \| ... \| STT for scribe-api \|"* |
| `docs/architecture/platform.md` | *"scribe-api ... calls `whisper-server` on gpu-01 via SSH tunnel"* |

None of that has been true since SPEC-VEXA-003. What answers on that tunnel port is an nginx load balancer in front of two faster-whisper CUDA workers — verified today:

```
POST /v1/audio/transcriptions (empty)  →  422
{"detail":[{"loc":["body","file"],"msg":"Field required"},
           {"loc":["body","model"],"msg":"Field required"}]}
```

That is the transcription app answering, not a proxy stub.

## Left alone on purpose

These were already correct and stay as they are:

- `klai-knowledge-architecture.md` — already says the Vexa `transcription-service` replaces the old `whisper-server`
- `knowledge-ingest-flow.md` — already calls the name legacy
- `scribe-transcription.md` — `whisper-server` there is an allowed **SSRF hostname** for self-hosters, which it still is

That is the actual shape of this drift: one true statement, one false one, and a reader with no way to tell which is which. Three files described a service that had been replaced for months, and I read past them for two days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)