### PR TITLE
feat(sec): narrow the transcription exception from a /16 to one address

### DIFF
--- a/.moai/specs/SPEC-SEC-022/spec.md
+++ b/.moai/specs/SPEC-SEC-022/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-SEC-022
-version: 0.3.0
+version: 0.4.0
 status: partially_implemented
 created: 2026-04-19
 updated: 2026-08-17
@@ -11,6 +11,41 @@ priority: medium
 # SPEC-SEC-022: vexa-bots network egress allowlist
 
 ## HISTORY
+
+### v0.4.0 (2026-08-17)
+
+**The transcription exception is closed down from a /16 to a single address.**
+
+v0.3.0 left tcp/8000 open to the whole bot subnet because meeting-api needed it
+and shared that subnet with the bots. Re-measuring showed the earlier claim that
+"meeting-api cannot reach 8000" was a false negative: that container has no `nc`,
+so the probe failed rather than the connection. With python, meeting-api reaches
+it fine — it is the consumer.
+
+Separating the two onto different networks is not possible: the runtime's
+`DOCKER_NETWORK` deliberately places each bot alongside redis and meeting-api,
+which is the name a bot dials for its callback. So the boundary is drawn inside
+the network instead. `vexa12-bots` now confines dynamic allocation to
+172.29.128.0/17 and pins meeting-api at 172.29.0.10, outside that pool, so a bot
+can never be handed the excepted address. The firewall allows that one /32.
+
+The script reads the pinned address from Docker rather than repeating the
+literal. If the pin is ever dropped from compose, the lookup comes back empty,
+the exception is not installed and the run warns — it fails closed, and
+transcription breaking loudly is the correct outcome there.
+
+Rejected alternative: binding the transcription forward on the vexa12-internal
+gateway, which bots are not attached to. It would have removed the exception
+entirely, but `gpu-tunnel.service` runs `autossh` with `ExitOnForwardFailure=yes`
+and `After=network-online.target` — it already survives the klai-net bridge not
+existing at boot only through `Restart=always`. Adding a vexa-specific bridge to
+its bind list would make all GPU inference — retrieval, embeddings, reranking,
+ollama — depend on a vexa network existing. Wrong trade.
+
+**Root cause, unfixed and out of scope here:** the endpoint behind 8000 is nginx
+with no authentication, so network position is the only control. Authenticating
+it on the GPU host would make this firewall rule defence-in-depth instead of the
+whole defence. That belongs in klai-infra.
 
 ### v0.3.0 (2026-08-17)
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -65,6 +65,23 @@ networks:
   vexa12-bots:
     name: vexa12-bots
     driver: bridge
+    # Split the address space so the firewall can tell a service from a bot.
+    #
+    # Bots and vexa12-meeting-api share this network by design — the runtime's
+    # DOCKER_NETWORK puts each bot alongside redis and meeting-api, which is the
+    # name a bot dials for its callback. But meeting-api also reaches the
+    # transcription endpoint on the host, and bots must not. With one flat /16 of
+    # dynamic addresses there was no way to express that: the INPUT exception for
+    # tcp/8000 had to cover the whole subnet, every ephemeral bot included
+    # (SPEC-SEC-022 REQ-2).
+    #
+    # ip_range confines dynamic allocation to the upper half, so a bot can never
+    # be handed an address out of the lower half. meeting-api is pinned there and
+    # the firewall exception narrows from ~65k addresses to one.
+    ipam:
+      config:
+        - subnet: 172.29.0.0/16
+          ip_range: 172.29.128.0/17
     # SPEC-VEXA-004: separate bot network for the parallel 0.12 stack. MUST stay
     # separate from vexa-bots: a 0.12 bot resolves its lifecycle callback by the
     # literal name `meeting-api`, which on vexa-bots would hit the 0.10 service.
@@ -1606,6 +1623,10 @@ services:
       vexa12-internal: {} # reaches vexa12-admin-api without exposing it to bots
       vexa12-storage: {}  # reaches garage for the S3 config it boots with
       vexa12-bots:
+        # Outside the ip_range on this network, so no bot can ever receive this
+        # address. harden-docker-user.sh allows only this IP to reach the host's
+        # transcription port (SPEC-SEC-022 REQ-2).
+        ipv4_address: 172.29.0.10
         aliases:
           - meeting-api   # the name a spawned 0.12 bot dials for its callback
     deploy:

--- a/deploy/scripts/harden-docker-user.sh
+++ b/deploy/scripts/harden-docker-user.sh
@@ -63,13 +63,19 @@ iptables -L DOCKER-USER -n --line-numbers
 # Default-deny with one exception rather than a blocklist, so a service bound to
 # a new host port later is covered without anyone remembering to add it.
 #
-# The exception is 8000: vexa12-meeting-api carries
-# TRANSCRIPTION_SERVICE_URL=http://172.18.0.1:8000/... and sits on this same
-# subnet. Transcription demonstrably works, and with no bot running there was no
-# way to prove which process actually opens that connection — so it stays open
-# rather than being closed on a guess. Narrowing it needs a capture during a real
-# meeting (SPEC-SEC-022 Phase 1); until then this is a deliberate, documented
-# hole and not an oversight.
+# The exception is tcp/8000, the transcription endpoint, and it is scoped to one
+# address. vexa12-meeting-api carries TRANSCRIPTION_SERVICE_URL pointing there
+# and shares this network with the bots by design — the runtime puts each bot
+# alongside redis and meeting-api, which is the name it dials for its callback.
+#
+# So the boundary cannot be drawn per network; it is drawn inside it. The compose
+# file confines dynamic allocation on vexa12-bots to 172.29.128.0/17 and pins
+# meeting-api at 172.29.0.10, outside that pool. A bot can never be handed that
+# address, so allowing it grants nothing to a compromised browser.
+#
+# Read the pinned address from Docker rather than repeating the literal — if the
+# compose pin is ever dropped, MEETING_API_IP comes back empty and the exception
+# is simply not installed, which fails closed.
 #
 # The subnet is read from Docker rather than hardcoded: 172.29.0.0/16 today, but
 # the SPEC was written against 172.27.0.0/16 and that range now belongs to a
@@ -83,13 +89,27 @@ if [ -n "$BOTS_CIDR" ]; then
     echo ""
     echo "Restricting $BOTS_NET ($BOTS_CIDR) → host ..."
 
-    # Idempotent: the unit re-runs on every boot and after every deploy.
+    MEETING_API_IP="$(docker inspect klai-core-vexa12-meeting-api-1 \
+        --format '{{range $k,$v := .NetworkSettings.Networks}}{{if eq $k "vexa12-bots"}}{{$v.IPAddress}}{{end}}{{end}}' \
+        2>/dev/null || true)"
+
+    # Idempotent: the unit re-runs on every boot and after every deploy. Clear the
+    # whole-subnet form too — it is what this script installed before the pin
+    # existed, and leaving it behind would keep every bot excepted.
     while iptables -D INPUT -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
+    [ -n "$MEETING_API_IP" ] && \
+        while iptables -D INPUT -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
     while iptables -D INPUT -s "$BOTS_CIDR" -j DROP 2>/dev/null; do :; done
 
     # Order matters: the exception has to sit above the deny.
     iptables -I INPUT 1 -s "$BOTS_CIDR" -j DROP
-    iptables -I INPUT 1 -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT
+    if [ -n "$MEETING_API_IP" ]; then
+        iptables -I INPUT 1 -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT
+        echo "  transcription exception: $MEETING_API_IP only"
+    else
+        echo "  WARNING: vexa12-meeting-api has no vexa12-bots address — transcription" >&2
+        echo "           exception NOT installed. Meetings will fail until this resolves." >&2
+    fi
 
     echo "Done. INPUT rules for $BOTS_CIDR:"
     iptables -L INPUT -n --line-numbers | grep -E "^(num|[0-9]+ .*${BOTS_CIDR//./\\.})" || true

--- a/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+++ b/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
@@ -28,12 +28,17 @@ FAIL=0
 
 run_script() {
     # $1 = subnet the docker stub reports ("" = network not found)
+    # $2 = meeting-api's address on that network ("" = pin missing)
     local subnet="$1"
+    local MEETING_IP="${2-172.29.0.10}"
     local tmp; tmp="$(mktemp -d)"
 
     cat > "$tmp/docker" <<STUB
 #!/usr/bin/env bash
-[ -n "$subnet" ] && echo "$subnet"
+case "\$*" in
+  *IPAM*)      [ -n "$subnet" ] && echo "$subnet" ;;
+  *meeting-api*) [ -n "$MEETING_IP" ] && echo "$MEETING_IP" ;;
+esac
 exit 0
 STUB
     cat > "$tmp/iptables" <<STUB
@@ -78,15 +83,21 @@ check "the SPEC's stale 172.27.0.0/16 is not used" \
 check "a default DROP is installed for the bot subnet" \
     bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
 
-check "transcription (8000) is excepted" \
-    bash -c 'echo "$0" | grep -q -- "-s 172.29.0.0/16 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
+check "transcription (8000) is excepted for the pinned address only" \
+    bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.10 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
+
+check "the whole subnet is NOT excepted — that would cover every bot" \
+    bash -c '! echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -p tcp --dport 8000"' "$LAST_CALLS"
+
+check "the old whole-subnet exception is cleared on re-run" \
+    bash -c 'echo "$0" | grep -q -- "-D INPUT -s 172.29.0.0/16 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
 
 # Both are inserted at position 1, so the LAST insert ends up on top. The ACCEPT
 # has to be the last one written or the DROP shadows it and transcription dies.
 check "the exception is inserted after the DROP, so it lands above it" \
     bash -c '
       drop=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP" | tail -1 | cut -d: -f1)
-      acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
+      acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.10 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
       [ -n "$drop" ] && [ -n "$acc" ] && [ "$acc" -gt "$drop" ]' "$LAST_CALLS"
 
 check "existing rules are cleared first, so re-runs do not stack" \
@@ -100,6 +111,21 @@ check "a missing bot network produces no INPUT rules" \
 
 check "a missing bot network warns loudly" \
     bash -c 'echo "$0" | grep -qi "WARNING.*not found"' "$LAST_OUT"
+
+# The pin disappearing must fail CLOSED: deny stays, exception is not installed,
+# and it says so. Silently widening back to the subnet would undo the whole point.
+run_script "172.29.0.0/16" ""
+
+check "a missing pin still installs the deny" \
+    bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
+
+# Match the INSERT specifically. The cleanup -D probes carry the same text, so a
+# looser grep passes even when the rule really was installed.
+check "a missing pin installs NO exception (fails closed)" \
+    bash -c '! echo "$0" | grep -q -- "-I INPUT 1 .*--dport 8000 -j ACCEPT"' "$LAST_CALLS"
+
+check "a missing pin warns loudly" \
+    bash -c 'echo "$0" | grep -qi "WARNING.*transcription"' "$LAST_OUT"
 
 echo "──────────────────────────────"
 if [ "$FAIL" -eq 0 ]; then


### PR DESCRIPTION
The bot host-isolation rule (#1027) landed with tcp/8000 open to the **whole bot subnet**, because `vexa12-meeting-api` needs that endpoint and shares the subnet with the bots. That exception covered every ephemeral Chromium too.

## Correcting why it was left open

The earlier finding that meeting-api could not reach 8000 was a **false negative**: that image has no `nc`, so the probe failed rather than the connection. Through python it reaches the endpoint fine — it is the consumer, and the bots are not.

## Why not just separate them

The runtime's `DOCKER_NETWORK` deliberately places each bot alongside redis and meeting-api — `meeting-api` is the name a bot dials for its callback. Moving meeting-api off the bot network breaks the meeting path.

So the boundary moves *inside* the network:

```yaml
vexa12-bots:
  ipam:
    config:
      - subnet:   172.29.0.0/16
        ip_range: 172.29.128.0/17   # dynamic pool — bots land here
```

`meeting-api` is pinned at `172.29.0.10`, outside that pool, so **a bot can never be handed the excepted address**. The firewall allows that single /32.

The script reads the pin from Docker rather than repeating the literal. Drop the pin from compose and the lookup returns empty, no exception is installed, and it warns — it **fails closed**, and transcription breaking loudly is the right outcome rather than silently widening back to the subnet.

## Rejected alternative

Binding the transcription forward on the `vexa12-internal` gateway, which bots are not attached to, would remove the exception entirely. But `gpu-tunnel.service` runs `autossh` with `ExitOnForwardFailure=yes` and only `After=network-online.target` — it already survives the klai-net bridge being absent at boot through `Restart=always` alone. Adding a vexa bridge to its bind list would make **all** GPU inference depend on a vexa network existing. Wrong trade.

## Root cause, named and out of scope

The endpoint behind 8000 is nginx with no authentication, so network position is the only control. Authenticating it on the GPU host would make this rule defence-in-depth instead of the whole defence. That belongs in klai-infra.

## Guard

Verified by mutation: widening the exception back to the subnet fails three assertions, defaulting a missing pin to the subnet fails two, dropping the cleanup of the old subnet-wide rule fails one.

SPEC-SEC-022 REQ-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)