### PR TITLE
fix(sec): the bot-isolation rules did not survive a deploy

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -257,6 +257,25 @@ jobs:
             sync_and_recreate caddy       deploy/caddy/Caddyfile        /opt/klai/caddy/Caddyfile
             sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
             sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
+
+            # Re-apply the firewall after compose has settled.
+            #
+            # klai-harden-firewall.service is After=docker.service / WantedBy=
+            # multi-user.target — it runs at boot and never again. The bot
+            # isolation rules (SPEC-SEC-022 REQ-2) carry the vexa12-bots subnet,
+            # read from Docker at the time they were installed. A compose change
+            # that recreates that network can hand it a different subnet, and the
+            # rules then match nothing at all: bots regain the host until the next
+            # reboot, silently.
+            #
+            # That is not hypothetical — recreating the network on 2026-08-17 is
+            # what surfaced this, and the rules had to be re-applied by hand.
+            # A deploy is exactly when the network can change, so a deploy is when
+            # the rules get rewritten.
+            echo "Re-applying firewall rules (network definitions may have changed) ..."
+            sudo systemctl restart klai-harden-firewall.service
+            systemctl is-active --quiet klai-harden-firewall.service \
+              || { echo "::error::klai-harden-firewall failed to re-apply"; exit 1; }
             clear_librechat_config_cache() {
               local pattern="${1:-configs:*}"
               docker compose --project-directory /opt/klai exec -T redis sh -lc '

--- a/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/orphan-audit-rules.yaml
@@ -291,3 +291,79 @@ groups:
             26 of these accumulated between April and May 2026 before anything
             watched for them. None held a service absent from git, so nothing
             was lost that time.
+
+      - uid: spec-sec-022-rules-stale
+        title: bot_isolation_rules_stale
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: victorialogs
+            queryType: instant
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: victoriametrics-logs-datasource
+                uid: victorialogs
+              expr: 'service:klai-orphan-audit AND event:bot_isolation_rules_stale'
+              queryType: instant
+          - refId: count
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: count
+              type: reduce
+              reducer: count
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 691200
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: count
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        keepFiringFor: 1h
+        isPaused: false
+        labels:
+          # warning, not critical, unlike the two rules above. Those describe a
+          # route or a container that is wrong right now; this describes a file
+          # that should not exist. It wants cleaning up, not waking anyone. The
+          # emitted event carries the same level, so the two agree.
+          severity: critical
+          spec: SPEC-INFRA-CONTAINER-HYGIENE-001
+          service_group: hygiene-orphan-audit
+        annotations:
+          summary: 'the meeting-bot host-isolation rules no longer match the bot network — bots can reach the host'
+          runbook_url: 'docs/runbooks/container-hygiene-systemd-install.md'
+          description: |
+            The INPUT deny installed by harden-docker-user.sh names a subnet
+            that vexa12-bots no longer uses, so it matches nothing. Every
+            counter on it reads zero because no packet ever hits it, which is
+            why this needs an alert rather than a dashboard.
+
+            Effect: meeting bots — Chromium against pages we do not control —
+            can reach the host again, including SSH and the unauthenticated GPU
+            inference ports (SPEC-SEC-022 REQ-2).
+
+            The deploy re-applies these rules after every compose sync, so this
+            firing means that step failed or was skipped.
+
+            Fix:
+              ssh core-01 "sudo systemctl restart klai-harden-firewall.service"
+
+            Then confirm the deny matches the live subnet:
+              ssh core-01 "docker network inspect vexa12-bots --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}'; sudo iptables -S INPUT | head -3"

--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -2,7 +2,7 @@
 # /opt/klai/scripts/docker-orphan-audit.sh
 #
 # Weekly orphan audit emitting structlog-events to stdout (Alloy →
-# VictoriaLogs). Detects seven categories of "wees" state:
+# VictoriaLogs). Detects eight categories of "wees" state:
 #
 #   1. orphan_no_managed_label
 #      Running container without klasse-A (compose-project=klai-core)
@@ -26,6 +26,10 @@
 #   5. caddy_upstream_missing
 #      Caddy upstream in the live config that does NOT match any running
 #      container — broken routing-rule.
+#
+#   8. bot_isolation_rules_stale
+#      The SPEC-SEC-022 INPUT deny names a subnet the bot network no longer
+#      uses, so it matches nothing and the bots can reach the host again.
 #
 #   7. compose_hand_edit_artifact
 #      A sibling of the deployed compose file (.bak / .orig / .pre-* / …).
@@ -325,6 +329,27 @@ if [[ -d "$COMPOSE_DIR" ]]; then
         emit_event "compose_hand_edit_artifact" "warning" "$(basename "$artifact")" \
             "{\"path\":\"$artifact\",\"detail\":\"sibling of the deployed compose file; the deploy pipeline never creates one, so this marks an edit made outside it\"}"
     done < <(find "$COMPOSE_DIR" -maxdepth 1 -type f -name "${COMPOSE_BASE}.*" 2>/dev/null | sort)
+fi
+
+# ─── Detection 8: bot-isolation rules that no longer match the network ───────
+#
+# The INPUT rules from SPEC-SEC-022 REQ-2 carry the vexa12-bots subnet as it was
+# when harden-docker-user.sh last ran. Recreating that network can hand it a
+# different subnet, and the rules then match nothing: bots regain the host, with
+# every counter reading zero because no packet ever hits them.
+#
+# The deploy re-applies the rules now, so this should never fire. That is the
+# point — it catches the case where the re-apply itself failed or was skipped,
+# which a green deploy log will not tell you.
+if command -v iptables >/dev/null 2>&1 && [[ -n "$(docker network ls -q -f name=^vexa12-bots$ 2>/dev/null)" ]]; then
+    live_cidr="$(docker network inspect vexa12-bots \
+        --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
+    rule_cidr="$(iptables -S INPUT 2>/dev/null | awk '/-j DROP/ && /-s /{for(i=1;i<=NF;i++) if($i=="-s") print $(i+1)}' | grep -E '^172\.' | head -1 || true)"
+
+    if [[ -n "$live_cidr" ]] && [[ "$rule_cidr" != "$live_cidr" ]]; then
+        emit_event "bot_isolation_rules_stale" "critical" "vexa12-bots" \
+            "{\"network\":\"$live_cidr\",\"rule\":\"${rule_cidr:-none}\",\"detail\":\"INPUT deny does not match the live bot subnet; bots can reach the host until harden-docker-user.sh is re-run\"}"
+    fi
 fi
 
 # ─── Always emit run-completed marker ────────────────────────────────────────


### PR DESCRIPTION
`klai-harden-firewall.service` is `After=docker.service` / `WantedBy=multi-user.target` — it runs **at boot and never again**. The INPUT rules it installs carry the `vexa12-bots` subnet as read from Docker at that moment.

A compose change that recreates that network can hand it a different subnet, and the rules then match nothing at all. The bots regain the host until someone reboots — silently, and with **every counter reading zero**, because no packet ever hits a rule that matches nothing. A dashboard would look identical to a healthy one.

Not hypothetical: recreating that network earlier today is what surfaced it, and the rules had to be re-applied by hand. Had that been forgotten, the isolation shipped this morning would have been undone by the very next deploy that touched the network.

## Fix

A deploy is exactly when the network can change, so a deploy is when the rules get rewritten. `deploy-compose` restarts the unit after the compose sync and fails the run if it does not come back active.

## Detector

Detection 8 in the orphan audit catches the case where that step fails or is skipped — it compares the subnet in the INPUT deny against the live network and emits both values.

Alert severity is **critical**, unlike the hygiene findings beside it: this one means Chromium containers can reach SSH and the unauthenticated GPU inference ports again.

Verified against the live host:

- current rules → **zero** findings
- with a docker stub reporting a different subnet → `network=172.31.0.0/16 rule=172.29.0.0/16`, without touching the real rules

SPEC-SEC-022 REQ-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)