### PR TITLE
chore(knowledge-ingest): enable ruff ARG on production code, and make two tests actually test their names

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
+++ b/klai-knowledge-ingest/knowledge_ingest/_patch_graphiti.py
@@ -433,7 +433,10 @@ def _patch_bidirectional_edge_dedup() -> None:
 
     @classmethod  # type: ignore[misc]
     async def get_between_nodes_bidirectional(
-        cls, driver: GraphDriver, node_uuid_a: str, node_uuid_b: str
+        cls,  # noqa: ARG001 — classmethod signature required to patch EntityEdge below
+        driver: GraphDriver,
+        node_uuid_a: str,
+        node_uuid_b: str,
     ):
         match_query = """
             MATCH (n:Entity {uuid: $node_uuid_a})-[e:RELATES_TO]-(m:Entity {uuid: $node_uuid_b})

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -31,7 +31,7 @@ _apply_graphiti_patch()
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI):  # noqa: ARG001 — FastAPI lifespan contract requires this param
     logger.info("starting_knowledge_ingest_service")
     await qdrant_store.ensure_collection()
     logger.info("qdrant_collection_ready")

--- a/klai-knowledge-ingest/knowledge_ingest/auto_categorise_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/auto_categorise_tasks.py
@@ -30,7 +30,10 @@ def register_auto_categorise_task(procrastinate_app: Any) -> None:
         _waits: ClassVar[list[int]] = [30, 300, 1800]
 
         def get_retry_decision(
-            self, *, exception: BaseException, job: Any
+            self,
+            *,
+            exception: BaseException,  # noqa: ARG002 — procrastinate.BaseRetryStrategy signature
+            job: Any,
         ) -> procrastinate.RetryDecision | None:
             if job.attempts >= len(self._waits):
                 logger.error(

--- a/klai-knowledge-ingest/knowledge_ingest/clustering.py
+++ b/klai-knowledge-ingest/knowledge_ingest/clustering.py
@@ -385,7 +385,6 @@ async def run_clustering_for_kb(
     org_id: str,
     kb_slug: str,
     qdrant_client: AsyncQdrantClient,
-    taxonomy_nodes: list,
 ) -> CentroidStore | None:
     """Fetch embeddings from Qdrant, run HDBSCAN, compute centroids.
 

--- a/klai-knowledge-ingest/knowledge_ingest/connector_purge_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_purge_tasks.py
@@ -48,7 +48,10 @@ def register_connector_purge_task(procrastinate_app: Any) -> None:
         max_attempts = 5
 
         def get_retry_decision(
-            self, *, exception: BaseException, job: procrastinate.JobContext
+            self,
+            *,
+            exception: BaseException,  # noqa: ARG002 — procrastinate.BaseRetryStrategy signature
+            job: procrastinate.JobContext,
         ) -> procrastinate.RetryDecision | None:
             attempt = job.attempts  # 0-based after first failure
             if attempt >= len(self._waits):

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -167,7 +167,11 @@ class _HTMLTextCounter(HTMLParser):
         self._skip_depth = 0
         self.parts: list[str] = []
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],  # noqa: ARG002 — stdlib HTMLParser override signature
+    ) -> None:
         if tag.lower() in {"script", "style", "noscript", "template", "svg"}:
             self._skip_depth += 1
 

--- a/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
@@ -491,7 +491,7 @@ async def search(
     user_id: str | None = None,
     sparse_vector: SparseVector | None = None,
     content_type_filter: str | None = None,
-    sparse_weight: float | None = None,
+    sparse_weight: float | None = None,  # noqa: ARG001 — parked, see @MX:TODO/@MX:REASON below
 ) -> list[dict]:
     """Search for chunks matching the query vector.
 

--- a/klai-knowledge-ingest/pyproject.toml
+++ b/klai-knowledge-ingest/pyproject.toml
@@ -82,6 +82,18 @@ ignore = [
 # mirror the real callable they replace even when a given test ignores some
 # parameters. Enforcing ARG here would force churn without catching anything.
 "tests/**" = ["ARG"]
+# Every ContentTypeProfile.hype_enabled is typed Callable[[int], bool]; some
+# profiles' lambdas don't need the depth value but must keep the shared
+# call signature so enrichment.py can invoke any profile uniformly.
+"knowledge_ingest/content_profiles.py" = ["ARG005"]
+# Every STRATEGIES entry is called with the same kwargs (e.g. chunk_index=)
+# regardless of which strategy is selected; **kwargs is the common-signature
+# escape hatch for strategies that don't need a given kwarg.
+"knowledge_ingest/context_strategies.py" = ["ARG001"]
+# Every route here declares request: Request per this file's FastAPI handler
+# convention; InternalSecretMiddleware already validates requests centrally,
+# so individual handlers don't need to inspect it today.
+"knowledge_ingest/routes/taxonomy.py" = ["ARG001"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/klai-knowledge-ingest/pyproject.toml
+++ b/klai-knowledge-ingest/pyproject.toml
@@ -64,7 +64,7 @@ line-length = 100
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG"]
+select = ["E", "F", "I", "UP", "B", "S", "RUF", "G", "LOG", "ARG"]
 ignore = [
     "S101",  # assert is fine in tests
     "S105",  # hardcoded passwords — false positives on config defaults
@@ -77,6 +77,11 @@ ignore = [
 "tests/test_alembic_bootstrap.py" = ["E501", "S603", "S607"]  # test file calls subprocess with known-safe args
 "tests/test_clustering_umap.py" = ["E501"]  # patch() strings and assert messages legitimately exceed 100 chars
 "tests/test_taxonomy_v2_bootstrap.py" = ["E501"]  # patch() strings and docstrings legitimately exceed 100 chars
+# Unused arguments in tests are structural, not bugs: pytest fixtures are
+# injected for their side effect (not read), and mock/stub signatures must
+# mirror the real callable they replace even when a given test ignores some
+# parameters. Enforcing ARG here would force churn without catching anything.
+"tests/**" = ["ARG"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/klai-knowledge-ingest/tests/test_clustering.py
+++ b/klai-knowledge-ingest/tests/test_clustering.py
@@ -289,6 +289,5 @@ async def test_run_clustering_too_few_docs():
         org_id="org-1",
         kb_slug="test-kb",
         qdrant_client=mock_client,
-        taxonomy_nodes=[],
     )
     assert result is None

--- a/klai-knowledge-ingest/tests/test_qdrant_metadata.py
+++ b/klai-knowledge-ingest/tests/test_qdrant_metadata.py
@@ -3,8 +3,18 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from qdrant_client.models import FieldCondition, MatchValue
 
 from knowledge_ingest.qdrant_store import search
+
+
+def _user_id_conditions(mock_query):
+    """Extract user_id FieldConditions from every prefetch leg's filter.must."""
+    prefetch = mock_query.call_args.kwargs["prefetch"]
+    conditions = []
+    for leg in prefetch:
+        conditions.extend(c for c in leg.filter.must if c.key == "user_id")
+    return conditions
 
 
 def _make_query_point(payload: dict, score: float = 0.9):
@@ -104,18 +114,33 @@ async def test_metadata_contains_allowed_fields():
 
 @pytest.mark.asyncio
 async def test_search_with_user_id_filter():
-    """When user_id and personal kb_slugs provided, filter should be applied."""
+    """When user_id and personal kb_slugs provided, the user_id filter must be
+    applied to every prefetch leg's Qdrant filter (see qdrant_store.search)."""
     with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
         mock_query = AsyncMock(return_value=_make_query_response([]))
         mock_client.return_value.query_points = mock_query
         await search("org1", [0.1] * 1024, kb_slugs=["personal-user123"], user_id="user123")
 
-        # TODO: call_kwargs is captured but never asserted on. The filter is
-        # passed via prefetch entries' `filter=` kwarg (see qdrant_store.search),
-        # so this test does not actually verify the user_id filter was applied —
-        # only that query_points was called at all.
-        _call_kwargs = mock_query.call_args
         mock_query.assert_called_once()
+        conditions = _user_id_conditions(mock_query)
+        assert len(conditions) > 0
+        expected = FieldCondition(key="user_id", match=MatchValue(value="user123"))
+        assert all(c == expected for c in conditions)
+
+
+@pytest.mark.asyncio
+async def test_search_with_user_id_non_personal_kb_no_user_filter():
+    """A user_id is present but kb_slugs is NOT a personal KB — the user_id
+    filter must NOT be applied. This is the tenant-isolation boundary that
+    test_search_with_user_id_filter alone does not cover: passing a user_id
+    is not sufficient to scope the search, kb_slugs must also be personal."""
+    with patch("knowledge_ingest.qdrant_store.get_client") as mock_client:
+        mock_query = AsyncMock(return_value=_make_query_response([]))
+        mock_client.return_value.query_points = mock_query
+        await search("org1", [0.1] * 1024, kb_slugs=["org"], user_id="user123")
+
+        mock_query.assert_called_once()
+        assert _user_id_conditions(mock_query) == []
 
 
 @pytest.mark.asyncio
@@ -127,6 +152,7 @@ async def test_search_without_user_id_no_extra_filter():
         await search("org1", [0.1] * 1024)
 
         mock_query.assert_called_once()
+        assert _user_id_conditions(mock_query) == []
 
 
 def test_allowed_metadata_fields_includes_assertion_mode():

--- a/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
+++ b/klai-knowledge-ingest/tests/test_taxonomy_v2_bootstrap.py
@@ -554,12 +554,23 @@ class TestBootstrapProposalsV2Integration:
         # If synthetic data gave us 3 clusters, we cap to 2
         if result.clusters_found >= 2:
             assert result.proposals_submitted <= 2
-            # TODO: this test's docstring says "log bootstrap_clusters_capped"
-            # (AC-7) but that event is never asserted here. Should likely be:
-            #   assert "bootstrap_clusters_capped" in _log_events
-            _log_events = [e["event"] for e in captured]
-            # Only log capped if we actually had more than max
-            # (synthetic data may give exactly 2 or 3 clusters)
+            # _make_synthetic_embeddings(seed=42) produces 3 clearly-separated
+            # clusters with 0 outliers. cluster_documents_hdbscan uses a fixed
+            # random_state (settings.taxonomy_bootstrap_umap_random_state,
+            # default 42) for its UMAP pre-reduction, so with
+            # taxonomy_bootstrap_max_clusters=2 the raw cluster count (3) is
+            # deterministically > max_clusters and the cap in
+            # proposal_generator.generate_bootstrap_proposals_v2 always fires
+            # here (verified empirically: 3 raw clusters across repeated runs
+            # with this fixture's seed/settings). Scope the assertion on the
+            # actual emitted event rather than asserting unconditionally.
+            capped_events = [e for e in captured if e["event"] == "bootstrap_clusters_capped"]
+            assert capped_events, (
+                "expected bootstrap_clusters_capped (AC-7) when raw cluster "
+                f"count exceeds max_clusters; got events={[e['event'] for e in captured]}"
+            )
+            assert capped_events[0]["total_clusters"] > 2
+            assert capped_events[0]["kept_clusters"] == 2
 
     @pytest.mark.asyncio
     async def test_ac8_all_duplicates_returns_reason(self, mock_settings):


### PR DESCRIPTION
## Why ARG

`ARG` (unused function arguments) is the rule that would have caught the `rate_limit` bug: that parameter was threaded through the entire crawl pipeline and never wired to anything, so every crawl hit every site at full speed. Days of debugging and a production regression, for a dead argument that a linter sees instantly.

## Scope: production code only

Measured before deciding: **25 findings in `knowledge_ingest/`, 201 in `tests/`**. The test findings are structurally noise — pytest fixtures present for their side effect, mock signatures mirroring real ones, `monkeypatch` args. Cleaning those makes tests more brittle and catches nothing, so `"tests/**" = ["ARG"]`.

The 25 production findings, classified:

| | count |
|---|---|
| Framework-mandated signature | 23 |
| Genuinely dead argument (removed) | 1 |
| Passed-but-ignored (the `rate_limit` class) | **0** |

The 23 are FastAPI `lifespan`, procrastinate `get_retry_decision`, stdlib `HTMLParser` overrides, and shared-callable contracts where every entry must accept the same kwargs even if its body ignores them. Each carries a targeted ignore with a stated reason — no blanket noqa.

The one removal is `taxonomy_nodes` from `clustering.py::run_clustering_for_kb`. Verified repo-wide that its only caller is a single test passing `[]`; the `taxonomy_nodes=` hits in `taxonomy_tasks.py` go to `classify_document`, a different function.

`sparse_weight` in `models.py` was checked specifically and is **not** the dangerous class: no caller anywhere passes it, and it already carries an `@MX:TODO` explaining it is parked pending SPEC-KB-007 gate D4. Left as-is with a noqa pointing at that rationale rather than changing behaviour.

## Two tests that did not test their names

Surfaced by the `F841`/`RUF059` findings in #1035, tracked and now closed.

**`test_search_with_user_id_filter`** asserted only that `query_points` was called. It would have stayed green if the personal-KB `user_id` filter vanished entirely — the filter that stops user A seeing user B's personal-KB chunks. Now asserts the `FieldCondition` is present in the prefetch filter, plus a new negative test for the previously uncovered boundary: `user_id` set but the KB is not personal, so the condition must be absent.

**`test_ac7_cluster_count_capped_at_max`** promised the AC-7 `bootstrap_clusters_capped` event in its docstring and never asserted it. Confirmed across three runs that the fixture deterministically yields 3 clusters against `max_clusters=2`, so the cap always fires and the assertion is not flaky.

Both were fail-verified: with the production behaviour removed the test fails, with it restored it passes. Re-confirmed independently for the isolation test.

## Verification

- `uv run ruff check .` → clean, with ARG active
- `uv run ruff format --check .` → 248 files already formatted
- `uv run --frozen --extra dev pytest -q -n auto` → 1282 passed, 4 skipped (+1 new test, no other movement)

## Follow-up, not in scope

`run_clustering_for_kb` appears to have no production callers at all — only its own test. Flagged separately rather than deleted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)