### PR TITLE
chore(mailer,scribe-api): close the missing ruff format gate, and the drift it let in

### DIFF
--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Lint (ruff)
         run: uv run ruff check .
 
+      - name: Format check (ruff)
+        run: uv run ruff format --check .
+
       # --skip-editable keeps the gate on external deps; internal klai-libs are
       # editable path deps, not PyPI releases to query by distribution name.
       - name: Dependency vulnerability scan (pip-audit)

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Lint (ruff)
         run: uv run ruff check .
 
+      - name: Format check (ruff)
+        run: uv run ruff format --check .
+
       # --skip-editable keeps the gate on external deps; internal klai-libs are
       # editable path deps, not PyPI releases to query by distribution name.
       - name: Dependency vulnerability scan (pip-audit)

--- a/klai-mailer/app/models.py
+++ b/klai-mailer/app/models.py
@@ -23,6 +23,7 @@ class ContextInfo(BaseModel):
 
 class TemplateData(BaseModel):
     """Pre-rendered message text fields from Zitadel's configured message texts."""
+
     title: str | None = None
     preHeader: str | None = None
     subject: str | None = None
@@ -35,6 +36,7 @@ class TemplateData(BaseModel):
 
 class ZitadelArgs(BaseModel):
     """Raw event arguments sent alongside templateData."""
+
     Code: str | None = None
     Expiry: str | None = None
     ApplicationName: str | None = None
@@ -68,4 +70,3 @@ class ZitadelPayload(BaseModel):
 
     def footer_note(self) -> str:
         return (self.templateData and self.templateData.footerText) or ""
-

--- a/klai-mailer/app/renderer.py
+++ b/klai-mailer/app/renderer.py
@@ -43,6 +43,7 @@ def _append_lang_to_url(url: str, lang: str | None) -> str:
     separator = "&" if "?" in url else "?"
     return f"{url}{separator}lang={lang}"
 
+
 # Inline styles injected on plain-text-to-HTML converted elements.
 # Applied via regex so they survive Outlook's CSS stripping.
 _ELEMENT_STYLES: list[tuple[str, str]] = [
@@ -155,8 +156,6 @@ class Renderer:
         # remaining content is the body HTML. The separator is a blank line.
         if rendered.startswith("Subject:"):
             first_line, _, body = rendered.partition("\n")
-            subject = first_line[len("Subject:"):].strip()
+            subject = first_line[len("Subject:") :].strip()
             return {"subject": subject, "body": body.lstrip()}
-        raise ValueError(
-            f"internal template {template_path} must start with `Subject: <line>\\n`"
-        )
+        raise ValueError(f"internal template {template_path} must start with `Subject: <line>\\n`")

--- a/klai-mailer/app/schemas.py
+++ b/klai-mailer/app/schemas.py
@@ -56,7 +56,6 @@ class JoinRequestApprovedVars(_BaseVars):
     workspace_url: HttpUrl
 
 
-
 class AutoJoinAdminNotificationVars(_BaseVars):
     """Variables for the `auto_join_admin_notification` email.
 

--- a/klai-mailer/app/signature.py
+++ b/klai-mailer/app/signature.py
@@ -43,14 +43,16 @@ class SignatureError(Exception):
     not returned — see REQ-7.2.
     """
 
-    REASONS = frozenset({
-        "missing_header",
-        "malformed_header",
-        "timestamp_out_of_window",
-        "hmac_mismatch",
-        "unknown_vN_field",
-        "replay",
-    })
+    REASONS = frozenset(
+        {
+            "missing_header",
+            "malformed_header",
+            "timestamp_out_of_window",
+            "hmac_mismatch",
+            "unknown_vN_field",
+            "replay",
+        }
+    )
 
     def __init__(self, reason: str, *, extra: dict[str, Any] | None = None) -> None:
         if reason not in self.REASONS:

--- a/klai-mailer/tests/conftest.py
+++ b/klai-mailer/tests/conftest.py
@@ -51,10 +51,19 @@ def settings_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Start from an empty env so per-test monkeypatch.setenv is deterministic."""
     for key in list(os.environ):
-        if key in DEFAULT_TEST_ENV or key.startswith((
-            "SMTP_", "WEBHOOK_", "INTERNAL_", "BRAND_", "LOGO_",
-            "PORTAL_", "REDIS_", "DEBUG", "MAILER_",
-        )):
+        if key in DEFAULT_TEST_ENV or key.startswith(
+            (
+                "SMTP_",
+                "WEBHOOK_",
+                "INTERNAL_",
+                "BRAND_",
+                "LOGO_",
+                "PORTAL_",
+                "REDIS_",
+                "DEBUG",
+                "MAILER_",
+            )
+        ):
             monkeypatch.delenv(key, raising=False)
 
 
@@ -76,11 +85,13 @@ class StubSMTPSender:
         subject: str,
         html_body: str,
     ) -> None:
-        self.sent.append({
-            "to_address": to_address,
-            "subject": subject,
-            "html_body": html_body,
-        })
+        self.sent.append(
+            {
+                "to_address": to_address,
+                "subject": subject,
+                "html_body": html_body,
+            }
+        )
 
     def reset(self) -> None:
         self.sent.clear()
@@ -97,10 +108,12 @@ def stub_smtp(monkeypatch: pytest.MonkeyPatch) -> StubSMTPSender:
     stub = StubSMTPSender()
     # Patch source module
     import app.mailer as mailer_module
+
     monkeypatch.setattr(mailer_module, "send_email", stub, raising=True)
     # Patch the re-export used by main.py (only if main is already imported)
     try:
         import app.main as main_module
+
         if hasattr(main_module, "send_email"):
             monkeypatch.setattr(main_module, "send_email", stub, raising=False)
     except ImportError:

--- a/klai-mailer/tests/test_debug_gate.py
+++ b/klai-mailer/tests/test_debug_gate.py
@@ -29,11 +29,13 @@ def _fresh_app(monkeypatch, **env_overrides: str):
     import fakeredis.aioredis
 
     import app.nonce as nonce_mod
+
     client = fakeredis.aioredis.FakeRedis(decode_responses=False)
     nonce_mod.set_redis_client(client)
     main = importlib.import_module("app.main")
     # re-apply (main re-imports nonce)
     import app.nonce as nonce_after
+
     nonce_after.set_redis_client(client)
     return main
 
@@ -41,9 +43,11 @@ def _fresh_app(monkeypatch, **env_overrides: str):
 @pytest.fixture
 def in_env(monkeypatch, settings_env, stub_smtp):
     """Yield a factory that produces a TestClient with `portal_env` + `debug` overridden."""
+
     def _build(portal_env: str, debug: str) -> tuple[TestClient, object]:
         main = _fresh_app(monkeypatch, PORTAL_ENV=portal_env, DEBUG=debug)
         return TestClient(main.app), main
+
     return _build
 
 
@@ -58,9 +62,7 @@ def test_production_env_returns_404_even_with_debug_true(in_env, settings_env):
 
     header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
     with capture_logs() as events:
-        resp = client.post(
-            "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
-        )
+        resp = client.post("/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header})
 
     assert resp.status_code == 404
     assert resp.json() == {"detail": "Not found"}
@@ -69,8 +71,7 @@ def test_production_env_returns_404_even_with_debug_true(in_env, settings_env):
     # mailer_debug_* or signature events). FastAPI's default 404 is a plain
     # HTTP response, not an application event.
     relevant_events = [
-        e for e in events
-        if (e.get("event") or "").startswith(("mailer_debug", "mailer_signature"))
+        e for e in events if (e.get("event") or "").startswith(("mailer_debug", "mailer_signature"))
     ]
     assert relevant_events == [], f"unexpected app events: {relevant_events}"
 
@@ -79,9 +80,7 @@ def test_development_debug_true_works(in_env, settings_env):
     """Sanity: PORTAL_ENV=development, DEBUG=true → /debug returns 200."""
     client, _ = in_env(portal_env="development", debug="true")
     header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
-    resp = client.post(
-        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
-    )
+    resp = client.post("/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header})
     assert resp.status_code == 200, resp.text
 
 
@@ -89,9 +88,7 @@ def test_development_debug_false_returns_404(in_env, settings_env):
     """REQ-5.2 legacy: PORTAL_ENV=development, DEBUG=false → 404."""
     client, _ = in_env(portal_env="development", debug="false")
     header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
-    resp = client.post(
-        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
-    )
+    resp = client.post("/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header})
     assert resp.status_code == 404
 
 
@@ -99,9 +96,7 @@ def test_staging_debug_true_works(in_env, settings_env):
     """Staging is NOT production — the gate only blocks the production value."""
     client, _ = in_env(portal_env="staging", debug="true")
     header, _ = sign(VALID_BODY, settings_env["WEBHOOK_SECRET"])
-    resp = client.post(
-        "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header}
-    )
+    resp = client.post("/debug", content=VALID_BODY, headers={"ZITADEL-Signature": header})
     assert resp.status_code == 200, resp.text
 
 
@@ -115,9 +110,7 @@ def test_signature_verify_not_called_in_production(in_env, settings_env):
     client, _ = in_env(portal_env="production", debug="true")
     bad_header = "t=1,v1=deadbeef"
     with capture_logs() as events:
-        resp = client.post(
-            "/debug", content=VALID_BODY, headers={"ZITADEL-Signature": bad_header}
-        )
+        resp = client.post("/debug", content=VALID_BODY, headers={"ZITADEL-Signature": bad_header})
     assert resp.status_code == 404
     sig_events = [e for e in events if (e.get("event") or "").startswith("mailer_signature")]
     assert sig_events == [], f"signature check ran in production: {sig_events}"

--- a/klai-mailer/tests/test_internal_send_auth.py
+++ b/klai-mailer/tests/test_internal_send_auth.py
@@ -20,6 +20,7 @@ def _get_client(settings_env, stub_smtp):
     # Fresh import so REQ-9 validator and REQ-8 compare_digest land in the module
     import importlib
     import sys
+
     for mod in ("app.main", "app.config"):
         sys.modules.pop(mod, None)
     main = importlib.import_module("app.main")

--- a/klai-mailer/tests/test_internal_send_golden.py
+++ b/klai-mailer/tests/test_internal_send_golden.py
@@ -58,11 +58,13 @@ def _load_main(fake_redis):
         sys.modules.pop(mod, None)
     import app.nonce as nonce_mod
     import app.rate_limit as rl_mod
+
     nonce_mod.set_redis_client(fake_redis)
     rl_mod.set_redis_client(fake_redis)
     main = importlib.import_module("app.main")
     import app.nonce as n
     import app.rate_limit as r
+
     n.set_redis_client(fake_redis)
     r.set_redis_client(fake_redis)
     return main

--- a/klai-mailer/tests/test_internal_send_rate_limit.py
+++ b/klai-mailer/tests/test_internal_send_rate_limit.py
@@ -23,11 +23,13 @@ def _load_main(redis_client):
         sys.modules.pop(mod, None)
     import app.nonce as nonce_mod
     import app.rate_limit as rl_mod
+
     nonce_mod.set_redis_client(redis_client)
     rl_mod.set_redis_client(redis_client)
     main = importlib.import_module("app.main")
     import app.nonce as n
     import app.rate_limit as r
+
     n.set_redis_client(redis_client)
     r.set_redis_client(redis_client)
     return main
@@ -158,9 +160,7 @@ def test_case_insensitive_collision(client_fakeredis, stub_smtp):
         assert resp.status_code == 429
 
 
-def test_redis_unavailable_fails_open(
-    client_brokenredis, stub_smtp, portal_ok, broken_redis
-):
+def test_redis_unavailable_fails_open(client_brokenredis, stub_smtp, portal_ok, broken_redis):
     """REQ-4.3: Redis down → allow sends, log mailer_rate_limit_redis_unavailable."""
     with capture_logs() as events:
         # Go past the normal ceiling — must all succeed
@@ -172,15 +172,11 @@ def test_redis_unavailable_fails_open(
             )
             assert resp.status_code == 200, resp.text
 
-    unavail_events = [
-        e for e in events if e.get("event") == "mailer_rate_limit_redis_unavailable"
-    ]
+    unavail_events = [e for e in events if e.get("event") == "mailer_rate_limit_redis_unavailable"]
     assert unavail_events, "expected fail-open warning log"
 
 
-def test_failed_validation_does_not_deplete_budget(
-    client_fakeredis, stub_smtp, portal_ok
-):
+def test_failed_validation_does_not_deplete_budget(client_fakeredis, stub_smtp, portal_ok):
     """REQ-4.5: schema-invalid requests MUST NOT count toward the budget."""
     # 10 invalid requests (missing org_id)
     bad_payload = {

--- a/klai-mailer/tests/test_internal_send_sandbox.py
+++ b/klai-mailer/tests/test_internal_send_sandbox.py
@@ -22,11 +22,13 @@ def _load_main(settings_env, fake_redis, stub_smtp):
         sys.modules.pop(mod, None)
     import app.nonce as nonce_mod
     import app.rate_limit as rl_mod
+
     nonce_mod.set_redis_client(fake_redis)
     rl_mod.set_redis_client(fake_redis)
     main = importlib.import_module("app.main")
     import app.nonce as n
     import app.rate_limit as r
+
     n.set_redis_client(fake_redis)
     r.set_redis_client(fake_redis)
     return main
@@ -42,9 +44,9 @@ def client(settings_env, fake_redis, stub_smtp):
 def respx_mock_portal(settings_env):
     """Mock portal-api admin-email lookup."""
     with respx.mock(assert_all_called=False) as router:
-        router.get(
-            url__regex=r"^.+/internal/org/\d+/admin-email$"
-        ).mock(return_value=httpx.Response(200, json={"admin_email": "admin@test.example"}))
+        router.get(url__regex=r"^.+/internal/org/\d+/admin-email$").mock(
+            return_value=httpx.Response(200, json={"admin_email": "admin@test.example"})
+        )
         yield router
 
 
@@ -162,9 +164,7 @@ def test_unknown_template_returns_400(client, respx_mock_portal, stub_smtp):
     assert "Unknown template" in resp.json()["detail"]
 
 
-def test_branding_not_overridable_by_caller(
-    client, respx_mock_portal, stub_smtp, settings_env
-):
+def test_branding_not_overridable_by_caller(client, respx_mock_portal, stub_smtp, settings_env):
     """REQ-2.4: `brand_url` comes from settings even if caller tries to
     inject it via `variables`. The extra key is rejected outright by
     extra=forbid."""
@@ -219,16 +219,17 @@ def test_sandbox_blocks_dunder_via_template_context(client, respx_mock_portal):
     renderer itself blocks dunder access."""
     import importlib as _il
     import sys as _sys
+
     for mod in ("app.renderer", "app.config"):
         _sys.modules.pop(mod, None)
     renderer_mod = _il.import_module("app.renderer")
     from pathlib import Path
-    r = renderer_mod.Renderer(
-        theme_dir=Path("theme")
-    )
+
+    r = renderer_mod.Renderer(theme_dir=Path("theme"))
     # Write a tiny template that tries dunder access — use Renderer's
     # env directly
     template = r._theme_env.from_string("{{ x.__class__ }}")
     from jinja2.exceptions import SecurityError
+
     with pytest.raises(SecurityError):
         template.render(x="test")

--- a/klai-mailer/tests/test_notify_error_taxonomy.py
+++ b/klai-mailer/tests/test_notify_error_taxonomy.py
@@ -75,9 +75,7 @@ def test_uniform_401_body_across_failure_modes(client, failure_cases):
 
     first = bodies[0]
     for i, b in enumerate(bodies[1:], start=1):
-        assert b == first, (
-            f"body-{i} differs from body-0: {b!r} vs {first!r}"
-        )
+        assert b == first, f"body-{i} differs from body-0: {b!r} vs {first!r}"
     assert json.loads(first) == {"detail": "invalid signature"}
 
 
@@ -98,18 +96,13 @@ def test_log_reason_distinct_per_mode(client, failure_cases, captured_logs):
         captured_logs.clear()
         resp = client.post("/notify", content=VALID_BODY, headers=headers)
         assert resp.status_code == 401
-        sig_events = [
-            e for e in captured_logs
-            if e.get("event") == "mailer_signature_invalid"
-        ]
+        sig_events = [e for e in captured_logs if e.get("event") == "mailer_signature_invalid"]
         assert sig_events, (
-            f"no mailer_signature_invalid event for {expected_reason}; "
-            f"captured: {captured_logs}"
+            f"no mailer_signature_invalid event for {expected_reason}; captured: {captured_logs}"
         )
         reasons = [e.get("reason") for e in sig_events]
         assert expected_reason in reasons, (
-            f"expected reason={expected_reason!r} for headers={headers}, "
-            f"got reasons={reasons}"
+            f"expected reason={expected_reason!r} for headers={headers}, got reasons={reasons}"
         )
         reasons_seen.append(expected_reason)
 

--- a/klai-mailer/tests/test_notify_replay.py
+++ b/klai-mailer/tests/test_notify_replay.py
@@ -31,10 +31,12 @@ def _load_main_with_redis(redis_client):
     for mod in ("app.main", "app.nonce", "app.signature"):
         sys.modules.pop(mod, None)
     import app.nonce as nonce_mod
+
     nonce_mod.set_redis_client(redis_client)
     main = importlib.import_module("app.main")
     # main.py imports nonce; ensure its reference is also patched
     import app.nonce as nonce_after
+
     nonce_after.set_redis_client(redis_client)
     return main
 
@@ -67,7 +69,8 @@ async def test_first_call_accepted_second_is_replay(client_with_fakeredis, setti
     assert resp2.status_code == 401
     assert resp2.json() == {"detail": "invalid signature"}
     replay_events = [
-        e for e in events
+        e
+        for e in events
         if e.get("event") == "mailer_signature_invalid" and e.get("reason") == "replay"
     ]
     assert replay_events, f"expected reason=replay log event; got {events}"
@@ -125,9 +128,7 @@ async def test_nonce_not_polluted_by_forged_signatures(
 
     # Forged: same timestamp, bogus v1
     forged = f"t={ts},v1=deadbeef"
-    resp_forged = client.post(
-        "/notify", content=VALID_BODY, headers={"ZITADEL-Signature": forged}
-    )
+    resp_forged = client.post("/notify", content=VALID_BODY, headers={"ZITADEL-Signature": forged})
     assert resp_forged.status_code == 401
 
     # Legitimate: real v1 for same body+timestamp — must be accepted

--- a/klai-scribe/scribe-api/alembic/versions/0001_create_scribe_schema.py
+++ b/klai-scribe/scribe-api/alembic/versions/0001_create_scribe_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2026-03-11 00:00:00.000000
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0002_fix_id_varchar_length.py
+++ b/klai-scribe/scribe-api/alembic/versions/0002_fix_id_varchar_length.py
@@ -8,6 +8,7 @@ txn_id is generated as "txn_" + uuid4().hex = 4 + 32 = 36 chars.
 The original migration defined id as VARCHAR(32), which is too short.
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0003_add_name_to_transcriptions.py
+++ b/klai-scribe/scribe-api/alembic/versions/0003_add_name_to_transcriptions.py
@@ -8,6 +8,7 @@ Optional user-provided name for a transcription (e.g. "Verkoopgesprek Jan").
 Nullable so existing rows remain valid.
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0004_add_summary_to_transcriptions.py
+++ b/klai-scribe/scribe-api/alembic/versions/0004_add_summary_to_transcriptions.py
@@ -9,6 +9,7 @@ NULL means the transcription has never been summarized.
 summary_json.type stores the recording type used for summarization.
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0005_add_segments_and_recording_type.py
+++ b/klai-scribe/scribe-api/alembic/versions/0005_add_segments_and_recording_type.py
@@ -8,6 +8,7 @@ Adds nullable recording_type (VARCHAR(32)) and segments_json (JSON)
 columns to scribe.transcriptions.
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0006_add_audio_path_and_status.py
+++ b/klai-scribe/scribe-api/alembic/versions/0006_add_audio_path_and_status.py
@@ -9,6 +9,7 @@ the record stays with status='failed' and the audio file is retained for
 retry. Columns that are only populated after successful transcription
 (text, language, duration, etc.) become nullable.
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0007_add_error_reason.py
+++ b/klai-scribe/scribe-api/alembic/versions/0007_add_error_reason.py
@@ -9,6 +9,7 @@ flips `status='processing'` rows older than the timeout to `failed` with
 `error_reason='worker_restart_stranded'`. Existing legitimate transitions
 to `failed` (whisper error during transcribe) leave `error_reason` NULL.
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
+++ b/klai-scribe/scribe-api/alembic/versions/0008_add_org_id_to_transcriptions.py
@@ -8,6 +8,7 @@ Scribe rows were historically scoped only by Zitadel user id. This adds an
 explicit tenant dimension and backfills it from portal membership so every
 user-facing transcription query can require both user_id and org_id.
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/klai-scribe/scribe-api/app/api/health.py
+++ b/klai-scribe/scribe-api/app/api/health.py
@@ -8,6 +8,7 @@ SPEC-SEC-HYGIENE-001 REQ-37.2 — error responses MUST NOT leak the internal
 whisper URL or exception detail. Generic 503 + opaque body; full traceback
 goes to structlog only.
 """
+
 from __future__ import annotations
 
 import httpx

--- a/klai-scribe/scribe-api/app/api/internal.py
+++ b/klai-scribe/scribe-api/app/api/internal.py
@@ -46,9 +46,7 @@ async def wipe_org_state(
 
     async with AsyncSessionLocal() as session:
         result = await session.execute(
-            select(Transcription.audio_path)
-            .where(Transcription.org_id == org_id)
-            .with_for_update()
+            select(Transcription.audio_path).where(Transcription.org_id == org_id).with_for_update()
         )
         audio_paths = [path for path in result.scalars().all() if path]
 

--- a/klai-scribe/scribe-api/app/api/transcribe.py
+++ b/klai-scribe/scribe-api/app/api/transcribe.py
@@ -10,6 +10,7 @@ Transcription API endpoints:
   POST /v1/transcriptions/{id}/summarize - AI summarization
   POST /v1/transcriptions/{id}/ingest    - ingest into knowledge base
 """
+
 import asyncio
 import logging
 import uuid
@@ -49,6 +50,7 @@ _FORCE_SUMMARY = Query(default=False)
 
 
 # -- Response models -----------------------------------------------------------
+
 
 class TranscriptionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -127,9 +129,7 @@ def _to_response(record: Transcription) -> TranscriptionResponse:
         language=record.language,
         duration_seconds=float(record.duration_seconds) if record.duration_seconds else None,
         inference_time_seconds=(
-            float(record.inference_time_seconds)
-            if record.inference_time_seconds
-            else None
+            float(record.inference_time_seconds) if record.inference_time_seconds else None
         ),
         summary_json=record.summary_json,
         created_at=record.created_at,
@@ -154,6 +154,7 @@ def _caller_transcription_filters(caller: CallerIdentity):
 
 
 # -- POST /v1/transcribe ------------------------------------------------------
+
 
 @router.post("/transcribe", response_model=TranscriptionResponse, status_code=201)
 async def transcribe(
@@ -243,6 +244,7 @@ async def transcribe(
 
 # -- POST /v1/transcriptions/{id}/retry ----------------------------------------
 
+
 @router.post("/transcriptions/{txn_id}/retry", response_model=TranscriptionResponse)
 async def retry_transcription(
     txn_id: str,
@@ -305,6 +307,7 @@ async def retry_transcription(
 
 # -- GET /v1/transcriptions ----------------------------------------------------
 
+
 @router.get("/transcriptions", response_model=TranscriptionListResponse)
 async def list_transcriptions(
     limit: int = _LIST_LIMIT,
@@ -313,7 +316,9 @@ async def list_transcriptions(
     db: AsyncSession = _DB,
 ) -> TranscriptionListResponse:
     total_result = await db.execute(
-        select(func.count()).select_from(Transcription).where(*_caller_transcription_filters(caller))
+        select(func.count())
+        .select_from(Transcription)
+        .where(*_caller_transcription_filters(caller))
     )
     total = total_result.scalar_one()
 
@@ -346,6 +351,7 @@ async def list_transcriptions(
 
 # -- GET /v1/transcriptions/{id} -----------------------------------------------
 
+
 @router.get("/transcriptions/{txn_id}", response_model=TranscriptionResponse)
 async def get_transcription(
     txn_id: str,
@@ -366,6 +372,7 @@ async def get_transcription(
 
 
 # -- PATCH /v1/transcriptions/{id} ---------------------------------------------
+
 
 @router.patch("/transcriptions/{txn_id}", response_model=TranscriptionResponse)
 async def patch_transcription(
@@ -394,6 +401,7 @@ async def patch_transcription(
 
 # -- DELETE /v1/transcriptions/{id} --------------------------------------------
 
+
 @router.delete("/transcriptions/{txn_id}", status_code=204)
 async def delete_transcription(
     txn_id: str,
@@ -413,13 +421,12 @@ async def delete_transcription(
     # Clean up audio file (legacy records that still have audio at time of delete)
     delete_audio(record.audio_path)
 
-    await db.execute(
-        delete(Transcription).where(*_owned_transcription_filters(txn_id, caller))
-    )
+    await db.execute(delete(Transcription).where(*_owned_transcription_filters(txn_id, caller)))
     await db.commit()
 
 
 # -- POST /v1/transcriptions/{id}/summarize ------------------------------------
+
 
 @router.post("/transcriptions/{txn_id}/summarize", response_model=SummarizeResponse)
 async def summarize_transcription(
@@ -471,6 +478,7 @@ async def summarize_transcription(
 
 
 # -- POST /v1/transcriptions/{id}/ingest --------------------------------------
+
 
 class IngestToKBRequest(BaseModel):
     """Body schema for transcription-to-KB ingest.

--- a/klai-scribe/scribe-api/app/main.py
+++ b/klai-scribe/scribe-api/app/main.py
@@ -30,9 +30,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # if that changes, consider an advisory lock or a leader election.
     try:
         async with AsyncSessionLocal() as session:
-            count = await reap_stranded(
-                session, timeout_min=settings.scribe_stranded_timeout_min
-            )
+            count = await reap_stranded(session, timeout_min=settings.scribe_stranded_timeout_min)
         if count:
             logger.warning("scribe_startup_reaped", count=count)
     except Exception:

--- a/klai-scribe/scribe-api/app/middleware/auth_guard.py
+++ b/klai-scribe/scribe-api/app/middleware/auth_guard.py
@@ -39,9 +39,7 @@ class AuthGuardMiddleware(BaseHTTPMiddleware):
     This guard only checks for *presence* of ``X-Internal-Secret``.
     """
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         path = request.url.path
 
         if path in _EXEMPT_PATHS or path.startswith(_EXEMPT_PREFIXES):

--- a/klai-scribe/scribe-api/app/services/audio.py
+++ b/klai-scribe/scribe-api/app/services/audio.py
@@ -5,6 +5,7 @@ Accepts raw upload bytes, validates format with python-magic,
 and converts to WAV 16 kHz mono int16 PCM using pydub + ffmpeg.
 Audio never touches disk outside the request lifecycle.
 """
+
 import io
 import logging
 

--- a/klai-scribe/scribe-api/app/services/audio_storage.py
+++ b/klai-scribe/scribe-api/app/services/audio_storage.py
@@ -8,6 +8,7 @@ Retention policy:
 
 Invariant: only `failed` records should have an audio file on disk at rest.
 """
+
 from __future__ import annotations
 
 import re
@@ -64,9 +65,7 @@ def _safe_audio_path(base: Path, user_id: str, txn_id: str) -> Path:
     base_resolved = base.resolve()
     candidate = (base_resolved / user_id / f"{txn_id}.wav").resolve()
     if not candidate.is_relative_to(base_resolved):
-        raise ValueError(
-            f"invalid audio path: {user_id!r}/{txn_id!r} escapes base"
-        )
+        raise ValueError(f"invalid audio path: {user_id!r}/{txn_id!r} escapes base")
     return candidate
 
 

--- a/klai-scribe/scribe-api/app/services/janitor.py
+++ b/klai-scribe/scribe-api/app/services/janitor.py
@@ -12,6 +12,7 @@ by any `transcriptions.audio_path` and removes them after a grace period.
 The grace period exists so that an in-flight save (file written, row not
 yet inserted) does not get clobbered.
 """
+
 from __future__ import annotations
 
 import os

--- a/klai-scribe/scribe-api/app/services/knowledge_adapter.py
+++ b/klai-scribe/scribe-api/app/services/knowledge_adapter.py
@@ -3,6 +3,7 @@ Scribe knowledge adapter.
 Ingests a scribe transcription into the klai knowledge pipeline
 by calling knowledge-ingest POST /ingest/v1/document.
 """
+
 from __future__ import annotations
 
 import logging

--- a/klai-scribe/scribe-api/app/services/providers.py
+++ b/klai-scribe/scribe-api/app/services/providers.py
@@ -8,6 +8,7 @@ Calls the Vexa transcription-service (OpenAI-compatible) with
 and yield to real-time meeting traffic (tier=realtime reserved slots).
 On HTTP 503 we honour ``Retry-After`` up to `_MAX_RETRIES` attempts.
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/klai-scribe/scribe-api/app/services/reaper.py
+++ b/klai-scribe/scribe-api/app/services/reaper.py
@@ -12,6 +12,7 @@ still possible.
 
 SPEC-SEC-HYGIENE-001 REQ-35.
 """
+
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta

--- a/klai-scribe/scribe-api/tests/conftest.py
+++ b/klai-scribe/scribe-api/tests/conftest.py
@@ -4,6 +4,7 @@ Sets required env vars BEFORE `app.core.config.Settings` is instantiated at
 module import time. pytest-asyncio is configured to auto mode in
 pyproject.toml, so async tests run without per-function markers.
 """
+
 from __future__ import annotations
 
 import os

--- a/klai-scribe/scribe-api/tests/test_audio_path_safety.py
+++ b/klai-scribe/scribe-api/tests/test_audio_path_safety.py
@@ -4,6 +4,7 @@ Defense-in-depth partner of HY-34 (sub regex). Even if a future auth flow
 returns a malformed `sub`, the path helper MUST refuse to escape the audio
 base directory. See SPEC-SEC-HYGIENE-001 REQ-33.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -14,11 +15,12 @@ import pytest
 # _safe_audio_path(base, user_id, txn_id) — REQ-33.1
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "user_id,txn_id",
     [
         ("269462541789364226", "txn_a1b2c3"),  # Normal Zitadel sub + UUID
-        ("X", "txn_short"),                    # Boundary: minimal
+        ("X", "txn_short"),  # Boundary: minimal
     ],
 )
 def test_safe_audio_path_normal(tmp_path: Path, user_id: str, txn_id: str) -> None:
@@ -36,19 +38,17 @@ def test_safe_audio_path_normal(tmp_path: Path, user_id: str, txn_id: str) -> No
 @pytest.mark.parametrize(
     "user_id,txn_id",
     [
-        ("../../../etc/passwd", "txn_a1"),    # Path traversal in user_id
-        ("../evil", "txn_a1"),                # Relative escape
-        ("/absolute/path", "txn_a1"),         # Absolute path attempt
-        ("..\\win", "txn_a1"),                # Windows-style traversal
-        ("user.with.dot", "txn_a1"),          # Defense-in-depth (HY-34 also rejects)
-        ("", "txn_a1"),                       # Empty user_id
-        ("user", ""),                         # Empty txn_id
-        ("user", "../etc"),                   # Traversal in txn_id
+        ("../../../etc/passwd", "txn_a1"),  # Path traversal in user_id
+        ("../evil", "txn_a1"),  # Relative escape
+        ("/absolute/path", "txn_a1"),  # Absolute path attempt
+        ("..\\win", "txn_a1"),  # Windows-style traversal
+        ("user.with.dot", "txn_a1"),  # Defense-in-depth (HY-34 also rejects)
+        ("", "txn_a1"),  # Empty user_id
+        ("user", ""),  # Empty txn_id
+        ("user", "../etc"),  # Traversal in txn_id
     ],
 )
-def test_safe_audio_path_rejects_traversal(
-    tmp_path: Path, user_id: str, txn_id: str
-) -> None:
+def test_safe_audio_path_rejects_traversal(tmp_path: Path, user_id: str, txn_id: str) -> None:
     from app.services.audio_storage import _safe_audio_path
 
     base = tmp_path / "audio_base"
@@ -61,6 +61,7 @@ def test_safe_audio_path_rejects_traversal(
 # ---------------------------------------------------------------------------
 # _safe_stored_path(base, rel) — REQ-33.2 helper for read / delete
 # ---------------------------------------------------------------------------
+
 
 def test_safe_stored_path_normal(tmp_path: Path) -> None:
     from app.services.audio_storage import _safe_stored_path
@@ -96,6 +97,7 @@ def test_safe_stored_path_rejects_traversal(tmp_path: Path, rel: str) -> None:
 # ---------------------------------------------------------------------------
 # save_audio integration — REQ-33.2 reroute confirmation
 # ---------------------------------------------------------------------------
+
 
 def test_save_audio_rejects_malformed_user_id(tmp_path: Path, monkeypatch) -> None:
     """save_audio MUST route through _safe_audio_path and refuse traversal."""

--- a/klai-scribe/scribe-api/tests/test_audio_retention.py
+++ b/klai-scribe/scribe-api/tests/test_audio_retention.py
@@ -8,6 +8,7 @@ WAV from 2026-04-10 still present on production.
 Policy (stated by product owner 2026-04-21): audio must be removed as soon as
 transcription succeeds. Audio is retained on `failed` status so retry can replay.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock

--- a/klai-scribe/scribe-api/tests/test_cors_annotation.py
+++ b/klai-scribe/scribe-api/tests/test_cors_annotation.py
@@ -7,6 +7,7 @@ exposes scribe to browsers triggers a review against SPEC-SEC-CORS-001.
 
 See SPEC-SEC-HYGIENE-001 REQ-38.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -49,10 +50,9 @@ def test_cors_mx_reason_mentions_back_end_only() -> None:
     preceding = src[:cors_idx]
     preceding_window = "\n".join(preceding.splitlines()[-25:]).lower()
 
-    assert (
-        "back-end-only" in preceding_window
-        or "not browser-reachable" in preceding_window
-    ), "@MX:REASON must mention 'back-end-only' or 'not browser-reachable'"
+    assert "back-end-only" in preceding_window or "not browser-reachable" in preceding_window, (
+        "@MX:REASON must mention 'back-end-only' or 'not browser-reachable'"
+    )
 
 
 def test_cors_mx_reason_references_spec() -> None:
@@ -64,6 +64,5 @@ def test_cors_mx_reason_references_spec() -> None:
     preceding_window = "\n".join(preceding.splitlines()[-25:])
 
     assert (
-        "SPEC-SEC-HYGIENE-001 REQ-38" in preceding_window
-        or "SPEC-SEC-CORS-001" in preceding_window
+        "SPEC-SEC-HYGIENE-001 REQ-38" in preceding_window or "SPEC-SEC-CORS-001" in preceding_window
     )

--- a/klai-scribe/scribe-api/tests/test_finalize_order.py
+++ b/klai-scribe/scribe-api/tests/test_finalize_order.py
@@ -10,6 +10,7 @@ Two concerns covered here:
 
 See SPEC-SEC-HYGIENE-001 REQ-36.
 """
+
 from __future__ import annotations
 
 import time
@@ -22,6 +23,7 @@ import pytest
 # ---------------------------------------------------------------------------
 # REQ-36.1 — order: delete BEFORE mutate
 # ---------------------------------------------------------------------------
+
 
 class _FakeResult(SimpleNamespace):
     pass
@@ -66,8 +68,12 @@ def test_finalize_calls_delete_before_mutate(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr(audio_storage, "delete_audio", _spy_delete)
 
     result = _FakeResult(
-        text="hello", language="nl", duration_seconds=1.0,
-        inference_time_seconds=0.1, provider="whisper", model="m",
+        text="hello",
+        language="nl",
+        duration_seconds=1.0,
+        inference_time_seconds=0.1,
+        provider="whisper",
+        model="m",
     )
     audio_storage.finalize_success(record, result)
 
@@ -98,8 +104,12 @@ def test_finalize_aborts_on_delete_failure(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(audio_storage, "delete_audio", _failing_delete)
 
     result = _FakeResult(
-        text="hello", language="nl", duration_seconds=1.0,
-        inference_time_seconds=0.1, provider="whisper", model="m",
+        text="hello",
+        language="nl",
+        duration_seconds=1.0,
+        inference_time_seconds=0.1,
+        provider="whisper",
+        model="m",
     )
 
     with pytest.raises(PermissionError):
@@ -121,8 +131,12 @@ def test_finalize_with_no_audio_path(tmp_path: Path, monkeypatch) -> None:
 
     record = _make_record(audio_path=None)
     result = _FakeResult(
-        text="hello", language="nl", duration_seconds=1.0,
-        inference_time_seconds=0.1, provider="whisper", model="m",
+        text="hello",
+        language="nl",
+        duration_seconds=1.0,
+        inference_time_seconds=0.1,
+        provider="whisper",
+        model="m",
     )
     audio_storage.finalize_success(record, result)
 
@@ -133,6 +147,7 @@ def test_finalize_with_no_audio_path(tmp_path: Path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 # REQ-36.2 — janitor sweep
 # ---------------------------------------------------------------------------
+
 
 def _async_session_returning(referenced_paths: list[str]) -> AsyncMock:
     """Build an AsyncSession mock whose execute returns the given audio_paths."""
@@ -156,6 +171,7 @@ async def test_janitor_deletes_orphan_after_grace(tmp_path: Path) -> None:
     # Backdate mtime to 25 hours ago.
     old = time.time() - (25 * 3600)
     import os
+
     os.utime(orphan, (old, old))
 
     session = _async_session_returning([])  # No DB references
@@ -194,6 +210,7 @@ async def test_janitor_keeps_referenced_file(tmp_path: Path) -> None:
     kept.write_bytes(b"keep-data")
     old = time.time() - (25 * 3600)
     import os
+
     os.utime(kept, (old, old))
 
     session = _async_session_returning(["user1/keep.wav"])
@@ -250,6 +267,7 @@ async def test_janitor_mixed(tmp_path: Path) -> None:
     old_orphan.parent.mkdir(parents=True)
     old_orphan.write_bytes(b"old")
     import os
+
     old = time.time() - (25 * 3600)
     os.utime(old_orphan, (old, old))
     os.utime(referenced, (old, old))  # also old, but referenced — must keep.

--- a/klai-scribe/scribe-api/tests/test_health_safety.py
+++ b/klai-scribe/scribe-api/tests/test_health_safety.py
@@ -10,6 +10,7 @@ Two concerns covered here:
 
 See SPEC-SEC-HYGIENE-001 REQ-37.
 """
+
 from __future__ import annotations
 
 import json
@@ -22,6 +23,7 @@ from pydantic import ValidationError
 # ---------------------------------------------------------------------------
 # REQ-37.1 — Settings validator allowlist
 # ---------------------------------------------------------------------------
+
 
 def _build_settings(whisper_url: str):
     """Build a Settings instance with the given whisper_server_url override.
@@ -41,7 +43,7 @@ def _build_settings(whisper_url: str):
         "http://whisper-server:8000",
         "http://localhost:8000",
         "http://127.0.0.1:8000",
-        "http://172.18.0.1:8000",          # current prod default — see config.py
+        "http://172.18.0.1:8000",  # current prod default — see config.py
         "https://whisper.getklai.com",
         "https://transcription.getklai.com:8443/v1",
     ],
@@ -56,17 +58,17 @@ def test_whisper_url_accepted(url: str) -> None:
     [
         "http://evil.com/",
         "http://evil.com:8000/health",
-        "http://169.254.169.254/",         # AWS instance metadata
-        "http://10.0.0.5:8000",            # private RFC1918 — not in allowlist
+        "http://169.254.169.254/",  # AWS instance metadata
+        "http://10.0.0.5:8000",  # private RFC1918 — not in allowlist
         "http://192.168.1.1:8000",
         "http://internal-admin-api/health",
-        "http://whisper.evil.com/",        # subdomain trickery
+        "http://whisper.evil.com/",  # subdomain trickery
         "https://attacker.getklai.com.evil/",  # suffix bypass attempt
         "file:///etc/passwd",
         "ftp://whisper:8000/",
         "javascript:alert(1)",
-        "",                                # empty
-        "not-a-url-at-all",                # no scheme
+        "",  # empty
+        "not-a-url-at-all",  # no scheme
     ],
 )
 def test_whisper_url_rejected(url: str) -> None:
@@ -109,9 +111,7 @@ async def test_health_returns_503_on_connect_error_with_sanitised_body() -> None
     from app.api.health import health
 
     async def _connect_error(self, url, **kw):
-        raise httpx.ConnectError(
-            "http://whisper-internal-secret:8000/health: connection refused"
-        )
+        raise httpx.ConnectError("http://whisper-internal-secret:8000/health: connection refused")
 
     with patch.object(httpx.AsyncClient, "get", _connect_error):
         result = await health()

--- a/klai-scribe/scribe-api/tests/test_providers.py
+++ b/klai-scribe/scribe-api/tests/test_providers.py
@@ -6,6 +6,7 @@ Covers:
 - Three consecutive 503s raise HTTPException(503)
 - ConnectError is retried up to _MAX_RETRIES
 """
+
 from __future__ import annotations
 
 import httpx
@@ -47,6 +48,7 @@ def _patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
     """Don't actually wait during retries."""
+
     async def _instant(_: float) -> None:
         return None
 
@@ -95,6 +97,7 @@ class _FakeClient:
 @pytest.fixture
 def patch_client(monkeypatch: pytest.MonkeyPatch):
     """Replace httpx.AsyncClient with a scripted FakeClient."""
+
     def _install(script: list[httpx.Response | Exception]) -> _FakeClient:
         client = _FakeClient(script)
         monkeypatch.setattr(providers.httpx, "AsyncClient", lambda **_: client)
@@ -232,18 +235,20 @@ class TestPayloadFieldsAreOptional:
     async def test_missing_inference_time_seconds_does_not_raise(self, patch_client) -> None:
         # Whisper-server response observed live on 2026-05-03 — no
         # `inference_time_seconds` field present.
-        client = patch_client([
-            httpx.Response(
-                200,
-                json={
-                    "text": "",
-                    "language": "en",
-                    "language_probability": 0.6,
-                    "duration": 0.0,
-                    "segments": [],
-                },
-            )
-        ])
+        client = patch_client(
+            [
+                httpx.Response(
+                    200,
+                    json={
+                        "text": "",
+                        "language": "en",
+                        "language_probability": 0.6,
+                        "duration": 0.0,
+                        "segments": [],
+                    },
+                )
+            ]
+        )
 
         result = await WhisperHttpProvider().transcribe(b"audio", language=None)
 

--- a/klai-scribe/scribe-api/tests/test_sec_internal_001.py
+++ b/klai-scribe/scribe-api/tests/test_sec_internal_001.py
@@ -79,10 +79,9 @@ class TestKnowledgeAdapterNoSilentOmit:
         src = src_path.read_text(encoding="utf-8")
         # The unconditional shape: dict literal with X-Internal-Secret ->
         # settings.knowledge_ingest_secret.
-        assert (
-            'headers = {"X-Internal-Secret": settings.knowledge_ingest_secret}'
-            in src
-        ), "expected unconditional X-Internal-Secret header injection in knowledge_adapter.py"
+        assert 'headers = {"X-Internal-Secret": settings.knowledge_ingest_secret}' in src, (
+            "expected unconditional X-Internal-Secret header injection in knowledge_adapter.py"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/klai-scribe/scribe-api/tests/test_stranded_reaper.py
+++ b/klai-scribe/scribe-api/tests/test_stranded_reaper.py
@@ -7,6 +7,7 @@ assignment, audio_path preservation).
 
 See SPEC-SEC-HYGIENE-001 REQ-35.
 """
+
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
@@ -46,11 +47,11 @@ def _session_returning(records: list[SimpleNamespace]) -> AsyncMock:
 # REQ-35.1 — flip stranded rows to failed
 # ---------------------------------------------------------------------------
 
+
 async def test_reaper_flips_stranded_to_failed() -> None:
     from app.services import reaper
 
-    stranded = _record("txn_old", status="processing", minutes_ago=35,
-                       audio_path="user1/old.wav")
+    stranded = _record("txn_old", status="processing", minutes_ago=35, audio_path="user1/old.wav")
     session = _session_returning([stranded])
 
     flipped = await reaper.reap_stranded(session, timeout_min=30)
@@ -65,8 +66,9 @@ async def test_reaper_preserves_audio_path(caplog) -> None:
     """REQ-35.3 — reaper MUST NOT delete the underlying audio file."""
     from app.services import reaper
 
-    stranded = _record("txn_old", status="processing", minutes_ago=40,
-                       audio_path="user1/preserved.wav")
+    stranded = _record(
+        "txn_old", status="processing", minutes_ago=40, audio_path="user1/preserved.wav"
+    )
     session = _session_returning([stranded])
 
     await reaper.reap_stranded(session, timeout_min=30)
@@ -108,8 +110,7 @@ async def test_reaper_emits_structlog_event() -> None:
     """REQ-35.2 — every recovered row emits scribe_stranded_recovered with txn_id + age_minutes."""
     from app.services import reaper
 
-    stranded = _record("txn_logged", status="processing", minutes_ago=42,
-                       audio_path="u/x.wav")
+    stranded = _record("txn_logged", status="processing", minutes_ago=42, audio_path="u/x.wav")
     session = _session_returning([stranded])
 
     with structlog.testing.capture_logs() as cap_logs:


### PR DESCRIPTION
## Why

Both services run `ruff check` in CI but not `ruff format --check`. Formatting drifted accordingly, invisibly:

| service | lint | files needing reformat |
|---|---|---|
| klai-mailer | clean | 12 of 31 |
| klai-scribe/scribe-api | clean | **28 of 47** |

More than half of scribe-api was not formatted to its own formatter's output. Left alone this only grows, and whoever eventually runs `ruff format` gets a several-hundred-line diff riding along in an unrelated PR.

## What

`ruff format` applied per service (own commit each, so the two diffs review separately), then a `Format check (ruff)` step added next to the existing `Lint (ruff)` step in each workflow.

The command mirrors each workflow's own existing lint step (`uv run ruff format --check .`, no `--frozen`) rather than being copied across services — knowledge-ingest uses `[dependency-groups]` with `--frozen --extra dev`, which does not apply here.

## Verification

Formatting is claimed to be behaviour-neutral, so it is checked rather than assumed: every changed file's AST was parsed before and after and compared.

```
python files changed: 40
AST identical:        40
AST changed:           0
non-python in diff:   the two workflow files
```

Plus, per service: `ruff check` still clean, `ruff format --check` now clean, and tests identical — mailer 108 passed / 1 deselected, scribe-api 108 passed, before and after.

Mail templates specifically: the golden HTML fixtures under `klai-mailer/tests/fixtures/golden/` are untouched, and no `"""` line appears anywhere in the added/removed lines, so no multi-line string content moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)