### PR TITLE
fix(crawler): stop cutting off the request before crawl4ai returns the real 429

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -94,6 +94,26 @@ class Settings(BaseSettings):
         default=1200.0,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_MAX_SECONDS"),
     )
+    # httpx timeout for the PER-URL request `_recover_bulk_5xx_batch` makes
+    # via `_crawl_page_with_config` (crawl4ai_client.py). MUST stay strictly
+    # above crawl4ai's own internal 429-backoff ceiling
+    # (`_CRAWL4AI_RATE_LIMIT_BACKOFF_CEILING_SECONDS` = 3 retries * 60.0s
+    # max_delay = 180.0s, hardcoded inside crawl4ai's RateLimiter, not
+    # exposed via CrawlerRunConfig) — otherwise our own httpx client cuts
+    # the request off before crawl4ai's real 429 result comes back, and a
+    # rate-limit storm gets classified as `timeout` instead of
+    # `rate_limited` (2026-08-17 intermedia.com incident: 105 of 107
+    # crawl4ai container-log failures were literally "Blocked by anti-bot
+    # protection: HTTP 429 Too Many Requests"; `fetch_outcomes` recorded
+    # 110x timeout, 2x blocked_anti_bot, 0x rate_limited). 180s backoff
+    # ceiling + 60s margin for the actual fetch/render once a retry is let
+    # through. Deliberately NOT applied to the seed/single-page callers of
+    # `_crawl_page_with_config` (`crawl_page`) — those keep the original
+    # 90.0s default, which is the right ceiling for a normal single fetch.
+    crawl_sequential_recovery_timeout_seconds: float = Field(
+        default=240.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_TIMEOUT_SECONDS"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -936,7 +936,16 @@ async def _crawl_page_with_config(
     selector: str | None,
     relaxed: bool = False,
     stealth: bool = False,
+    timeout: float = 90.0,
 ) -> CrawlResult:
+    """Fetch a single page via ``POST /crawl``.
+
+    ``timeout`` defaults to 90.0s, the right ceiling for the seed/single-page
+    callers (``crawl_page``). The sequential bulk-5xx recovery path
+    (``_recover_bulk_5xx_batch``) passes a longer, configurable timeout
+    (``settings.crawl_sequential_recovery_timeout_seconds``) — see that
+    setting's docstring in config.py for why 90s is too short there.
+    """
     payload: dict[str, Any] = {
         "urls": [url],
         "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_config},
@@ -945,7 +954,7 @@ async def _crawl_page_with_config(
     if bc:
         payload["browser_config"] = bc
 
-    async with httpx.AsyncClient(timeout=90.0) as client:
+    async with httpx.AsyncClient(timeout=timeout) as client:
         try:
             data = await _crawl_sync(client, payload)
         except Exception as exc:
@@ -1849,7 +1858,16 @@ async def _recover_bulk_5xx_batch(
 
         attempted += 1
         result = await _crawl_page_with_config(
-            url, crawler_config, cookies=cookies, selector=None, stealth=stealth
+            url,
+            crawler_config,
+            cookies=cookies,
+            selector=None,
+            stealth=stealth,
+            # See settings.crawl_sequential_recovery_timeout_seconds
+            # docstring: must exceed crawl4ai's internal 429-backoff
+            # ceiling or we cut the request off before the real 429
+            # comes back (2026-08-17 intermedia.com incident).
+            timeout=settings.crawl_sequential_recovery_timeout_seconds,
         )
         reason_code = _classify_fetch_outcome(
             {
@@ -2125,6 +2143,19 @@ _BULK_CHUNK_SIZE = 100
 # once exhausted, remaining URLs are marked HTTP_5XX (not a guessed
 # BLOCKED_ANTI_BOT) without a network call (crawl_bulk_5xx_recovery_capped).
 _MAX_SEQUENTIAL_RECOVERY = 60
+
+# crawl4ai's own RateLimiter (inside its dispatcher, used for both the bulk
+# arun_many path AND the single-page /crawl path) retries a 429 up to
+# max_retries=3 times with an exponential backoff capped at max_delay=60.0
+# seconds — both hardcoded in crawl4ai, not exposed via CrawlerRunConfig
+# (only mean_delay / max_range / semaphore_count come through, see
+# build_crawl_config's rate_limit handling). Worst case before crawl4ai
+# gives up and returns the REAL 429 result to us: 3 * 60.0 = 180s of pure
+# backoff, before whatever the actual page fetch/render itself costs on
+# top. Reference only — see settings.crawl_sequential_recovery_timeout_seconds
+# (config.py) for the httpx timeout that must stay above this ceiling, and
+# why (2026-08-17 intermedia.com incident).
+_CRAWL4AI_RATE_LIMIT_BACKOFF_CEILING_SECONDS = 3 * 60.0
 
 # Indirection so tests can drive the recovery loop's pacing without ever
 # sleeping for real: a suite that honours the 75s production cooldown would

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 from unittest.mock import patch
 
@@ -1687,6 +1688,7 @@ async def test_recovery_stops_immediately_on_rate_limited(
         selector: str | None,
         relaxed: bool = False,
         stealth: bool = False,
+        timeout: float = 90.0,
     ) -> CrawlResult:
         nonlocal call_count
         call_count += 1
@@ -1744,6 +1746,85 @@ async def test_recovery_stops_immediately_on_rate_limited(
     assert kwargs["recovered"] == 0
     assert kwargs["still_failing"] == 3
     assert kwargs["remaining"] == 2
+
+
+def test_recovery_timeout_exceeds_crawl4ai_internal_backoff_ceiling() -> None:
+    """2026-08-17 (intermedia.com incident, second act): crawl4ai's own
+    RateLimiter retries a 429 up to ``max_retries=3`` times with backoff
+    capped at ``max_delay=60.0`` seconds each — hardcoded inside crawl4ai's
+    dispatcher, not exposed via CrawlerRunConfig (only mean_delay /
+    max_range / semaphore_count come through). Worst case before crawl4ai
+    gives up and returns the REAL 429 result to us: 3 * 60.0 = 180s of pure
+    backoff.
+
+    If the httpx timeout the sequential-recovery path uses for its
+    per-URL requests (``_recover_bulk_5xx_batch`` -> ``_crawl_page_with_config``)
+    is not strictly greater than that 180s ceiling, our own client cuts
+    the request off before crawl4ai's real 429 comes back. The recovery
+    loop then sees an ``httpx.TimeoutException`` instead of the 429, and
+    ``_classify_fetch_outcome`` — which is otherwise correct — has nothing
+    to classify but a timeout. Confirmed in production 2026-08-17 on
+    intermedia.com: 105 of 107 crawl4ai container-log failures were
+    literally ``Error: Blocked by anti-bot protection: HTTP 429 Too Many
+    Requests``, while ``crawl_jobs.fetch_outcomes`` recorded 110x
+    ``timeout``, 2x ``blocked_anti_bot``, and 0x ``rate_limited``."""
+    assert (
+        settings.crawl_sequential_recovery_timeout_seconds
+        > crawl4ai_client._CRAWL4AI_RATE_LIMIT_BACKOFF_CEILING_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_recovery_passes_the_longer_timeout_to_crawl_page_with_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard for the fix itself, not just the ceiling contract
+    above: ``_recover_bulk_5xx_batch`` must actually pass
+    ``settings.crawl_sequential_recovery_timeout_seconds`` down to
+    ``_crawl_page_with_config`` on every per-URL attempt. Without this
+    wiring, ``test_recovery_timeout_exceeds_crawl4ai_internal_backoff_ceiling``
+    could pass (the settings value exists and is large enough) while the
+    recovery loop still used the old 90s default underneath — the
+    contract test alone cannot catch a forgotten call-site."""
+    captured_timeouts: list[float | None] = []
+
+    async def _fake_fetch(
+        url: str,
+        _crawler_config: dict[str, Any],
+        *,
+        cookies: list[dict[str, Any]] | None = None,
+        selector: str | None = None,
+        relaxed: bool = False,
+        stealth: bool = False,
+        timeout: float | None = None,
+    ) -> CrawlResult:
+        captured_timeouts.append(timeout)
+        return _ok_result(url)
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_page_with_config", _fake_fetch)
+
+    await crawl4ai_client._recover_bulk_5xx_batch(
+        ["https://example.com/a", "https://example.com/b"],
+        crawler_config={},
+        cookies=None,
+        base_domain="example.com",
+        recovery_budget=60,
+    )
+
+    assert captured_timeouts == [settings.crawl_sequential_recovery_timeout_seconds] * 2
+    assert settings.crawl_sequential_recovery_timeout_seconds != 90.0, (
+        "if this ever equals 90.0, the test above stops proving anything"
+    )
+
+
+def test_seed_crawl_page_keeps_the_default_ninety_second_timeout() -> None:
+    """The seed/single-page callers (``crawl_page`` at lines ~902/919) must
+    NOT inherit the longer recovery timeout. The diagnosis is explicit that
+    90s remains the right ceiling there — only the sequential-recovery path
+    needs the longer one, to actually observe crawl4ai's internal 429
+    backoff instead of cutting it off."""
+    sig = inspect.signature(crawl4ai_client._crawl_page_with_config)
+    assert sig.parameters["timeout"].default == 90.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The bug

A 429 storm is recorded as `timeout`, so the domain rate limit is never lowered for it.

Production, 17-08, `www.intermedia.com`, two consecutive runs:

| | crawl4ai's own log | our `fetch_outcomes` |
|---|---|---|
| run 1 | 105 of 107 failures are `Blocked by anti-bot protection: HTTP 429 Too Many Requests` | 110 `timeout`, 1 `blocked_anti_bot`, **0 `rate_limited`** |
| run 2 | same shape | 110 `timeout`, 2 `blocked_anti_bot`, **0 `rate_limited`** |

Exactly 110 both times — deterministic, not noise.

`_RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES` holds `RATE_LIMITED` and `BLOCKED_ANTI_BOT`, and rightly not `TIMEOUT`. So a pure 429 storm lowers nothing. Intermedia was only lowered at all because one, then two, outcomes happened to carry the anti-bot label. The self-correction was running on luck, on precisely the site it was built for.

## Why it happens

1. The bulk chunk dies with `Server error '500 Internal Server Error'`, carrying no trace of the 429. That rules out reading the cause from the bulk response.
2. The 5xx triggers `_recover_bulk_5xx_batch`.
3. That path is already correct: it classifies per URL from the real `error_message`, and on `RATE_LIMITED` it abandons the whole remaining batch with the right reason.
4. **It just never sees the 429.** `_crawl_page_with_config` used `httpx.AsyncClient(timeout=90.0)`. crawl4ai's own `RateLimiter` retries a 429 up to `max_retries=3` with backoff capped at `max_delay=60.0` — both hardcoded in `arun_many`, not reachable through `CrawlerRunConfig` (only `mean_delay`, `max_range` and `semaphore_count` come through). Worst case is 180s of backoff before crawl4ai hands us the real 429. We gave up at 90.

Corroborating: measured fetch times on intermedia were median 37.4s, **p90 92.5s**, max 155.2s. The p90 sits right on our own 90s limit — the distribution is being clipped by us.

## The fix

Give the recovery path a timeout above crawl4ai's internal ceiling, so the 429 arrives and the existing correct logic can act on it.

`_crawl_page_with_config` takes an optional `timeout`, defaulting to the current 90.0 so the two seed callers are unchanged. `_recover_bulk_5xx_batch` passes `settings.crawl_sequential_recovery_timeout_seconds`, default 240s: 180s of documented backoff ceiling plus 60s of margin for the fetch itself once a retry gets through.

Deliberately not done: adding `TIMEOUT` to the lowering trigger set. That would make a genuine network timeout throttle the domain, which is the wrong fix for the right symptom.

## Budget effect, calculated rather than hoped

The recovery loop sleeps 75s before every attempt, with a 1200s job-wide deadline and a breaker at 6 consecutive failures.

- Before: 6 × (75+90) = 990s — the breaker bound, not the deadline.
- After: 6 × (75+240) = 1890s > 1200s — the deadline now binds, at ~4 attempts.

So a batch that fails for reasons *other* than rate limiting gets 4 diagnosed URLs instead of 6. Judged acceptable: it is bounded, it only affects the narrow case of a batch that fails structurally without ever emitting a rate-limit signal, and it buys the main case outright — a real 429 storm is now recognised on the first attempt and the rest of the batch is abandoned correctly, instead of burning up to 990s writing everything down as `timeout` and learning nothing.

Cooldown, deadline and breaker are unchanged.

## Verification

Three new tests, all confirmed to fail against main's production code and pass with the fix — checked independently by reverting only `config.py` and `crawl4ai_client.py` to main and re-running:

```
FAILED test_recovery_timeout_exceeds_crawl4ai_internal_backoff_ceiling
FAILED test_recovery_passes_the_longer_timeout_to_crawl_page_with_config
FAILED test_seed_crawl_page_keeps_the_default_ninety_second_timeout
```

The first locks the relationship that was violated; the third locks the regression most likely to creep back — the seed callers quietly inheriting the long timeout.

Suite: 1282 → 1285 passed, 4 skipped. `ruff check` and `ruff format --check` clean.

## What this does not yet prove

Unit tests cannot show that the 429 actually arrives within 240s in production. The real proof is an intermedia run whose `fetch_outcomes` contain `rate_limited` instead of `timeout`, with `crawl_domain_rate_limit_lowered` firing without an incidental anti-bot outcome carrying it. That check runs after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)