### PR TITLE
chore(portal-api,connector): enable ruff ARG, and what it found

### DIFF
--- a/klai-connector/pyproject.toml
+++ b/klai-connector/pyproject.toml
@@ -76,8 +76,27 @@ target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "UP", "B", "SIM", "G", "LOG"]
+select = ["E", "F", "I", "N", "UP", "B", "SIM", "G", "LOG", "ARG"]
 ignore = ["B008"]  # Depends() in FastAPI endpoint defaults is standard pattern
+
+[tool.ruff.lint.per-file-ignores]
+# Unused arguments in tests are structural, not bugs: pytest fixtures are
+# injected for their side effect (not read), and mock/stub signatures must
+# mirror the real callable they replace even when a given test ignores some
+# parameters. Enforcing ARG here would force churn without catching anything.
+"tests/**" = ["ARG"]
+# BaseAdapter.list_documents/get_cursor_state/post_sync share one call
+# signature so sync_engine can invoke every adapter uniformly (see the
+# adapter-framework-bleed pitfall in .claude/rules/klai/pitfalls). Airtable
+# and Confluence are full-scan (no incremental cursor), so cursor_context is
+# unused there; both cursor-state methods just return a timestamp, so
+# connector is unused; the base class's post_sync default no-op takes
+# connector only to keep every override's signature identical.
+"app/adapters/airtable.py" = ["ARG002"]
+"app/adapters/base.py" = ["ARG002"]
+"app/adapters/confluence.py" = ["ARG002"]
+"app/adapters/github.py" = ["ARG002"]
+"app/adapters/notion.py" = ["ARG002"]
 
 [tool.pyright]
 pythonVersion = "3.12"

--- a/klai-portal/backend/app/api/admin/billing.py
+++ b/klai-portal/backend/app/api/admin/billing.py
@@ -186,8 +186,10 @@ async def per_seat_billing_status(
 
 @router.post("/billing/switch-to-per-seat", response_model=None)
 async def switch_to_per_seat_billing(
-    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
-    db: AsyncSession = Depends(get_db),
+    # perms/db: unread, but Depends() still runs the ADMIN auth gate below —
+    # see the docstring note on why the 501 sits behind that check.
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),  # noqa: ARG001
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001
 ) -> None:
     """Phase 5 light stub for the per-seat-type Moneybird migration.
 

--- a/klai-portal/backend/app/api/admin/products.py
+++ b/klai-portal/backend/app/api/admin/products.py
@@ -63,7 +63,7 @@ class EffectiveProductsResponse(BaseModel):
 @router.get("/products", response_model=ProductsResponse)
 async def list_available_products(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; ADMIN Depends() chain still gates the route
 ) -> ProductsResponse:
     """Return products available to the caller given (profile, seat_type, platform_unlocked_features).
 
@@ -132,18 +132,21 @@ async def get_user_effective_products(
 # ---------------------------------------------------------------------------
 
 
+# zitadel_user_id/product below: required in the signature so the path
+# template matches (FastAPI binds {zitadel_user_id}/{product} regardless of
+# whether the stub body reads them); the 410 body never needs the value.
 @router.post("/users/{zitadel_user_id}/products", status_code=status.HTTP_410_GONE)
-async def assign_product_gone(zitadel_user_id: str) -> dict:
+async def assign_product_gone(zitadel_user_id: str) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 
 @router.delete("/users/{zitadel_user_id}/products/{product}", status_code=status.HTTP_410_GONE)
-async def revoke_product_gone(zitadel_user_id: str, product: str) -> dict:
+async def revoke_product_gone(zitadel_user_id: str, product: str) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 
 @router.get("/users/{zitadel_user_id}/products", status_code=status.HTTP_410_GONE)
-async def get_user_products_gone(zitadel_user_id: str) -> dict:
+async def get_user_products_gone(zitadel_user_id: str) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 

--- a/klai-portal/backend/app/api/admin/settings.py
+++ b/klai-portal/backend/app/api/admin/settings.py
@@ -161,7 +161,7 @@ class AddonsOut(BaseModel):
 @router.get("/settings/addons", response_model=AddonsOut, deprecated=True)
 async def get_addons(
     perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; ADMIN Depends() chain still gates the route
 ) -> AddonsOut:
     """Read-only facade — returns the subset of platform_unlocked_features
     that are user-facing products (scribe/docs).

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -563,7 +563,7 @@ async def create_app_knowledge_base(
     if body.owner_type == "user":
         await assert_can_create_personal_kb(user_id=perms.user_id, org=org, db=db, role=perms.role)
     elif body.owner_type == "org":
-        await assert_can_create_org_kb(org=org, db=db, role=perms.role)
+        await assert_can_create_org_kb(org=org, role=perms.role)
 
     owner_user_id = perms.user_id if body.owner_type == "user" else None
 

--- a/klai-portal/backend/app/api/app_knowledge_sources.py
+++ b/klai-portal/backend/app/api/app_knowledge_sources.py
@@ -298,7 +298,7 @@ async def add_youtube_source(
     kb_slug: str,
     request: Request,
     perms: UserPermissions = Depends(get_caller),
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; kept only so the route keeps its normal auth Depends() chain
 ) -> dict[str, Any]:
     """SPEC-KB-YOUTUBE-REMOVE-001: removed route, returns HTTP 410 Gone.
 

--- a/klai-portal/backend/app/api/groups.py
+++ b/klai-portal/backend/app/api/groups.py
@@ -429,18 +429,21 @@ async def toggle_group_admin(
 # ---------------------------------------------------------------------------
 
 
+# group_id/product below: required in the signature so the path template
+# matches (FastAPI binds {group_id}/{product} regardless of whether the stub
+# body reads them); the 410 body never needs the value.
 @router.get("/groups/{group_id}/products", status_code=status.HTTP_410_GONE)
-async def list_group_products_gone(group_id: int) -> dict:
+async def list_group_products_gone(group_id: int) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 
 @router.post("/groups/{group_id}/products", status_code=status.HTTP_410_GONE)
-async def assign_group_product_gone(group_id: int) -> dict:
+async def assign_group_product_gone(group_id: int) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 
 @router.delete("/groups/{group_id}/products/{product}", status_code=status.HTTP_410_GONE)
-async def revoke_group_product_gone(group_id: int, product: str) -> dict:
+async def revoke_group_product_gone(group_id: int, product: str) -> dict:  # noqa: ARG001
     raise HTTPException(status_code=status.HTTP_410_GONE, detail=_GONE_BODY)
 
 

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -971,7 +971,7 @@ async def notify_page_saved(
     org_id: int,
     body: PageSavedNotification,
     request: Request,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; schedule_rescore() opens its own session via db_factory
 ) -> None:
     """Notify portal-api that a page was saved in a Klai-native KB.
 
@@ -2631,7 +2631,7 @@ class McpTokenVerifyDeny(BaseModel):
 async def verify_mcp_token(
     request: Request,
     body: McpTokenVerifyRequest,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; the handler opens its own cross_org_session() below
 ) -> Response:
     """Verify a klai_mcp_<...> bearer token, return verified identity tuple.
 

--- a/klai-portal/backend/app/api/mcp_oauth.py
+++ b/klai-portal/backend/app/api/mcp_oauth.py
@@ -418,7 +418,6 @@ async def authorize_get(
 
 @router.post("/oauth/authorize")
 async def authorize_post(
-    request: Request,
     request_id: str = Form(...),
     csrf_token: str = Form(...),
     decision: str = Form(...),

--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -537,7 +537,6 @@ class VexaWebhookPayload(BaseModel):
 def _correlate_speakers(
     segments: list[dict],
     speaker_events: list["SpeakerEvent"],
-    duration_seconds: float,
 ) -> list[dict]:
     """Assign speaker labels to Whisper segments using timed speaker events."""
     if not speaker_events:
@@ -573,7 +572,7 @@ def _correlate_speakers(
     return result
 
 
-async def run_transcription(meeting: VexaMeeting, db: AsyncSession) -> None:
+async def run_transcription(meeting: VexaMeeting) -> None:
     """Fetch transcript segments from Vexa meeting-api; fall back to Whisper audio."""
     from app.services.transcript_filter import filter_segments
 
@@ -720,7 +719,7 @@ async def _claim_webhook_event(payload: "VexaWebhookPayload") -> bool:
 async def vexa_webhook(
     payload: VexaWebhookPayload,
     request: Request,
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db),  # noqa: ARG001 — unread; the handler opens its own tenant/cross-org sessions below
 ) -> dict:
     _require_webhook_secret(request)
 
@@ -850,7 +849,7 @@ async def vexa_webhook(
         await scoped_db.commit()
 
         await set_tenant(scoped_db, meeting_org_id)
-        await run_transcription(meeting, scoped_db)
+        await run_transcription(meeting)
         await scoped_db.commit()
 
         if meeting.status == "done":

--- a/klai-portal/backend/app/api/oauth.py
+++ b/klai-portal/backend/app/api/oauth.py
@@ -291,7 +291,7 @@ def _frontend_redirect_url(path: str) -> str:
 
 @router.get("/providers")
 async def list_providers(
-    user_id: str = Depends(get_current_user_id),
+    user_id: str = Depends(get_current_user_id),  # noqa: ARG001 — unread; Depends() still enforces the caller is authenticated
 ) -> dict[str, dict[str, Any]]:
     """Advertise which OAuth providers are enabled via backend settings.
 
@@ -495,7 +495,7 @@ async def callback_provider(
     state: str = Query(...),
     code: str | None = Query(None, description="Authorization code from provider (absent if user denied consent)"),
     error: str | None = Query(None, description="OAuth error code (e.g. 'access_denied' when user denies consent)"),
-    error_description: str | None = Query(None, description="Human-readable error detail from provider"),
+    error_description: str | None = Query(None, description="Human-readable error detail from provider"),  # noqa: ARG001  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
     klai_oauth_state: str | None = Cookie(default=None),
     user_id: str = Depends(get_current_user_id),
     db: AsyncSession = Depends(get_db),

--- a/klai-portal/backend/app/logging_setup.py
+++ b/klai-portal/backend/app/logging_setup.py
@@ -10,7 +10,7 @@ from pydantic import SecretStr
 
 
 def mask_secret_str(
-    logger: Any,
+    logger: Any,  # noqa: ARG001 — structlog processor signature is fixed: (logger, method_name, event_dict)
     _method_name: str,
     event_dict: structlog.types.EventDict,
 ) -> structlog.types.EventDict:

--- a/klai-portal/backend/app/services/bot_poller.py
+++ b/klai-portal/backend/app/services/bot_poller.py
@@ -97,7 +97,7 @@ async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
         await db.commit()
 
         await set_tenant(db, snap.org_id)
-        await run_transcription(m, db)
+        await run_transcription(m)
         await db.commit()
         if m.status == "done":
             await cleanup_recording(m, db)
@@ -142,7 +142,7 @@ async def _recover_stuck_meeting(snap: _ActiveMeetingSnapshot) -> None:
         )
         if m is None:
             return
-        await run_transcription(m, db)
+        await run_transcription(m)
         await db.commit()
         if m.status == "done":
             await cleanup_recording(m, db)

--- a/klai-portal/backend/app/services/docling_client.py
+++ b/klai-portal/backend/app/services/docling_client.py
@@ -162,7 +162,6 @@ async def submit_file_async(
     content: bytes,
     content_type: str,
     input_format: str | None = None,
-    to_formats: tuple[str, ...] = ("md",),
 ) -> DoclingSubmitResult:
     """Submit a file to docling-serve's async queue.
 

--- a/klai-portal/backend/app/services/kb_quota.py
+++ b/klai-portal/backend/app/services/kb_quota.py
@@ -157,7 +157,6 @@ async def assert_can_add_item_to_kb(
 
 async def assert_can_create_org_kb(
     org: PortalOrg,
-    db: AsyncSession,
     role: str = "company",
 ) -> None:
     """Raise HTTP 403 when the (role, plan) combination does not allow org-scoped KBs.

--- a/klai-portal/backend/app/services/partner_knowledge.py
+++ b/klai-portal/backend/app/services/partner_knowledge.py
@@ -16,7 +16,7 @@ logger = structlog.get_logger()
 
 
 async def ingest_knowledge(
-    org_id: int,
+    org_id: int,  # noqa: ARG001  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
     zitadel_org_id: str,
     kb_slug: str,
     title: str | None,

--- a/klai-portal/backend/app/services/provisioning/infrastructure.py
+++ b/klai-portal/backend/app/services/provisioning/infrastructure.py
@@ -377,7 +377,9 @@ def _sync_librechat_tenant_config_files(slug: str, mcp_servers: dict | None = No
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
+    # Signature is fixed by urllib.request.HTTPRedirectHandler; only the
+    # override's presence (returning None to suppress the redirect) matters.
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ARG002
         return None
 
 

--- a/klai-portal/backend/app/services/quality_scorer.py
+++ b/klai-portal/backend/app/services/quality_scorer.py
@@ -128,7 +128,8 @@ def schedule_quality_update(
     """Fire-and-forget quality score update via asyncio.create_task."""
     try:
         task = asyncio.create_task(apply_quality_score(chunk_ids, rating, org_id))
-        # prevent GC
-        task.add_done_callback(lambda t: None)
+        # prevent GC — asyncio.Task.add_done_callback always invokes the
+        # callback with the completed task; this callback only needs to exist.
+        task.add_done_callback(lambda t: None)  # noqa: ARG005
     except RuntimeError:
         logger.warning("quality_score_schedule_failed: no running event loop")

--- a/klai-portal/backend/app/services/recording_cleanup.py
+++ b/klai-portal/backend/app/services/recording_cleanup.py
@@ -51,7 +51,7 @@ async def delete_recording(recording_id: int, meeting_id: str | None = None) -> 
 # @MX:SPEC SPEC-GDPR-002
 async def cleanup_recording(
     meeting: VexaMeeting,
-    db: AsyncSession,
+    db: AsyncSession,  # noqa: ARG001 — intentionally unread, see @MX:REASON above
     *,
     recording_id: int | None = None,
 ) -> None:

--- a/klai-portal/backend/app/services/zitadel.py
+++ b/klai-portal/backend/app/services/zitadel.py
@@ -366,7 +366,7 @@ class ZitadelClient:
         )
         resp.raise_for_status()
 
-    async def verify_user_email(self, org_id: str, user_id: str, code: str) -> None:
+    async def verify_user_email(self, org_id: str, user_id: str, code: str) -> None:  # noqa: ARG002  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
         """Verify a user's email address using a v2 email verification code.
 
         ``org_id`` is kept for the public method contract and legacy callers,
@@ -778,7 +778,7 @@ class ZitadelClient:
         user = result[0]
         return user["userId"], user["details"]["resourceOwner"]
 
-    async def has_totp(self, user_id: str, org_id: str | None = None) -> bool:
+    async def has_totp(self, user_id: str, org_id: str | None = None) -> bool:  # noqa: ARG002  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
         """Return True if the user has a verified TOTP factor registered."""
         resp = await self._http.get(f"/v2/users/{user_id}/authentication_methods")
         resp.raise_for_status()
@@ -1075,8 +1075,8 @@ def _grant_has_project_role(grant: dict, role: str) -> bool:
 
 async def _sync_zitadel_role_grant(
     zitadel_user_id: str,
-    old_role: str,
-    new_role: str,
+    old_role: str,  # noqa: ARG001  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
+    new_role: str,  # noqa: ARG001  # TODO: doorgegeven maar ongebruikt — zie rapport (ruff ARG audit)
 ) -> None:
     """Reconcile the global Zitadel org:owner grant for one portal identity.
 

--- a/klai-portal/backend/pyproject.toml
+++ b/klai-portal/backend/pyproject.toml
@@ -134,7 +134,7 @@ line-length = 120
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "C90", "B", "TRY", "S", "RUF", "G", "LOG"]
+select = ["E", "F", "I", "UP", "C90", "B", "TRY", "S", "RUF", "G", "LOG", "ARG"]
 ignore = [
     "E501",    # line length — handled by formatter
     "B008",    # Depends() in default args — standard FastAPI pattern, not a bug
@@ -154,4 +154,8 @@ max-complexity = 15
 # tests/*: hardcoded "passwords" in test fixtures are fake tokens —
 # S105 already global-ignored, S106 covers module-level kwargs, S107
 # covers function default arguments (e.g. token: str = "test-secret").
-"tests/*" = ["S106", "S107"]
+# ARG: pytest fixtures are injected for their side effect (not read), and
+# mock/stub signatures must mirror the real callable they replace even when
+# a given test ignores some parameters. Enforcing ARG here would force
+# churn without catching anything.
+"tests/*" = ["S106", "S107", "ARG"]

--- a/klai-portal/backend/tests/test_bot_poller.py
+++ b/klai-portal/backend/tests/test_bot_poller.py
@@ -132,7 +132,7 @@ async def test_handle_meeting_ended_rearms_tenant_context_after_stopping_commit(
     async def _set_tenant(_db, _org_id):
         events.append("set_tenant")
 
-    async def _run_transcription(_meeting, _db):
+    async def _run_transcription(_meeting):
         events.append("run_transcription")
 
     monkeypatch.setattr(bot_poller, "tenant_scoped_session", _tenant_session)

--- a/klai-portal/backend/tests/test_kb_quota_service.py
+++ b/klai-portal/backend/tests/test_kb_quota_service.py
@@ -190,18 +190,14 @@ class TestAssertCanCreateOrgKB:
     async def test_passes_for_complete_plan(self) -> None:
         from app.services.kb_quota import assert_can_create_org_kb
 
-        mock_db = _make_db_mock()
-
-        await assert_can_create_org_kb(org=_make_org("knowledge"), db=mock_db, role="kb_manager")
+        await assert_can_create_org_kb(org=_make_org("knowledge"), role="kb_manager")
 
     @pytest.mark.asyncio
     async def test_raises_403_for_core_plan(self) -> None:
         from app.services.kb_quota import assert_can_create_org_kb
 
-        mock_db = _make_db_mock()
-
         with pytest.raises(HTTPException) as exc_info:
-            await assert_can_create_org_kb(org=_make_org("chat"), db=mock_db)
+            await assert_can_create_org_kb(org=_make_org("chat"))
 
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail["error_code"] == "kb_quota_org_kb_not_allowed"
@@ -210,10 +206,8 @@ class TestAssertCanCreateOrgKB:
     async def test_raises_403_for_professional_plan(self) -> None:
         from app.services.kb_quota import assert_can_create_org_kb
 
-        mock_db = _make_db_mock()
-
         with pytest.raises(HTTPException) as exc_info:
-            await assert_can_create_org_kb(org=_make_org("chat"), db=mock_db)
+            await assert_can_create_org_kb(org=_make_org("chat"))
 
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail["error_code"] == "kb_quota_org_kb_not_allowed"
@@ -222,10 +216,8 @@ class TestAssertCanCreateOrgKB:
     async def test_error_detail_includes_plan(self) -> None:
         from app.services.kb_quota import assert_can_create_org_kb
 
-        mock_db = _make_db_mock()
-
         with pytest.raises(HTTPException) as exc_info:
-            await assert_can_create_org_kb(org=_make_org("chat"), db=mock_db)
+            await assert_can_create_org_kb(org=_make_org("chat"))
 
         detail = exc_info.value.detail
         assert "plan" in detail

--- a/klai-portal/backend/tests/test_meetings.py
+++ b/klai-portal/backend/tests/test_meetings.py
@@ -95,7 +95,7 @@ def test_correlate_speakers_with_events() -> None:
         SpeakerEvent(timestamp=5.5, participant_name="Bob"),
         SpeakerEvent(timestamp=11.0, participant_name="Alice"),
     ]
-    result = _correlate_speakers(segments, events, duration_seconds=15.0)
+    result = _correlate_speakers(segments, events)
 
     assert len(result) == 3
     assert result[0]["speaker"] == "Alice"
@@ -114,7 +114,7 @@ def test_correlate_speakers_unknown_fallback() -> None:
         SpeakerEvent(timestamp=0.0, participant_name=None),
         SpeakerEvent(timestamp=3.5, participant_name=None),
     ]
-    result = _correlate_speakers(segments, events, duration_seconds=6.0)
+    result = _correlate_speakers(segments, events)
 
     assert len(result) == 2
     # Unknown speakers get "Deelnemer N" labels
@@ -127,7 +127,7 @@ def test_correlate_speakers_empty_events() -> None:
         {"start": 0.0, "end": 5.0, "text": "Hello"},
         {"start": 6.0, "end": 10.0, "text": "World"},
     ]
-    result = _correlate_speakers(segments, speaker_events=[], duration_seconds=10.0)
+    result = _correlate_speakers(segments, speaker_events=[])
 
     # With no speaker events, segments are returned unchanged
     assert result == segments
@@ -144,7 +144,7 @@ def test_correlate_speakers_mixed_known_unknown() -> None:
         SpeakerEvent(timestamp=0.0, participant_name="Alice"),
         SpeakerEvent(timestamp=4.0, participant_name=None),
     ]
-    result = _correlate_speakers(segments, events, duration_seconds=8.0)
+    result = _correlate_speakers(segments, events)
 
     assert result[0]["speaker"] == "Alice"
     assert result[1]["speaker"].startswith("Deelnemer")

--- a/klai-portal/backend/tests/test_vexa_webhook.py
+++ b/klai-portal/backend/tests/test_vexa_webhook.py
@@ -205,7 +205,7 @@ async def test_webhook_rearms_tenant_context_after_stopping_commit(monkeypatch) 
     async def _set_tenant(_db, _org_id):
         events.append("set_tenant")
 
-    async def _run_transcription(_meeting, _db):
+    async def _run_transcription(_meeting):
         events.append("run_transcription")
         _meeting.status = "done"
 


### PR DESCRIPTION
## Why

`ARG` is the rule that would have caught the `rate_limit` bug: a parameter threaded through the whole crawl pipeline, wired to nothing, for months. Landed on knowledge-ingest in #1036; this extends it to portal-api and klai-connector.

Tests are excluded (`"tests/**" = ["ARG"]`) — unused pytest fixtures and mirrored mock signatures are correct by design there.

## The 44 production findings

| | portal-api | connector |
|---|---|---|
| Framework-mandated signature | 26 | 7 |
| Genuinely dead (removed) | 5 | 0 |
| Passed-but-ignored — reported only | **6** | 0 |

All 7 connector findings are `BaseAdapter` interface overrides that `sync_engine` calls polymorphically.

### Removed as dead (each with evidence)

`mcp_oauth.authorize_post(request)` — unused, while the sibling `authorize_get` does use `request.url`, which rules out a copy error. `meetings._correlate_speakers(duration_seconds)` — no production caller at all, 4 test calls updated. `meetings.run_transcription(db)` — `meeting` is already bound to the same session the caller commits. `docling_client.submit_file_async(to_formats)` — repo-wide grep finds only the definition. `kb_quota.assert_can_create_org_kb(db)` — the function runs no query, it derives a boolean from `role` + `org.plan`.

### Passed-but-ignored — not fixed here, deliberately

These are the `rate_limit` shape: a caller passes a real value and the callee drops it. Removing the parameter is wrong (the caller meant something) and wiring it up is a behaviour change that deserves its own review. Each carries a `# noqa: ARGxxx  # TODO` pointing here.

**`zitadel._sync_zitadel_role_grant(old_role, new_role)`** — reconciles the global `org:owner` grant after a role change and reads neither argument; it re-derives the desired state from committed DB state instead. Five real callers pass genuine before/after values. Current behaviour is plausibly *safer* (self-healing rather than trusting caller state), but a security-relevant function ignoring two explicit parameters should be a decision, not an accident.

**`zitadel.verify_user_email(org_id)`** — called from the unauthenticated `/auth/verify-email` with a client-supplied `body.org_id`. The docstring already says v2 VerifyEmail is user-scoped. Worth noting: the audit log in that handler hardcodes `org_id=0`, so the submitted value reaches nothing at all.

**`zitadel.has_totp(org_id)`** — login flow, documented as a UI flag with fail-open behaviour; Zitadel's v2 endpoint is user-scoped. Low risk, flagged because it sits in auth.

**`oauth.callback_provider(error_description)`** — `error` is logged, `error_description` is not. That is the human-readable half of every failed OAuth link, silently discarded.

**`partner_knowledge.ingest_knowledge(org_id)`** — receives portal's internal int org id but sends only `zitadel_org_id` on the wire (correct — knowledge-ingest expects the string form). The real tenant check `kb.org_id == auth.org_id` already ran upstream, so this looks benign.

## Separately: a setting whose feature was never built

`taxonomy_cluster_trigger_count` is defined at exactly the SPEC value (20) and read by nothing.

SPEC-KB-024 R7 specifies re-clustering "after N ≥ 20 new documents", owned by `knowledge_ingest/clustering_tasks.py`. That file does not exist. `app.py` has no periodic registration. And `run_clustering_for_kb` — the function that performs the clustering — has no production caller either.

So this is not dead config to tidy away: it is an engine with no trigger. The neighbouring `taxonomy_cluster_min_size` is read normally, which is what makes the gap visible. Reported, unchanged.

The other two settings checked are fine: `docs_internal_secret` is actively used in portal-api and knowledge-mcp (the knowledge-ingest copy is a documented `@MX:NOTE` placeholder), and `sparse_index_on_disk` is already logged as DEAD-011 "keep + annotate".

## Verification

portal-api: `ruff check` clean with ARG active, `ruff format --check` 682 files clean, `pyright` 0 errors / 0 warnings, `pytest` 3587 passed / 9 deselected / 1 xfailed — identical to baseline.

connector: `ruff check` clean, `pytest` 413 passed / 1 skipped — identical. Its 34 files of format drift and 1020 pyright errors are pre-existing (confirmed unchanged via `git stash`) and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)