### PR TITLE
chore(knowledge-ingest): ruff gate in CI, plus the 118 findings that accumulated without one

### DIFF
--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -67,6 +67,12 @@ jobs:
       #                            transitively by ragas. Local attack vector
       #                            (AV:L) + user interaction; the cache dir is
       #                            container-internal and not attacker-writable.
+      - name: Lint (ruff)
+        run: uv run --frozen --extra dev ruff check .
+
+      - name: Format check (ruff)
+        run: uv run --frozen --extra dev ruff format --check .
+
       - name: Dependency vulnerability scan (pip-audit)
         run: >
           uv run --with pip-audit pip-audit --skip-editable

--- a/klai-knowledge-ingest/alembic/versions/0006_crawled_pages_simhash.py
+++ b/klai-knowledge-ingest/alembic/versions/0006_crawled_pages_simhash.py
@@ -44,8 +44,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     op.execute(
-        "ALTER TABLE knowledge.crawled_pages "
-        "ADD COLUMN IF NOT EXISTS content_simhash bigint"
+        "ALTER TABLE knowledge.crawled_pages ADD COLUMN IF NOT EXISTS content_simhash bigint"
     )
     op.execute(
         "CREATE INDEX IF NOT EXISTS idx_crawled_pages_simhash_org_kb "
@@ -56,6 +55,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("DROP INDEX IF EXISTS knowledge.idx_crawled_pages_simhash_org_kb")
-    op.execute(
-        "ALTER TABLE knowledge.crawled_pages DROP COLUMN IF EXISTS content_simhash"
-    )
+    op.execute("ALTER TABLE knowledge.crawled_pages DROP COLUMN IF EXISTS content_simhash")

--- a/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
+++ b/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
@@ -45,6 +45,7 @@ def apply() -> None:
 #    We patch BOTH to be safe.
 # ---------------------------------------------------------------------------
 
+
 def _patch_edge_search() -> None:
     from graphiti_core.driver.driver import GraphDriver, GraphProvider
     from graphiti_core.edges import EntityEdge, get_entity_edge_from_record
@@ -73,7 +74,7 @@ def _patch_edge_search() -> None:
             )
 
         fuzzy_query = search_utils.fulltext_query(query, group_ids, driver)
-        if fuzzy_query == '':
+        if fuzzy_query == "":
             return []
 
         # FIX: use startNode/endNode instead of re-MATCH
@@ -98,15 +99,15 @@ def _patch_edge_search() -> None:
             search_filter, driver.provider
         )
         if group_ids is not None:
-            filter_queries.append('e.group_id IN $group_ids')
-            filter_params['group_ids'] = group_ids
+            filter_queries.append("e.group_id IN $group_ids")
+            filter_params["group_ids"] = group_ids
 
-        filter_query = ''
+        filter_query = ""
         if filter_queries:
-            filter_query = ' WHERE ' + (' AND '.join(filter_queries))
+            filter_query = " WHERE " + (" AND ".join(filter_queries))
 
         cypher = (
-            get_relationships_query('edge_name_and_fact', limit=limit, provider=driver.provider)
+            get_relationships_query("edge_name_and_fact", limit=limit, provider=driver.provider)
             + match_query
             + filter_query
             + """
@@ -119,7 +120,11 @@ def _patch_edge_search() -> None:
             """
         )
         records, _, _ = await driver.execute_query(
-            cypher, query=fuzzy_query, limit=limit, routing_='r', **filter_params,
+            cypher,
+            query=fuzzy_query,
+            limit=limit,
+            routing_="r",
+            **filter_params,
         )
         return [get_entity_edge_from_record(r, driver.provider) for r in records]
 
@@ -149,12 +154,12 @@ def _patch_edge_search() -> None:
             search_filter, driver.provider
         )
         if group_ids is not None:
-            filter_queries.append('e.group_id IN $group_ids')
-            filter_params['group_ids'] = group_ids
+            filter_queries.append("e.group_id IN $group_ids")
+            filter_params["group_ids"] = group_ids
 
-        filter_query = ''
+        filter_query = ""
         if filter_queries:
-            filter_query = ' WHERE ' + (' AND '.join(filter_queries))
+            filter_query = " WHERE " + (" AND ".join(filter_queries))
 
         # FIX: use startNode/endNode for FalkorDB
         if driver.provider == GraphProvider.FALKORDB:
@@ -166,7 +171,7 @@ def _patch_edge_search() -> None:
                 WITH rel AS e, startNode(rel) AS n, endNode(rel) AS m
                 WHERE type(e) = 'RELATES_TO'
                 """
-                + (' AND ' + ' AND '.join(filter_queries) if filter_queries else '')
+                + (" AND " + " AND ".join(filter_queries) if filter_queries else "")
                 + """
                 RETURN DISTINCT
                 """
@@ -195,8 +200,12 @@ def _patch_edge_search() -> None:
             )
 
         records, _, _ = await driver.execute_query(
-            query, bfs_origin_node_uuids=bfs_origin_node_uuids, depth=bfs_max_depth,
-            limit=limit, routing_='r', **filter_params,
+            query,
+            bfs_origin_node_uuids=bfs_origin_node_uuids,
+            depth=bfs_max_depth,
+            limit=limit,
+            routing_="r",
+            **filter_params,
         )
         return [get_entity_edge_from_record(r, driver.provider) for r in records]
 
@@ -206,6 +215,7 @@ def _patch_edge_search() -> None:
 
     # Also patch the import in search.py (it imports at module level)
     from graphiti_core.search import search as search_module
+
     search_module.edge_fulltext_search = _patched_module_edge_fulltext_search
     search_module.edge_bfs_search = _patched_module_edge_bfs_search
 
@@ -216,19 +226,31 @@ def _patch_edge_search() -> None:
 # 2. Node dedup: case-insensitive duplicate_name matching
 # ---------------------------------------------------------------------------
 
+
 def _patch_node_dedup() -> None:
     from graphiti_core.utils.maintenance import node_operations
 
     _original = node_operations._resolve_with_llm
 
-    async def _patched(llm_client, extracted_nodes, indexes, state,
-                       episode=None, previous_episodes=None, entity_types=None):
+    async def _patched(
+        llm_client,
+        extracted_nodes,
+        indexes,
+        state,
+        episode=None,
+        previous_episodes=None,
+        entity_types=None,
+    ):
         lower_to_node = {n.name.lower(): n for n in indexes.existing_nodes}
         exact_names = {n.name for n in indexes.existing_nodes}
 
         result = await _original(
-            llm_client, extracted_nodes, indexes, state,
-            episode=episode, previous_episodes=previous_episodes,
+            llm_client,
+            extracted_nodes,
+            indexes,
+            state,
+            episode=episode,
+            previous_episodes=previous_episodes,
             entity_types=entity_types,
         )
 
@@ -244,8 +266,10 @@ def _patch_node_dedup() -> None:
                 state.resolved_nodes[i] = existing
                 state.uuid_map[extracted.uuid] = existing.uuid
                 state.duplicate_pairs.append((extracted, existing))
-                logger.info("case_insensitive_dedup_fixed",
-                            extra={"extracted": extracted.name, "matched": existing.name})
+                logger.info(
+                    "case_insensitive_dedup_fixed",
+                    extra={"extracted": extracted.name, "matched": existing.name},
+                )
 
         return result
 
@@ -259,6 +283,7 @@ def _patch_node_dedup() -> None:
 #    From getzep/graphiti#1305
 # ---------------------------------------------------------------------------
 
+
 def _patch_driver_clone() -> None:
     from graphiti_core.driver.falkordb_driver import FalkorDriver
 
@@ -266,7 +291,7 @@ def _patch_driver_clone() -> None:
 
     def _patched_init(self, *args, **kwargs):
         _original_init(self, *args, **kwargs)
-        if not hasattr(self, '_initialized_databases'):
+        if not hasattr(self, "_initialized_databases"):
             self._initialized_databases: set[str] = set()
         self._initialized_databases.add(self._database)
 
@@ -278,7 +303,7 @@ def _patch_driver_clone() -> None:
         return cloned
 
     async def _ensure_database_initialized(self) -> None:
-        if not hasattr(self, '_initialized_databases'):
+        if not hasattr(self, "_initialized_databases"):
             self._initialized_databases = set()
         if self._database not in self._initialized_databases:
             self._initialized_databases.add(self._database)
@@ -296,6 +321,7 @@ def _patch_driver_clone() -> None:
 #    single-tenant case entirely. From getzep/graphiti#1305, #1326
 # ---------------------------------------------------------------------------
 
+
 def _patch_decorator_routing() -> None:
     import functools
 
@@ -306,6 +332,7 @@ def _patch_decorator_routing() -> None:
 
     def _get_parameter_position(func, param_name: str) -> int | None:
         import inspect
+
         sig = inspect.signature(func)
         for idx, (name, _) in enumerate(sig.parameters.items()):
             if name == param_name:
@@ -315,16 +342,16 @@ def _patch_decorator_routing() -> None:
     def handle_multiple_group_ids(func):
         @functools.wraps(func)
         async def wrapper(self, *args, **kwargs):
-            group_ids_func_pos = _get_parameter_position(func, 'group_ids')
-            group_ids_pos = (group_ids_func_pos - 1 if group_ids_func_pos is not None else None)
-            group_ids = kwargs.get('group_ids')
+            group_ids_func_pos = _get_parameter_position(func, "group_ids")
+            group_ids_pos = group_ids_func_pos - 1 if group_ids_func_pos is not None else None
+            group_ids = kwargs.get("group_ids")
 
             if group_ids is None and group_ids_pos is not None and len(args) > group_ids_pos:
                 group_ids = args[group_ids_pos]
 
             if (
-                hasattr(self, 'clients')
-                and hasattr(self.clients, 'driver')
+                hasattr(self, "clients")
+                and hasattr(self.clients, "driver")
                 and self.clients.driver.provider == GraphProvider.FALKORDB
                 and group_ids
             ):
@@ -336,17 +363,18 @@ def _patch_decorator_routing() -> None:
                         filtered_args.pop(group_ids_pos)
 
                     cloned = driver.clone(database=gid)
-                    if hasattr(cloned, 'ensure_database_initialized'):
+                    if hasattr(cloned, "ensure_database_initialized"):
                         await cloned.ensure_database_initialized()
 
                     return await func(
-                        self, *filtered_args,
-                        **{**kwargs, 'group_ids': [gid], 'driver': cloned},
+                        self,
+                        *filtered_args,
+                        **{**kwargs, "group_ids": [gid], "driver": cloned},
                     )
 
                 results = await semaphore_gather(
                     *[execute_for_group(gid) for gid in group_ids],
-                    max_coroutines=getattr(self, 'max_coroutines', None),
+                    max_coroutines=getattr(self, "max_coroutines", None),
                 )
 
                 if isinstance(results[0], SearchResults):
@@ -373,11 +401,16 @@ def _patch_decorator_routing() -> None:
 
     try:
         from graphiti_core.graphiti import Graphiti
-        for method_name in ['search', 'build_communities', 'build_communities_with_endpoint',
-                            'get_all_edges']:
+
+        for method_name in [
+            "search",
+            "build_communities",
+            "build_communities_with_endpoint",
+            "get_all_edges",
+        ]:
             if hasattr(Graphiti, method_name):
                 method = getattr(Graphiti, method_name)
-                original = getattr(method, '__wrapped__', method)
+                original = getattr(method, "__wrapped__", method)
                 setattr(Graphiti, method_name, handle_multiple_group_ids(original))
     except Exception as e:
         logger.warning("could not re-decorate Graphiti methods: %s", e)
@@ -390,6 +423,7 @@ def _patch_decorator_routing() -> None:
 #    Edge dedup only searched forward direction, missing reversed duplicates.
 #    From getzep/graphiti#1303
 # ---------------------------------------------------------------------------
+
 
 def _patch_bidirectional_edge_dedup() -> None:
     from graphiti_core.driver.driver import GraphDriver
@@ -405,11 +439,12 @@ def _patch_bidirectional_edge_dedup() -> None:
             MATCH (n:Entity {uuid: $node_uuid_a})-[e:RELATES_TO]-(m:Entity {uuid: $node_uuid_b})
         """
         records, _, _ = await driver.execute_query(
-            match_query + "\n            RETURN\n            "
+            match_query
+            + "\n            RETURN\n            "
             + get_entity_edge_return_query(driver.provider),
             node_uuid_a=node_uuid_a,
             node_uuid_b=node_uuid_b,
-            routing_='r',
+            routing_="r",
         )
         return [entity_edge_from_record(r) for r in records]
 
@@ -419,14 +454,26 @@ def _patch_bidirectional_edge_dedup() -> None:
 
     _original_resolve = edge_operations.resolve_extracted_edges
 
-    async def _patched_resolve(clients, extracted_edges, existing_edges, episode, nodes,
-                               previous_episodes=None, entity_types=None):
+    async def _patched_resolve(
+        clients,
+        extracted_edges,
+        existing_edges,
+        episode,
+        nodes,
+        previous_episodes=None,
+        entity_types=None,
+    ):
         _original_get = EntityEdge.get_between_nodes
         EntityEdge.get_between_nodes = EntityEdge.get_between_nodes_bidirectional
         try:
             return await _original_resolve(
-                clients, extracted_edges, existing_edges, episode, nodes,
-                previous_episodes=previous_episodes, entity_types=entity_types,
+                clients,
+                extracted_edges,
+                existing_edges,
+                episode,
+                nodes,
+                previous_episodes=previous_episodes,
+                entity_types=entity_types,
             )
         finally:
             EntityEdge.get_between_nodes = _original_get
@@ -442,6 +489,7 @@ def _patch_bidirectional_edge_dedup() -> None:
 #    Patches the module-level fulltext_query() in search_utils.py
 # ---------------------------------------------------------------------------
 
+
 def _patch_empty_fulltext_guard() -> None:
     from graphiti_core.search import search_utils
 
@@ -451,15 +499,16 @@ def _patch_empty_fulltext_guard() -> None:
         result = _original_fulltext_query(query, group_ids, driver)
         # Guard: if all query words were stopwords, the result may be
         # "(@group_id:...) ()" which is invalid RediSearch syntax.
-        if result and result.endswith('()'):
-            return ''
+        if result and result.endswith("()"):
+            return ""
         return result
 
     search_utils.fulltext_query = _patched_fulltext_query
 
     # Also patch in search.py which imports it
     from graphiti_core.search import search as search_module
-    if hasattr(search_module, 'fulltext_query'):
+
+    if hasattr(search_module, "fulltext_query"):
         search_module.fulltext_query = _patched_fulltext_query
 
     logger.info("graphiti_empty_fulltext_guard_patched")

--- a/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
+++ b/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
@@ -50,11 +50,11 @@ def _patch_edge_search() -> None:
     from graphiti_core.edges import EntityEdge, get_entity_edge_from_record
     from graphiti_core.graph_queries import get_relationships_query
     from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
+    from graphiti_core.search import search_utils
     from graphiti_core.search.search_filters import (
         SearchFilters,
         edge_search_filter_query_constructor,
     )
-    from graphiti_core.search import search_utils
 
     # --- Patch (a): module-level edge_fulltext_search in search_utils.py ---
     _original_fulltext = search_utils.edge_fulltext_search
@@ -299,8 +299,8 @@ def _patch_driver_clone() -> None:
 def _patch_decorator_routing() -> None:
     import functools
 
-    from graphiti_core.driver.driver import GraphProvider
     from graphiti_core import decorators
+    from graphiti_core.driver.driver import GraphProvider
     from graphiti_core.helpers import semaphore_gather
     from graphiti_core.search.search_config import SearchResults
 
@@ -392,10 +392,10 @@ def _patch_decorator_routing() -> None:
 # ---------------------------------------------------------------------------
 
 def _patch_bidirectional_edge_dedup() -> None:
-    from graphiti_core.edges import EntityEdge
     from graphiti_core.driver.driver import GraphDriver
-    from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
     from graphiti_core.driver.record_parsers import entity_edge_from_record
+    from graphiti_core.edges import EntityEdge
+    from graphiti_core.models.edges.edge_db_queries import get_entity_edge_return_query
 
     @classmethod  # type: ignore[misc]
     async def get_between_nodes_bidirectional(

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
         # Keeps the lifespan focused on lifecycle ordering, not task-runner
         # internals. See SPEC-PROCRASTINATE-ZOMBIE-001 +
         # SPEC-INGEST-QUEUE-SEPARATION-001.
-        from knowledge_ingest.worker import WorkerLifecycle  # noqa: PLC0415
+        from knowledge_ingest.worker import WorkerLifecycle
 
         async with WorkerLifecycle.start(postgres_dsn=settings.postgres_dsn):
             listener_task = asyncio.create_task(org_config.start_listener(pool))
@@ -131,7 +131,7 @@ async def health():
     # Uses TCP check — graphiti-core[falkordb] is deferred in requirements.txt (pydantic constraint)
     if settings.graphiti_enabled:
         try:
-            import socket  # noqa: PLC0415
+            import socket
 
             s = socket.create_connection(
                 (settings.falkordb_host, settings.falkordb_port), timeout=3.0

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -57,9 +57,7 @@ async def lifespan(app: FastAPI):
                 logger.info("shutting_down_config_listeners")
                 listener_task.cancel()
                 kb_config_listener_task.cancel()
-                await asyncio.gather(
-                    listener_task, kb_config_listener_task, return_exceptions=True
-                )
+                await asyncio.gather(listener_task, kb_config_listener_task, return_exceptions=True)
     else:
         logger.info("enrichment_disabled_skipping_worker")
         yield

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -5,6 +5,7 @@ import structlog
 from fastapi import FastAPI
 
 from knowledge_ingest import db, kb_config, org_config, qdrant_store
+from knowledge_ingest._patch_graphiti import apply as _apply_graphiti_patch
 from knowledge_ingest.config import settings
 from knowledge_ingest.logging_setup import RequestContextMiddleware, setup_logging
 from knowledge_ingest.middleware.auth import InternalSecretMiddleware
@@ -26,8 +27,6 @@ logger = structlog.get_logger()
 # Patch graphiti-core FalkorDB search before any Graphiti usage.
 # See: https://github.com/getzep/graphiti/issues/1272
 # Remove once graphiti-core >= 0.29 includes the fix.
-from knowledge_ingest._patch_graphiti import apply as _apply_graphiti_patch
-
 _apply_graphiti_patch()
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill_tasks.py
@@ -200,9 +200,7 @@ async def backfill_detect_login_walls(
         )
 
         # Pass 1: ensure every row has a SimHash (Phase D, plan.md item 1).
-        url_to_hash = await _ensure_simhashes(
-            conn, list(rows), org_id=org_id, kb_slug=kb_slug
-        )
+        url_to_hash = await _ensure_simhashes(conn, list(rows), org_id=org_id, kb_slug=kb_slug)
 
         # Pass 2: cluster eval in-memory (single O(N^2) scan, no extra SQL).
         processed = len(rows)
@@ -314,9 +312,7 @@ async def recover_purged_pages(
             kb_slug,
         )
 
-        url_to_hash = await _ensure_simhashes(
-            conn, list(rows), org_id=org_id, kb_slug=kb_slug
-        )
+        url_to_hash = await _ensure_simhashes(conn, list(rows), org_id=org_id, kb_slug=kb_slug)
 
         processed = 0
         recovered = 0
@@ -367,9 +363,7 @@ def register_backfill_login_walls_task(procrastinate_app: Any) -> None:
     """Register the backfill + recover tasks on the given app."""
 
     @procrastinate_app.task(queue=queues.ENRICH_BULK)
-    async def backfill_detect_login_walls_task(
-        org_id: str, kb_slug: str
-    ) -> dict[str, int]:
+    async def backfill_detect_login_walls_task(org_id: str, kb_slug: str) -> dict[str, int]:
         return await backfill_detect_login_walls(org_id=org_id, kb_slug=kb_slug)
 
     @procrastinate_app.task(queue=queues.ENRICH_BULK)

--- a/klai-knowledge-ingest/knowledge_ingest/clustering.py
+++ b/klai-knowledge-ingest/knowledge_ingest/clustering.py
@@ -258,7 +258,7 @@ def cluster_documents_hdbscan(
         EOM under-fitted at typical KB sizes (e.g. Voys/support 154 docs → 3 clusters even
         with min_cluster_size_floor=3) because EOM rejects smaller stable sub-clusters in
         favour of bigger 'most stable' merges. Leaf returns the leaves of the cluster
-        hierarchy → typically 2-4× more clusters, lands in the 5-9 IA sweet spot.
+        hierarchy → typically 2-4x more clusters, lands in the 5-9 IA sweet spot.
 
     Args:
         embeddings: (n_docs, dim) float32 array of unit-normalised embeddings.

--- a/klai-knowledge-ingest/knowledge_ingest/connector_purge_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_purge_tasks.py
@@ -53,9 +53,7 @@ def register_connector_purge_task(procrastinate_app: Any) -> None:
             attempt = job.attempts  # 0-based after first failure
             if attempt >= len(self._waits):
                 return None  # exhausted, give up
-            return procrastinate.RetryDecision(
-                retry_in={"seconds": self._waits[attempt]}
-            )
+            return procrastinate.RetryDecision(retry_in={"seconds": self._waits[attempt]})
 
     @procrastinate_app.task(
         queue=queues.CONNECTOR_PURGE,

--- a/klai-knowledge-ingest/knowledge_ingest/content_profiles.py
+++ b/klai-knowledge-ingest/knowledge_ingest/content_profiles.py
@@ -2,6 +2,7 @@
 Content-type parameter profiles for enrichment.
 Each profile specifies HyPE behavior, context strategy, token ranges, and prompt focus.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -12,7 +13,7 @@ from dataclasses import dataclass
 class ContentTypeProfile:
     content_type: str
     hype_enabled: Callable[[int], bool]  # (synthesis_depth) -> bool
-    context_strategy: str                # name of function in context_strategies.STRATEGIES
+    context_strategy: str  # name of function in context_strategies.STRATEGIES
     context_tokens_min: int
     context_tokens_max: int
     chunk_tokens_min: int
@@ -56,8 +57,7 @@ PROFILES: dict[str, ContentTypeProfile] = {
         chunk_tokens_min=100,
         chunk_tokens_max=300,
         hype_question_focus=(
-            "Genereer vragen over toezeggingen, besproken onderwerpen "
-            "en genoemde namen."
+            "Genereer vragen over toezeggingen, besproken onderwerpen en genoemde namen."
         ),
     ),
     "email_thread": ContentTypeProfile(
@@ -69,8 +69,7 @@ PROFILES: dict[str, ContentTypeProfile] = {
         chunk_tokens_min=200,
         chunk_tokens_max=500,
         hype_question_focus=(
-            "Genereer vragen over de status, beslissingen "
-            "en verzoeken in deze e-mailthread."
+            "Genereer vragen over de status, beslissingen en verzoeken in deze e-mailthread."
         ),
     ),
     "pdf_document": ContentTypeProfile(

--- a/klai-knowledge-ingest/knowledge_ingest/content_profiles.py
+++ b/klai-knowledge-ingest/knowledge_ingest/content_profiles.py
@@ -4,8 +4,8 @@ Each profile specifies HyPE behavior, context strategy, token ranges, and prompt
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 
 @dataclass(frozen=True)

--- a/klai-knowledge-ingest/knowledge_ingest/context_strategies.py
+++ b/klai-knowledge-ingest/knowledge_ingest/context_strategies.py
@@ -2,6 +2,7 @@
 Context extraction strategies for enrichment.
 Each strategy extracts the most relevant document context for a given content type.
 """
+
 from __future__ import annotations
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/context_strategies.py
+++ b/klai-knowledge-ingest/knowledge_ingest/context_strategies.py
@@ -35,7 +35,9 @@ def extract_most_recent_messages(doc: str, n: int, **kwargs: object) -> str:
     return doc[-max_chars:] if len(doc) > max_chars else doc
 
 
-def extract_front_matter(doc: str, n: int, *, front_matter: str | None = None, **kwargs: object) -> str:
+def extract_front_matter(
+    doc: str, n: int, *, front_matter: str | None = None, **kwargs: object
+) -> str:
     """Title + TOC extracted during PDF parsing.
     Falls back to first_n if no front_matter is provided."""
     if front_matter:

--- a/klai-knowledge-ingest/knowledge_ingest/fingerprint.py
+++ b/klai-knowledge-ingest/knowledge_ingest/fingerprint.py
@@ -52,9 +52,7 @@ def _sample_tokens(text: str) -> list[str]:
 
 def _token_hash(token: str) -> int:
     """64-bit hash of a single token via blake2b (matches trafilatura._hash)."""
-    return int.from_bytes(
-        blake2b(token.encode(), digest_size=8).digest(), "big"
-    )
+    return int.from_bytes(blake2b(token.encode(), digest_size=8).digest(), "big")
 
 
 def compute_content_fingerprint(markdown: str) -> str:

--- a/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/ingest_tasks.py
@@ -13,6 +13,7 @@ version of the document.
 Queue: ingest-kb (separate from enrichment queues so it can be tuned
 independently; drained by the same Procrastinate worker in app.py).
 """
+
 from __future__ import annotations
 
 import structlog

--- a/klai-knowledge-ingest/knowledge_ingest/middleware/auth.py
+++ b/klai-knowledge-ingest/knowledge_ingest/middleware/auth.py
@@ -10,6 +10,7 @@ emptiness is rejected at settings load time, so this middleware never runs
 with an unset secret. There is no fail-open branch; the only possible
 outcomes are "valid secret → allow" or "invalid/missing secret → 401".
 """
+
 import hmac
 import json
 

--- a/klai-knowledge-ingest/knowledge_ingest/models.py
+++ b/klai-knowledge-ingest/knowledge_ingest/models.py
@@ -18,8 +18,8 @@ class IngestRequest(BaseModel):
             "Reference: SPEC-SEC-AUDIT-2026-04 C3."
         ),
     )
-    kb_slug: str         # e.g. "personal"
-    path: str            # e.g. "my-note.md" (relative within KB)
+    kb_slug: str  # e.g. "personal"
+    path: str  # e.g. "my-note.md" (relative within KB)
     content: str = Field(max_length=500_000)  # Full markdown content (with optional frontmatter)
     title: str | None = None  # Human-readable source title from portal/connectors
     user_id: str | None = Field(
@@ -58,7 +58,7 @@ class RetrieveRequest(BaseModel):
 
 class ChunkResult(BaseModel):
     text: str
-    source: str          # "{kb_slug}/{path}"
+    source: str  # "{kb_slug}/{path}"
     score: float
     metadata: dict = {}
     artifact_id: str | None = None
@@ -75,8 +75,8 @@ class RetrieveResponse(BaseModel):
 class CrawlRequest(BaseModel):
     org_id: str
     kb_slug: str
-    url: str                          # URL to fetch and ingest
-    path: str | None = None           # Override storage path (default: derived from URL)
+    url: str  # URL to fetch and ingest
+    path: str | None = None  # Override storage path (default: derived from URL)
 
 
 class CrawlResponse(BaseModel):
@@ -152,11 +152,11 @@ class GiteaCommit(BaseModel):
 
 
 class GiteaRepository(BaseModel):
-    full_name: str        # e.g. "org-myslug/personal"
+    full_name: str  # e.g. "org-myslug/personal"
 
 
 class GiteaPushEvent(BaseModel):
-    ref: str              # e.g. "refs/heads/main"
+    ref: str  # e.g. "refs/heads/main"
     commits: list[GiteaCommit] = []
     repository: GiteaRepository
     pusher: GiteaPusher | None = None

--- a/klai-knowledge-ingest/knowledge_ingest/routes/knowledge.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/knowledge.py
@@ -9,7 +9,7 @@ import uuid
 import structlog
 from fastapi import APIRouter, Request
 
-from knowledge_ingest.db import get_pool, tenant_scoped_connection
+from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.identity import assert_caller_identity
 from knowledge_ingest.models import BulkCrawlRequest, BulkCrawlResponse
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/knowledge.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/knowledge.py
@@ -2,6 +2,7 @@
 Knowledge management routes:
   POST /knowledge/v1/crawl - enqueue a bulk web crawl job
 """
+
 import json
 import time
 import uuid
@@ -37,11 +38,15 @@ async def start_crawl(req: BulkCrawlRequest, request: Request) -> BulkCrawlRespo
             """INSERT INTO knowledge.crawl_jobs
                (id, org_id, kb_slug, config, status, created_at, updated_at)
                VALUES ($1, $2, $3, $4, 'pending', $5, $5)""",
-            job_id, verified_org_id, req.kb_slug,
-            json.dumps(req.model_dump()), now,
+            job_id,
+            verified_org_id,
+            req.kb_slug,
+            json.dumps(req.model_dump()),
+            now,
         )
 
     from knowledge_ingest import enrichment_tasks
+
     proc_app = enrichment_tasks.get_app()
     await proc_app.run_crawl.defer_async(  # type: ignore[attr-defined]
         job_id=job_id,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/taxonomy.py
@@ -175,11 +175,7 @@ async def _remove_taxonomy_node_from_qdrant(
             if not isinstance(raw_ids, list):
                 raw_ids = [raw_ids]
 
-            remaining_ids = [
-                raw_id
-                for raw_id in raw_ids
-                if _payload_int(raw_id) != node_id
-            ]
+            remaining_ids = [raw_id for raw_id in raw_ids if _payload_int(raw_id) != node_id]
             ids_changed = len(remaining_ids) != len(raw_ids)
             legacy_changed = _payload_int(payload.get("taxonomy_node_id")) == node_id
 

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/migrate_collection.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/migrate_collection.py
@@ -78,7 +78,10 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 )
 
                 if not existing_points:
-                    logger.warning("No Qdrant points for artifact %s (%s/%s) — skipping", artifact_id, kb_slug, path)
+                    logger.warning(
+                        "No Qdrant points for artifact %s (%s/%s) — skipping",
+                        artifact_id, kb_slug, path,
+                    )
                     continue
 
                 # Reconstruct chunks and document text from existing points
@@ -88,7 +91,10 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 title = existing_points[0].payload.get("title", path)
                 extra_payload = {
                     k: existing_points[0].payload[k]
-                    for k in ("title", "source_type", "tags", "provenance_type", "confidence", "artifact_id")
+                    for k in (
+                        "title", "source_type", "tags",
+                        "provenance_type", "confidence", "artifact_id",
+                    )
                     if k in existing_points[0].payload
                 }
                 user_id = existing_points[0].payload.get("user_id")
@@ -108,7 +114,10 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 # Embed questions for depth 0-1
                 question_vectors: list[list[float] | None]
                 if synthesis_depth <= 1:
-                    q_strings = [" ".join(ec.questions) if ec.questions else ec.original_text for ec in enriched_chunks]
+                    q_strings = [
+                        " ".join(ec.questions) if ec.questions else ec.original_text
+                        for ec in enriched_chunks
+                    ]
                     question_vectors = await embedder.embed(q_strings)
                 else:
                     question_vectors = [None] * len(enriched_chunks)
@@ -130,7 +139,9 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                     logger.info("Progress: %d/%d artifacts migrated", processed, total)
 
             except Exception as exc:
-                logger.error("Failed to migrate artifact %s (%s/%s): %s", artifact_id, kb_slug, path, exc)
+                logger.error(
+                    "Failed to migrate artifact %s (%s/%s): %s", artifact_id, kb_slug, path, exc
+                )
                 errors += 1
 
         logger.info(
@@ -150,9 +161,13 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Migrate Qdrant collection to v2 with named vectors")
+    parser = argparse.ArgumentParser(
+        description="Migrate Qdrant collection to v2 with named vectors"
+    )
     parser.add_argument("--dry-run", action="store_true", help="List artifacts without migrating")
-    parser.add_argument("--batch-size", type=int, default=10, help="Concurrent enrichment batch size")
+    parser.add_argument(
+        "--batch-size", type=int, default=10, help="Concurrent enrichment batch size"
+    )
     args = parser.parse_args()
 
     try:

--- a/klai-knowledge-ingest/knowledge_ingest/scripts/migrate_collection.py
+++ b/klai-knowledge-ingest/knowledge_ingest/scripts/migrate_collection.py
@@ -11,6 +11,7 @@ Usage:
 After validation, switch the active collection:
     Set QDRANT_COLLECTION=klai_knowledge_v2 in /opt/klai/.env and restart knowledge-ingest.
 """
+
 import argparse
 import asyncio
 import logging
@@ -65,6 +66,7 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 # Fetch document content from Qdrant v1 (existing raw points)
                 client = qdrant_store.get_client()
                 from qdrant_client.models import FieldCondition, Filter, MatchValue
+
                 existing_points, _ = await client.scroll(
                     qdrant_store.COLLECTION,
                     scroll_filter=Filter(
@@ -80,7 +82,9 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 if not existing_points:
                     logger.warning(
                         "No Qdrant points for artifact %s (%s/%s) — skipping",
-                        artifact_id, kb_slug, path,
+                        artifact_id,
+                        kb_slug,
+                        path,
                     )
                     continue
 
@@ -92,8 +96,12 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
                 extra_payload = {
                     k: existing_points[0].payload[k]
                     for k in (
-                        "title", "source_type", "tags",
-                        "provenance_type", "confidence", "artifact_id",
+                        "title",
+                        "source_type",
+                        "tags",
+                        "provenance_type",
+                        "confidence",
+                        "artifact_id",
                     )
                     if k in existing_points[0].payload
                 }
@@ -146,7 +154,9 @@ async def migrate(dry_run: bool, batch_size: int) -> None:
 
         logger.info(
             "Migration complete: %d/%d processed, %d errors.",
-            processed, total, errors,
+            processed,
+            total,
+            errors,
         )
 
         if not dry_run:

--- a/klai-knowledge-ingest/knowledge_ingest/source_label.py
+++ b/klai-knowledge-ingest/knowledge_ingest/source_label.py
@@ -1,4 +1,5 @@
 """Source label computation for chunk payload (SPEC-KB-021 Change 1)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/klai-knowledge-ingest/knowledge_ingest/sparse_embedder.py
+++ b/klai-knowledge-ingest/knowledge_ingest/sparse_embedder.py
@@ -4,6 +4,7 @@ Sparse embedding client for BGE-M3 FlagEmbedding sidecar.
 Calls the bge-m3-sparse FastAPI sidecar and returns a Qdrant SparseVector.
 Falls back gracefully when the sidecar is unavailable.
 """
+
 from __future__ import annotations
 
 import httpx

--- a/klai-knowledge-ingest/knowledge_ingest/sparse_embedder.py
+++ b/klai-knowledge-ingest/knowledge_ingest/sparse_embedder.py
@@ -6,9 +6,8 @@ Falls back gracefully when the sidecar is unavailable.
 """
 from __future__ import annotations
 
-import structlog
-
 import httpx
+import structlog
 from qdrant_client.models import SparseVector
 
 from knowledge_ingest.config import settings

--- a/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/taxonomy_tasks.py
@@ -142,6 +142,7 @@ async def _run_backfill(org_id: str, kb_slug: str, batch_size: int) -> dict:
     # Taxonomy phases require nodes — skip if none exist.
     # Always bypass cache: new nodes may have been approved just before this job ran.
     from knowledge_ingest.portal_client import invalidate_cache
+
     invalidate_cache(org_id, kb_slug)
     taxonomy_nodes = await fetch_taxonomy_nodes(kb_slug, org_id)
     if not taxonomy_nodes:

--- a/klai-knowledge-ingest/knowledge_ingest/validation.py
+++ b/klai-knowledge-ingest/knowledge_ingest/validation.py
@@ -119,9 +119,7 @@ def _build_report(
     # Find URLs that meet the cluster threshold (>= cluster_min OTHERS).
     flagged_urls: set[str] = set()
     for url, target_hash in url_to_hash.items():
-        siblings = _count_cluster_siblings(
-            url, target_hash, url_to_hash, hamming_max=hamming_max
-        )
+        siblings = _count_cluster_siblings(url, target_hash, url_to_hash, hamming_max=hamming_max)
         if siblings >= cluster_min:
             flagged_urls.add(url)
 
@@ -142,10 +140,7 @@ def _build_report(
             for other in flagged_urls:
                 if other in visited:
                     continue
-                if (
-                    hamming_distance(url_to_hash[current], url_to_hash[other])
-                    <= hamming_max
-                ):
+                if hamming_distance(url_to_hash[current], url_to_hash[other]) <= hamming_max:
                     stack.append(other)
         component.sort()
         clusters.append({"size": len(component), "sample_urls": component[:sample_size]})
@@ -159,9 +154,7 @@ def _build_report(
             continue
         url = row["url"]
         target_hash = url_to_hash[url]
-        siblings = _count_cluster_siblings(
-            url, target_hash, url_to_hash, hamming_max=hamming_max
-        )
+        siblings = _count_cluster_siblings(url, target_hash, url_to_hash, hamming_max=hamming_max)
         if siblings < cluster_min:
             recovery_candidates.append(url)
 

--- a/klai-knowledge-ingest/pyproject.toml
+++ b/klai-knowledge-ingest/pyproject.toml
@@ -72,6 +72,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "knowledge_ingest/crawl4ai_client.py" = ["E501"]  # JS strings in multiline literals
+"knowledge_ingest/_patch_graphiti.py" = ["E501"]  # Cypher query strings in multiline literals, wrapping risks changing query syntax
 "alembic/versions/*.py" = ["E501"]  # SQL DDL lines legitimately exceed 100 chars
 "tests/test_alembic_bootstrap.py" = ["E501", "S603", "S607"]  # test file calls subprocess with known-safe args
 "tests/test_clustering_umap.py" = ["E501"]  # patch() strings and assert messages legitimately exceed 100 chars

--- a/klai-knowledge-ingest/tests/integration/test_crawl_sync_end_to_end.py
+++ b/klai-knowledge-ingest/tests/integration/test_crawl_sync_end_to_end.py
@@ -40,6 +40,7 @@ Expected runtime: < 60 s.
 
 Acceptance: SPEC-CRAWLER-005 AC-07.1.
 """
+
 from __future__ import annotations
 
 import os

--- a/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
+++ b/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
@@ -7,8 +7,6 @@ import sys
 from types import ModuleType
 from unittest.mock import MagicMock
 
-import pytest
-
 # The knowledge_adapter module lives in klai-scribe/scribe-api/ and imports from
 # app.core.config which requires the full Scribe app context.  We mock the
 # entire app.* package tree so that Python can resolve the import chain, then
@@ -38,7 +36,6 @@ from app.services.knowledge_adapter import (  # noqa: E402
     _detect_content_type,
     _split_paragraphs,
 )
-
 
 # -- _cluster_segments --
 

--- a/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
+++ b/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
@@ -11,7 +11,9 @@ from unittest.mock import MagicMock
 # app.core.config which requires the full Scribe app context.  We mock the
 # entire app.* package tree so that Python can resolve the import chain, then
 # add scribe-api to sys.path so the actual knowledge_adapter module is found.
-_scribe_api = str(__import__("pathlib").Path(__file__).resolve().parents[2] / "klai-scribe" / "scribe-api")
+_scribe_api = str(
+    __import__("pathlib").Path(__file__).resolve().parents[2] / "klai-scribe" / "scribe-api"
+)
 sys.path.insert(0, _scribe_api)
 
 _mock_app = ModuleType("app")

--- a/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
+++ b/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
@@ -3,6 +3,7 @@
 Tests _cluster_segments, _split_paragraphs, and _detect_content_type
 from klai-scribe/scribe-api/app/services/knowledge_adapter.py.
 """
+
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock

--- a/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
+++ b/klai-knowledge-ingest/tests/test_adapters_scribe_chunking.py
@@ -21,7 +21,7 @@ _mock_core.__path__ = [_scribe_api + "/app/core"]
 _mock_config = ModuleType("app.core.config")
 _mock_config.settings = MagicMock(
     knowledge_ingest_url="http://test:9100",
-    knowledge_ingest_secret="test-secret",
+    knowledge_ingest_secret="test-secret",  # noqa: S106  # testfixture, geen echt secret
 )
 _mock_services = ModuleType("app.services")
 _mock_services.__path__ = [_scribe_api + "/app/services"]

--- a/klai-knowledge-ingest/tests/test_alembic_simhash_migration.py
+++ b/klai-knowledge-ingest/tests/test_alembic_simhash_migration.py
@@ -46,11 +46,10 @@ def test_revision_id_is_distinct_uuid_style() -> None:
     """Revision id must be a 12-char hex string and not collide with predecessors."""
     content = MIGRATION.read_text()
     match = re.search(r'^revision: str = "([^"]+)"', content, re.MULTILINE)
-    assert match, "top-level `revision: str = \"...\"` declaration not found"
+    assert match, 'top-level `revision: str = "..."` declaration not found'
     rev = match.group(1)
     assert re.fullmatch(r"[0-9a-f]{12}", rev), (
-        f"revision id {rev!r} must be 12 lowercase hex chars, matching "
-        "the pattern set by 0002-0004"
+        f"revision id {rev!r} must be 12 lowercase hex chars, matching the pattern set by 0002-0004"
     )
     assert rev not in {
         "603787256fb8",

--- a/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
+++ b/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
@@ -7,9 +7,6 @@ to enriched_text only, leaving original_text and context_prefix unchanged.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 # ---------------------------------------------------------------------------
 # Fake EnrichedChunk -- mirrors knowledge_ingest.enrichment.EnrichedChunk

--- a/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
+++ b/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
@@ -4,6 +4,7 @@ SPEC-CRAWLER-003: R9, R10, R11
 Verifies that anchor texts from linking pages are deduplicated and appended
 to enriched_text only, leaving original_text and context_prefix unchanged.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -12,6 +13,7 @@ from dataclasses import dataclass, field
 # Fake EnrichedChunk -- mirrors knowledge_ingest.enrichment.EnrichedChunk
 # without pulling in the real module and its heavy transitive deps.
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class FakeEnrichedChunk:
@@ -44,6 +46,7 @@ def _make_chunks(texts: list[str]) -> list[FakeEnrichedChunk]:
 # ---------------------------------------------------------------------------
 # Scenario 4.1: Anchor text deduplicated and appended
 # ---------------------------------------------------------------------------
+
 
 class TestAnchorTextDeduplicatedAndAppended:
     """Given enriched chunks and extra_payload with duplicate anchor_texts,
@@ -86,6 +89,7 @@ class TestAnchorTextDeduplicatedAndAppended:
 # ---------------------------------------------------------------------------
 # Scenario 4.2: Empty anchor_texts list -- no modification
 # ---------------------------------------------------------------------------
+
 
 class TestEmptyAnchorTextsNoModification:
     """Given extra_payload with empty anchor_texts, enriched_text is unchanged."""
@@ -138,6 +142,7 @@ class TestEmptyAnchorTextsNoModification:
 # ---------------------------------------------------------------------------
 # Scenario 4.3: original_text and context_prefix unchanged
 # ---------------------------------------------------------------------------
+
 
 class TestOriginalFieldsUnchanged:
     """Given anchor_texts, original_text and context_prefix must NOT be modified."""

--- a/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
+++ b/klai-knowledge-ingest/tests/test_anchor_text_augmentation.py
@@ -101,7 +101,7 @@ class TestEmptyAnchorTextsNoModification:
             for ec in chunks:
                 ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_texts):
+        for ec, orig in zip(chunks, original_texts, strict=True):
             assert ec.enriched_text == orig
 
     def test_missing_key_no_change(self):
@@ -116,7 +116,7 @@ class TestEmptyAnchorTextsNoModification:
             for ec in chunks:
                 ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_texts):
+        for ec, orig in zip(chunks, original_texts, strict=True):
             assert ec.enriched_text == orig
 
     def test_none_extra_payload_no_change(self):
@@ -131,7 +131,7 @@ class TestEmptyAnchorTextsNoModification:
             for ec in chunks:
                 ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_texts):
+        for ec, orig in zip(chunks, original_texts, strict=True):
             assert ec.enriched_text == orig
 
 
@@ -152,7 +152,7 @@ class TestOriginalFieldsUnchanged:
         for ec in chunks:
             ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_original):
+        for ec, orig in zip(chunks, original_original, strict=True):
             assert ec.original_text == orig
 
     def test_context_prefix_unchanged(self):
@@ -165,7 +165,7 @@ class TestOriginalFieldsUnchanged:
         for ec in chunks:
             ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_prefixes):
+        for ec, orig in zip(chunks, original_prefixes, strict=True):
             assert ec.context_prefix == orig
 
     def test_questions_unchanged(self):
@@ -178,5 +178,5 @@ class TestOriginalFieldsUnchanged:
         for ec in chunks:
             ec.enriched_text += anchor_block
 
-        for ec, orig in zip(chunks, original_questions):
+        for ec, orig in zip(chunks, original_questions, strict=True):
             assert ec.questions == orig

--- a/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
@@ -32,7 +32,6 @@ from fastapi.testclient import TestClient
 
 from knowledge_ingest.routes.crawl import _ProbeResponse
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_auth_probe_endpoint.py
@@ -110,12 +110,8 @@ def test_auth_probe_no_cookies_short_circuits_without_fetching(
 def test_auth_probe_significant_word_diff_returns_auth_ok(client: TestClient) -> None:
     """Cookies that produce a measurably larger response authenticate."""
     with _patch_probe_fetch(
-        with_cookies=_probe(
-            word_count=7299, byte_size=181000, text="Logged in body. " * 500
-        ),
-        without_cookies=_probe(
-            word_count=5572, byte_size=140000, text="Anonymous body. " * 300
-        ),
+        with_cookies=_probe(word_count=7299, byte_size=181000, text="Logged in body. " * 500),
+        without_cookies=_probe(word_count=5572, byte_size=140000, text="Anonymous body. " * 300),
     ):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
@@ -155,9 +151,7 @@ def test_auth_probe_no_diff_returns_auth_failed_still_walled(
     """Cookies that produce an identical (or near-identical) response to the
     anonymous baseline have no authenticating effect — the wizard MUST NOT
     green-light this case."""
-    identical = _probe(
-        word_count=250, byte_size=10000, text="Same body for both fetches."
-    )
+    identical = _probe(word_count=250, byte_size=10000, text="Same body for both fetches.")
     with _patch_probe_fetch(with_cookies=identical, without_cookies=identical):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",
@@ -224,9 +218,7 @@ def test_auth_probe_auth_ok_emits_canary_fingerprint(client: TestClient) -> None
             byte_size=30000,
             text="Long unique logged-in content. " * 200,
         ),
-        without_cookies=_probe(
-            word_count=300, byte_size=8000, text="Short anonymous body. " * 50
-        ),
+        without_cookies=_probe(word_count=300, byte_size=8000, text="Short anonymous body. " * 50),
     ):
         resp = client.post(
             "/ingest/v1/crawl/auth-probe",

--- a/klai-knowledge-ingest/tests/test_auth_wall_classifier.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_classifier.py
@@ -210,8 +210,7 @@ def test_long_article_with_login_link_in_nav_does_not_match_marker() -> None:
     """
     body = (
         "Log in | Sign up | Help\n\n"  # nav header text up front
-        + "Welcome to our article. This article is about how to use the API. "
-        * 60
+        + "Welcome to our article. This article is about how to use the API. " * 60
         + "Read more at the end of the article. The conclusion is left as an "
         + "exercise to the reader.\n"
     )
@@ -231,7 +230,8 @@ def test_marker_in_middle_of_body_does_not_match() -> None:
     body = (
         "Article start, lots of content. "
         "log in to read this article in the middle of the body. "
-        + "More content following the supposed marker, plenty of words. " * 30
+        + "More content following the supposed marker, plenty of words. "
+        * 30
     )
     result = classify_auth_wall(
         response_status_code=200,
@@ -382,11 +382,13 @@ def test_repeated_login_marker_anywhere_in_body_classified_as_walled() -> None:
         "Bubble Desktop Pop-up is een slimme aanvulling op uw werkomgeving. "
         "Log in when you want to read this article. "  # tab 1 marker
         "This article is providing information to users of our software. "
-        + "More tab content here with words to push marker out of tail. " * 30
+        + "More tab content here with words to push marker out of tail. "
+        * 30
         + "Compatibiliteit Bubble Desktop Pop-up is compatibel. "
         "Log in when you want to read this article. "  # tab 2 marker, mid-body
         "This article is providing information to users of our software. "
-        + "Even more padding so the marker is NOT in the last 200 chars. " * 40
+        + "Even more padding so the marker is NOT in the last 200 chars. "
+        * 40
     )
     result = classify_auth_wall(
         response_status_code=200,
@@ -413,7 +415,8 @@ def test_single_embedded_login_gate_in_body_classified_as_walled() -> None:
         "Information that contains things like, how to install our software, "
         "how to use certain options and more. If you want to read this article, "
         "you will have to log in with your Red Cactus account.\n"
-        + "Trailing public content that pushes the marker out of the tail. " * 50
+        + "Trailing public content that pushes the marker out of the tail. "
+        * 50
     )
     result = classify_auth_wall(
         response_status_code=200,

--- a/klai-knowledge-ingest/tests/test_auth_wall_detector.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_detector.py
@@ -447,9 +447,12 @@ class TestConfigurableThreshold:
         conn = _FakeConn([target] * 3)  # 3 OTHERS
 
         # Default 5 → no flag
-        assert await detect_anonymous_auth_wall(
-            wall_text, org_id="x", kb_slug="y", url="https://x", conn=conn
-        ) is None
+        assert (
+            await detect_anonymous_auth_wall(
+                wall_text, org_id="x", kb_slug="y", url="https://x", conn=conn
+            )
+            is None
+        )
         # Lowered to 3 → flag
         signal = await detect_anonymous_auth_wall(
             wall_text,

--- a/klai-knowledge-ingest/tests/test_auto_categorise_job.py
+++ b/klai-knowledge-ingest/tests/test_auto_categorise_job.py
@@ -2,6 +2,7 @@
 
 Verifies the new job enqueue endpoint and Procrastinate task registration.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -76,11 +77,13 @@ class TestAutoCategoriseTaskRegistration:
                 registered_tasks[fn.__name__] = kwargs
                 mock_app.__setattr__(fn.__name__, fn)
                 return fn
+
             return decorator
 
         mock_app.task = mock_task
 
         import sys
+
         mock_procrastinate = MagicMock()
 
         # _StepwiseRetry inherits from BaseRetryStrategy — provide a real base class.
@@ -101,4 +104,3 @@ class TestAutoCategoriseTaskRegistration:
         # Verify stepwise backoff: 30s, 5m, 30m (SPEC-KB-026 R5)
         retry = task_config["retry"]
         assert retry._waits == [30, 300, 1800]
-

--- a/klai-knowledge-ingest/tests/test_backfill_login_walls.py
+++ b/klai-knowledge-ingest/tests/test_backfill_login_walls.py
@@ -62,10 +62,7 @@ def _row(
 def _walled_cluster(count: int) -> list[dict]:
     """Build ``count`` rows, all sharing the wall content (= one cluster)."""
     base = _walled_md()
-    return [
-        _row(url=f"https://wiki.redcactus.cloud/wall-{i}", raw=base)
-        for i in range(count)
-    ]
+    return [_row(url=f"https://wiki.redcactus.cloud/wall-{i}", raw=base) for i in range(count)]
 
 
 def _make_conn(rows: list[dict]):
@@ -157,9 +154,7 @@ class TestBackfillCluster:
         assert qdrant.delete.await_count == 6
 
     @pytest.mark.asyncio()
-    async def test_at_threshold_minus_one_not_flagged(
-        self, patched_externals
-    ) -> None:
+    async def test_at_threshold_minus_one_not_flagged(self, patched_externals) -> None:
         """5 identical pages → 4 OTHERS each → below default threshold 5 → no flag."""
         _conn, qdrant, set_rows = patched_externals
         set_rows(_walled_cluster(5))
@@ -276,14 +271,10 @@ class TestSimhashBackfillPass:
             for c in conn.fetchval.await_args_list
             if c.args and "SET content_simhash" in c.args[0]
         ]
-        assert update_calls == [], (
-            "content_simhash UPDATE should not run when already populated"
-        )
+        assert update_calls == [], "content_simhash UPDATE should not run when already populated"
 
     @pytest.mark.asyncio()
-    async def test_empty_raw_markdown_does_not_store_zero_hash(
-        self, patched_externals
-    ) -> None:
+    async def test_empty_raw_markdown_does_not_store_zero_hash(self, patched_externals) -> None:
         """Pages with empty/whitespace raw_markdown produce simhash=0; the
         backfill MUST NOT persist 0 (would let empty pages cluster across a
         tenant). Row stays content_simhash=NULL.
@@ -308,9 +299,7 @@ class TestSimhashBackfillPass:
             for c in conn.fetchval.await_args_list
             if c.args and "SET content_simhash" in c.args[0]
         ]
-        assert update_calls == [], (
-            "Empty-content rows must not have content_simhash=0 written"
-        )
+        assert update_calls == [], "Empty-content rows must not have content_simhash=0 written"
 
 
 class TestZeroHashSafeguard:
@@ -356,9 +345,7 @@ class TestZeroHashSafeguard:
 
 class TestTenantIsolation:
     @pytest.mark.asyncio()
-    async def test_qdrant_filter_includes_org_id_kb_slug_path(
-        self, patched_externals
-    ) -> None:
+    async def test_qdrant_filter_includes_org_id_kb_slug_path(self, patched_externals) -> None:
         """REQ-09.1 — Qdrant delete filter MUST contain org_id + kb_slug + path.
 
         Removing any one of these is blocked by the semgrep rule in

--- a/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
+++ b/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
@@ -1,4 +1,5 @@
 """Tests for _BatchSplittingEmbedder in knowledge_ingest.graph."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
+++ b/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
@@ -9,8 +9,9 @@ import pytest
 from knowledge_ingest.graph import _GRAPHITI_AVAILABLE
 
 if _GRAPHITI_AVAILABLE:
-    from knowledge_ingest.graph import _BatchSplittingEmbedder
     from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
+
+    from knowledge_ingest.graph import _BatchSplittingEmbedder
 
 pytestmark = pytest.mark.skipif(not _GRAPHITI_AVAILABLE, reason="graphiti-core not installed")
 

--- a/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
+++ b/klai-knowledge-ingest/tests/test_batch_splitting_embedder.py
@@ -111,7 +111,9 @@ async def test_create_delegates_to_inner():
 async def test_tei_info_resolves_batch_size():
     """Batch size is discovered from TEI /info endpoint."""
     inner = _make_inner(batch_result=[[0.1, 0.2, 0.3]])
-    wrapper = _BatchSplittingEmbedder(inner, tei_base_url="http://tei:7997/v1", default_batch_size=32)
+    wrapper = _BatchSplittingEmbedder(
+        inner, tei_base_url="http://tei:7997/v1", default_batch_size=32
+    )
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200

--- a/klai-knowledge-ingest/tests/test_centroid_max_age.py
+++ b/klai-knowledge-ingest/tests/test_centroid_max_age.py
@@ -3,6 +3,7 @@
 Verifies that stale centroid files (older than taxonomy_centroid_max_age_hours)
 are rejected and a warning is logged.
 """
+
 from __future__ import annotations
 
 import json
@@ -113,7 +114,6 @@ class TestCentroidMaxAge:
             result = load_centroids("org1", "kb1")
 
         assert result is not None
-
 
     def test_naive_datetime_treated_as_utc(self, tmp_path):
         """Naive computed_at is treated as UTC and stale check works correctly."""

--- a/klai-knowledge-ingest/tests/test_centroid_max_age.py
+++ b/klai-knowledge-ingest/tests/test_centroid_max_age.py
@@ -6,12 +6,8 @@ are rejected and a warning is logged.
 from __future__ import annotations
 
 import json
-import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
-
-import pytest
-import structlog
 
 from knowledge_ingest.clustering import CentroidStore, load_centroids
 

--- a/klai-knowledge-ingest/tests/test_chunker_parent_child.py
+++ b/klai-knowledge-ingest/tests/test_chunker_parent_child.py
@@ -110,14 +110,9 @@ def test_no_heading_doc_falls_back_to_single_section() -> None:
 
 def test_frontmatter_is_stripped_from_chunks() -> None:
     """YAML frontmatter must not appear in any child or parent text."""
-    doc = (
-        "---\n"
-        "title: Test\n"
-        "tags: [crm, voys]\n"
-        "---\n"
-        "\n"
-        "# Visible heading\n\n"
-    ) + ("Visible body content. " * 30)
+    doc = ("---\ntitle: Test\ntags: [crm, voys]\n---\n\n# Visible heading\n\n") + (
+        "Visible body content. " * 30
+    )
     children, parents = chunk_markdown_with_parents(doc)
     for c in children:
         assert "title: Test" not in c.text
@@ -149,12 +144,7 @@ def test_blocknote_json_is_normalized_before_chunking() -> None:
             "children": [],
         },
     ]
-    content = (
-        "---\n"
-        "title: Invite people\n"
-        "---\n\n"
-        f"{json.dumps(blocks)}"
-    )
+    content = f"---\ntitle: Invite people\n---\n\n{json.dumps(blocks)}"
 
     normalized = normalize_document_for_chunking(content)
     children, parents = chunk_markdown_with_parents(normalized)
@@ -184,6 +174,4 @@ def test_parent_text_contains_all_child_content() -> None:
         # First 50 chars of the child body must appear somewhere in the parent.
         sample = child_body[:50].strip()
         if sample:
-            assert sample in parent_body, (
-                f"Child fragment {sample!r} not found in parent text"
-            )
+            assert sample in parent_body, f"Child fragment {sample!r} not found in parent text"

--- a/klai-knowledge-ingest/tests/test_content_fingerprint.py
+++ b/klai-knowledge-ingest/tests/test_content_fingerprint.py
@@ -124,9 +124,7 @@ def test_anchor_text_normalised_url_dropped() -> None:
     page_a = "Click [here](https://example.com/a) for the doc."
     page_b = "Click [here](https://example.com/totally-different-url) for the doc."
     distance = hamming_distance(compute_simhash(page_a), compute_simhash(page_b))
-    assert distance == 0, (
-        f"Anchor URL change should not affect hash, got distance {distance}"
-    )
+    assert distance == 0, f"Anchor URL change should not affect hash, got distance {distance}"
 
 
 # ---------------------------------------------------------------------------
@@ -164,9 +162,7 @@ def test_cross_cms_pages_hash_far_apart() -> None:
         compute_simhash(voys_clean),
         compute_simhash(redcactus_wall),
     )
-    assert distance > 10, (
-        f"Cross-CMS fingerprints produced Hamming {distance}, expected > 10"
-    )
+    assert distance > 10, f"Cross-CMS fingerprints produced Hamming {distance}, expected > 10"
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_content_labeler.py
+++ b/klai-knowledge-ingest/tests/test_content_labeler.py
@@ -34,7 +34,9 @@ def _mock_litellm_response(keywords: list[str]) -> AsyncMock:
 class TestGenerateContentLabel:
     @pytest.mark.asyncio
     async def test_returns_keywords_on_success(self):
-        mock_client = _mock_litellm_response(["sip-trunk", "provider-portability", "telefooncentrale"])
+        mock_client = _mock_litellm_response(
+            ["sip-trunk", "provider-portability", "telefooncentrale"]
+        )
         with patch("knowledge_ingest.content_labeler.httpx.AsyncClient", return_value=mock_client):
             labels = await generate_content_label("Fanvil Opties", "Hardware setup guide...")
         assert labels == ["sip-trunk", "provider-portability", "telefooncentrale"]

--- a/klai-knowledge-ingest/tests/test_content_labeler.py
+++ b/klai-knowledge-ingest/tests/test_content_labeler.py
@@ -1,7 +1,6 @@
 """Tests for content_labeler -- blind keyword generation before taxonomy (SPEC-KB-023)."""
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -44,7 +43,7 @@ class TestGenerateContentLabel:
     async def test_returns_empty_list_on_timeout(self):
         with patch(
             "knowledge_ingest.content_labeler._call_litellm",
-            side_effect=asyncio.TimeoutError(),
+            side_effect=TimeoutError(),
         ):
             labels = await generate_content_label("Title", "Content")
         assert labels == []

--- a/klai-knowledge-ingest/tests/test_content_labeler.py
+++ b/klai-knowledge-ingest/tests/test_content_labeler.py
@@ -1,4 +1,5 @@
 """Tests for content_labeler -- blind keyword generation before taxonomy (SPEC-KB-023)."""
+
 from __future__ import annotations
 
 import json
@@ -11,15 +12,7 @@ from knowledge_ingest.content_labeler import generate_content_label
 
 def _mock_litellm_response(keywords: list[str]) -> AsyncMock:
     """Build a mock httpx client returning a LiteLLM-style response."""
-    response_json = {
-        "choices": [
-            {
-                "message": {
-                    "content": json.dumps({"keywords": keywords})
-                }
-            }
-        ]
-    }
+    response_json = {"choices": [{"message": {"content": json.dumps({"keywords": keywords})}}]}
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json = MagicMock(return_value=response_json)
@@ -123,9 +116,9 @@ class TestGenerateContentLabel:
 
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
-        mock_resp.json = MagicMock(return_value={
-            "choices": [{"message": {"content": '{"keywords": ["test"]}'}}]
-        })
+        mock_resp.json = MagicMock(
+            return_value={"choices": [{"message": {"content": '{"keywords": ["test"]}'}}]}
+        )
 
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -147,6 +140,7 @@ class TestGenerateContentLabel:
     async def test_system_prompt_has_no_taxonomy_reference(self):
         """System prompt must not reference taxonomy (no list of categories is injected)."""
         from knowledge_ingest.content_labeler import _SYSTEM_PROMPT
+
         assert "taxonomy" not in _SYSTEM_PROMPT.lower()
         # "category names" is allowed — it instructs the LLM NOT to use them
         # What must be absent: any taxonomy node data injected into the prompt

--- a/klai-knowledge-ingest/tests/test_content_profiles.py
+++ b/klai-knowledge-ingest/tests/test_content_profiles.py
@@ -1,4 +1,5 @@
 """Tests for knowledge_ingest/content_profiles.py"""
+
 from knowledge_ingest.content_profiles import PROFILES, ContentTypeProfile, get_profile
 
 
@@ -72,6 +73,7 @@ def test_all_six_content_types_defined():
 
 def test_all_profiles_have_valid_context_strategy():
     from knowledge_ingest.context_strategies import STRATEGIES
+
     for name, profile in PROFILES.items():
         assert profile.context_strategy in STRATEGIES, (
             f"{name} has unknown strategy: {profile.context_strategy}"

--- a/klai-knowledge-ingest/tests/test_context_strategies.py
+++ b/klai-knowledge-ingest/tests/test_context_strategies.py
@@ -1,4 +1,5 @@
 """Tests for knowledge_ingest/context_strategies.py"""
+
 from knowledge_ingest.context_strategies import (
     STRATEGIES,
     extract_first_n_tokens,

--- a/klai-knowledge-ingest/tests/test_contextual.py
+++ b/klai-knowledge-ingest/tests/test_contextual.py
@@ -96,8 +96,7 @@ def test_detect_language_unknown_lang_falls_back_to_default() -> None:
 
 
 _SUMMARY_CONTENT_NL = (
-    "Dit document beschrijft de Voys customer-service "
-    "procedures voor portering en integraties."
+    "Dit document beschrijft de Voys customer-service procedures voor portering en integraties."
 )
 _SUMMARY_200_BODY = {
     "choices": [

--- a/klai-knowledge-ingest/tests/test_crawl_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawl_link_fields.py
@@ -139,12 +139,8 @@ async def test_crawl_url_caps_links_to_at_20():
             new_callable=AsyncMock,
             return_value=[f"https://example.com/page-{i}" for i in range(25)],
         ),
-        patch.object(
-            link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]
-        ),
-        patch.object(
-            link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0
-        ),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
     ):
         mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
         mock_pg.upsert_crawled_page = AsyncMock()
@@ -195,12 +191,8 @@ async def test_crawl_url_graceful_degradation_on_link_graph_error():
             new_callable=AsyncMock,
             side_effect=Exception("DB connection failed"),
         ),
-        patch.object(
-            link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]
-        ),
-        patch.object(
-            link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0
-        ),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
     ):
         mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
         mock_pg.upsert_crawled_page = AsyncMock()

--- a/klai-knowledge-ingest/tests/test_crawl_preview_ssrf.py
+++ b/klai-knowledge-ingest/tests/test_crawl_preview_ssrf.py
@@ -53,9 +53,7 @@ def no_crawl() -> AsyncMock:
         "https://10.0.0.5/",
     ],
 )
-def test_preview_rejects_ssrf_urls(
-    client: TestClient, no_crawl: AsyncMock, url: str
-) -> None:
+def test_preview_rejects_ssrf_urls(client: TestClient, no_crawl: AsyncMock, url: str) -> None:
     """AC-1 + AC-6: preview returns 400 and never calls the crawl engine."""
 
     resp = client.post("/ingest/v1/crawl/preview", json={"url": url})
@@ -80,23 +78,15 @@ def test_crawl_url_ssrf_parity(client: TestClient, no_crawl: AsyncMock) -> None:
     assert no_crawl.await_count == 0
 
 
-def test_preview_http_scheme_rejected(
-    client: TestClient, no_crawl: AsyncMock
-) -> None:
+def test_preview_http_scheme_rejected(client: TestClient, no_crawl: AsyncMock) -> None:
     """Non-HTTPS URLs are rejected by the first guard check."""
 
-    resp = client.post(
-        "/ingest/v1/crawl/preview", json={"url": "http://example.com/path"}
-    )
+    resp = client.post("/ingest/v1/crawl/preview", json={"url": "http://example.com/path"})
     assert resp.status_code == 400
     assert no_crawl.await_count == 0
 
 
-def test_preview_no_hostname_rejected(
-    client: TestClient, no_crawl: AsyncMock
-) -> None:
-    resp = client.post(
-        "/ingest/v1/crawl/preview", json={"url": "https:///nohost"}
-    )
+def test_preview_no_hostname_rejected(client: TestClient, no_crawl: AsyncMock) -> None:
+    resp = client.post("/ingest/v1/crawl/preview", json={"url": "https:///nohost"})
     assert resp.status_code == 400
     assert no_crawl.await_count == 0

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -6,6 +6,7 @@ Note: the post-crawl compute_incoming_counts + update_link_counts calls were
 removed in SPEC-CRAWLER-005 REQ-05.1. See test_crawler_link_fields_complete.py
 for the two-phase pipeline tests.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -62,16 +63,22 @@ async def test_ingest_crawl_result_populates_link_fields():
     with (
         patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
         patch.object(
-            link_graph, "get_outbound_urls",
-            new_callable=AsyncMock, return_value=outbound_urls,
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            return_value=outbound_urls,
         ),
         patch.object(
-            link_graph, "get_anchor_texts",
-            new_callable=AsyncMock, return_value=["Link to B"],
+            link_graph,
+            "get_anchor_texts",
+            new_callable=AsyncMock,
+            return_value=["Link to B"],
         ),
         patch.object(
-            link_graph, "get_incoming_count",
-            new_callable=AsyncMock, return_value=3,
+            link_graph,
+            "get_incoming_count",
+            new_callable=AsyncMock,
+            return_value=3,
         ),
         patch(
             "knowledge_ingest.routes.ingest.ingest_document",
@@ -112,16 +119,22 @@ async def test_ingest_crawl_result_graceful_on_link_graph_error():
     with (
         patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
         patch.object(
-            link_graph, "get_outbound_urls",
-            new_callable=AsyncMock, side_effect=Exception("DB down"),
+            link_graph,
+            "get_outbound_urls",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB down"),
         ),
         patch.object(
-            link_graph, "get_anchor_texts",
-            new_callable=AsyncMock, return_value=[],
+            link_graph,
+            "get_anchor_texts",
+            new_callable=AsyncMock,
+            return_value=[],
         ),
         patch.object(
-            link_graph, "get_incoming_count",
-            new_callable=AsyncMock, return_value=0,
+            link_graph,
+            "get_incoming_count",
+            new_callable=AsyncMock,
+            return_value=0,
         ),
         patch(
             "knowledge_ingest.routes.ingest.ingest_document",

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -131,7 +131,6 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
     """
     results = _build_cross_linked_results()
     graph = _build_in_memory_graph(results)
-    mock_pool = _make_mock_pool()
 
     # Capture all ingest calls to verify extra dicts
     captured_ingest_calls: list[dict] = []
@@ -252,7 +251,6 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
             [{"href": "https://example.com/b", "text": "B"}],
         ),
     ]
-    mock_pool = _make_mock_pool()
 
     with (
         patch(

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -6,6 +6,7 @@ Verifies:
 2. Every ingested page gets correct link fields because the graph is ready.
 3. qdrant_store.update_link_counts is NEVER called (REQ-05.1).
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -87,8 +88,10 @@ def _get_outbound_urls_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_outbound_urls backed by in-memory graph."""
+
     async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> list[str]:
         return [link["href"] for link in graph.get(url, [])]
+
     return AsyncMock(side_effect=_impl)
 
 
@@ -96,6 +99,7 @@ def _get_anchor_texts_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_anchor_texts backed by in-memory graph."""
+
     async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> list[str]:
         texts = []
         for _from_url, links in graph.items():
@@ -103,6 +107,7 @@ def _get_anchor_texts_from_graph(
                 if link["href"] == url and link.get("text"):
                     texts.append(link["text"])
         return texts
+
     return AsyncMock(side_effect=_impl)
 
 
@@ -110,6 +115,7 @@ def _get_incoming_count_from_graph(
     graph: dict[str, list[dict]],
 ) -> AsyncMock:
     """Return an AsyncMock for link_graph.get_incoming_count backed by in-memory graph."""
+
     async def _impl(conn: object, url: str, org_id: str, kb_slug: str) -> int:
         count = 0
         for _from_url, links in graph.items():
@@ -117,6 +123,7 @@ def _get_incoming_count_from_graph(
                 if link["href"] == url:
                     count += 1
         return count
+
     return AsyncMock(side_effect=_impl)
 
 
@@ -205,11 +212,11 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
     # Build expected counts from graph
     base = "https://example.com"
     expected_incoming = {
-        f"{base}/a": 1,   # D→A
-        f"{base}/b": 1,   # A→B
-        f"{base}/c": 2,   # A→C + B→C
-        f"{base}/d": 1,   # C→D
-        f"{base}/e": 0,   # nobody links to E
+        f"{base}/a": 1,  # D→A
+        f"{base}/b": 1,  # A→B
+        f"{base}/c": 2,  # A→C + B→C
+        f"{base}/d": 1,  # C→D
+        f"{base}/e": 0,  # nobody links to E
     }
 
     for entry in captured_ingest_calls:
@@ -217,9 +224,7 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
         extra = entry["extra"]
         expected_count = expected_incoming[url]
 
-        assert "incoming_link_count" in extra, (
-            f"Page {url}: missing 'incoming_link_count' in extra"
-        )
+        assert "incoming_link_count" in extra, f"Page {url}: missing 'incoming_link_count' in extra"
         assert extra["incoming_link_count"] == expected_count, (
             f"Page {url}: expected incoming_link_count={expected_count}, "
             f"got {extra['incoming_link_count']}"
@@ -308,8 +313,11 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
                 max_depth=1,
             )
 
-            mock_update_link_counts.assert_not_called(), (
-                "qdrant_store.update_link_counts was called from run_crawl_job. "
-                "REQ-05.1: this function must NOT be called — the two-phase pipeline "
-                "makes the post-crawl batch update dead code."
+            (
+                mock_update_link_counts.assert_not_called(),
+                (
+                    "qdrant_store.update_link_counts was called from run_crawl_job. "
+                    "REQ-05.1: this function must NOT be called — the two-phase pipeline "
+                    "makes the post-crawl batch update dead code."
+                ),
             )

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -181,7 +181,6 @@ async def test_run_crawl_job_populates_link_fields_on_every_page():
         mock_pg.upsert_page_links = AsyncMock()
 
         from knowledge_ingest.adapters.crawler import run_crawl_job
-
         from tests.test_crawl_registry_dedup import _make_mock_conn as _make_conn
 
         await run_crawl_job(
@@ -300,7 +299,6 @@ async def test_run_crawl_job_no_post_crawl_link_counts_call():
             qs_mod, "update_link_counts", new_callable=AsyncMock
         ) as mock_update_link_counts:
             from knowledge_ingest.adapters.crawler import run_crawl_job
-
             from tests.test_crawl_registry_dedup import _make_mock_conn as _make_conn
 
             await run_crawl_job(

--- a/klai-knowledge-ingest/tests/test_crawler_template_detection.py
+++ b/klai-knowledge-ingest/tests/test_crawler_template_detection.py
@@ -198,9 +198,7 @@ class TestSimhashStorage:
             )
 
         pg.update_crawled_page_simhash.assert_called_once()
-        assert (
-            pg.update_crawled_page_simhash.call_args.kwargs["content_simhash"] == target
-        )
+        assert pg.update_crawled_page_simhash.call_args.kwargs["content_simhash"] == target
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_description_generator.py
+++ b/klai-knowledge-ingest/tests/test_description_generator.py
@@ -35,7 +35,9 @@ class TestGenerateNodeDescription:
     @pytest.mark.asyncio
     async def test_returns_description(self):
         mock_client = _mock_litellm_response("Questions about invoices and payments")
-        with patch("knowledge_ingest.description_generator.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.description_generator.httpx.AsyncClient", return_value=mock_client
+        ):
             desc = await generate_node_description("Billing", None, ["Invoice FAQ"])
         assert desc == "Questions about invoices and payments"
 
@@ -43,7 +45,9 @@ class TestGenerateNodeDescription:
     async def test_truncates_to_200_chars(self):
         long_desc = "x" * 300
         mock_client = _mock_litellm_response(long_desc)
-        with patch("knowledge_ingest.description_generator.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.description_generator.httpx.AsyncClient", return_value=mock_client
+        ):
             desc = await generate_node_description("Billing", None, [])
         assert len(desc) <= 200
 

--- a/klai-knowledge-ingest/tests/test_description_generator.py
+++ b/klai-knowledge-ingest/tests/test_description_generator.py
@@ -1,4 +1,5 @@
 """Tests for description_generator -- taxonomy node description generation."""
+
 from __future__ import annotations
 
 import json
@@ -12,13 +13,7 @@ from knowledge_ingest.description_generator import generate_node_description
 def _mock_litellm_response(description: str) -> AsyncMock:
     """Build a mock httpx response for description generation."""
     response_json = {
-        "choices": [
-            {
-                "message": {
-                    "content": json.dumps({"description": description})
-                }
-            }
-        ]
+        "choices": [{"message": {"content": json.dumps({"description": description})}}]
     }
     mock_resp = MagicMock()
     mock_resp.raise_for_status = MagicMock()

--- a/klai-knowledge-ingest/tests/test_description_generator.py
+++ b/klai-knowledge-ingest/tests/test_description_generator.py
@@ -1,7 +1,6 @@
 """Tests for description_generator -- taxonomy node description generation."""
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -52,7 +51,7 @@ class TestGenerateNodeDescription:
     async def test_returns_empty_on_timeout(self):
         with patch(
             "knowledge_ingest.description_generator._call_litellm",
-            side_effect=asyncio.TimeoutError(),
+            side_effect=TimeoutError(),
         ):
             desc = await generate_node_description("Billing", None, [])
         assert desc == ""

--- a/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
@@ -5,7 +5,6 @@ import pytest
 
 from knowledge_ingest.enrichment import enrich_chunks
 
-
 DOCUMENT = " ".join([f"word{i}" for i in range(500)])  # ~500 words, long enough for all strategies
 
 

--- a/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
@@ -1,13 +1,12 @@
 """Tests that context strategies are correctly applied in enrich_chunks."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from knowledge_ingest.enrichment import enrich_chunks
 
-DOCUMENT = " ".join(
-    [f"word{i}" for i in range(500)]
-)  # ~500 words, long enough for all strategies
+DOCUMENT = " ".join([f"word{i}" for i in range(500)])  # ~500 words, long enough for all strategies
 
 
 def _fake_enrich_chunk_factory(captured: list) -> AsyncMock:

--- a/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_context_strategy.py
@@ -5,13 +5,25 @@ import pytest
 
 from knowledge_ingest.enrichment import enrich_chunks
 
-DOCUMENT = " ".join([f"word{i}" for i in range(500)])  # ~500 words, long enough for all strategies
+DOCUMENT = " ".join(
+    [f"word{i}" for i in range(500)]
+)  # ~500 words, long enough for all strategies
 
 
 def _fake_enrich_chunk_factory(captured: list) -> AsyncMock:
     """Return an AsyncMock that records the context_window argument each call receives."""
 
-    async def _fake(document_text, chunk_text, title, path, *, question_focus="", participant_context="", context_window=None, **kwargs):
+    async def _fake(
+        document_text,
+        chunk_text,
+        title,
+        path,
+        *,
+        question_focus="",
+        participant_context="",
+        context_window=None,
+        **kwargs,
+    ):
         captured.append(context_window)
         return MagicMock(context_prefix="prefix", questions=["q?"])
 
@@ -23,7 +35,10 @@ async def test_first_n_strategy_uses_start_of_document():
     """first_n strategy: context window should start from the beginning of the document."""
     captured: list = []
 
-    with patch("knowledge_ingest.enrichment.enrich_chunk", side_effect=_fake_enrich_chunk_factory(captured)):
+    with patch(
+        "knowledge_ingest.enrichment.enrich_chunk",
+        side_effect=_fake_enrich_chunk_factory(captured),
+    ):
         await enrich_chunks(
             document_text=DOCUMENT,
             chunks=["chunk A", "chunk B"],
@@ -46,7 +61,10 @@ async def test_rolling_window_strategy_differs_per_chunk():
     """rolling_window strategy: context window should differ for different chunk positions."""
     captured: list = []
 
-    with patch("knowledge_ingest.enrichment.enrich_chunk", side_effect=_fake_enrich_chunk_factory(captured)):
+    with patch(
+        "knowledge_ingest.enrichment.enrich_chunk",
+        side_effect=_fake_enrich_chunk_factory(captured),
+    ):
         await enrich_chunks(
             document_text=DOCUMENT,
             chunks=["chunk A", "chunk B", "chunk C", "chunk D", "chunk E"],
@@ -70,7 +88,10 @@ async def test_most_recent_strategy_uses_end_of_document():
     captured: list = []
     doc = "start " * 100 + "end_content"
 
-    with patch("knowledge_ingest.enrichment.enrich_chunk", side_effect=_fake_enrich_chunk_factory(captured)):
+    with patch(
+        "knowledge_ingest.enrichment.enrich_chunk",
+        side_effect=_fake_enrich_chunk_factory(captured),
+    ):
         await enrich_chunks(
             document_text=doc,
             chunks=["chunk A"],
@@ -91,7 +112,10 @@ async def test_unknown_strategy_falls_back_to_first_n():
     """Unknown strategy name falls back to first_n (via STRATEGIES.get default)."""
     captured: list = []
 
-    with patch("knowledge_ingest.enrichment.enrich_chunk", side_effect=_fake_enrich_chunk_factory(captured)):
+    with patch(
+        "knowledge_ingest.enrichment.enrich_chunk",
+        side_effect=_fake_enrich_chunk_factory(captured),
+    ):
         await enrich_chunks(
             document_text=DOCUMENT,
             chunks=["chunk A"],
@@ -112,7 +136,10 @@ async def test_context_window_passed_to_enrich_chunk():
     """Verify that enrich_chunk receives context_window (not None) when strategy is active."""
     captured: list = []
 
-    with patch("knowledge_ingest.enrichment.enrich_chunk", side_effect=_fake_enrich_chunk_factory(captured)):
+    with patch(
+        "knowledge_ingest.enrichment.enrich_chunk",
+        side_effect=_fake_enrich_chunk_factory(captured),
+    ):
         await enrich_chunks(
             document_text="hello world " * 100,
             chunks=["chunk"],

--- a/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
@@ -589,7 +589,9 @@ async def test_load_and_enrich_skips_superseded_artifact():
             new_callable=AsyncMock,
             return_value=fake_artifact,
         ),
-        patch("knowledge_ingest.enrichment_tasks._enrich_document", new_callable=AsyncMock) as enrich,
+        patch(
+            "knowledge_ingest.enrichment_tasks._enrich_document", new_callable=AsyncMock
+        ) as enrich,
     ):
         from knowledge_ingest.enrichment_tasks import _load_and_enrich
 

--- a/klai-knowledge-ingest/tests/test_fingerprint.py
+++ b/klai-knowledge-ingest/tests/test_fingerprint.py
@@ -22,7 +22,10 @@ def test_empty_input_returns_empty() -> None:
 
 def test_deterministic() -> None:
     """Same input produces same fingerprint."""
-    text = "This is a test document with enough words for a meaningful fingerprint computation result"
+    text = (
+        "This is a test document with enough words for a meaningful fingerprint "
+        "computation result"
+    )
     assert compute_content_fingerprint(text) == compute_content_fingerprint(text)
 
 

--- a/klai-knowledge-ingest/tests/test_fingerprint.py
+++ b/klai-knowledge-ingest/tests/test_fingerprint.py
@@ -23,8 +23,7 @@ def test_empty_input_returns_empty() -> None:
 def test_deterministic() -> None:
     """Same input produces same fingerprint."""
     text = (
-        "This is a test document with enough words for a meaningful fingerprint "
-        "computation result"
+        "This is a test document with enough words for a meaningful fingerprint computation result"
     )
     assert compute_content_fingerprint(text) == compute_content_fingerprint(text)
 

--- a/klai-knowledge-ingest/tests/test_graph.py
+++ b/klai-knowledge-ingest/tests/test_graph.py
@@ -1,4 +1,5 @@
 """Tests for knowledge_ingest.graph module."""
+
 from __future__ import annotations
 
 from datetime import UTC, datetime

--- a/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
@@ -10,12 +10,12 @@ environments where libpq is not installed (CI, local dev on Windows).
 """
 from __future__ import annotations
 
+import logging
 import sys
 import types
-import logging
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Minimal procrastinate stub — avoids the psycopg / libpq import chain
@@ -75,7 +75,7 @@ _QUEUEING_LOCK = "{org_id}:{kb_slug}:{path}:{artifact_id}".format(**_DEFER_KWARG
 async def _run_enqueue(task_fn):
     """Replicate the try/except block from ingest.py."""
     try:
-        from procrastinate.exceptions import AlreadyEnqueued as _AE  # noqa: PLC0415
+        from procrastinate.exceptions import AlreadyEnqueued as _AE
         await task_fn.configure(
             queueing_lock=_QUEUEING_LOCK,
         ).defer_async(artifact_id=_DEFER_KWARGS["artifact_id"])
@@ -141,7 +141,7 @@ async def test_queueing_lock_includes_org_kb_path_and_artifact():
     for org_id, artifact_id, task_fn in scenarios:
         lock = f"{org_id}:{kb_slug}:{path}:{artifact_id}"
         try:
-            from procrastinate.exceptions import AlreadyEnqueued as _AE  # noqa: PLC0415
+            from procrastinate.exceptions import AlreadyEnqueued as _AE
             await task_fn.configure(queueing_lock=lock).defer_async(
                 artifact_id=artifact_id,
             )

--- a/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
@@ -126,9 +126,9 @@ async def test_first_ingest_not_skipped():
 async def test_queueing_lock_includes_org_kb_path_and_artifact():
     """queueing_lock includes path identity plus the concrete artifact version."""
     # Two tasks for different orgs, same KB+path — must get different locks
-    task_fn_a, configured_a = _make_task_fn(side_effects=[None])
-    task_fn_b, configured_b = _make_task_fn(side_effects=[None])
-    task_fn_c, configured_c = _make_task_fn(side_effects=[None])
+    task_fn_a, _configured_a = _make_task_fn(side_effects=[None])
+    task_fn_b, _configured_b = _make_task_fn(side_effects=[None])
+    task_fn_c, _configured_c = _make_task_fn(side_effects=[None])
 
     org_a, org_b = "orgA", "orgB"
     kb_slug, path = "shared-kb", "docs/page.md"

--- a/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_enrichment_dedup.py
@@ -8,6 +8,7 @@ older queued job can be the only enrichment job left after a re-ingest.
 procrastinate is mocked at the sys.modules level so this file runs in
 environments where libpq is not installed (CI, local dev on Windows).
 """
+
 from __future__ import annotations
 
 import logging
@@ -20,6 +21,7 @@ import pytest
 # ---------------------------------------------------------------------------
 # Minimal procrastinate stub — avoids the psycopg / libpq import chain
 # ---------------------------------------------------------------------------
+
 
 class _AlreadyEnqueued(Exception):
     """Stub for procrastinate.exceptions.AlreadyEnqueued."""
@@ -50,6 +52,7 @@ AlreadyEnqueued = sys.modules["procrastinate.exceptions"].AlreadyEnqueued
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_task_fn(side_effects):
     """
     Return a mock task function whose .configure().defer_async() uses the
@@ -76,6 +79,7 @@ async def _run_enqueue(task_fn):
     """Replicate the try/except block from ingest.py."""
     try:
         from procrastinate.exceptions import AlreadyEnqueued as _AE
+
         await task_fn.configure(
             queueing_lock=_QUEUEING_LOCK,
         ).defer_async(artifact_id=_DEFER_KWARGS["artifact_id"])
@@ -91,6 +95,7 @@ async def _run_enqueue(task_fn):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_second_ingest_skipped_when_already_enqueued(caplog):
@@ -142,6 +147,7 @@ async def test_queueing_lock_includes_org_kb_path_and_artifact():
         lock = f"{org_id}:{kb_slug}:{path}:{artifact_id}"
         try:
             from procrastinate.exceptions import AlreadyEnqueued as _AE
+
             await task_fn.configure(queueing_lock=lock).defer_async(
                 artifact_id=artifact_id,
             )

--- a/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
+++ b/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
@@ -167,8 +167,12 @@ class TestRejectMode:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"
+            ),
         ):
             with pytest.raises(AnonymousAuthWallDetected) as excinfo:
                 await _ingest_crawl_result(
@@ -198,8 +202,12 @@ class TestRejectMode:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"
+            ),
         ):
             with pytest.raises(AnonymousAuthWallDetected) as excinfo:
                 await _ingest_crawl_result(
@@ -232,8 +240,13 @@ class TestDegradeMode:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "degrade"),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode",
+                "degrade",
+            ),
         ):
             await _ingest_crawl_result(
                 pool,
@@ -263,7 +276,9 @@ class TestAuditOnlyMode:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
             patch(
                 "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode",
                 "audit_only",
@@ -298,7 +313,9 @@ class TestCleanPageUntouched:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
             patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", mode),
         ):
             await _ingest_crawl_result(
@@ -330,8 +347,12 @@ class TestAuthenticatedClusterHeuristic:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"
+            ),
         ):
             await _ingest_crawl_result(
                 pool,
@@ -367,8 +388,12 @@ class TestDisabledFlag:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", False),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", False
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode", "reject"
+            ),
         ):
             # Even in reject mode, a walled page should ingest because flag is off.
             await _ingest_crawl_result(
@@ -405,7 +430,9 @@ class TestInvalidModeFailsSafe:
             patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
             patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
             patch("knowledge_ingest.link_graph", lg, create=True),
-            patch("knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
             patch(
                 "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode",
                 "garbage_value",

--- a/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
+++ b/klai-knowledge-ingest/tests/test_ingest_login_wall_integration.py
@@ -86,7 +86,8 @@ def _embedded_gate_result() -> CrawlResult:
         "when you want to read this article\n"
         "This article is available to authenticated users. Sign in to access "
         "the protected content and documentation.\n"
-        + "More public text after the protected section. " * 50
+        + "More public text after the protected section. "
+        * 50
     )
     return CrawlResult(
         url="https://wiki.example.test/nl/crm-software/example",

--- a/klai-knowledge-ingest/tests/test_kb_config_personal_visibility.py
+++ b/klai-knowledge-ingest/tests/test_kb_config_personal_visibility.py
@@ -12,6 +12,7 @@ were returned for other users' org-scope queries in the same org. The
 ``get_kb_visibility`` override below makes that drift impossible to recur
 on new ingests.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock
@@ -42,9 +43,7 @@ class TestPersonalKbVisibilityOverride:
         conn = AsyncMock()
         conn.fetchrow = AsyncMock(return_value={"visibility": "internal"})
 
-        visibility = await kb_config.get_kb_visibility(
-            conn, "org-1", "personal-364818484816773122"
-        )
+        visibility = await kb_config.get_kb_visibility(conn, "org-1", "personal-364818484816773122")
         assert visibility == "private"
         # The DB lookup MUST NOT be the source of truth — the helper
         # should short-circuit before any fetchrow call.
@@ -59,9 +58,7 @@ class TestPersonalKbVisibilityOverride:
         conn = AsyncMock()
         conn.fetchrow = AsyncMock(return_value=None)
 
-        visibility = await kb_config.get_kb_visibility(
-            conn, "org-1", "personal-someuser"
-        )
+        visibility = await kb_config.get_kb_visibility(conn, "org-1", "personal-someuser")
         assert visibility == "private"
 
     @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_knowledge_rls.py
+++ b/klai-knowledge-ingest/tests/test_knowledge_rls.py
@@ -27,8 +27,6 @@ import pytest
 
 pytestmark = pytest.mark.no_mock_db_helpers
 
-import pytest
-
 # ---------------------------------------------------------------------------
 # Helpers: mock pool + connection
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_link_density.py
+++ b/klai-knowledge-ingest/tests/test_link_density.py
@@ -152,6 +152,5 @@ def test_link_density_long_urls_do_not_dilute_density() -> None:
     # Visible after sub: "a a a ... a" — link chars 20, visible chars 39
     # → density ~51% (was ~3% under old formula).
     assert density > LINK_DENSITY_THRESHOLD, (
-        f"Short-anchor + long-URL nav must score above {LINK_DENSITY_THRESHOLD}; "
-        f"got {density:.3f}"
+        f"Short-anchor + long-URL nav must score above {LINK_DENSITY_THRESHOLD}; got {density:.3f}"
     )

--- a/klai-knowledge-ingest/tests/test_models_validation.py
+++ b/klai-knowledge-ingest/tests/test_models_validation.py
@@ -1,4 +1,5 @@
 """Tests for Pydantic Field constraints (TASK-010)."""
+
 import pytest
 from pydantic import ValidationError
 

--- a/klai-knowledge-ingest/tests/test_personal_kb_e2e.py
+++ b/klai-knowledge-ingest/tests/test_personal_kb_e2e.py
@@ -9,6 +9,7 @@ Verifies the full roundtrip:
 These tests validate the core security property of personal KB:
 content indexed with user_id=A cannot be retrieved when filtering for user_id=B.
 """
+
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -53,7 +54,7 @@ async def mem_client():
 
 def _unit_vector(dim: int = EMBED_DIM) -> list[float]:
     """Return a normalised vector of ones (valid for cosine distance)."""
-    val = 1.0 / dim ** 0.5
+    val = 1.0 / dim**0.5
     return [val] * dim
 
 
@@ -71,9 +72,7 @@ async def test_upsert_chunks_stores_user_id(mem_client):
             user_id="user-aaa",
         )
 
-    points, _ = await mem_client.scroll(
-        COLLECTION, with_payload=True, limit=10
-    )
+    points, _ = await mem_client.scroll(COLLECTION, with_payload=True, limit=10)
     assert len(points) == 1
     payload = points[0].payload
     assert payload["user_id"] == "user-aaa"
@@ -216,9 +215,7 @@ async def test_personal_chunk_not_returned_without_user_id_filter(mem_client):
         )
 
     # Without user_id filter: chunk is present (org-level scroll)
-    all_points, _ = await mem_client.scroll(
-        COLLECTION, with_payload=True, limit=10
-    )
+    all_points, _ = await mem_client.scroll(COLLECTION, with_payload=True, limit=10)
     assert len(all_points) == 1
 
     # With wrong user_id filter: chunk is NOT returned

--- a/klai-knowledge-ingest/tests/test_pg_store_simhash_update.py
+++ b/klai-knowledge-ingest/tests/test_pg_store_simhash_update.py
@@ -63,9 +63,7 @@ async def test_update_warns_when_no_row() -> None:
         if log.get("event") == "crawled_pages_simhash_update_no_row"
         and log.get("log_level") == "warning"
     ]
-    assert matched, (
-        "expected structlog warning event crawled_pages_simhash_update_no_row"
-    )
+    assert matched, "expected structlog warning event crawled_pages_simhash_update_no_row"
     assert matched[0]["url"] == "https://x/missing-row"
     assert matched[0]["org_id"] == "org-1"
     assert matched[0]["kb_slug"] == "kb-1"

--- a/klai-knowledge-ingest/tests/test_portal_client.py
+++ b/klai-knowledge-ingest/tests/test_portal_client.py
@@ -1,7 +1,6 @@
 """Tests for portal_client — taxonomy node fetching and proposal submission."""
 from __future__ import annotations
 
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,7 +11,6 @@ from knowledge_ingest.portal_client import (
     invalidate_cache,
     submit_taxonomy_proposal,
 )
-from knowledge_ingest.taxonomy_classifier import TaxonomyNode
 
 
 def _mock_httpx_response(status_code: int, body: object) -> MagicMock:

--- a/klai-knowledge-ingest/tests/test_portal_client.py
+++ b/klai-knowledge-ingest/tests/test_portal_client.py
@@ -1,4 +1,5 @@
 """Tests for portal_client — taxonomy node fetching and proposal submission."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -40,8 +41,10 @@ class TestFetchTaxonomyNodes:
         mock_resp = _mock_httpx_response(200, nodes_data)
         mock_client = _mock_client(mock_resp)
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             nodes = await fetch_taxonomy_nodes("kb1", "org1")
@@ -62,8 +65,10 @@ class TestFetchTaxonomyNodes:
         mock_resp = _mock_httpx_response(404, None)
         mock_client = _mock_client(mock_resp)
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             nodes = await fetch_taxonomy_nodes("kb1", "org1")
@@ -76,8 +81,10 @@ class TestFetchTaxonomyNodes:
         mock_resp = _mock_httpx_response(200, nodes_data)
         mock_client = _mock_client(mock_resp)
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             nodes1 = await fetch_taxonomy_nodes("kb1", "org1")
@@ -94,8 +101,10 @@ class TestFetchTaxonomyNodes:
         mock_client.__aexit__ = AsyncMock(return_value=None)
         mock_client.get = AsyncMock(side_effect=Exception("connection refused"))
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             nodes = await fetch_taxonomy_nodes("kb1", "org1")
@@ -116,8 +125,10 @@ class TestSubmitTaxonomyProposal:
             sample_titles=["API Guide", "REST Docs"],
         )
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             await submit_taxonomy_proposal("kb1", "org1", proposal)
@@ -139,8 +150,10 @@ class TestSubmitTaxonomyProposal:
             sample_titles=[],
         )
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = ""
             await submit_taxonomy_proposal("kb1", "org1", proposal)
 
@@ -161,8 +174,10 @@ class TestSubmitTaxonomyProposal:
             sample_titles=[],
         )
 
-        with patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client), \
-             patch("knowledge_ingest.portal_client.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.portal_client.httpx.AsyncClient", return_value=mock_client),
+            patch("knowledge_ingest.portal_client.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.portal_url = "http://portal-api:8000"
             # Must not raise

--- a/klai-knowledge-ingest/tests/test_proposal_generator_description.py
+++ b/klai-knowledge-ingest/tests/test_proposal_generator_description.py
@@ -2,6 +2,7 @@
 
 Verifies that incremental proposals (not bootstrap) include a generated description.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -19,20 +20,19 @@ class TestMaybeGenerateProposalDescription:
     @pytest.mark.asyncio
     async def test_calls_generate_node_description(self):
         """generate_node_description must be called with the suggested_name."""
-        docs = [
-            DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}")
-            for i in range(5)
-        ]
+        docs = [DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}") for i in range(5)]
         existing_nodes: list[TaxonomyNode] = []
 
         mock_suggest = AsyncMock(return_value="Facturen")
         mock_desc = AsyncMock(return_value="Categorie voor factuurgerelateerde documenten")
         mock_submit = AsyncMock()
 
-        with patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest), \
-             patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc), \
-             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit), \
-             patch("knowledge_ingest.proposal_generator.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc),
+            patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit),
+            patch("knowledge_ingest.proposal_generator.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.taxonomy_classification_timeout = 30.0
 
@@ -50,19 +50,18 @@ class TestMaybeGenerateProposalDescription:
     @pytest.mark.asyncio
     async def test_description_included_in_proposal(self):
         """The generated description must end up in the TaxonomyProposal."""
-        docs = [
-            DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}")
-            for i in range(5)
-        ]
+        docs = [DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}") for i in range(5)]
 
         mock_suggest = AsyncMock(return_value="HR Beleid")
         mock_desc = AsyncMock(return_value="Human resources policy documents")
         mock_submit = AsyncMock()
 
-        with patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest), \
-             patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc), \
-             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit), \
-             patch("knowledge_ingest.proposal_generator.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc),
+            patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit),
+            patch("knowledge_ingest.proposal_generator.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.taxonomy_classification_timeout = 30.0
 
@@ -80,19 +79,18 @@ class TestMaybeGenerateProposalDescription:
     @pytest.mark.asyncio
     async def test_description_fallback_on_error(self):
         """If generate_node_description raises, description falls back to empty string."""
-        docs = [
-            DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}")
-            for i in range(5)
-        ]
+        docs = [DocumentSummary(title=f"Doc {i}", content_preview=f"Content {i}") for i in range(5)]
 
         mock_suggest = AsyncMock(return_value="Technisch")
         mock_desc = AsyncMock(side_effect=Exception("LLM timeout"))
         mock_submit = AsyncMock()
 
-        with patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest), \
-             patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc), \
-             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit), \
-             patch("knowledge_ingest.proposal_generator.settings") as mock_settings:
+        with (
+            patch("knowledge_ingest.proposal_generator._suggest_category_name", mock_suggest),
+            patch("knowledge_ingest.proposal_generator.generate_node_description", mock_desc),
+            patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit),
+            patch("knowledge_ingest.proposal_generator.settings") as mock_settings,
+        ):
             mock_settings.portal_internal_token = "secret"
             mock_settings.taxonomy_classification_timeout = 30.0
 

--- a/klai-knowledge-ingest/tests/test_qdrant_metadata.py
+++ b/klai-knowledge-ingest/tests/test_qdrant_metadata.py
@@ -103,9 +103,11 @@ async def test_search_with_user_id_filter():
         mock_client.return_value.query_points = mock_query
         await search("org1", [0.1] * 1024, kb_slugs=["personal-user123"], user_id="user123")
 
-        call_kwargs = mock_query.call_args
-        # The filter is passed via prefetch entries; check that user_id filter exists
-        # by verifying query_points was called (the filter construction is tested implicitly)
+        # TODO: call_kwargs is captured but never asserted on. The filter is
+        # passed via prefetch entries' `filter=` kwarg (see qdrant_store.search),
+        # so this test does not actually verify the user_id filter was applied —
+        # only that query_points was called at all.
+        _call_kwargs = mock_query.call_args
         mock_query.assert_called_once()
 
 

--- a/klai-knowledge-ingest/tests/test_qdrant_metadata.py
+++ b/klai-knowledge-ingest/tests/test_qdrant_metadata.py
@@ -1,4 +1,5 @@
 """Tests for metadata allowlist in qdrant_store.py (TASK-007)."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,15 +25,17 @@ def _make_query_response(points):
 @pytest.mark.asyncio
 async def test_metadata_does_not_contain_user_id():
     """user_id must NOT appear in metadata (V008)."""
-    mock_point = _make_query_point({
-        "text": "some text",
-        "kb_slug": "personal-secret-user-123",
-        "path": "note.md",
-        "org_id": "org1",
-        "user_id": "secret-user-123",
-        "chunk_index": 0,
-        "title": "My Note",
-    })
+    mock_point = _make_query_point(
+        {
+            "text": "some text",
+            "kb_slug": "personal-secret-user-123",
+            "path": "note.md",
+            "org_id": "org1",
+            "user_id": "secret-user-123",
+            "chunk_index": 0,
+            "title": "My Note",
+        }
+    )
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
         mock_client.return_value.query_points = AsyncMock(
@@ -47,13 +50,15 @@ async def test_metadata_does_not_contain_user_id():
 @pytest.mark.asyncio
 async def test_metadata_does_not_contain_org_id():
     """org_id must NOT appear in metadata."""
-    mock_point = _make_query_point({
-        "text": "some text",
-        "kb_slug": "org",
-        "path": "doc.md",
-        "org_id": "org1",
-        "chunk_index": 0,
-    })
+    mock_point = _make_query_point(
+        {
+            "text": "some text",
+            "kb_slug": "org",
+            "path": "doc.md",
+            "org_id": "org1",
+            "chunk_index": 0,
+        }
+    )
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
         mock_client.return_value.query_points = AsyncMock(
@@ -67,16 +72,18 @@ async def test_metadata_does_not_contain_org_id():
 @pytest.mark.asyncio
 async def test_metadata_contains_allowed_fields():
     """Allowed fields should appear in metadata."""
-    mock_point = _make_query_point({
-        "text": "some text",
-        "kb_slug": "org",
-        "path": "doc.md",
-        "org_id": "org1",
-        "chunk_index": 3,
-        "title": "Test Title",
-        "created_at": "2026-01-01",
-        "user_id": "leak-me-not",
-    })
+    mock_point = _make_query_point(
+        {
+            "text": "some text",
+            "kb_slug": "org",
+            "path": "doc.md",
+            "org_id": "org1",
+            "chunk_index": 3,
+            "title": "Test Title",
+            "created_at": "2026-01-01",
+            "user_id": "leak-me-not",
+        }
+    )
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
         mock_client.return_value.query_points = AsyncMock(
@@ -132,15 +139,17 @@ def test_allowed_metadata_fields_includes_assertion_mode():
 @pytest.mark.asyncio
 async def test_metadata_contains_assertion_mode():
     """assertion_mode should pass through metadata when present in payload."""
-    mock_point = _make_query_point({
-        "text": "some text",
-        "kb_slug": "org",
-        "path": "doc.md",
-        "org_id": "org1",
-        "assertion_mode": "fact",
-        "content_type": "kb_article",
-        "ingested_at": 1711843200,
-    })
+    mock_point = _make_query_point(
+        {
+            "text": "some text",
+            "kb_slug": "org",
+            "path": "doc.md",
+            "org_id": "org1",
+            "assertion_mode": "fact",
+            "content_type": "kb_article",
+            "ingested_at": 1711843200,
+        }
+    )
 
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
         mock_client.return_value.query_points = AsyncMock(

--- a/klai-knowledge-ingest/tests/test_quality_payload.py
+++ b/klai-knowledge-ingest/tests/test_quality_payload.py
@@ -122,5 +122,3 @@ async def test_upsert_enriched_chunks_persists_heading_path(mock_qdrant_client):
 
         points = mock_qdrant_client.upsert.call_args.kwargs["points"]
         assert points[0].payload["heading_path"] == "Admin > Mensen"
-
-

--- a/klai-knowledge-ingest/tests/test_sparse_embedder.py
+++ b/klai-knowledge-ingest/tests/test_sparse_embedder.py
@@ -1,4 +1,5 @@
 """Tests for knowledge_ingest/sparse_embedder.py"""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/klai-knowledge-ingest/tests/test_sparse_embedder.py
+++ b/klai-knowledge-ingest/tests/test_sparse_embedder.py
@@ -6,7 +6,6 @@ import pytest
 
 from knowledge_ingest.sparse_embedder import embed_sparse, embed_sparse_batch
 
-
 # --- embed_sparse (single text, delegates to batch) ---
 
 

--- a/klai-knowledge-ingest/tests/test_stale_pending_artifact_reaper.py
+++ b/klai-knowledge-ingest/tests/test_stale_pending_artifact_reaper.py
@@ -97,8 +97,7 @@ def test_register_stale_pending_artifact_reaper_registers_periodic_io_task():
     assert len(app.tasks) == 1
     task_kwargs = app.tasks[0][1]
     assert task_kwargs["name"] == (
-        "knowledge_ingest.stale_pending_artifact_reaper."
-        "reap_stale_pending_artifacts_periodic"
+        "knowledge_ingest.stale_pending_artifact_reaper.reap_stale_pending_artifacts_periodic"
     )
     assert task_kwargs["queue"] == "ingest-kb"
     assert task_kwargs["queueing_lock"] == "stale-pending-artifact-reaper"

--- a/klai-knowledge-ingest/tests/test_taxonomy_bootstrap_route.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_bootstrap_route.py
@@ -28,5 +28,7 @@ def test_bootstrap_filter_scans_only_untagged_when_taxonomy_exists():
     must = scroll_filter.must or []
     assert len(must) == 3
     assert any(isinstance(condition, IsEmptyCondition) for condition in must)
-    empty_condition = next(condition for condition in must if isinstance(condition, IsEmptyCondition))
+    empty_condition = next(
+        condition for condition in must if isinstance(condition, IsEmptyCondition)
+    )
     assert empty_condition.is_empty.key == "taxonomy_node_ids"

--- a/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
@@ -1,4 +1,5 @@
 """Tests for taxonomy_classifier -- multi-label classification + tag suggestion."""
+
 from __future__ import annotations
 
 import json
@@ -15,24 +16,23 @@ def _make_nodes(*names: str) -> list[TaxonomyNode]:
 
 def _make_nodes_with_desc(*items: tuple[str, str | None]) -> list[TaxonomyNode]:
     return [
-        TaxonomyNode(id=i + 1, name=name, description=desc)
-        for i, (name, desc) in enumerate(items)
+        TaxonomyNode(id=i + 1, name=name, description=desc) for i, (name, desc) in enumerate(items)
     ]
 
 
-def _mock_litellm_response(
-    nodes: list[dict], tags: list[str] | None = None
-) -> AsyncMock:
+def _mock_litellm_response(nodes: list[dict], tags: list[str] | None = None) -> AsyncMock:
     """Build a mock httpx response for multi-label LiteLLM response."""
     response_json = {
         "choices": [
             {
                 "message": {
-                    "content": json.dumps({
-                        "nodes": nodes,
-                        "tags": tags or [],
-                        "reasoning": "test",
-                    })
+                    "content": json.dumps(
+                        {
+                            "nodes": nodes,
+                            "tags": tags or [],
+                            "reasoning": "test",
+                        }
+                    )
                 }
             }
         ]

--- a/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
@@ -14,7 +14,10 @@ def _make_nodes(*names: str) -> list[TaxonomyNode]:
 
 
 def _make_nodes_with_desc(*items: tuple[str, str | None]) -> list[TaxonomyNode]:
-    return [TaxonomyNode(id=i + 1, name=name, description=desc) for i, (name, desc) in enumerate(items)]
+    return [
+        TaxonomyNode(id=i + 1, name=name, description=desc)
+        for i, (name, desc) in enumerate(items)
+    ]
 
 
 def _mock_litellm_response(
@@ -56,7 +59,9 @@ class TestClassifyDocumentMultiLabel:
             ],
             tags=["sso", "billing"],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, tags = await classify_document("SSO billing setup", "...", nodes)
         assert len(matched) == 2
         assert matched[0] == (1, 0.9)
@@ -72,7 +77,9 @@ class TestClassifyDocumentMultiLabel:
                 {"node_id": 2, "confidence": 0.3},  # below threshold
             ],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, _tags = await classify_document("Invoice", "...", nodes)
         assert len(matched) == 1
         assert matched[0] == (1, 0.9)
@@ -86,7 +93,9 @@ class TestClassifyDocumentMultiLabel:
                 {"node_id": 2, "confidence": 0.2},
             ],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, _tags = await classify_document("Ambiguous", "...", nodes)
         assert matched == []
 
@@ -125,7 +134,9 @@ class TestClassifyDocumentMultiLabel:
         mock_client = _mock_litellm_response(
             nodes=[{"node_id": 999, "confidence": 0.95}],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, _tags = await classify_document("Title", "Content", nodes)
         assert matched == []
 
@@ -135,7 +146,9 @@ class TestClassifyDocumentMultiLabel:
         mock_client = _mock_litellm_response(
             nodes=[{"node_id": i, "confidence": 0.9 - i * 0.01} for i in range(1, 10)],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, _tags = await classify_document("Title", "Content", nodes)
         assert len(matched) <= 5
 
@@ -146,7 +159,9 @@ class TestClassifyDocumentMultiLabel:
             nodes=[{"node_id": 1, "confidence": 0.9}],
             tags=["a", "b", "c", "d", "e", "f", "g"],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             _matched, tags = await classify_document("Title", "Content", nodes)
         assert len(tags) <= 5
 
@@ -157,7 +172,9 @@ class TestClassifyDocumentMultiLabel:
             nodes=[{"node_id": 1, "confidence": 0.9}],
             tags=["SSO", "sso", "OKTA", " billing "],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             _matched, tags = await classify_document("Title", "Content", nodes)
         assert tags == ["sso", "okta", "billing"]
 
@@ -209,6 +226,8 @@ class TestClassifyDocumentMultiLabel:
                 {"node_id": 2, "confidence": 0.7},
             ],
         )
-        with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
+        with patch(
+            "knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client
+        ):
             matched, _tags = await classify_document("Title", "Content", nodes)
         assert matched[0][1] >= matched[1][1] >= matched[2][1]

--- a/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
@@ -73,7 +73,7 @@ class TestClassifyDocumentMultiLabel:
             ],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Invoice", "...", nodes)
+            matched, _tags = await classify_document("Invoice", "...", nodes)
         assert len(matched) == 1
         assert matched[0] == (1, 0.9)
 
@@ -87,7 +87,7 @@ class TestClassifyDocumentMultiLabel:
             ],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Ambiguous", "...", nodes)
+            matched, _tags = await classify_document("Ambiguous", "...", nodes)
         assert matched == []
 
     @pytest.mark.asyncio
@@ -126,7 +126,7 @@ class TestClassifyDocumentMultiLabel:
             nodes=[{"node_id": 999, "confidence": 0.95}],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Title", "Content", nodes)
+            matched, _tags = await classify_document("Title", "Content", nodes)
         assert matched == []
 
     @pytest.mark.asyncio
@@ -136,7 +136,7 @@ class TestClassifyDocumentMultiLabel:
             nodes=[{"node_id": i, "confidence": 0.9 - i * 0.01} for i in range(1, 10)],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Title", "Content", nodes)
+            matched, _tags = await classify_document("Title", "Content", nodes)
         assert len(matched) <= 5
 
     @pytest.mark.asyncio
@@ -147,7 +147,7 @@ class TestClassifyDocumentMultiLabel:
             tags=["a", "b", "c", "d", "e", "f", "g"],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Title", "Content", nodes)
+            _matched, tags = await classify_document("Title", "Content", nodes)
         assert len(tags) <= 5
 
     @pytest.mark.asyncio
@@ -158,7 +158,7 @@ class TestClassifyDocumentMultiLabel:
             tags=["SSO", "sso", "OKTA", " billing "],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Title", "Content", nodes)
+            _matched, tags = await classify_document("Title", "Content", nodes)
         assert tags == ["sso", "okta", "billing"]
 
     @pytest.mark.asyncio
@@ -210,5 +210,5 @@ class TestClassifyDocumentMultiLabel:
             ],
         )
         with patch("knowledge_ingest.taxonomy_classifier.httpx.AsyncClient", return_value=mock_client):
-            matched, tags = await classify_document("Title", "Content", nodes)
+            matched, _tags = await classify_document("Title", "Content", nodes)
         assert matched[0][1] >= matched[1][1] >= matched[2][1]

--- a/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_classifier.py
@@ -1,7 +1,6 @@
 """Tests for taxonomy_classifier -- multi-label classification + tag suggestion."""
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -102,7 +101,7 @@ class TestClassifyDocumentMultiLabel:
         nodes = _make_nodes("Billing")
         with patch(
             "knowledge_ingest.taxonomy_classifier._call_litellm",
-            side_effect=asyncio.TimeoutError(),
+            side_effect=TimeoutError(),
         ):
             matched, tags = await classify_document("Title", "Content", nodes)
         assert matched == []

--- a/klai-knowledge-ingest/tests/test_taxonomy_classify_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_classify_endpoint.py
@@ -2,6 +2,7 @@
 
 Verifies the new classify endpoint calls classify_document and returns node IDs.
 """
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -22,8 +23,10 @@ class TestTaxonomyClassifyEndpoint:
         mock_classify = AsyncMock(return_value=([(5, 0.9), (7, 0.7)], ["billing"]))
         mock_fetch = AsyncMock(return_value=mock_nodes)
 
-        with patch("knowledge_ingest.routes.taxonomy.classify_document", mock_classify), \
-             patch("knowledge_ingest.routes.taxonomy.fetch_taxonomy_nodes", mock_fetch):
+        with (
+            patch("knowledge_ingest.routes.taxonomy.classify_document", mock_classify),
+            patch("knowledge_ingest.routes.taxonomy.fetch_taxonomy_nodes", mock_fetch),
+        ):
             # SPEC-SEC-011: ``client`` fixture provides the default header.
             resp = client.post(
                 "/ingest/v1/taxonomy/classify",
@@ -59,8 +62,10 @@ class TestTaxonomyClassifyEndpoint:
         mock_classify = AsyncMock(return_value=([], []))
         mock_fetch = AsyncMock(return_value=mock_nodes)
 
-        with patch("knowledge_ingest.routes.taxonomy.classify_document", mock_classify), \
-             patch("knowledge_ingest.routes.taxonomy.fetch_taxonomy_nodes", mock_fetch):
+        with (
+            patch("knowledge_ingest.routes.taxonomy.classify_document", mock_classify),
+            patch("knowledge_ingest.routes.taxonomy.fetch_taxonomy_nodes", mock_fetch),
+        ):
             # SPEC-SEC-011: ``client`` fixture provides the default header.
             resp = client.post(
                 "/ingest/v1/taxonomy/classify",

--- a/klai-knowledge-ingest/tests/test_taxonomy_qdrant.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_qdrant.py
@@ -1,4 +1,5 @@
 """Tests for taxonomy_node_ids and tags in qdrant_store payload handling."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch

--- a/klai-knowledge-ingest/tests/test_taxonomy_qdrant.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_qdrant.py
@@ -1,7 +1,7 @@
 """Tests for taxonomy_node_ids and tags in qdrant_store payload handling."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -1717,8 +1717,8 @@ class TestConsolidate:
         from unittest.mock import patch as _patch
 
         from knowledge_ingest.proposal_generator import (
-            generate_bootstrap_proposals_v2,
             DocumentSummary,
+            generate_bootstrap_proposals_v2,
         )
 
         # Build a fixture that yields exactly 4 base clusters (well under target_max=9)
@@ -1802,8 +1802,8 @@ class TestConsolidate:
         from unittest.mock import patch as _patch
 
         from knowledge_ingest.proposal_generator import (
-            generate_bootstrap_proposals_v2,
             DocumentSummary,
+            generate_bootstrap_proposals_v2,
         )
 
         # Build a fixture with > target_max=9 base clusters so consolidate WOULD trigger.

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -131,7 +131,7 @@ class TestClusterDocumentsHdbscan:
         from knowledge_ingest.clustering import cluster_documents_hdbscan
 
         embeddings, _true_labels = _make_synthetic_embeddings()
-        labels, metrics = cluster_documents_hdbscan(
+        labels, _metrics = cluster_documents_hdbscan(
             embeddings, min_cluster_size=5, pre_reduce=False
         )
 
@@ -150,7 +150,7 @@ class TestClusterDocumentsHdbscan:
         from knowledge_ingest.clustering import cluster_documents_hdbscan
 
         embeddings, _ = _make_synthetic_embeddings()
-        labels, metrics = cluster_documents_hdbscan(embeddings, min_cluster_size=5)
+        _labels, metrics = cluster_documents_hdbscan(embeddings, min_cluster_size=5)
 
         assert "clusters_found" in metrics
         assert "outlier_count" in metrics
@@ -219,8 +219,6 @@ class TestAdaptiveClusterCount:
         """closest_to_centroid returns top-N indices closest to cluster centroid."""
         from knowledge_ingest.clustering import closest_to_centroid
 
-        rng = np.random.RandomState(42)
-        center = np.array([1.0, 0.0, 0.0, 0.0])
         # Make 5 vectors: first 3 close to center, last 2 far
         vecs = np.array(
             [
@@ -445,7 +443,7 @@ class TestBootstrapProposalsV2Integration:
                 AsyncMock(return_value=""),
             ),
         ):
-            result = await generate_bootstrap_proposals_v2(
+            await generate_bootstrap_proposals_v2(
                 org_id="org1",
                 kb_slug="test-kb",
                 document_summaries=doc_summaries,
@@ -556,7 +554,10 @@ class TestBootstrapProposalsV2Integration:
         # If synthetic data gave us 3 clusters, we cap to 2
         if result.clusters_found >= 2:
             assert result.proposals_submitted <= 2
-            log_events = [e["event"] for e in captured]
+            # TODO: this test's docstring says "log bootstrap_clusters_capped"
+            # (AC-7) but that event is never asserted here. Should likely be:
+            #   assert "bootstrap_clusters_capped" in _log_events
+            _log_events = [e["event"] for e in captured]
             # Only log capped if we actually had more than max
             # (synthetic data may give exactly 2 or 3 clusters)
 
@@ -646,7 +647,7 @@ class TestBootstrapProposalsV2Integration:
                     AsyncMock(return_value="a description"),
                 ),
             ):
-                result = await generate_bootstrap_proposals_v2(
+                await generate_bootstrap_proposals_v2(
                     org_id="org-test",
                     kb_slug="kb-test",
                     document_summaries=doc_summaries,
@@ -743,7 +744,7 @@ class TestBootstrapLatency:
                 AsyncMock(return_value=""),
             ),
         ):
-            result = await generate_bootstrap_proposals_v2(
+            await generate_bootstrap_proposals_v2(
                 org_id="org1",
                 kb_slug="perf-kb",
                 document_summaries=doc_summaries,
@@ -779,7 +780,7 @@ class TestBootstrapLatency:
                 AsyncMock(return_value=""),
             ),
         ):
-            result = await generate_bootstrap_proposals_v2(
+            await generate_bootstrap_proposals_v2(
                 org_id="org1",
                 kb_slug="large-kb",
                 document_summaries=doc_summaries,
@@ -920,7 +921,7 @@ class TestDuplicatePreventionRegression:
             patch("knowledge_ingest.proposal_generator.submit_taxonomy_proposal", mock_submit),
             patch("knowledge_ingest.proposal_generator.settings", mock_settings),
         ):
-            result = await generate_bootstrap_proposals_v2(
+            await generate_bootstrap_proposals_v2(
                 org_id="voys-org",
                 kb_slug="voys-help-notion",
                 document_summaries=doc_summaries,

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -1386,7 +1386,7 @@ class TestConsolidate:
 
     @pytest.fixture
     def document_embeddings(self, base_proposals):
-        # 12 clusters × 5 docs = 60 unit-norm vectors.
+        # 12 clusters x 5 docs = 60 unit-norm vectors.
         rng = np.random.RandomState(42)
         embs = rng.randn(60, DIM).astype(np.float32)
         embs = embs / np.linalg.norm(embs, axis=1, keepdims=True)
@@ -1472,7 +1472,7 @@ class TestConsolidate:
             )
 
         assert len(parents) == 3
-        assert all(p.document_count == 20 for p in parents)  # 4 children × 5 docs
+        assert all(p.document_count == 20 for p in parents)  # 4 children x 5 docs
         # Child cluster names propagated
         assert parents[0].child_cluster_names == [
             "Cluster 0 name",
@@ -1701,7 +1701,7 @@ class TestConsolidate:
             )
 
         prompt = captured_system_prompt["text"]
-        # Total docs = 12 clusters × 5 = 60 → doc_cap = 60 // 4 = 15
+        # Total docs = 12 clusters x 5 = 60 → doc_cap = 60 // 4 = 15
         assert "60" in prompt  # total docs
         assert "12" in prompt  # n_clusters
         assert "15" in prompt or "~15" in prompt  # doc_cap
@@ -1808,7 +1808,7 @@ class TestConsolidate:
         )
 
         # Build a fixture with > target_max=9 base clusters so consolidate WOULD trigger.
-        # 12 well-separated clusters × 5 docs = 60 docs.
+        # 12 well-separated clusters x 5 docs = 60 docs.
         rng = np.random.RandomState(7)
         embs_list = []
         for cluster_idx in range(12):

--- a/klai-knowledge-ingest/tests/test_validate_login_wall_detector.py
+++ b/klai-knowledge-ingest/tests/test_validate_login_wall_detector.py
@@ -88,9 +88,7 @@ class TestClusterDiscovery:
         )
         assert len(report["clusters"]) == 1
         assert report["clusters"][0]["size"] == 6
-        assert "https://help.voys.nl/2fa-freedom" not in (
-            report["clusters"][0]["sample_urls"]
-        )
+        assert "https://help.voys.nl/2fa-freedom" not in (report["clusters"][0]["sample_urls"])
 
     def test_sample_size_caps_url_list(self) -> None:
         report = _build_report(
@@ -210,9 +208,7 @@ class TestReportShape:
     def test_clusters_sorted_by_size_desc(self) -> None:
         # Two distinct clusters: 6 walls (large) and 6 clean dupes (small group).
         wall_rows = _walls(6)
-        clean_rows = [
-            _row(url=f"https://x/clean-{i}", raw=_clean()) for i in range(7)
-        ]
+        clean_rows = [_row(url=f"https://x/clean-{i}", raw=_clean()) for i in range(7)]
         report = _build_report(
             wall_rows + clean_rows,
             org_id="org-1",


### PR DESCRIPTION
## Why

`.github/workflows/knowledge-ingest.yml` had **zero** references to ruff. The ruff config in `pyproject.toml` has existed all along and is fine — nothing ever ran it in CI, so the codebase drifted to 118 findings while portal-api (which does have the gate) stayed clean.

Cleaning first and gating second, in one PR, so the gate cannot be added while the tree is dirty.

## What

- 118 → 0 findings. Auto-fixes, then per-rule manual work: `E501` reflowed rather than ignored, `B905` given explicit `strict=`, `RUF002/003` ASCII-ised in comments only, `RUF100` unused noqa removed.
- `ruff format` applied as its own commit (61 files had never been formatted) so formatter noise stays separable from substantive fixes in review.
- `Lint (ruff)` + `Format check (ruff)` added to the existing `quality` job, matching the `uv run --frozen --extra dev` pattern the pytest step already uses.

One new per-file-ignore: `_patch_graphiti.py = ["E501"]` — it holds Cypher query strings that monkey-patch graphiti-core's FalkorDB queries, and reflowing them risks altering query syntax. Same precedent as the existing `crawl4ai_client.py` ignore for JS strings.

## Two tests that do not test what their names claim

The `F841`/`RUF059` findings surfaced these. Both are left with a `_` prefix and a `# TODO` rather than quietly papered over, and tracked separately:

- `test_search_with_user_id_filter` captures `call_args` and never asserts on it. It would stay green if the personal-KB `user_id` filter disappeared entirely. Production code is correct (`qdrant_store.py:517-518`), so this is an unguarded isolation boundary, not a live bug.
- `test_ac7_cluster_count_capped_at_max` builds `log_events` and never asserts, while its docstring promises the AC-7 `bootstrap_clusters_capped` event.

## Verification

No behaviour change intended. The one edit that could have had any: moving the `_patch_graphiti` import to top-of-file. Checked that its module body is imports, a `getLogger`, and function definitions only — no import-time side effects — and the `_apply_graphiti_patch()` call stayed where it was.

- `uv run ruff check .` → clean
- `uv run ruff format --check .` → 248 files already formatted
- `uv run --frozen --extra dev pytest -q -n auto` → 1281 passed, 4 skipped — identical to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)