### PR TITLE
chore(retrieval-api): add the ruff gate its config always assumed was there

### DIFF
--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -65,6 +65,16 @@ jobs:
       - name: Dependency vulnerability scan (pip-audit)
         run: uv run --with pip-audit pip-audit --skip-editable
 
+      # pyproject.toml's [tool.ruff.lint] select already included TRY (SPEC-SEC-HYGIENE-001
+      # REQ-43.4, to catch logger.error(...) inside except blocks dropping the traceback)
+      # but nothing in CI ran ruff, so the config was decorative. Two TRY400 violations had
+      # already landed unnoticed before this gate was wired up.
+      - name: Lint (ruff)
+        run: uv run --extra dev ruff check .
+
+      - name: Format check (ruff)
+        run: uv run --extra dev ruff format --check .
+
       - name: Test (pytest)
         run: uv run --extra dev pytest -q --tb=short
 

--- a/klai-retrieval-api/evaluation/cross_lingual_runner.py
+++ b/klai-retrieval-api/evaluation/cross_lingual_runner.py
@@ -132,7 +132,7 @@ async def _http_synthesize(
                 # SSE: "data: <json>"
                 if not line or not line.startswith("data: "):
                     continue
-                payload = line[len("data: "):].strip()
+                payload = line[len("data: ") :].strip()
                 try:
                     evt = json.loads(payload)
                 except json.JSONDecodeError:
@@ -343,9 +343,7 @@ def main() -> int:
     import os
 
     args = _parse_args()
-    internal_secret = (
-        args.internal_secret or os.environ.get("RETRIEVAL_INTERNAL_SECRET") or None
-    )
+    internal_secret = args.internal_secret or os.environ.get("RETRIEVAL_INTERNAL_SECRET") or None
 
     async def _http_synth(query: str, org_id: str) -> str:
         return await _http_synthesize(

--- a/klai-retrieval-api/evaluation/eval_runner.py
+++ b/klai-retrieval-api/evaluation/eval_runner.py
@@ -74,7 +74,8 @@ async def retry_with_backoff(
             last_exc = exc
             if attempt == max_retries - 1:
                 break
-            delay = min(base_delay * (2 ** attempt) + random.uniform(0, 1), max_delay)
+            jitter = random.uniform(0, 1)  # noqa: S311 -- retry backoff jitter, not security-sensitive
+            delay = min(base_delay * (2**attempt) + jitter, max_delay)
             logger.warning(
                 "Attempt %d/%d failed: %s. Retrying in %.1fs...",
                 attempt + 1, max_retries, exc, delay,
@@ -200,7 +201,7 @@ async def run_baseline(
                 "chunks": resp.get("chunks", []),
             })
         except Exception as exc:
-            logger.error("Baseline query %d failed: %s", i + 1, exc)
+            logger.exception("Baseline query %d failed", i + 1)
             results.append({"query": q["query"], "error": str(exc)})
         finally:
             # Restore original env
@@ -268,7 +269,7 @@ async def run_evidence_tier(
                 "chunks": resp.get("chunks", []),
             })
         except Exception as exc:
-            logger.error("Evidence-tier query %d failed: %s", i + 1, exc)
+            logger.exception("Evidence-tier query %d failed", i + 1)
             results.append({"query": q["query"], "error": str(exc)})
         finally:
             for k, v in original_env.items():
@@ -314,7 +315,9 @@ def compare_results(
             continue
 
         if len(baseline_scores) < 5:
-            logger.warning("Too few samples (%d) for Wilcoxon test on %s", len(baseline_scores), metric)
+            logger.warning(
+                "Too few samples (%d) for Wilcoxon test on %s", len(baseline_scores), metric
+            )
             report["metrics"][metric] = {
                 "baseline_mean": sum(baseline_scores) / max(len(baseline_scores), 1),
                 "treatment_mean": sum(treatment_scores) / max(len(treatment_scores), 1),
@@ -433,7 +436,9 @@ async def main(
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="RAGAS evaluation for evidence-tier scoring")
-    parser.add_argument("--baseline-only", action="store_true", help="Only run baseline measurement")
+    parser.add_argument(
+        "--baseline-only", action="store_true", help="Only run baseline measurement"
+    )
     parser.add_argument(
         "--dimension",
         choices=["content_type", "temporal_decay", "assertion_mode"],

--- a/klai-retrieval-api/evaluation/eval_runner.py
+++ b/klai-retrieval-api/evaluation/eval_runner.py
@@ -78,7 +78,10 @@ async def retry_with_backoff(
             delay = min(base_delay * (2**attempt) + jitter, max_delay)
             logger.warning(
                 "Attempt %d/%d failed: %s. Retrying in %.1fs...",
-                attempt + 1, max_retries, exc, delay,
+                attempt + 1,
+                max_retries,
+                exc,
+                delay,
             )
             await asyncio.sleep(delay)
 
@@ -193,13 +196,15 @@ async def run_baseline(
             retrieved_ids = [c["chunk_id"] for c in resp.get("chunks", [])]
             gt_ids = q.get("ground_truth_chunks", [])
 
-            results.append({
-                "query": q["query"],
-                "retrieved_chunk_ids": retrieved_ids,
-                "ndcg_at_10": compute_ndcg_at_k(retrieved_ids, gt_ids, k=10),
-                "recall_at_10": compute_recall_at_k(retrieved_ids, gt_ids, k=10),
-                "chunks": resp.get("chunks", []),
-            })
+            results.append(
+                {
+                    "query": q["query"],
+                    "retrieved_chunk_ids": retrieved_ids,
+                    "ndcg_at_10": compute_ndcg_at_k(retrieved_ids, gt_ids, k=10),
+                    "recall_at_10": compute_recall_at_k(retrieved_ids, gt_ids, k=10),
+                    "chunks": resp.get("chunks", []),
+                }
+            )
         except Exception as exc:
             logger.exception("Baseline query %d failed", i + 1)
             results.append({"query": q["query"], "error": str(exc)})
@@ -261,13 +266,15 @@ async def run_evidence_tier(
             retrieved_ids = [c["chunk_id"] for c in resp.get("chunks", [])]
             gt_ids = q.get("ground_truth_chunks", [])
 
-            results.append({
-                "query": q["query"],
-                "retrieved_chunk_ids": retrieved_ids,
-                "ndcg_at_10": compute_ndcg_at_k(retrieved_ids, gt_ids, k=10),
-                "recall_at_10": compute_recall_at_k(retrieved_ids, gt_ids, k=10),
-                "chunks": resp.get("chunks", []),
-            })
+            results.append(
+                {
+                    "query": q["query"],
+                    "retrieved_chunk_ids": retrieved_ids,
+                    "ndcg_at_10": compute_ndcg_at_k(retrieved_ids, gt_ids, k=10),
+                    "recall_at_10": compute_recall_at_k(retrieved_ids, gt_ids, k=10),
+                    "chunks": resp.get("chunks", []),
+                }
+            )
         except Exception as exc:
             logger.exception("Evidence-tier query %d failed", i + 1)
             results.append({"query": q["query"], "error": str(exc)})
@@ -303,12 +310,8 @@ def compare_results(
     }
 
     for metric in ("ndcg_at_10", "recall_at_10"):
-        baseline_scores = [
-            r.get(metric, 0.0) for r in baseline if "error" not in r
-        ]
-        treatment_scores = [
-            r.get(metric, 0.0) for r in treatment if "error" not in r
-        ]
+        baseline_scores = [r.get(metric, 0.0) for r in baseline if "error" not in r]
+        treatment_scores = [r.get(metric, 0.0) for r in treatment if "error" not in r]
 
         if len(baseline_scores) != len(treatment_scores):
             logger.warning("Mismatched result counts for %s, skipping", metric)
@@ -328,8 +331,7 @@ def compare_results(
         baseline_mean = sum(baseline_scores) / len(baseline_scores)
         treatment_mean = sum(treatment_scores) / len(treatment_scores)
         improvement_pct = (
-            ((treatment_mean - baseline_mean) / baseline_mean * 100)
-            if baseline_mean > 0 else 0.0
+            ((treatment_mean - baseline_mean) / baseline_mean * 100) if baseline_mean > 0 else 0.0
         )
 
         # Wilcoxon signed-rank test (paired, non-parametric)

--- a/klai-retrieval-api/retrieval_api/services/evidence_tier.py
+++ b/klai-retrieval-api/retrieval_api/services/evidence_tier.py
@@ -97,7 +97,7 @@ def _content_type_weight(content_type: str | None, profile: EvidenceProfile) -> 
 
 
 # PageRank boost constants.
-# Scale brings typical FalkorDB algo.pageRank values (0.003–0.05) into log1p-friendly range.
+# Scale brings typical FalkorDB algo.pageRank values (0.003-0.05) into log1p-friendly range.
 # Alpha caps the max boost at ~25% for hub entities in the current graph size.
 # Consistent with the Hebbian boost pattern in graph_search._convert_results.
 _PAGERANK_SCALE = 100.0
@@ -112,9 +112,9 @@ def _pagerank_weight(pagerank_max: float | None) -> float:
     graph data or when the feature flag is disabled.
 
     Typical boost range (production graph, 290 entities):
-        pagerank_max 0.003 → ×1.05  (+5%)
-        pagerank_max 0.010 → ×1.14  (+14%)
-        pagerank_max 0.020 → ×1.22  (+22%)
+        pagerank_max 0.003 -> x1.05  (+5%)
+        pagerank_max 0.010 -> x1.14  (+14%)
+        pagerank_max 0.020 -> x1.22  (+22%)
     """
     if not _is_enabled("EVIDENCE_PAGERANK_ENABLED"):
         return 1.0
@@ -126,7 +126,8 @@ def _pagerank_weight(pagerank_max: float | None) -> float:
 # @MX:NOTE: [AUTO] assertion_mode now applies the conservative weight table from
 # @MX:NOTE: DEFAULT_EVIDENCE_PROFILE, but stays shadow-gated at the retrieve.py caller
 # @MX:NOTE: (EVIDENCE_SHADOW_MODE=true) so it is measured, not served.
-# @MX:SPEC: SPEC-EVIDENCE-002 — go-live preconditions in docs/research/assertion-modes/assertion-mode-weights.md §8-9.
+# @MX:SPEC: SPEC-EVIDENCE-002 — go-live preconditions in
+# @MX:SPEC: docs/research/assertion-modes/assertion-mode-weights.md §8-9.
 def _assertion_weight(assertion_mode: str | None, profile: EvidenceProfile) -> float:
     """Return the multiplicative weight for a chunk's assertion_mode.
 

--- a/klai-retrieval-api/retrieval_api/services/gate.py
+++ b/klai-retrieval-api/retrieval_api/services/gate.py
@@ -85,7 +85,7 @@ async def _ensure_reference_vectors() -> list[list[float]]:
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
     norm_a = math.sqrt(sum(x * x for x in a))
     norm_b = math.sqrt(sum(x * x for x in b))
     if norm_a == 0 or norm_b == 0:

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -8,6 +8,7 @@ AC-7:  returns [] on timeout or error (graceful degradation).
 AC-8:  returns [] immediately when GRAPHITI_ENABLED=false.
 AC-10: group_ids=[org_id] enforces tenant isolation.
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/klai-retrieval-api/retrieval_api/util/payload.py
+++ b/klai-retrieval-api/retrieval_api/util/payload.py
@@ -6,6 +6,7 @@ consumer of list-shaped payload keys (``anchor_texts``, ``links_to``,
 ``image_urls``) MUST read through :func:`payload_list` to avoid silent
 drift between the two shapes.
 """
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/klai-retrieval-api/tests/test_assertion_mode_taxonomy.py
+++ b/klai-retrieval-api/tests/test_assertion_mode_taxonomy.py
@@ -4,6 +4,7 @@ RED phase: verify that assertion_mode flows through search results.
 The retrieval-api search.py already passes assertion_mode through — these tests
 verify the new vocabulary values are correctly returned.
 """
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -40,7 +41,9 @@ class TestNewTaxonomyValuesPassthrough:
     async def test_new_assertion_mode_values_pass_through(self, mode):
         """Each new taxonomy value must appear in search results."""
         point = _make_point(
-            "c1", "chunk text", 0.8,
+            "c1",
+            "chunk text",
+            0.8,
             org_id="org-1",
             assertion_mode=mode,
         )

--- a/klai-retrieval-api/tests/test_assertion_mode_taxonomy.py
+++ b/klai-retrieval-api/tests/test_assertion_mode_taxonomy.py
@@ -34,7 +34,9 @@ class TestNewTaxonomyValuesPassthrough:
         search._client = None
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("mode", ["fact", "claim", "speculation", "procedural", "quoted", "unknown"])
+    @pytest.mark.parametrize(
+        "mode", ["fact", "claim", "speculation", "procedural", "quoted", "unknown"]
+    )
     async def test_new_assertion_mode_values_pass_through(self, mode):
         """Each new taxonomy value must appear in search results."""
         point = _make_point(

--- a/klai-retrieval-api/tests/test_auth_jwks_timeout.py
+++ b/klai-retrieval-api/tests/test_auth_jwks_timeout.py
@@ -54,13 +54,13 @@ async def test_fetch_jwks_timeout_capped_at_three_seconds(monkeypatch):
     # ``_fetch_jwks`` does ``import httpx`` locally — patch the httpx
     # module attribute itself so the local rebind picks up our stub.
     import httpx as _httpx
+
     monkeypatch.setattr(_httpx, "AsyncClient", _RecordingClient)
 
     await auth._fetch_jwks()
 
     assert _RecordingClient.timeout_seen is not None, (
-        "Test scaffolding broken — _fetch_jwks did not construct an httpx "
-        "AsyncClient via our stub."
+        "Test scaffolding broken — _fetch_jwks did not construct an httpx AsyncClient via our stub."
     )
     assert _RecordingClient.timeout_seen <= 3.0, (
         f"_fetch_jwks built httpx.AsyncClient with timeout="

--- a/klai-retrieval-api/tests/test_eval_framework.py
+++ b/klai-retrieval-api/tests/test_eval_framework.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 EVAL_DIR = Path(__file__).resolve().parent.parent / "evaluation"
 
 

--- a/klai-retrieval-api/tests/test_eval_framework.py
+++ b/klai-retrieval-api/tests/test_eval_framework.py
@@ -125,9 +125,7 @@ class TestEvalRunner:
         """eval_runner.py must include Wilcoxon signed-rank test."""
         runner_path = EVAL_DIR / "eval_runner.py"
         source = runner_path.read_text()
-        assert "wilcoxon" in source.lower(), (
-            "eval_runner.py must include wilcoxon signed-rank test"
-        )
+        assert "wilcoxon" in source.lower(), "eval_runner.py must include wilcoxon signed-rank test"
 
     def test_eval_runner_has_retry_logic(self):
         """eval_runner.py must include retry/backoff for rate-limited LLM calls."""
@@ -143,9 +141,7 @@ class TestEvalRunner:
         source = runner_path.read_text().lower()
         forbidden = ["gpt-4", "gpt-3.5", "claude-", "text-davinci"]
         for model in forbidden:
-            assert model not in source, (
-                f"eval_runner.py references forbidden model: {model}"
-            )
+            assert model not in source, f"eval_runner.py references forbidden model: {model}"
 
     def test_eval_runner_uses_per_dimension_isolation(self):
         """eval_runner.py must support per-dimension isolation testing."""

--- a/klai-retrieval-api/tests/test_events_bounded.py
+++ b/klai-retrieval-api/tests/test_events_bounded.py
@@ -65,6 +65,7 @@ async def clean_events(monkeypatch):
 def log_capture():
     """Capture structlog event records emitted at WARNING+."""
     from retrieval_api.logging_setup import setup_logging
+
     setup_logging()
 
     records: list[logging.LogRecord] = []
@@ -132,7 +133,8 @@ async def test_pending_set_capped_at_configured_max(clean_events, monkeypatch, l
 
     # REQ-40.2: at least one rate-limited cap-hit log was emitted.
     cap_hit_logs = [
-        rec for rec in log_capture
+        rec
+        for rec in log_capture
         if isinstance(rec.msg, dict) and rec.msg.get("event") == "retrieval_events_cap_hit"
     ]
     assert cap_hit_logs, (
@@ -165,7 +167,8 @@ async def test_cap_hit_log_is_rate_limited(clean_events, monkeypatch, log_captur
     await asyncio.sleep(0)
 
     cap_hit_logs = [
-        rec for rec in log_capture
+        rec
+        for rec in log_capture
         if isinstance(rec.msg, dict) and rec.msg.get("event") == "retrieval_events_cap_hit"
     ]
     assert len(cap_hit_logs) <= 2, (

--- a/klai-retrieval-api/tests/test_evidence_pack.py
+++ b/klai-retrieval-api/tests/test_evidence_pack.py
@@ -232,6 +232,7 @@ def test_evidence_pack_preserves_heading_metadata_for_prompt_context():
 # when ``source_url`` is absent. All chunks from the same upload
 # collapse into one synthetic source ``artifact:<uuid>``.
 
+
 def test_evidence_pack_includes_uploaded_documents_without_source_url():
     """Uploads (PDFs, pasted text) have no public URL — their chunks
     must still reach the evidence pack via the ``artifact_id``
@@ -308,8 +309,7 @@ def test_evidence_pack_prefers_original_filename_for_file_sha_upload_title():
                 "chunk_id": "cv-chunk-1",
                 "artifact_id": "853797a1-3a22-4d90-872e-6a917d996c9a",
                 "title": (
-                    "file:sha256:"
-                    "59f8048203feeb17818abffa52de51405e0705c9e7907e2a57ebd5aa48c6697a"
+                    "file:sha256:59f8048203feeb17818abffa52de51405e0705c9e7907e2a57ebd5aa48c6697a"
                 ),
                 "original_filename": "CV_Jantine_Doornbos.pdf",
                 "text": "WERKERVARING\nMede-oprichter bij Klai jan 2026 - heden.",

--- a/klai-retrieval-api/tests/test_evidence_pipeline.py
+++ b/klai-retrieval-api/tests/test_evidence_pipeline.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 from unittest.mock import AsyncMock, patch
 
-import pytest
-
 
 class TestEvidenceTierInPipeline:
     """Verify evidence_tier.apply() is called after reranking."""

--- a/klai-retrieval-api/tests/test_evidence_tier.py
+++ b/klai-retrieval-api/tests/test_evidence_tier.py
@@ -23,8 +23,13 @@ class TestEvidenceProfile:
         from retrieval_api.services.evidence_tier import DEFAULT_EVIDENCE_PROFILE
 
         expected_types = {
-            "kb_article", "pdf_document", "meeting_transcript",
-            "1on1_transcript", "web_crawl", "graph_edge", "unknown",
+            "kb_article",
+            "pdf_document",
+            "meeting_transcript",
+            "1on1_transcript",
+            "web_crawl",
+            "graph_edge",
+            "unknown",
         }
         assert set(DEFAULT_EVIDENCE_PROFILE["content_type_weights"].keys()) == expected_types
 
@@ -47,9 +52,7 @@ class TestEvidenceProfile:
         from retrieval_api.services.evidence_tier import DEFAULT_EVIDENCE_PROFILE
 
         weights = DEFAULT_EVIDENCE_PROFILE["content_type_weights"]
-        assert weights["kb_article"] >= max(
-            v for k, v in weights.items() if k != "kb_article"
-        )
+        assert weights["kb_article"] >= max(v for k, v in weights.items() if k != "kb_article")
 
     def test_default_profile_specific_values(self):
         """Verify specific weight values from the SPEC."""
@@ -228,8 +231,9 @@ class TestTemporalDecay:
 # -- TASK-006: apply() + U-shape ordering (R7, R2) ----------------------------
 
 
-def _make_chunk(chunk_id: str, score: float, content_type: str = "kb_article",
-                ingested_at: int | None = None) -> dict:
+def _make_chunk(
+    chunk_id: str, score: float, content_type: str = "kb_article", ingested_at: int | None = None
+) -> dict:
     """Create a chunk dict as returned by the reranker."""
     return {
         "chunk_id": chunk_id,
@@ -324,7 +328,7 @@ class TestUShapeOrdering:
         # Sorted desc: c1(0.9), c3(0.8), c2(0.7)
         # U-shape: even indices front [c1, c2], odd indices reversed [c3]
         # Result: [c1, c2, c3]
-        assert ids[0] == "c1"   # strongest at front
+        assert ids[0] == "c1"  # strongest at front
         assert ids[-1] == "c3"  # second strongest at back
 
     def test_u_shape_6_chunks(self):

--- a/klai-retrieval-api/tests/test_evidence_tier.py
+++ b/klai-retrieval-api/tests/test_evidence_tier.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 # -- TASK-004: EvidenceProfile structure (R6) ----------------------------------
 
 
@@ -264,7 +263,9 @@ class TestApply:
         assert result[0]["final_score"] is not None
 
     def test_final_score_formula(self):
-        """final_score = reranker_score * content_type_weight * assertion_weight * temporal_decay."""
+        """final_score = reranker_score * content_type_weight * assertion_weight *
+        temporal_decay.
+        """
         from retrieval_api.services.evidence_tier import apply
 
         chunks = [_make_chunk("c1", 0.80, content_type="kb_article")]

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -127,9 +127,7 @@ async def test_search_skips_graphiti_empty_fulltext_syntax_error():
 async def test_search_warns_on_non_empty_fulltext_syntax_error():
     mock_graphiti = AsyncMock()
     mock_graphiti.search = AsyncMock(
-        side_effect=RuntimeError(
-            'RediSearch syntax error near "(@group_id:\\"org-1\\") (hello)"'
-        )
+        side_effect=RuntimeError('RediSearch syntax error near "(@group_id:\\"org-1\\") (hello)"')
     )
 
     with (

--- a/klai-retrieval-api/tests/test_health_safety.py
+++ b/klai-retrieval-api/tests/test_health_safety.py
@@ -207,9 +207,7 @@ def test_health_response_body_does_not_leak_internal_topology(monkeypatch, log_c
     # AC-39 step 6: no internal IPs / hostnames / verbose error strings anywhere in the body
     body_str = str(body)
     for needle in ("172.18.", "connection refused", "no route to host"):
-        assert needle not in body_str, (
-            f"/health response leaks topology via {needle!r}: {body_str}"
-        )
+        assert needle not in body_str, f"/health response leaks topology via {needle!r}: {body_str}"
 
     # AC-39 step 7: structlog captures the full exception via exc_info
     exc_records = [rec for rec in log_capture if rec.exc_info is not None]

--- a/klai-retrieval-api/tests/test_link_expand_config.py
+++ b/klai-retrieval-api/tests/test_link_expand_config.py
@@ -1,4 +1,5 @@
 """Tests for link expansion config settings (SPEC-CRAWLER-003, R19, R20)."""
+
 import pytest
 
 

--- a/klai-retrieval-api/tests/test_link_expand_retrieve.py
+++ b/klai-retrieval-api/tests/test_link_expand_retrieve.py
@@ -1,10 +1,11 @@
-"""Tests for link expansion + authority boost in the retrieve pipeline (SPEC-CRAWLER-003 R14-R17)."""
+"""Tests for link expansion + authority boost in the retrieve pipeline.
+
+SPEC-CRAWLER-003 R14-R17.
+"""
 
 from __future__ import annotations
 
 import math
-
-import pytest
 
 
 def _make_chunk(

--- a/klai-retrieval-api/tests/test_link_expand_search.py
+++ b/klai-retrieval-api/tests/test_link_expand_search.py
@@ -138,8 +138,10 @@ class TestFetchChunksByUrls:
         mock_client = AsyncMock()
         mock_client.scroll.side_effect = TimeoutError()
 
-        with patch.object(search, "_get_client", return_value=mock_client), \
-             patch.object(search, "logger") as mock_logger:
+        with (
+            patch.object(search, "_get_client", return_value=mock_client),
+            patch.object(search, "logger") as mock_logger,
+        ):
             req = RetrieveRequest(query="test", org_id="org-1", scope="org")
             results = await search.fetch_chunks_by_urls(
                 urls=["https://docs.example.com/x"],
@@ -157,8 +159,10 @@ class TestFetchChunksByUrls:
         mock_client = AsyncMock()
         mock_client.scroll.side_effect = RuntimeError("connection lost")
 
-        with patch.object(search, "_get_client", return_value=mock_client), \
-             patch.object(search, "logger") as mock_logger:
+        with (
+            patch.object(search, "_get_client", return_value=mock_client),
+            patch.object(search, "logger") as mock_logger,
+        ):
             req = RetrieveRequest(query="test", org_id="org-1", scope="org")
             results = await search.fetch_chunks_by_urls(
                 urls=["https://docs.example.com/x"],

--- a/klai-retrieval-api/tests/test_link_expand_search.py
+++ b/klai-retrieval-api/tests/test_link_expand_search.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -137,7 +136,7 @@ class TestFetchChunksByUrls:
     async def test_timeout_returns_empty_with_warning(self):
         """6.5: Timeout on scroll returns [] and logs a warning."""
         mock_client = AsyncMock()
-        mock_client.scroll.side_effect = asyncio.TimeoutError()
+        mock_client.scroll.side_effect = TimeoutError()
 
         with patch.object(search, "_get_client", return_value=mock_client), \
              patch.object(search, "logger") as mock_logger:

--- a/klai-retrieval-api/tests/test_payload_util.py
+++ b/klai-retrieval-api/tests/test_payload_util.py
@@ -1,4 +1,5 @@
 """Tests for retrieval_api.util.payload.payload_list (SPEC-CRAWLER-005 AC-04.1)."""
+
 from __future__ import annotations
 
 import pytest

--- a/klai-retrieval-api/tests/test_rate_limit_annotation.py
+++ b/klai-retrieval-api/tests/test_rate_limit_annotation.py
@@ -50,8 +50,8 @@ def test_rate_limit_fail_open_carries_mx_warn_annotation():
     # Find the fail-open except block (the one returning True, 0).
     fail_open_block = re.search(
         r"except\s+Exception:[^\n]*\n"  # except line
-        r"(?:[ \t]+[^\n]*\n)+"           # body lines
-        r"[ \t]+return\s+True,\s*0",     # ending in `return True, 0`
+        r"(?:[ \t]+[^\n]*\n)+"  # body lines
+        r"[ \t]+return\s+True,\s*0",  # ending in `return True, 0`
         src,
     )
     assert fail_open_block, (

--- a/klai-retrieval-api/tests/test_request_id_validation.py
+++ b/klai-retrieval-api/tests/test_request_id_validation.py
@@ -81,12 +81,12 @@ async def _dispatch_and_capture_context(headers: dict[str, str] | None) -> dict:
     [
         ("abc-123", True),
         ("plain_id", True),
-        ("A" * 128, True),                       # exactly at cap
-        ("A" * 129, False),                      # over cap → UUID
-        ("<script>", False),                     # invalid charset
-        ("\x1b[31mred\x1b[0m", False),           # ANSI escape
-        ("hello world", False),                  # space disallowed
-        ("rid;rm -rf /", False),                 # shell metacharacters
+        ("A" * 128, True),  # exactly at cap
+        ("A" * 129, False),  # over cap → UUID
+        ("<script>", False),  # invalid charset
+        ("\x1b[31mred\x1b[0m", False),  # ANSI escape
+        ("hello world", False),  # space disallowed
+        ("rid;rm -rf /", False),  # shell metacharacters
     ],
     ids=[
         "kebab-id",
@@ -117,9 +117,7 @@ async def test_request_id_validation(inbound: str, should_keep: bool):
             f"X-Request-ID {inbound!r} fails the regex / length cap and "
             f"must be replaced — got {request_id!r}"
         )
-        assert _UUID_RE.match(request_id), (
-            f"Replacement `request_id` is not a UUID: {request_id!r}"
-        )
+        assert _UUID_RE.match(request_id), f"Replacement `request_id` is not a UUID: {request_id!r}"
 
 
 async def test_request_id_oversized_garbage_does_not_pollute_context():
@@ -152,13 +150,13 @@ async def test_request_id_missing_or_empty_gets_uuid(missing_value: str | None):
     [
         ("42", True),
         ("0", True),
-        ("9" * 20, True),                        # exactly at cap
-        ("1" * 22, False),                       # over cap → drop
-        ("abc", False),                          # non-numeric
-        ("-5", False),                           # negative sign
-        ("3.14", False),                         # decimal
-        ("12 34", False),                        # space
-        ("<svg>", False),                        # HTML tag
+        ("9" * 20, True),  # exactly at cap
+        ("1" * 22, False),  # over cap → drop
+        ("abc", False),  # non-numeric
+        ("-5", False),  # negative sign
+        ("3.14", False),  # decimal
+        ("12 34", False),  # space
+        ("<svg>", False),  # HTML tag
     ],
     ids=[
         "small-int",

--- a/klai-retrieval-api/tests/test_reranker.py
+++ b/klai-retrieval-api/tests/test_reranker.py
@@ -12,8 +12,7 @@ from retrieval_api.services.reranker import rerank
 
 def _make_candidates(n: int) -> list[dict]:
     return [
-        {"chunk_id": f"c{i}", "text": f"Chunk {i} text", "score": 0.9 - i * 0.1}
-        for i in range(n)
+        {"chunk_id": f"c{i}", "text": f"Chunk {i} text", "score": 0.9 - i * 0.1} for i in range(n)
     ]
 
 

--- a/klai-retrieval-api/tests/test_search_error_handling.py
+++ b/klai-retrieval-api/tests/test_search_error_handling.py
@@ -104,9 +104,8 @@ def test_no_error_str_exc_anywhere_under_retrieval_api():
         if "error=str(exc)" in _strip_comments(_read(py)):
             offenders.append(str(py.relative_to(_REPO_ROOT)))
 
-    assert not offenders, (
-        "Files still using `error=str(exc)` (drops traceback): "
-        + ", ".join(offenders)
+    assert not offenders, "Files still using `error=str(exc)` (drops traceback): " + ", ".join(
+        offenders
     )
 
 
@@ -185,8 +184,7 @@ async def test_search_logs_exception_with_traceback_on_qdrant_failure(monkeypatc
         return {}
 
     qdrant_records = [
-        rec for rec in log_capture
-        if _event_dict(rec).get("event") == "qdrant_search_failed"
+        rec for rec in log_capture if _event_dict(rec).get("event") == "qdrant_search_failed"
     ]
     assert qdrant_records, (
         "Expected `qdrant_search_failed` log record, found none. "
@@ -194,8 +192,7 @@ async def test_search_logs_exception_with_traceback_on_qdrant_failure(monkeypatc
     )
 
     has_traceback = any(
-        "TimeoutError" in str(_event_dict(rec).get("exception", ""))
-        for rec in qdrant_records
+        "TimeoutError" in str(_event_dict(rec).get("exception", "")) for rec in qdrant_records
     )
     assert has_traceback, (
         "qdrant_search_failed log record has no rendered traceback in the "

--- a/klai-retrieval-api/tests/test_synthesis.py
+++ b/klai-retrieval-api/tests/test_synthesis.py
@@ -442,6 +442,8 @@ class TestSynthesize:
         async for item in synthesize("Wat staat er over Obsidian?", [], []):
             items.append(item)
 
-        assert items[0] == "Ik kan dit niet betrouwbaar beantwoorden op basis van de beschikbare kennisbronnen."
+        assert items[0] == (
+            "Ik kan dit niet betrouwbaar beantwoorden op basis van de beschikbare kennisbronnen."
+        )
         assert items[1]["citations"] == []
         assert items[1]["evidence_pack"]["no_citable_reason"] == "no_evidence"

--- a/klai-retrieval-api/tests/test_synthesis.py
+++ b/klai-retrieval-api/tests/test_synthesis.py
@@ -217,9 +217,7 @@ class TestBuildCitations:
         assert result[0]["index"] == 1
         assert result[0]["indices"] == [1, 2]
         assert result[0]["chunk_ids"] == ["c1", "c2"]
-        assert result[0]["source_url"] == (
-            "https://getklai.com/docs/company/steward-ownership"
-        )
+        assert result[0]["source_url"] == ("https://getklai.com/docs/company/steward-ownership")
         assert result[0]["relevance_score"] == 0.9
         assert result[1]["source_url"] == "https://getklai.com/docs/company/mission"
 

--- a/klai-retrieval-api/tests/test_taxonomy_filter.py
+++ b/klai-retrieval-api/tests/test_taxonomy_filter.py
@@ -7,6 +7,7 @@ Verifies that:
 - A non-empty list adds appropriate filters
 - Backward-compatible: OR filter matches both taxonomy_node_ids and taxonomy_node_id
 """
+
 from __future__ import annotations
 
 from retrieval_api.models import RetrieveRequest


### PR DESCRIPTION
## Why

`.github/workflows/retrieval-api.yml` had **zero** references to ruff. The config in `pyproject.toml` is complete and ruff is already in the dev deps — nothing ever ran it.

The config carries this comment:

> SPEC-SEC-HYGIENE-001 REQ-43.4: TRY rules added so future regressions of `logger.error(...)` inside `except` (TRY400) or `error=str(exc)`-style traceback dropping (TRY401) are caught in CI.

They were not caught in CI, because nothing checked. Same shape as the `rate_limit` bug fixed earlier today: present, assumed working, never wired up.

Scope note, to avoid overstating it: the two live TRY400 violations are both in `evaluation/eval_runner.py`, a standalone RAGAS script the service does not import. Production logging was never affected. The gap was in the guarantee, not in production behaviour.

## What

20 findings → 0; 21 of 97 files reformatted (own commit, so formatter noise stays separable).

**The two TRY400s** (`eval_runner.py:203` and `:271`) both convert `logger.error("... %s", exc)` → `logger.exception(...)`. Each catches any `Exception` around a retrieve call, where the traceback is exactly what tells you why an eval run failed. `exc` stays used for `results.append({"error": str(exc)})`. Dropping it from the message also avoids introducing a TRY401 — verified 0 hits with `--select TRY401`.

**S311** (`eval_runner.py:77`) is `random.uniform(0, 1)` as jitter on exponential backoff for rate-limited LLM calls. Timing only — it reaches no token, id, key or nonce. Isolated to its own variable with a reasoned noqa.

**B905** (`services/gate.py:88`) gets `strict=True`: `_cosine_similarity` compares a query embedding against reference vectors from the same TEI model, so a length mismatch means a real bug (e.g. cached reference vectors against a changed model) rather than something to silently truncate.

The rest: E501 reflowed, RUF002/003 ASCII-ised in docstrings and comments only, F401/I001/UP041 auto-fixed.

## Gate

Two steps in the existing `quality` job, matching this service's own `uv run --extra dev` convention — deliberately not copied from knowledge-ingest.yml, which uses `--frozen` and a `[dependency-groups]` layout that retrieval-api does not have.

## Verification

- `uv run ruff check .` → clean
- `uv run ruff format --check .` → 97/97 formatted
- `uv run pytest -q` → 587 passed, 1 skipped — identical to main

## Noted, not changed

`_cosine_similarity` in `router.py` uses `strict=False` while the `gate.py` twin now uses `strict=True`. Pre-existing inconsistency between two implementations of the same function; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)