### PR TITLE
fix(crawler): stop timing out on the delay we imposed ourselves

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -114,6 +114,22 @@ class Settings(BaseSettings):
         default=240.0,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_TIMEOUT_SECONDS"),
     )
+    # Base component of the bulk-crawl httpx timeout (crawl4ai_client
+    # ._bulk_crawl_timeout_for_chunk / _chunked_bulk_fetch). Historically a
+    # fixed 300.0s covering fetch/render time only. Since PR #1034,
+    # `rate_limit` is translated into crawl4ai's own `mean_delay` pacing
+    # (build_crawl_config), so a chunk's minimum duration now also scales
+    # with `len(chunk_urls) * mean_delay` — that pacing component is added
+    # on top of this base at request time, never folded into the base
+    # itself. 300.0 default keeps behaviour unchanged for every caller that
+    # does not set rate_limit (2026-08-18 fix/bulk-timeout-scales-with-pacing,
+    # intermedia.com incident: 146 real crawl4ai-side 429s were recorded as
+    # `timeout` because the fixed 300.0s cut the request off before the
+    # chunk's own self-imposed delay had even elapsed).
+    crawl_bulk_base_timeout_seconds: float = Field(
+        default=300.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_BULK_BASE_TIMEOUT_SECONDS"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -646,8 +646,8 @@ def _classify_fetch_outcome(
         # production: crawl4ai's real bulk-request 500 body is opaque
         # (``{"error":"Internal server error","correlation_id":"..."}"``),
         # so the anti-bot cause was never diagnosable client-side. See
-        # ``_is_bulk_5xx_error`` for the cause-independent trigger that
-        # replaced this, and ``_is_antibot_block_error`` (kept only for
+        # ``_is_recoverable_bulk_failure`` for the cause-independent trigger
+        # that replaced this, and ``_is_antibot_block_error`` (kept only for
         # ``_is_minimal_content_antibot_error``) for the retired approach.
         if isinstance(error, httpx.HTTPStatusError):
             status_code = error.response.status_code
@@ -1196,8 +1196,8 @@ def _is_antibot_block_error(exc: BaseException) -> bool:
     its own docstring) still calls it; that call site was out of scope for
     the 2026-08-14 fix. Do NOT use this function for terminal-status or
     sequential-recovery decisions in ``crawl_site`` — see
-    :func:`_is_bulk_5xx_error` for the cause-independent replacement that
-    actually fires in production.
+    :func:`_is_recoverable_bulk_failure` for the cause-independent
+    replacement that actually fires in production.
     """
     if not isinstance(exc, httpx.HTTPStatusError) or exc.response.status_code != 500:
         return False
@@ -1222,27 +1222,62 @@ def _is_minimal_content_antibot_error(exc: Exception) -> bool:
     return "minimal_text" in body or "no_content_elements" in body or "0 chars visible" in body
 
 
-def _is_bulk_5xx_error(exc: BaseException) -> bool:
-    """True when a bulk-crawl transport failure is an HTTP 5xx from crawl4ai.
+def _is_recoverable_bulk_failure(exc: BaseException) -> bool:
+    """True when a bulk-crawl transport failure is worth a one-URL-at-a-time
+    sequential retry (see ``_recover_bulk_5xx_batch``) — cause-independent
+    trigger covering two cases that share the same property: the client-side
+    cause is UNKNOWABLE from the transport response alone, so the per-URL
+    retry is simultaneously the mitigation and the diagnosis.
 
-    Cause-independent replacement for the retired antibot-body-match
-    trigger. Evidence 2026-08-14 (intermedia.com): crawl4ai's bulk
-    ``arun_many`` endpoint fails the WHOLE concurrent batch with one 500
+    Case 1 — HTTP 5xx (originally the only trigger, named
+    ``_is_bulk_5xx_error``). Evidence 2026-08-14 (intermedia.com): crawl4ai's
+    bulk ``arun_many`` endpoint fails the WHOLE concurrent batch with one 500
     the moment ANY url in it hits an anti-bot challenge — but the response
     body is opaque
     (``{"error":"Internal server error","correlation_id":"188834187d7d"}"``),
-    never a diagnosable reason. The client-side cause of a bulk 500 is
-    therefore UNKNOWABLE from the transport response alone. Rather than
-    guess at the cause, ``crawl_site`` treats every bulk-level 5xx as
-    worth a one-URL-at-a-time sequential retry (see
-    ``_recover_bulk_5xx_batch``): the retry is simultaneously the
-    mitigation (some URLs recover — the same intermedia.com incident saw
+    never a diagnosable reason. ``crawl_site`` treats every bulk-level 5xx as
+    worth a one-URL-at-a-time sequential retry: the retry is simultaneously
+    the mitigation (some URLs recover — the same intermedia.com incident saw
     ``/products/unite`` succeed seconds after the bulk 500 while
-    ``/products/ai`` stayed blocked, via the same single-page path) and
-    the diagnosis (the per-URL retry result tells us the REAL per-URL
+    ``/products/ai`` stayed blocked, via the same single-page path) and the
+    diagnosis (the per-URL retry result tells us the REAL per-URL
     reason_code, honestly, instead of a guessed BLOCKED_ANTI_BOT).
+
+    Case 2 — ``httpx.TimeoutException`` (added 2026-08-18,
+    fix/bulk-timeout-scales-with-pacing). Since PR #1034, ``rate_limit`` is
+    translated into crawl4ai's own ``mean_delay`` pacing, so a bulk-request
+    read-timeout can now legitimately mean "the request was still waiting out
+    its own self-imposed delay when the client gave up" rather than a real
+    server failure. Evidence 2026-08-17 (intermedia.com, rate_limit=0.5): the
+    crawl4ai container log recorded 254 real ``HTTP 429 Too Many Requests``
+    responses, while ``fetch_outcomes`` recorded 146 ``timeout`` and 0
+    ``rate_limited`` — the fixed bulk httpx timeout fired before crawl4ai's
+    own 429 signal could come back, and because a timeout is not an
+    ``httpx.HTTPStatusError`` at all, the pre-fix ``_is_bulk_5xx_error``
+    check never triggered recovery for it — the whole chunk was written off
+    as a bare ``timeout`` batch-wide with no per-URL diagnosis attempted.
+    Same remedy as case 1: retry sequentially, and let the per-URL result
+    (including a genuine ``RATE_LIMITED``, which correctly stops the
+    recovery loop early — see the rate-limit branch in
+    ``_recover_bulk_5xx_batch``) tell us the honest reason instead of
+    guessing.
     """
-    return isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600
+    if isinstance(exc, httpx.HTTPStatusError):
+        return 500 <= exc.response.status_code < 600
+    return isinstance(exc, httpx.TimeoutException)
+
+
+def _bulk_failure_trigger_reason_code(exc: BaseException) -> str:
+    """Honest default abandon-reason for ``_recover_bulk_5xx_batch``, matching
+    what ``crawl_site`` actually observed on the bulk request that triggered
+    recovery — never a guessed value. Only meaningful for exceptions that
+    pass ``_is_recoverable_bulk_failure``; every other transport failure is
+    classified directly by ``_classify_fetch_outcome`` without ever reaching
+    the sequential-recovery path.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return FetchReasonCode.HTTP_5XX.value
+    return FetchReasonCode.TIMEOUT.value
 
 
 def _status_code_from_exception(exc: BaseException) -> int | None:
@@ -1453,7 +1488,7 @@ async def crawl_site(
         )
         fetched_count += len(batch)
 
-        if transport_error is not None and _is_bulk_5xx_error(transport_error):
+        if transport_error is not None and _is_recoverable_bulk_failure(transport_error):
             # Escalation step 1: retry the SAME batch once with crawl4ai's
             # stealth mode + a randomised UA. Measured on intermedia.com
             # 2026-08-15: the plain bulk request 500s wholesale, the identical
@@ -1470,15 +1505,16 @@ async def crawl_site(
                 stealth=True,
             )
 
-        if transport_error is not None and _is_bulk_5xx_error(transport_error):
-            # crawl4ai's bulk endpoint failed the WHOLE batch with an
-            # opaque 5xx (evidence + budget: see _MAX_SEQUENTIAL_RECOVERY,
-            # _is_bulk_5xx_error). The client-side cause is unknowable from
-            # the transport response alone, so we don't guess it — recover
-            # what we can by retrying one URL at a time via the single-page
-            # path, which tells us the REAL per-URL reason_code, instead of
-            # writing off every URL in the batch as unknown_exception (or
-            # guessing blocked_anti_bot without evidence).
+        if transport_error is not None and _is_recoverable_bulk_failure(transport_error):
+            # crawl4ai's bulk endpoint failed the WHOLE batch with either an
+            # opaque 5xx or a read-timeout (evidence + budget: see
+            # _MAX_SEQUENTIAL_RECOVERY, _is_recoverable_bulk_failure). The
+            # client-side cause is unknowable from the transport response
+            # alone, so we don't guess it — recover what we can by retrying
+            # one URL at a time via the single-page path, which tells us the
+            # REAL per-URL reason_code, instead of writing off every URL in
+            # the batch as unknown_exception (or guessing blocked_anti_bot
+            # without evidence).
             (
                 batch_results,
                 link_source_results,
@@ -1491,12 +1527,16 @@ async def crawl_site(
                 base_domain=base_domain,
                 recovery_budget=sequential_recovery_budget,
                 deadline=sequential_recovery_deadline,
-                # Stealth already earned by two consecutive bulk 5xx; the
-                # per-URL retries get it too. Measured: with stealth a failure
-                # no longer poisons the session (3 of 5 succeeded back-to-back
-                # with no cooldown at all), which is exactly what the cooldown
-                # was working around.
+                # Stealth already earned by two consecutive bulk failures;
+                # the per-URL retries get it too. Measured: with stealth a
+                # failure no longer poisons the session (3 of 5 succeeded
+                # back-to-back with no cooldown at all), which is exactly
+                # what the cooldown was working around.
                 stealth=True,
+                # Honest abandon-reason if the recovery budget/deadline/
+                # breaker caps out mid-batch: whatever this trigger actually
+                # was (5xx or timeout), not a hardcoded 5xx-flavoured guess.
+                trigger_reason_code=_bulk_failure_trigger_reason_code(transport_error),
             )
             sequential_recovery_budget -= recovery_attempted
         else:
@@ -1729,24 +1769,29 @@ async def _recover_bulk_5xx_batch(
     recovery_budget: int,
     deadline: float | None = None,
     stealth: bool = False,
+    trigger_reason_code: str = FetchReasonCode.HTTP_5XX.value,
 ) -> tuple[list[CrawlResult], list[CrawlResult], list[FetchOutcome], int]:
     """Sequentially re-fetch a batch that failed WHOLESALE via bulk fetch.
 
     Called from ``crawl_site`` only when ``_chunked_bulk_fetch`` returned a
-    ``transport_error`` that is a bulk-level 5xx (see ``_is_bulk_5xx_error``
-    — the cause is unknowable from the transport response alone, so this
-    retry is both the mitigation and the diagnosis). Reuses the single-page
-    fetch path (``_crawl_page_with_config``, same one ``crawl_page`` uses)
-    one URL at a time instead of duplicating fetch logic — see module-level
-    comment on ``_MAX_SEQUENTIAL_RECOVERY`` for the supporting evidence.
+    ``transport_error`` that is a recoverable bulk-level failure — either a
+    5xx or a read-timeout (see ``_is_recoverable_bulk_failure`` — the cause
+    is unknowable from the transport response alone, so this retry is both
+    the mitigation and the diagnosis). Reuses the single-page fetch path
+    (``_crawl_page_with_config``, same one ``crawl_page`` uses) one URL at a
+    time instead of duplicating fetch logic — see module-level comment on
+    ``_MAX_SEQUENTIAL_RECOVERY`` for the supporting evidence.
 
     Bounded by ``recovery_budget`` (the crawl-job-wide remainder of
     ``_MAX_SEQUENTIAL_RECOVERY``). Once exhausted, remaining URLs in this
-    batch are marked ``HTTP_5XX`` — honestly, matching the actual signal we
-    have (the bulk request 5xx'd; we simply ran out of budget to verify
-    these particular URLs individually) rather than guessing
-    ``BLOCKED_ANTI_BOT`` without evidence — without a network call, and the
-    cap is logged once via ``crawl_bulk_5xx_recovery_capped``.
+    batch are marked with ``trigger_reason_code`` — honestly, matching the
+    actual signal we have (the bulk request failed with THIS reason; we
+    simply ran out of budget to verify these particular URLs individually)
+    rather than guessing ``BLOCKED_ANTI_BOT`` without evidence, and rather
+    than always defaulting to ``HTTP_5XX`` even when the trigger was a
+    timeout — without a network call, and the cap is logged once via
+    ``crawl_bulk_5xx_recovery_capped``. Defaults to ``HTTP_5XX`` for direct
+    callers (e.g. tests) that don't pass one explicitly.
 
     Returns ``(crawl_results, link_source_results, outcomes, attempted)``:
 
@@ -1788,8 +1833,15 @@ async def _recover_bulk_5xx_batch(
         max_seconds=time_budget,
     )
 
-    def _abandon_remaining(index: int, *, reason_code: str = FetchReasonCode.HTTP_5XX.value) -> int:
-        """Mark every not-yet-attempted URL with ``reason_code``; return how many."""
+    def _abandon_remaining(index: int, *, reason_code: str = trigger_reason_code) -> int:
+        """Mark every not-yet-attempted URL with ``reason_code``; return how many.
+
+        Default is ``trigger_reason_code`` — the honest reason recovery was
+        entered in the first place (HTTP_5XX or TIMEOUT). Callers override
+        it explicitly only for the RATE_LIMITED abandon branch below, which
+        is a strictly more specific and more actionable signal than the
+        trigger that started this batch's recovery.
+        """
         for leftover_url in urls[index:]:
             outcomes.append(
                 {
@@ -2115,11 +2167,51 @@ async def _recover_thin_bulk_results(
     return recovered
 
 
-# Single bulk-crawl request budget. crawl4ai's MemoryAdaptiveDispatcher
-# handles in-batch concurrency server-side; the client just waits for
-# the whole batch. Voys-scale Voys/support (~500 candidates) completes
-# well under 90s on the production container — tuned to give 5x headroom.
-_BULK_CRAWL_TIMEOUT = 5 * 60.0
+# Base bulk-crawl request budget — see settings.crawl_bulk_base_timeout_seconds
+# (config.py) for the tunable value and _bulk_crawl_timeout_for_chunk below
+# for how the chunk's own rate_limit pacing is added on top of it.
+#
+# crawl4ai's MemoryAdaptiveDispatcher handles in-batch concurrency
+# server-side; the client just waits for the whole batch. Voys-scale
+# Voys/support (~500 candidates) completes well under 90s on the production
+# container — tuned to give 5x headroom for fetch/render time.
+#
+# 2026-08-18 (fix/bulk-timeout-scales-with-pacing, intermedia.com incident
+# #2): this used to be the WHOLE timeout, fixed regardless of rate_limit.
+# Since PR #1034, ``rate_limit`` is translated into crawl4ai's own
+# ``mean_delay`` pacing (build_crawl_config) — crawl4ai's RateLimiter keeps
+# per-domain state and serialises starts globally, so on a single-domain
+# crawl a chunk's minimum duration is >= ``len(chunk_urls) * mean_delay``
+# regardless of ``semaphore_count``. A fixed timeout does not scale with
+# that self-imposed delay: at rate_limit=0.25 (mean_delay=4.0s) a 100-URL
+# chunk needs >= 400s of pure pacing alone, well past a fixed 300s.
+
+
+def _bulk_crawl_timeout_for_chunk(chunk_size: int, crawler_config: dict[str, Any]) -> float:
+    """httpx timeout for one bulk ``/crawl`` chunk request.
+
+    Invariant: we must never time out on vertraging die we zelf hebben
+    ingesteld (pacing WE imposed via ``rate_limit``). The historical fixed
+    ``settings.crawl_bulk_base_timeout_seconds`` (300.0 default) covers the
+    fetch/render headroom that has always been there; on top of it we add
+    exactly the pacing this chunk's ``mean_delay`` imposes —
+    ``chunk_size * mean_delay`` — because crawl4ai's RateLimiter serialises
+    request starts per-domain across the whole dispatcher regardless of
+    ``semaphore_count``, so that pacing directly determines the chunk's
+    minimum wall-clock duration.
+
+    ``mean_delay`` is read from ``crawler_config`` (set by
+    ``build_crawl_config`` when ``rate_limit`` is passed). When absent —
+    no rate_limit was configured for this crawl — there is no client-imposed
+    pacing to account for, so the timeout is exactly the base value,
+    unchanged from the historical fixed constant.
+    """
+    base = settings.crawl_bulk_base_timeout_seconds
+    mean_delay = crawler_config.get("mean_delay")
+    if mean_delay is None:
+        return base
+    return base + chunk_size * mean_delay
+
 
 # crawl4ai 0.8 server enforces ``List should have at most 100 items after
 # validation`` on POST /crawl ``urls``. The constant lives here so it can
@@ -2128,8 +2220,9 @@ _BULK_CRAWL_TIMEOUT = 5 * 60.0
 _BULK_CHUNK_SIZE = 100
 
 # Total budget (per crawl_site call) for sequential one-URL-at-a-time
-# recovery of a bulk batch that failed as a whole with an opaque 5xx (see
-# _recover_bulk_5xx_batch, _is_bulk_5xx_error). Evidence 2026-08-14
+# recovery of a bulk batch that failed as a whole with an opaque 5xx (or,
+# since 2026-08-18, a read-timeout — see _recover_bulk_5xx_batch,
+# _is_recoverable_bulk_failure). Evidence 2026-08-14
 # (intermedia.com): crawl4ai's bulk arun_many fails the ENTIRE concurrent
 # batch with one opaque 500
 # (``{"error":"Internal server error","correlation_id":"..."}"``, no
@@ -2359,6 +2452,11 @@ async def _chunked_bulk_fetch(
     Submitting more in one request returns 422. We chunk client-side and
     accumulate raw results; per-chunk transport failure is logged but the
     remaining chunks still ship — partial coverage beats zero coverage.
+
+    Each chunk's httpx timeout is computed from that chunk's own size and
+    pacing via ``_bulk_crawl_timeout_for_chunk`` — see that function's
+    docstring for the invariant this protects (never time out on pacing we
+    imposed on ourselves).
     """
     raw_results: list[dict[str, Any]] = []
     transport_error: BaseException | None = None
@@ -2373,8 +2471,9 @@ async def _chunked_bulk_fetch(
         bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
         if bc:
             payload["browser_config"] = bc
+        chunk_timeout = _bulk_crawl_timeout_for_chunk(len(chunk_urls), crawler_config)
         try:
-            async with httpx.AsyncClient(timeout=_BULK_CRAWL_TIMEOUT) as client:
+            async with httpx.AsyncClient(timeout=chunk_timeout) as client:
                 data = await _crawl_sync(client, payload)
             raw_results.extend(_normalise_results_block(data))
         except Exception as exc:

--- a/klai-knowledge-ingest/tests/test_bulk_timeout_scaling.py
+++ b/klai-knowledge-ingest/tests/test_bulk_timeout_scaling.py
@@ -1,0 +1,95 @@
+"""fix/bulk-timeout-scales-with-pacing — the bulk-crawl httpx timeout must
+scale with the pacing WE impose via ``rate_limit``.
+
+Regression coverage for the 2026-08-17/2026-08-18 intermedia.com incident:
+since PR #1034, ``rate_limit`` is translated into crawl4ai's own pacing
+controls (``semaphore_count`` + ``mean_delay`` — see
+``crawl4ai_client.build_crawl_config``). A single-domain crawl is paced by
+``mean_delay`` per URL (crawl4ai's ``RateLimiter`` keeps per-domain state and
+serialises starts globally, regardless of ``semaphore_count``), so a chunk's
+minimum duration is >= ``len(chunk_urls) * mean_delay``. The httpx timeout
+around the bulk request stayed fixed at 300.0s regardless — at
+``rate_limit=0.25`` (``mean_delay=4.0s``) a 100-URL chunk needs >= 400s of
+pure self-imposed pacing alone, so the request timed out on its own
+deliberate delay before a real failure could even be observed. Production
+evidence (17-08 22:00, intermedia.com, rate_limit=0.5): 146 timeout outcomes
+against 254 real crawl4ai-side 429s in the container log — the fixed timeout
+cut the request off before crawl4ai's own rate-limit signal came back.
+
+The invariant this file locks in: **we must never time out on vertraging die
+we zelf hebben ingesteld.**
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
+
+
+class TestBulkCrawlTimeoutScalesWithPacing:
+    @pytest.mark.parametrize("rate_limit", [2.0, 1.0, 0.5, 0.25])
+    def test_timeout_exceeds_minimum_chunk_pacing_duration(self, rate_limit: float) -> None:
+        """For every supported rate_limit, the computed bulk timeout must be
+        strictly greater than the minimum time a full 100-URL chunk needs
+        just to pace itself (``chunk_size * mean_delay``) — otherwise the
+        client times out on its own deliberate delay before crawl4ai's
+        slowest page even starts fetching. This is the invariant that was
+        broken in production; it must hold for every rate_limit we support.
+        """
+        chunk_size = 100
+        mean_delay = 1.0 / rate_limit
+        crawler_config = crawl4ai_client.build_crawl_config(None, rate_limit=rate_limit)
+
+        timeout = crawl4ai_client._bulk_crawl_timeout_for_chunk(chunk_size, crawler_config)
+
+        minimum_pacing_duration = chunk_size * mean_delay
+        assert timeout > minimum_pacing_duration, (
+            f"rate_limit={rate_limit}: computed timeout={timeout}s must exceed "
+            f"the chunk's own minimum pacing duration={minimum_pacing_duration}s "
+            "— otherwise we time out on vertraging die we zelf hebben ingesteld."
+        )
+
+    def test_quarter_rps_100_url_chunk_needs_well_over_400_seconds(self) -> None:
+        """Concrete regression for the production incident: rate_limit=0.25
+        (mean_delay=4.0s) on a 100-URL chunk needs >= 400s of pure pacing
+        before a single failure signal could even occur. Today (before the
+        fix) the bulk timeout is a fixed 300.0s — this assertion fails
+        against that fixed value."""
+        crawler_config = crawl4ai_client.build_crawl_config(None, rate_limit=0.25)
+
+        timeout = crawl4ai_client._bulk_crawl_timeout_for_chunk(100, crawler_config)
+
+        assert timeout > 400.0
+
+    def test_default_timeout_unchanged_without_rate_limit(self) -> None:
+        """No rate_limit means no mean_delay key in crawler_config — no
+        client-imposed pacing exists, so the timeout stays exactly the
+        historical 300.0s default. Every caller that never sets rate_limit
+        must see byte-for-byte unchanged behaviour."""
+        crawler_config = crawl4ai_client.build_crawl_config(None)  # no rate_limit
+
+        timeout = crawl4ai_client._bulk_crawl_timeout_for_chunk(100, crawler_config)
+
+        assert timeout == 300.0
+
+    def test_uses_configured_base_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The base component is sourced from settings (in line with the
+        other crawl_* settings in config.py), not a hardcoded module
+        constant, so operators can tune it without a code change."""
+        monkeypatch.setattr(settings, "crawl_bulk_base_timeout_seconds", 120.0)
+        crawler_config = crawl4ai_client.build_crawl_config(None)  # no rate_limit
+
+        timeout = crawl4ai_client._bulk_crawl_timeout_for_chunk(100, crawler_config)
+
+        assert timeout == 120.0
+
+    def test_formula_matches_base_plus_pacing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Documents the exact formula: base + chunk_size * mean_delay. At
+        rate_limit=0.25 that is 300 + 100*4.0 = 700.0 with the default base."""
+        crawler_config = crawl4ai_client.build_crawl_config(None, rate_limit=0.25)
+
+        timeout = crawl4ai_client._bulk_crawl_timeout_for_chunk(100, crawler_config)
+
+        assert timeout == pytest.approx(700.0)

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -1095,6 +1095,39 @@ def test_combine_bulk_responses_opaque_5xx_transport_error_all_http_5xx() -> Non
 
 
 # ---------------------------------------------------------------------------
+# _is_recoverable_bulk_failure (fix/bulk-timeout-scales-with-pacing) —
+# widens the old 5xx-only trigger (_is_bulk_5xx_error) to also cover a bulk
+# read-timeout, since both share the same "client-side cause is unknowable
+# from the transport response alone" property that makes a one-URL-at-a-time
+# retry simultaneously the mitigation and the diagnosis.
+# ---------------------------------------------------------------------------
+
+
+class TestIsRecoverableBulkFailure:
+    def test_5xx_status_error_is_recoverable(self) -> None:
+        assert crawl4ai_client._is_recoverable_bulk_failure(_opaque_bulk_500_http_status_error())
+
+    def test_4xx_status_error_is_not_recoverable(self) -> None:
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(400, json={"detail": "Bad Request"}, request=request)
+        exc = httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+        assert not crawl4ai_client._is_recoverable_bulk_failure(exc)
+
+    def test_read_timeout_is_recoverable(self) -> None:
+        assert crawl4ai_client._is_recoverable_bulk_failure(
+            httpx.ReadTimeout("simulated bulk timeout")
+        )
+
+    def test_connect_timeout_is_recoverable(self) -> None:
+        assert crawl4ai_client._is_recoverable_bulk_failure(
+            httpx.ConnectTimeout("simulated connect timeout")
+        )
+
+    def test_generic_exception_is_not_recoverable(self) -> None:
+        assert not crawl4ai_client._is_recoverable_bulk_failure(ValueError("boom"))
+
+
+# ---------------------------------------------------------------------------
 # crawl_site — sequential bulk-5xx recovery (2026-08-14, intermedia.com)
 # ---------------------------------------------------------------------------
 
@@ -1305,29 +1338,124 @@ async def test_crawl_site_no_sequential_recovery_on_bulk_4xx(
 
 
 @pytest.mark.asyncio
-async def test_crawl_site_no_sequential_recovery_on_bulk_timeout(
+async def test_crawl_site_recovers_batch_via_sequential_bulk_timeout_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A bulk transport timeout (not an HTTPStatusError at all) must NOT
-    trigger the sequential-recovery fallback — _is_bulk_5xx_error requires
-    an httpx.HTTPStatusError with a 5xx status, which a timeout is not."""
+    """A bulk transport read-timeout (not an HTTPStatusError at all) MUST
+    ALSO trigger the sequential-recovery fallback, exactly like a bulk 5xx
+    does — ``_is_recoverable_bulk_failure`` widens the old 5xx-only trigger
+    (``_is_bulk_5xx_error``) to include ``httpx.TimeoutException``.
+
+    Regression test for the 17-08 22:00 production run (intermedia.com,
+    rate_limit=0.5): ``crawl_sequential_recovery_started`` was 0 while 5
+    bulk chunks failed on read-timeout, so the real 429 signal crawl4ai
+    itself logged (254 occurrences in the container log) never reached
+    ``fetch_outcomes`` — every URL in a timed-out chunk was written off as
+    a bare ``timeout`` batch-wide, with no per-URL diagnosis attempted."""
 
     async def _fake_sitemap(_base: str) -> list[str]:
-        return ["https://example.com/page-a", "https://example.com/page-b"]
+        return [
+            "https://example.com/page-a",
+            "https://example.com/page-b",
+            "https://example.com/page-c",
+        ]
 
     monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
     _patch_seed(monkeypatch, _seed("https://example.com"))
 
-    single_page_calls: list[str] = []
+    def _success_page(url: str) -> dict[str, Any]:
+        return {
+            "url": url,
+            "success": True,
+            "status_code": 200,
+            "html": "<html><body>Real page content, plenty of words here.</body></html>",
+            "markdown": "Real page content, plenty of words here.",
+            "links": {"internal": []},
+            "media": {},
+        }
 
     async def _fake_crawl_sync(
         _client: httpx.AsyncClient,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         urls = payload["urls"]
-        if len(urls) == 1:
-            single_page_calls.append(urls[0])
-        raise httpx.ReadTimeout("simulated bulk timeout")
+        if len(urls) > 1:
+            # The bulk batch request — always times out (the self-imposed
+            # pacing scenario: the chunk's own mean_delay exceeded the
+            # fixed httpx read timeout before a real result came back).
+            raise httpx.ReadTimeout("simulated bulk timeout")
+
+        # Sequential single-page recovery request.
+        (url,) = urls
+        if url == "https://example.com/page-b":
+            raise httpx.ReadTimeout("simulated per-url timeout")
+        return {"results": [_success_page(url)]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    by_url = {o["url"]: o for o in outcomes}
+    assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.TIMEOUT.value
+    assert by_url["https://example.com/page-c"]["reason_code"] == FetchReasonCode.SUCCESS.value
+
+    result_urls = {r.url for r in results}
+    assert "https://example.com/page-a" in result_urls
+    assert "https://example.com/page-c" in result_urls
+    assert "https://example.com/page-b" not in result_urls
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_bulk_timeout_recovery_cap_marks_timeout_not_http_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When sequential recovery is triggered by a bulk TIMEOUT (not a 5xx)
+    and its budget runs out mid-batch, the abandoned URLs must be labelled
+    ``timeout`` — not the historical hardcoded ``http_5xx`` default, which
+    would misreport what was actually observed for a trigger that was never
+    a 5xx at all."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [
+            "https://example.com/page-a",
+            "https://example.com/page-b",
+            "https://example.com/page-c",
+        ]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+    _patch_seed(monkeypatch, _seed("https://example.com"))
+    # Force the cap to trip after the very first sequential retry.
+    monkeypatch.setattr(crawl4ai_client, "_MAX_SEQUENTIAL_RECOVERY", 1)
+
+    attempted_urls: list[str] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        urls = payload["urls"]
+        if len(urls) > 1:
+            raise httpx.ReadTimeout("simulated bulk timeout")
+
+        (url,) = urls
+        attempted_urls.append(url)
+        return {
+            "results": [
+                {
+                    "url": url,
+                    "success": True,
+                    "status_code": 200,
+                    "html": "<html><body>Recovered page content, several words.</body></html>",
+                    "markdown": "Recovered page content, several words.",
+                    "links": {"internal": []},
+                    "media": {},
+                }
+            ]
+        }
 
     monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
 
@@ -1336,10 +1464,15 @@ async def test_crawl_site_no_sequential_recovery_on_bulk_timeout(
         max_pages=10,
     )
 
-    assert single_page_calls == []
-    by_url = {o["url"]: o for o in outcomes}
-    assert by_url["https://example.com/page-a"]["reason_code"] == FetchReasonCode.TIMEOUT.value
-    assert by_url["https://example.com/page-b"]["reason_code"] == FetchReasonCode.TIMEOUT.value
+    # Budget of 1: only the first URL in the batch is actually re-fetched.
+    assert attempted_urls == ["https://example.com/page-a"]
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/page-a"] == FetchReasonCode.SUCCESS.value
+    # Capped mid-batch by a TIMEOUT trigger — the abandoned URLs must carry
+    # the honest `timeout` label, not the 5xx-flavoured default.
+    assert by_url["https://example.com/page-b"] == FetchReasonCode.TIMEOUT.value
+    assert by_url["https://example.com/page-c"] == FetchReasonCode.TIMEOUT.value
 
 
 # ---------------------------------------------------------------------------
@@ -1673,11 +1806,18 @@ class TestClassifyFetchOutcomeRateLimitedWrapper:
 async def test_recovery_stops_immediately_on_rate_limited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A confirmed rate-limit during sequential bulk-5xx recovery means the
+    """A confirmed rate-limit during sequential bulk recovery means the
     target site explicitly told us to back off. The recovery loop must stop
     after the FIRST 429 — no second attempt — and mark every remaining URL
-    in the batch RATE_LIMITED (not HTTP_5XX, the default abandon reason),
-    with the stop event logged exactly once."""
+    in the batch RATE_LIMITED (never the abandon-reason default, whatever
+    that default is), with the stop event logged exactly once.
+
+    Extended (fix/bulk-timeout-scales-with-pacing) to pass
+    ``trigger_reason_code=TIMEOUT`` explicitly: the RATE_LIMITED abandon
+    branch MUST win regardless of what triggered recovery (a bulk 5xx or a
+    bulk timeout) — a real 429 is always the more specific, more actionable
+    signal. This is the guard against the trigger_reason_code plumbing
+    accidentally leaking into the one branch that must never use it."""
     call_count = 0
 
     async def _fake_crawl_page_with_config(
@@ -1723,6 +1863,7 @@ async def test_recovery_stops_immediately_on_rate_limited(
             cookies=None,
             base_domain="example.com",
             recovery_budget=60,
+            trigger_reason_code=FetchReasonCode.TIMEOUT.value,
         )
 
     # Only the first URL was actually attempted over the network.


### PR DESCRIPTION
## The flaw

`_BULK_CRAWL_TIMEOUT = 300.0` and `_BULK_CHUNK_SIZE = 100` are both fixed. Since #1034, `rate_limit` is translated into crawl4ai's `mean_delay = 1/rate_limit`, so a chunk's duration now scales with `1/rate_limit` while the timeout does not.

crawl4ai's `RateLimiter` keeps per-domain state and serialises request *starts* globally across sessions — verified in the running container. So on a single-domain crawl a chunk's minimum duration is `len(chunk) × mean_delay`, **regardless of `semaphore_count`**:

| rate_limit | mean_delay | 100 URLs need | fits in 300s? |
|---|---|---|---|
| 2.0 | 0.5s | 50s | yes |
| 1.0 | 1.0s | 100s | yes |
| 0.5 | 2.0s | 200s | barely |
| 0.25 | 4.0s | 400s | **no** |

And `lower_domain_rate_limit` halves the limit whenever a site pushes back, so this gets worse precisely as a site gets harder to crawl. We introduced it in #1034 and it bit within hours.

## What it did in production

Run 2026-08-17 22:00, intermedia.com alone, rate_limit 0.5:

```
crawl_site_bulk_chunk_failed:       5
crawl_sequential_recovery_started:  0
fetch_outcomes: 125 success, 146 timeout, 3 blocked_anti_bot, 0 rate_limited
crawl4ai container log:             254 mentions of 429
```

The bulk request dies on an httpx read-timeout. That is not an `httpx.HTTPStatusError`, so `_is_bulk_5xx_error` returns False, so `_recover_bulk_5xx_batch` never runs and every URL in the chunk is written off as `timeout`. crawl4ai saw the 429s; we never did.

That also means #1040's 429 fix — which lives entirely inside that recovery path — has never executed in production. It is not wrong, it is unreachable. This PR is what makes it reachable.

## Two changes

**The timeout scales with the pacing we chose.** `timeout = crawl_bulk_base_timeout_seconds + len(chunk) × mean_delay`. The 300s base is unchanged and still covers fetch/render; on top of it sits exactly the delay we added. 350s / 400s / 500s / 700s at the four rate limits above. `mean_delay` is read from the `crawler_config` dict `build_crawl_config` already populates; when the key is absent (no rate limit set) the result is byte-identical to the historical fixed 300.0.

The invariant, stated once so it can be tested: **we must never time out on delay we imposed ourselves.**

**A read-timeout now also earns a per-URL diagnosis.** `_is_bulk_5xx_error` becomes `_is_recoverable_bulk_failure`, covering both a 5xx and an `httpx.TimeoutException` — in both cases the client-side cause is unknowable and the per-URL retry is simultaneously the diagnosis and the mitigation. `_abandon_remaining` now takes the trigger's reason so abandoned URLs are labelled honestly (`timeout` for a timeout trigger, `http_5xx` for a 5xx) instead of always claiming 5xx. The existing branch that abandons the rest as `rate_limited` on a confirmed 429 is untouched — that is the branch that makes the auto-lowering fire correctly.

Deliberately not done: shrinking the chunk size (explodes request count and does nothing about fetch time), touching the cooldown / deadline / breaker, or adding `TIMEOUT` to the lowering trigger set.

## Verification

15 new tests, all confirmed to fail against main's production code and pass with the fix — checked by reverting only `config.py` and `crawl4ai_client.py` to main and re-running:

```
8 failed  tests/test_bulk_timeout_scaling.py
7 failed  tests/test_crawl_site_reconcile.py -k "bulk_timeout or recoverable"
```

The one that matters most is `test_crawl_site_recovers_batch_via_sequential_bulk_timeout_fallback`: it pins the exact production failure, where 5 chunks died and recovery was entered zero times.

Suite: 1285 → 1299 passed, 4 skipped. `ruff check` and `ruff format --check` clean.

## What this still does not prove

That a 429 now actually surfaces as `rate_limited` in production. Unit tests cannot show that. The check is an intermedia run where either no chunk times out at all, or `crawl_sequential_recovery_started` > 0 and `rate_limited` appears in `fetch_outcomes` without an incidental anti-bot outcome carrying the lowering. That runs after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)