### PR TITLE
fix(crawler): stop when the site says stop, and stop throwing away work that succeeded

### DIFF
--- a/klai-connector/app/reason_codes.py
+++ b/klai-connector/app/reason_codes.py
@@ -45,6 +45,12 @@ class FetchReasonCode(StrEnum):
     NOT_FETCHED_DISCOVERY_LIMIT = "not_fetched_discovery_limit"
     NOT_FETCHED_EXCLUDED = "not_fetched_excluded"
     NOT_FETCHED_DUPLICATE = "not_fetched_duplicate"
+    # Mirror of knowledge-ingest's FetchReasonCode (bulk-path defects block
+    # A / A1, 2026-08-18) — the connector does not itself produce this
+    # value today, but the parity test (tests/test_reason_codes_parity.py)
+    # requires both copies to carry the same value set regardless of which
+    # side currently emits it.
+    NOT_FETCHED_RATE_LIMIT_STOP = "not_fetched_rate_limit_stop"
     UNKNOWN_EXCEPTION = "unknown_exception"
     # Mirror of knowledge-ingest's FetchReasonCode; the parity test
     # (tests/test_reason_codes_parity.py) keeps both copies in lockstep.

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -128,6 +128,12 @@ _FETCH_NON_FAILURE_REASON_CODES: frozenset[str] = frozenset(
         FetchReasonCode.NOT_FETCHED_DISCOVERY_LIMIT.value,
         FetchReasonCode.NOT_FETCHED_EXCLUDED.value,
         FetchReasonCode.NOT_FETCHED_DUPLICATE.value,
+        # 2026-08-18 (bulk-path defects block A / A1): a URL we deliberately
+        # never sent because an earlier chunk already told us to stop — a
+        # scheduling decision, not a fetch failure. Must NOT inflate
+        # fetch_failure_dominant the way the real RATE_LIMITED observation
+        # correctly does.
+        FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
     }
 )
 _uncategorized_fetch_reason_codes = (

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -1366,15 +1366,23 @@ async def sample_linked_pages(
     if not candidates:
         return LinkedPageSample(0, 0)
 
-    raw_results, transport_error = await _chunked_bulk_fetch(
+    fetch = await _chunked_bulk_fetch(
         urls=candidates,
         crawler_config=build_crawl_config(selector),
         cookies=cookies,
     )
+    # Only candidates whose OWN chunk actually transported are worth
+    # combining — a candidate whose chunk failed or was never attempted
+    # (A1/A2) has no raw result to match against and must not be
+    # misclassified as UNKNOWN_EXCEPTION via a phantom "whole batch failed"
+    # transport_error the way the old single-error contract forced.
+    ok_candidates = [
+        c for c in candidates if c not in fetch.failed and c not in fetch.not_attempted
+    ]
     results, _outcomes = _combine_bulk_responses(
-        candidates=candidates,
-        raw_results=raw_results,
-        transport_error=transport_error,
+        candidates=ok_candidates,
+        raw_results=fetch.raw_results,
+        transport_error=None,
         base_domain=base_domain,
     )
     usable = sum(1 for r in results if r.word_count >= _THIN_CONTENT_WORD_COUNT)
@@ -1483,7 +1491,7 @@ async def crawl_site(
         if not batch:
             break
 
-        raw_results, transport_error = await _chunked_bulk_fetch(
+        fetch = await _chunked_bulk_fetch(
             urls=batch,
             crawler_config=crawler_config,
             cookies=cookies,
@@ -1491,48 +1499,78 @@ async def crawl_site(
         )
         fetched_count += len(batch)
 
-        if transport_error is not None and _is_recoverable_bulk_failure(transport_error):
-            # Escalation step 1: retry the SAME batch once with crawl4ai's
-            # stealth mode + a randomised UA. Measured on intermedia.com
-            # 2026-08-15: the plain bulk request 500s wholesale, the identical
-            # batch with stealth returns 200 with 5 of 6 pages — seconds, not
-            # the ~20 minutes the sequential path costs. Stealth is not the
-            # default because a randomised UA can change what a site serves,
-            # and every crawl that works today works without it; earning it
-            # via a failure keeps healthy sites untouched.
-            logger.info("crawl_bulk_5xx_stealth_retry", urls=len(batch))
-            raw_results, transport_error = await _chunked_bulk_fetch(
-                urls=batch,
+        # A1: URLs whose chunk was never even sent because an earlier chunk
+        # in THIS attempt already saw a RATE_LIMITED/BLOCKED_ANTI_BOT
+        # signal. Carried through the stealth retry below (which can ALSO
+        # stop early on its own chunking) — never retried, never counted
+        # as a failure.
+        not_attempted_urls: list[str] = list(fetch.not_attempted)
+
+        # A2: only the subset of `batch` whose OWN chunk failed to
+        # transport is worth a stealth retry — everything else already has
+        # a real per-URL result in fetch.raw_results (or was intentionally
+        # skipped above) and must not be re-fetched or reclassified.
+        retry_urls = [u for u, exc in fetch.failed.items() if _is_recoverable_bulk_failure(exc)]
+        if retry_urls:
+            # Escalation step 1: retry ONLY the still-failing subset with
+            # crawl4ai's stealth mode + a randomised UA. Measured on
+            # intermedia.com 2026-08-15: the plain bulk request 500s
+            # wholesale, the identical batch with stealth returns 200 with
+            # 5 of 6 pages — seconds, not the ~20 minutes the sequential
+            # path costs. Stealth is not the default because a randomised
+            # UA can change what a site serves, and every crawl that works
+            # today works without it; earning it via a failure keeps
+            # healthy sites untouched.
+            logger.info("crawl_bulk_5xx_stealth_retry", urls=len(retry_urls))
+            stealth_fetch = await _chunked_bulk_fetch(
+                urls=retry_urls,
                 crawler_config=crawler_config,
                 cookies=cookies,
                 stealth=True,
                 rate_limit=rate_limit,
             )
+            fetch.raw_results.extend(stealth_fetch.raw_results)
+            for retried_url in retry_urls:
+                fetch.failed.pop(retried_url, None)
+            fetch.failed.update(stealth_fetch.failed)
+            not_attempted_urls.extend(stealth_fetch.not_attempted)
 
-        if transport_error is not None and _is_recoverable_bulk_failure(transport_error):
-            # crawl4ai's bulk endpoint failed the WHOLE batch with either an
-            # opaque 5xx or a read-timeout (evidence + budget: see
-            # _MAX_SEQUENTIAL_RECOVERY, _is_recoverable_bulk_failure). The
-            # client-side cause is unknowable from the transport response
-            # alone, so we don't guess it — recover what we can by retrying
-            # one URL at a time via the single-page path, which tells us the
-            # REAL per-URL reason_code, instead of writing off every URL in
-            # the batch as unknown_exception (or guessing blocked_anti_bot
-            # without evidence).
+        recovered_results: list[CrawlResult] = []
+        recovered_link_source_results: list[CrawlResult] = []
+        recovered_outcomes: list[FetchOutcome] = []
+        sequential_recovery_urls: list[str] = []
+        recoverable_failed = {
+            u: exc for u, exc in fetch.failed.items() if _is_recoverable_bulk_failure(exc)
+        }
+        if recoverable_failed:
+            # crawl4ai's bulk endpoint still failed this subset after the
+            # stealth retry — either an opaque 5xx or a read-timeout
+            # (evidence + budget: see _MAX_SEQUENTIAL_RECOVERY,
+            # _is_recoverable_bulk_failure). The client-side cause is
+            # unknowable from the transport response alone, so we don't
+            # guess it — recover what we can by retrying one URL at a time
+            # via the single-page path, which tells us the REAL per-URL
+            # reason_code, instead of writing off every URL as
+            # unknown_exception (or guessing blocked_anti_bot without
+            # evidence). Only the URLs STILL unresolved go here — not the
+            # whole original batch (A2): everything the bulk path already
+            # resolved, successfully or via a non-recoverable failure, is
+            # never touched again.
             #
             # The deadline handed to this call is derived from the
             # job-wide time REMAINING, evaluated right now — not a
             # deadline fixed at crawl_site's start — so that only the time
             # this call itself spends recovering is ever charged against
             # the budget (see sequential_recovery_time_remaining above).
+            sequential_recovery_urls = list(recoverable_failed.keys())
             recovery_started_at = _recovery_monotonic()
             (
-                batch_results,
-                link_source_results,
-                batch_outcomes,
+                recovered_results,
+                recovered_link_source_results,
+                recovered_outcomes,
                 recovery_attempted,
             ) = await _recover_bulk_5xx_batch(
-                batch,
+                sequential_recovery_urls,
                 crawler_config=crawler_config,
                 cookies=cookies,
                 base_domain=base_domain,
@@ -1547,7 +1585,12 @@ async def crawl_site(
                 # Honest abandon-reason if the recovery budget/deadline/
                 # breaker caps out mid-batch: whatever this trigger actually
                 # was (5xx or timeout), not a hardcoded 5xx-flavoured guess.
-                trigger_reason_code=_bulk_failure_trigger_reason_code(transport_error),
+                # `recoverable_failed` may hold more than one distinct
+                # exception across its URLs (A2) — this picks the first
+                # one, in submission order, as the representative trigger.
+                trigger_reason_code=_bulk_failure_trigger_reason_code(
+                    next(iter(recoverable_failed.values()))
+                ),
             )
             sequential_recovery_budget -= recovery_attempted
             # Debit only the wall-clock time THIS call actually spent
@@ -1558,16 +1601,43 @@ async def crawl_site(
                 sequential_recovery_time_remaining - (_recovery_monotonic() - recovery_started_at),
                 0.0,
             )
-        else:
-            batch_results, batch_outcomes = _combine_bulk_responses(
-                candidates=batch,
-                raw_results=raw_results,
-                transport_error=transport_error,
-                base_domain=base_domain,
-            )
-            link_source_results = _crawl_results_from_raw_results(
-                raw_results, base_domain=base_domain
-            )
+            # These URLs' fate is now fully captured in recovered_outcomes
+            # (success, still-failed, or abandoned-mid-recovery) — remove
+            # them from fetch.failed so they are not ALSO reclassified
+            # below from their now-stale pre-recovery exception.
+            for recovered_url in sequential_recovery_urls:
+                fetch.failed.pop(recovered_url, None)
+
+        # Everything NOT sent to sequential recovery, not abandoned as
+        # not-attempted (A1), and not still failed (non-recoverable
+        # transport errors, e.g. DNS/connection/4xx-wrapper) has a real
+        # per-URL result sitting in fetch.raw_results.
+        excluded_from_combine = (
+            set(fetch.failed) | set(not_attempted_urls) | set(sequential_recovery_urls)
+        )
+        ok_urls = [u for u in batch if u not in excluded_from_combine]
+        batch_results, batch_outcomes = _combine_bulk_responses(
+            candidates=ok_urls,
+            raw_results=fetch.raw_results,
+            transport_error=None,
+            base_domain=base_domain,
+        )
+        link_source_results = _crawl_results_from_raw_results(
+            fetch.raw_results, base_domain=base_domain
+        )
+        # Non-recoverable failures (DNS/connection/4xx-wrapper errors etc.)
+        # never entered the stealth retry or sequential recovery —
+        # classify them directly from the exception that failed THEIR
+        # chunk (A2: each keeps its own exception, never borrowed).
+        for failed_url, failed_exc in fetch.failed.items():
+            batch_outcomes.append(_outcome_for_failed_url(failed_url, failed_exc))
+        # A1: URLs whose chunk was deliberately never sent.
+        for skipped_url in not_attempted_urls:
+            batch_outcomes.append(_outcome_for_not_attempted_url(skipped_url))
+
+        batch_results.extend(recovered_results)
+        batch_outcomes.extend(recovered_outcomes)
+        link_source_results.extend(recovered_link_source_results)
         # Preview↔ingest parity: the single-page preview recovers thin-but-rich
         # pages via a relaxed retry; do the same for BFS pages so site ingest
         # does not silently store them thin. Only when no selector is active
@@ -1857,10 +1927,11 @@ async def _recover_bulk_5xx_batch(
         """Mark every not-yet-attempted URL with ``reason_code``; return how many.
 
         Default is ``trigger_reason_code`` — the honest reason recovery was
-        entered in the first place (HTTP_5XX or TIMEOUT). Callers override
-        it explicitly only for the RATE_LIMITED abandon branch below, which
-        is a strictly more specific and more actionable signal than the
-        trigger that started this batch's recovery.
+        entered in the first place (HTTP_5XX or TIMEOUT). The RATE_LIMITED
+        abandon branch below overrides it with
+        ``NOT_FETCHED_RATE_LIMIT_STOP`` (A1) — never with RATE_LIMITED
+        itself, which stays reserved for the one URL that was actually
+        attempted and got that answer.
         """
         for leftover_url in urls[index:]:
             outcomes.append(
@@ -1969,8 +2040,18 @@ async def _recover_bulk_5xx_batch(
         # recovering pages. Stop this batch's recovery immediately rather
         # than burning the remaining budget/cooldown on attempts that will
         # only add to the 429 pressure.
+        #
+        # ``url`` itself keeps the real, observed RATE_LIMITED outcome
+        # appended above. The REST of the batch (index i+1 onward) was
+        # never attempted at all — labelling those with RATE_LIMITED too
+        # (the pre-A1 behaviour) inflates "how many times did this domain
+        # actually reject us" with URLs we deliberately chose not to ask.
+        # NOT_FETCHED_RATE_LIMIT_STOP keeps the one real observation
+        # distinct from every abandoned-without-a-network-call URL (A1).
         if reason_code == FetchReasonCode.RATE_LIMITED.value:
-            remaining = _abandon_remaining(i + 1, reason_code=FetchReasonCode.RATE_LIMITED.value)
+            remaining = _abandon_remaining(
+                i + 1, reason_code=FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+            )
             still_failing += 1 + remaining
             logger.warning(
                 "crawl_sequential_recovery_rate_limited",
@@ -2118,6 +2199,38 @@ def _combine_bulk_responses(
     return crawl_results, outcomes
 
 
+def _outcome_for_failed_url(url: str, error: BaseException) -> FetchOutcome:
+    """Outcome for a URL whose OWN chunk failed to transport (A2).
+
+    Classified from THAT chunk's actual exception — never borrowed from a
+    different chunk's failure, and never a guess.
+    """
+    return {
+        "url": url,
+        "reason_code": _classify_fetch_outcome(None, error=error),
+        "status_code": _status_code_from_exception(error),
+        "content_length": 0,
+    }
+
+
+def _outcome_for_not_attempted_url(url: str) -> FetchOutcome:
+    """Outcome for a URL whose chunk was never even sent (A1).
+
+    An earlier chunk already observed RATE_LIMITED/BLOCKED_ANTI_BOT, so
+    ``_chunked_bulk_fetch`` stopped before this URL's chunk went out.
+    Deliberately NOT ``FetchReasonCode.RATE_LIMITED`` — that value stays
+    reserved for a URL we actually asked and got that answer from, so a
+    "how many times did this domain really reject us" count is not
+    inflated by URLs we chose not to send.
+    """
+    return {
+        "url": url,
+        "reason_code": FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+        "status_code": None,
+        "content_length": 0,
+    }
+
+
 async def _recover_thin_bulk_results(
     batch_results: list[CrawlResult],
     *,
@@ -2157,16 +2270,26 @@ async def _recover_thin_bulk_results(
         thin_count=len(thin_urls),
         batch_size=len(batch_results),
     )
-    relaxed_raw, relaxed_error = await _chunked_bulk_fetch(
+    relaxed_fetch = await _chunked_bulk_fetch(
         urls=thin_urls,
         crawler_config=_relax_seed_crawl_config(crawler_config),
         cookies=cookies,
         rate_limit=rate_limit,
     )
+    # Only the subset that actually transported can be compared against the
+    # strict result — a URL whose relaxed chunk failed or was never
+    # attempted (A1/A2) simply keeps its strict result below (no relaxed
+    # candidate found for it), rather than every candidate in this batch
+    # being treated as failed via a single shared transport_error.
+    relaxed_ok_urls = [
+        u
+        for u in thin_urls
+        if u not in relaxed_fetch.failed and u not in relaxed_fetch.not_attempted
+    ]
     relaxed_results, _ = _combine_bulk_responses(
-        candidates=thin_urls,
-        raw_results=relaxed_raw,
-        transport_error=relaxed_error,
+        candidates=relaxed_ok_urls,
+        raw_results=relaxed_fetch.raw_results,
+        transport_error=None,
         base_domain=base_domain,
     )
     relaxed_by_canonical = {_canonicalise_url(r.url): r for r in relaxed_results}
@@ -2495,6 +2618,62 @@ async def _bfs_deep_crawl(
     return crawl_results, None
 
 
+# Reason codes that mean "the target site just told us to back off" —
+# observed either as a per-URL page result inside an otherwise-successful
+# chunk, or as the whole chunk's own transport exception. Either shape MUST
+# stop ``_chunked_bulk_fetch`` from sending any further chunk (A1): sending
+# chunk 2..N after chunk 1 already saw this signal is precisely the
+# "ignore the 429, keep hammering" bug this fixes.
+_STOP_CHUNKING_REASON_CODES = frozenset(
+    {FetchReasonCode.RATE_LIMITED.value, FetchReasonCode.BLOCKED_ANTI_BOT.value}
+)
+
+
+@dataclass
+class ChunkedFetchResult:
+    """Per-chunk outcome of one ``_chunked_bulk_fetch`` call.
+
+    Replaces the old ``tuple[list[dict], BaseException | None]`` return
+    shape, which had two bugs (bulk-path defects block A):
+
+    - it kept only the LAST failing chunk's exception, silently discarding
+      the exception (and the honest cause) of every earlier failed chunk
+      (A2);
+    - a caller that saw ``transport_error is not None`` had no way to tell
+      "which URLs actually failed" from "which URLs already succeeded in
+      an earlier chunk" — so a retry had to redo the WHOLE batch, and a
+      combine step had to treat every candidate as failed even when most
+      of them had a perfectly good result sitting in ``raw_results``.
+
+    Attributes:
+        raw_results: flattened per-URL page dicts from every chunk that
+            transported successfully (an httpx-level 2xx bulk response).
+            A page dict here may still carry ``success: false`` at the
+            page level (404, 500, ...) — that is a normal per-URL outcome,
+            classified downstream by ``_classify_fetch_outcome``, not a
+            transport failure.
+        failed: URL -> the transport exception raised by ITS OWN chunk. A
+            dict (not a single ``transport_error``) so two different
+            chunks that both fail keep their own, distinct exceptions —
+            never the second silently overwriting the first (A2).
+        not_attempted: URLs belonging to chunks that were never submitted
+            at all because an earlier chunk's outcome (page-level
+            classification, or the chunk's own transport exception)
+            classified as RATE_LIMITED or BLOCKED_ANTI_BOT and the loop
+            stopped sending further chunks (A1, see ``stopped_early``).
+            These made ZERO network calls — kept out of ``failed`` so a
+            caller never conflates "the site rejected this URL" with "we
+            chose not to ask".
+        stopped_early: True when ``not_attempted`` is non-empty for the
+            reason described above.
+    """
+
+    raw_results: list[dict[str, Any]] = field(default_factory=list)
+    failed: dict[str, BaseException] = field(default_factory=dict)
+    not_attempted: list[str] = field(default_factory=list)
+    stopped_early: bool = False
+
+
 async def _chunked_bulk_fetch(
     *,
     urls: list[str],
@@ -2502,13 +2681,15 @@ async def _chunked_bulk_fetch(
     cookies: list[dict[str, Any]] | None,
     stealth: bool = False,
     rate_limit: float | None = None,
-) -> tuple[list[dict[str, Any]], BaseException | None]:
+) -> ChunkedFetchResult:
     """Submit ``urls`` to crawl4ai's bulk ``/crawl`` endpoint in chunks.
 
     crawl4ai 0.8 server enforces a 100-URL cap on the ``urls`` array.
     Submitting more in one request returns 422. We chunk client-side and
-    accumulate raw results; per-chunk transport failure is logged but the
-    remaining chunks still ship — partial coverage beats zero coverage.
+    accumulate raw results; per-chunk transport failure is recorded per URL
+    (see ``ChunkedFetchResult.failed``) but does not by itself stop the
+    remaining chunks from shipping — partial coverage beats zero coverage.
+    The one exception is a confirmed rate-limit/anti-bot signal — see below.
 
     ``rate_limit`` (requests/second, optional) additionally paces the
     chunks client-side. crawl4ai's server ignores our ``mean_delay`` /
@@ -2527,11 +2708,18 @@ async def _chunked_bulk_fetch(
     setting's docstring (config.py) for the margin it keeps over crawl4ai's
     server-side ``timeouts.batch_process``. The pacing gap above happens
     BEFORE a chunk's request starts, so it never eats into that timeout.
+
+    A1 (2026-08-18): once a chunk's outcome classifies as RATE_LIMITED or
+    BLOCKED_ANTI_BOT — either a per-URL page result within a successfully
+    transported chunk, or the chunk's own transport exception — every
+    later, not-yet-submitted chunk is skipped entirely instead of being
+    sent anyway. The chunk that produced the signal still fully completes
+    (its own request already went out; we cannot un-send it), only chunks
+    AFTER it are affected. See ``ChunkedFetchResult.not_attempted``.
     """
-    raw_results: list[dict[str, Any]] = []
-    transport_error: BaseException | None = None
+    result = ChunkedFetchResult()
     if not urls:
-        return raw_results, None
+        return result
     chunk_size = _burst_size_for(rate_limit)
     previous_chunk_start: float | None = None
     for chunk_start in range(0, len(urls), chunk_size):
@@ -2550,21 +2738,44 @@ async def _chunked_bulk_fetch(
         bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
         if bc:
             payload["browser_config"] = bc
+
+        chunk_reason_codes: set[str] = set()
         try:
             async with httpx.AsyncClient(
                 timeout=settings.crawl_bulk_base_timeout_seconds
             ) as client:
                 data = await _crawl_sync(client, payload)
-            raw_results.extend(_normalise_results_block(data))
+            chunk_pages = _normalise_results_block(data)
+            result.raw_results.extend(chunk_pages)
+            for page in chunk_pages:
+                chunk_reason_codes.add(_classify_fetch_outcome(page))
         except Exception as exc:
-            transport_error = exc
+            for chunk_url in chunk_urls:
+                result.failed[chunk_url] = exc
+            chunk_reason_codes.add(_classify_fetch_outcome(None, error=exc))
             logger.warning(
                 "crawl_site_bulk_chunk_failed",
                 chunk_index=chunk_start // chunk_size,
                 chunk_size=len(chunk_urls),
                 error=str(exc),
             )
-    return raw_results, transport_error
+
+        if chunk_reason_codes & _STOP_CHUNKING_REASON_CODES:
+            remaining_urls = urls[chunk_start + chunk_size :]
+            if remaining_urls:
+                result.stopped_early = True
+                result.not_attempted = remaining_urls
+                logger.warning(
+                    "crawl_bulk_stopped_after_rate_limit_signal",
+                    sent_urls=chunk_start + len(chunk_urls),
+                    not_attempted_urls=len(remaining_urls),
+                    triggering_reason_codes=sorted(
+                        chunk_reason_codes & _STOP_CHUNKING_REASON_CODES
+                    ),
+                )
+            break
+
+    return result
 
 
 def _normalise_results_block(data: dict[str, Any]) -> list[dict[str, Any]]:

--- a/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
@@ -25,10 +25,54 @@ from urllib.parse import urlparse
 
 import asyncpg
 
+# Ports that are implied by the scheme and therefore carry no distinguishing
+# information in the domain key — ``example.com:443`` (https) and
+# ``example.com`` MUST collide onto the same rate-limit/selector row.
+_DEFAULT_PORTS_BY_SCHEME = {"http": "80", "https": "443"}
+
 
 def extract_domain(url: str) -> str:
-    """Return the netloc (hostname) of the given URL, e.g. 'help.example.com'."""
-    return urlparse(url).netloc
+    """Return a normalised domain key for ``url``, e.g. 'help.example.com'.
+
+    Used as the lookup/storage key for ``knowledge.crawl_domains`` (selector
+    + rate-limit persistence, see module docstring) — so two URLs that are
+    the SAME site to a human MUST produce the SAME key, or they silently
+    become two independent rate limits / selector rows.
+
+    Normalisation (all four independently observed as real-world variance
+    in crawl targets, none handled by a bare ``urlparse(url).netloc``):
+
+    - lowercase (``Example.com`` == ``example.com``)
+    - default port stripped when it matches the URL's scheme
+      (``example.com:443`` over https == ``example.com``) — a NON-default
+      port (``example.com:8080``) is kept, since that genuinely is a
+      different origin for rate-limiting purposes
+    - trailing dot stripped (``example.com.`` == ``example.com`` — a valid
+      absolute-DNS-name suffix that is otherwise a distinct string)
+    - IDNA-normalised for non-ASCII hostnames, so a Unicode domain and its
+      punycode form (``münchen.example`` vs ``xn--mnchen-3ya.example``)
+      collide onto the same key
+
+    No data migration ships with this change: production
+    ``knowledge.crawl_domains`` rows were audited and are already lowercase
+    with no port suffix, so a backfill would touch zero rows. See
+    docs/pitfalls or the SPEC changelog for the RLS reason a migration-time
+    UPDATE would be unsafe on this table regardless.
+    """
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    if hostname:
+        try:
+            hostname = hostname.encode("idna").decode("ascii")
+        except UnicodeError:
+            # Not a valid IDNA hostname (e.g. already punycode, or contains
+            # characters idna can't encode) — keep the lowercased form
+            # rather than raising out of a pure key-derivation helper.
+            pass
+    port = parsed.port
+    if port is None or _DEFAULT_PORTS_BY_SCHEME.get(parsed.scheme) == str(port):
+        return hostname
+    return f"{hostname}:{port}"
 
 
 async def get_domain_selector(

--- a/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
+++ b/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
@@ -54,6 +54,15 @@ class FetchReasonCode(StrEnum):
     NOT_FETCHED_DISCOVERY_LIMIT = "not_fetched_discovery_limit"
     NOT_FETCHED_EXCLUDED = "not_fetched_excluded"
     NOT_FETCHED_DUPLICATE = "not_fetched_duplicate"
+    # 2026-08-18 (bulk-path defects block A / A1): a chunk earlier in the
+    # SAME bulk-fetch attempt (or the sequential-recovery loop) came back
+    # RATE_LIMITED or BLOCKED_ANTI_BOT, so every URL still queued behind it
+    # is deliberately never sent — not attempted, not observed, and
+    # therefore honestly distinct from RATE_LIMITED itself. Keeping this
+    # separate from RATE_LIMITED matters downstream: a domain-level
+    # "how many times did this site actually reject us" count must not be
+    # inflated by URLs we chose not to ask.
+    NOT_FETCHED_RATE_LIMIT_STOP = "not_fetched_rate_limit_stop"
     UNKNOWN_EXCEPTION = "unknown_exception"
     # 2026-08-14: distinguishes a Cloudflare/anti-bot JS-challenge block from
     # a generic unknown_exception. Additive and safe without a migration —

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
@@ -1,0 +1,320 @@
+"""A2 (bulk-path defects block A) — partial success must survive a retry.
+
+Before this fix ``_chunked_bulk_fetch`` kept only the LAST chunk's
+transport exception (earlier failures silently discarded), and
+``crawl_site``'s stealth-retry step re-sent the WHOLE original batch —
+including the URLs whose chunk had already succeeded — throwing away real
+results. This locks in the fix: only the failed subset is retried, and
+already-succeeded results survive untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import ChunkedFetchResult, _chunked_bulk_fetch
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# One URL per chunk (see test_chunked_bulk_fetch_rate_limit_stop.py for the
+# derivation), so N urls produce N distinct HTTP requests we can fail
+# independently.
+_ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _opaque_500() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+    response = httpx.Response(
+        500, json={"error": "Internal server error", "correlation_id": "abc"}, request=request
+    )
+    return httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# _chunked_bulk_fetch: multiple failed chunks each keep their own exception.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_differently_failed_chunks_both_keep_their_own_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before this fix, only the LAST chunk's transport_error survived —
+    the first chunk's failure (and its distinct exception) vanished."""
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        url = payload["urls"][0]
+        if url == "https://example.com/1":
+            raise _opaque_500()
+        if url == "https://example.com/2":
+            raise httpx.ReadTimeout("simulated timeout")
+        return {"results": [_ok_page(url)]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = ["https://example.com/1", "https://example.com/2", "https://example.com/3"]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert set(fetch.failed) == {"https://example.com/1", "https://example.com/2"}
+    assert isinstance(fetch.failed["https://example.com/1"], httpx.HTTPStatusError)
+    assert isinstance(fetch.failed["https://example.com/2"], httpx.ReadTimeout)
+    # The third chunk succeeded and is untouched.
+    assert [p["url"] for p in fetch.raw_results] == ["https://example.com/3"]
+
+
+# ---------------------------------------------------------------------------
+# crawl_site: stealth retry only re-sends the failed subset; the already-
+# succeeded chunk's result is preserved, not thrown away and re-fetched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stealth_retry_only_resends_the_failed_subset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One chunk fails, one chunk succeeds. The stealth retry must be sent
+    for the failed URL only — the succeeded URL must never appear in a
+    second (or stealth) bulk request."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/ok", "https://example.com/broken"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> crawl4ai_client.CrawlResult:
+        return crawl4ai_client.CrawlResult(
+            url=start_url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    seen_url_sets: list[frozenset[str]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *,
+        urls: list[str],
+        crawler_config: dict[str, Any],
+        cookies: list[dict[str, Any]] | None,
+        stealth: bool = False,
+        rate_limit: float | None = None,
+    ) -> ChunkedFetchResult:
+        seen_url_sets.append(frozenset(urls))
+        if not stealth:
+            # Main attempt: /ok succeeds, /broken fails as its OWN chunk.
+            return ChunkedFetchResult(
+                raw_results=[_ok_page("https://example.com/ok")],
+                failed={"https://example.com/broken": _opaque_500()},
+            )
+        # Stealth retry — only /broken should ever be requested here.
+        assert urls == ["https://example.com/broken"]
+        return ChunkedFetchResult(raw_results=[_ok_page("https://example.com/broken")])
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    # Main attempt requested both URLs; the stealth retry requested ONLY
+    # the failed one.
+    assert seen_url_sets == [
+        frozenset({"https://example.com/ok", "https://example.com/broken"}),
+        frozenset({"https://example.com/broken"}),
+    ]
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/ok"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/broken"] == FetchReasonCode.SUCCESS.value
+    result_urls = {r.url for r in results}
+    assert "https://example.com/ok" in result_urls
+    assert "https://example.com/broken" in result_urls
+
+
+@pytest.mark.asyncio
+async def test_first_attempts_successful_result_survives_into_final_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The specific regression: a URL that succeeded on the FIRST attempt
+    must appear in the final results even though a DIFFERENT URL in the
+    same batch triggered a stealth retry and sequential recovery."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/already-ok", "https://example.com/needs-recovery"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> crawl4ai_client.CrawlResult:
+        return crawl4ai_client.CrawlResult(
+            url=start_url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    async def _fake_chunked_bulk_fetch(
+        *,
+        urls: list[str],
+        crawler_config: dict[str, Any],
+        cookies: list[dict[str, Any]] | None,
+        stealth: bool = False,
+        rate_limit: float | None = None,
+    ) -> ChunkedFetchResult:
+        if not stealth:
+            return ChunkedFetchResult(
+                raw_results=[_ok_page("https://example.com/already-ok")],
+                failed={"https://example.com/needs-recovery": _opaque_500()},
+            )
+        # Stealth retry for the failed URL also fails — falls through to
+        # sequential recovery.
+        assert urls == ["https://example.com/needs-recovery"]
+        return ChunkedFetchResult(failed={"https://example.com/needs-recovery": _opaque_500()})
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    async def _fake_recover_bulk_5xx_batch(
+        urls: list[str],
+        *,
+        crawler_config: dict[str, Any],
+        cookies: list[dict[str, Any]] | None,
+        base_domain: str,
+        recovery_budget: int,
+        deadline: float | None = None,
+        stealth: bool = False,
+        trigger_reason_code: str = FetchReasonCode.HTTP_5XX.value,
+    ) -> tuple[
+        list[crawl4ai_client.CrawlResult],
+        list[crawl4ai_client.CrawlResult],
+        list[dict[str, Any]],
+        int,
+    ]:
+        # Only the still-failing URL must ever reach sequential recovery —
+        # never the whole original batch (the second half of A2's bug).
+        assert urls == ["https://example.com/needs-recovery"]
+        recovered = crawl4ai_client.CrawlResult(
+            url="https://example.com/needs-recovery",
+            fit_markdown="recovered",
+            raw_markdown="recovered",
+            html="<html>recovered</html>",
+            word_count=50,
+            success=True,
+        )
+        outcome = {
+            "url": "https://example.com/needs-recovery",
+            "reason_code": FetchReasonCode.SUCCESS.value,
+            "status_code": 200,
+            "content_length": 10,
+        }
+        return [recovered], [recovered], [outcome], 1
+
+    monkeypatch.setattr(crawl4ai_client, "_recover_bulk_5xx_batch", _fake_recover_bulk_5xx_batch)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/already-ok"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/needs-recovery"] == FetchReasonCode.SUCCESS.value
+    result_urls = {r.url for r in results}
+    assert "https://example.com/already-ok" in result_urls
+    assert "https://example.com/needs-recovery" in result_urls
+
+
+@pytest.mark.asyncio
+async def test_not_attempted_urls_never_enter_retry_or_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interaction with A1: URLs skipped because an earlier chunk hit a
+    rate-limit signal are NOT "failed" URLs — they must never be sent to
+    the stealth retry or the sequential-recovery path."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return ["https://example.com/1", "https://example.com/2"]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> crawl4ai_client.CrawlResult:
+        return crawl4ai_client.CrawlResult(
+            url=start_url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *,
+        urls: list[str],
+        crawler_config: dict[str, Any],
+        cookies: list[dict[str, Any]] | None,
+        stealth: bool = False,
+        rate_limit: float | None = None,
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "stealth": stealth})
+        # Chunk 1 rate-limited, chunk 2 never attempted — no `failed` entry.
+        return ChunkedFetchResult(
+            not_attempted=["https://example.com/2"],
+            stopped_early=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    async def _fail_if_called(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("sequential recovery must never be called for not_attempted URLs")
+
+    monkeypatch.setattr(crawl4ai_client, "_recover_bulk_5xx_batch", _fail_if_called)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    # Only ONE call — no stealth retry, since `failed` was empty.
+    assert calls == [{"urls": ["https://example.com/1", "https://example.com/2"], "stealth": False}]
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/2"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
@@ -1,0 +1,274 @@
+"""A1 (bulk-path defects block A) — an observed 429 must stop the
+remaining chunks of a ``_chunked_bulk_fetch`` call.
+
+Before this fix ``_chunked_bulk_fetch`` classified nothing inside its own
+loop: it POSTed every chunk regardless of what an earlier chunk's response
+said, so a site that rate-limited us on chunk 1 got hammered with chunks
+2..N anyway. This locks in the opposite: the first RATE_LIMITED (or
+BLOCKED_ANTI_BOT) signal — whether a per-URL page result inside an
+otherwise-successful chunk, or the chunk's own transport exception — stops
+every later chunk from ever being sent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# URL per chunk, so three URLs produce three distinct HTTP requests.
+_ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
+
+
+def _rate_limited_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 429,
+        "error_message": "Too Many Requests",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_per_url_429_in_chunk_one_stops_chunk_two_and_three(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact scenario from the task: chunk 1 returns a per-URL 429.
+    No further HTTP requests may be made, and the skipped URLs must NOT
+    be labelled rate_limited (they were never asked)."""
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_rate_limited_page(payload["urls"][0])]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [
+        "https://example.com/1",
+        "https://example.com/2",
+        "https://example.com/3",
+    ]
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    # GEEN verdere HTTP-requests: only chunk 1 (the first URL) was ever sent.
+    assert calls == [["https://example.com/1"]]
+
+    # De niet-verstuurde URL's krijgen de niet-geprobeerd-code, niet rate_limited.
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted == ["https://example.com/2", "https://example.com/3"]
+    assert fetch.failed == {}
+
+    # The one real observation is still classifiable as RATE_LIMITED from
+    # fetch.raw_results — that page dict is untouched.
+    assert len(fetch.raw_results) == 1
+    assert fetch.raw_results[0]["url"] == "https://example.com/1"
+
+
+@pytest.mark.asyncio
+async def test_blocked_anti_bot_signal_also_stops_further_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLOCKED_ANTI_BOT is the sibling trigger to RATE_LIMITED — both mean
+    "stop asking this site right now"."""
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        url = payload["urls"][0]
+        return {
+            "results": [
+                {
+                    "url": url,
+                    "success": False,
+                    "status_code": None,
+                    "error_message": "Blocked by anti-bot protection: JS challenge",
+                    "html": "",
+                    "markdown": "",
+                    "links": {"internal": []},
+                    "media": {},
+                }
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = ["https://example.com/1", "https://example.com/2"]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert calls == [["https://example.com/1"]]
+    assert fetch.not_attempted == ["https://example.com/2"]
+
+
+@pytest.mark.asyncio
+async def test_chunk_level_transport_429_also_stops_further_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 429 wrapped as the CHUNK's own transport exception (not a per-URL
+    page result) must trigger the same stop."""
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(429, json={"detail": "Too Many Requests"}, request=request)
+        raise httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = ["https://example.com/1", "https://example.com/2"]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert calls == [["https://example.com/1"]]
+    assert fetch.stopped_early is True
+    # The chunk that actually failed keeps its real transport exception —
+    # NOT the not-attempted code, that is reserved for chunks never sent.
+    assert set(fetch.failed) == {"https://example.com/1"}
+    assert fetch.not_attempted == ["https://example.com/2"]
+
+
+@pytest.mark.asyncio
+async def test_no_stop_when_no_chunk_observes_rate_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy multi-chunk fetch is completely unaffected by the new
+    stop-check — every chunk still ships."""
+    # Real inter-chunk pacing sleeps would otherwise cost real wall-clock
+    # time here (three chunks over the small burst size used to force
+    # multi-chunk behaviour) — same virtual-clock pattern as
+    # test_client_side_pacing.py, this test asserts on chunking, not pacing.
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_ok_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = ["https://example.com/1", "https://example.com/2", "https://example.com/3"]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert calls == [
+        ["https://example.com/1"],
+        ["https://example.com/2"],
+        ["https://example.com/3"],
+    ]
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
+    assert len(fetch.raw_results) == 3
+
+
+@pytest.mark.asyncio
+async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard for the interaction with
+    ``adapters.crawler._RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES``: even
+    though only ONE chunk's URL was actually rate-limited, that single real
+    observation must still appear in ``crawl_site``'s outcomes as
+    RATE_LIMITED — the NOT_FETCHED_RATE_LIMIT_STOP entries for the skipped
+    URLs must not silently replace it."""
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [
+            "https://example.com/1",
+            "https://example.com/2",
+            "https://example.com/3",
+        ]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> crawl4ai_client.CrawlResult:
+        return crawl4ai_client.CrawlResult(
+            url=start_url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {"results": [_rate_limited_page(payload["urls"][0])]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/1"] == FetchReasonCode.RATE_LIMITED.value
+    assert by_url["https://example.com/2"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    assert by_url["https://example.com/3"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+
+    # The lowering trigger set in adapters/crawler.py fires on RATE_LIMITED
+    # / BLOCKED_ANTI_BOT — confirm the one real observation is present and
+    # would still trip it.
+    from knowledge_ingest.adapters.crawler import _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES
+
+    assert any(o["reason_code"] in _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES for o in outcomes)

--- a/klai-knowledge-ingest/tests/test_client_side_pacing.py
+++ b/klai-knowledge-ingest/tests/test_client_side_pacing.py
@@ -136,15 +136,15 @@ async def test_chunked_bulk_fetch_honours_rate_limit_cadence(
     num_urls = burst * 50
     urls = [f"https://example.com/p{i}" for i in range(num_urls)]
 
-    raw_results, transport_error = await _chunked_bulk_fetch(
+    fetch = await _chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
         rate_limit=rate_limit,
     )
 
-    assert transport_error is None
-    assert len(raw_results) == num_urls
+    assert fetch.failed == {}
+    assert len(fetch.raw_results) == num_urls
 
     elapsed = clock.now
     assert elapsed > 0
@@ -246,15 +246,15 @@ async def test_no_rate_limit_means_no_behaviour_change(monkeypatch: pytest.Monke
     num_urls = 250  # spans 3 chunks at the historical fixed size of 100
     urls = [f"https://example.com/p{i}" for i in range(num_urls)]
 
-    raw_results, transport_error = await _chunked_bulk_fetch(
+    fetch = await _chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
         rate_limit=None,
     )
 
-    assert transport_error is None
-    assert len(raw_results) == num_urls
+    assert fetch.failed == {}
+    assert len(fetch.raw_results) == num_urls
     assert calls == [100, 100, 50]
     assert clock.sleeps == []
     assert clock.now == 0.0

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -614,7 +614,7 @@ async def test_crawl_site_frontier_fetches_listing_children(
         *,
         urls: list[str],
         **_kwargs: Any,
-    ) -> tuple[list[dict[str, Any]], BaseException | None]:
+    ) -> crawl4ai_client.ChunkedFetchResult:
         pages: list[dict[str, Any]] = []
         for url in urls:
             if url == "https://wiki.redcactus.cloud/nl/crm-software":
@@ -656,7 +656,7 @@ async def test_crawl_site_frontier_fetches_listing_children(
                         "media": {},
                     }
                 )
-        return pages, None
+        return crawl4ai_client.ChunkedFetchResult(raw_results=pages)
 
     monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_bulk_fetch)
 
@@ -697,25 +697,27 @@ async def test_crawl_site_records_budget_exhausted_for_unfetched_frontier(
         *,
         urls: list[str],
         **_kwargs: Any,
-    ) -> tuple[list[dict[str, Any]], BaseException | None]:
+    ) -> crawl4ai_client.ChunkedFetchResult:
         assert urls == ["https://example.com/nl/crm-software"]
-        return [
-            {
-                "url": "https://example.com/nl/crm-software",
-                "success": True,
-                "status_code": 200,
-                "html": "<html>CRM listing</html>",
-                "markdown": "CRM listing",
-                "links": {
-                    "internal": [
-                        {"href": "https://example.com/nl/crm-software/zoho-bigin", "text": ""},
-                        {"href": "https://example.com/nl/crm-software/zoho-crm", "text": ""},
-                        {"href": "https://example.com/nl/crm-software/zoho-desk", "text": ""},
-                    ]
-                },
-                "media": {},
-            }
-        ], None
+        return crawl4ai_client.ChunkedFetchResult(
+            raw_results=[
+                {
+                    "url": "https://example.com/nl/crm-software",
+                    "success": True,
+                    "status_code": 200,
+                    "html": "<html>CRM listing</html>",
+                    "markdown": "CRM listing",
+                    "links": {
+                        "internal": [
+                            {"href": "https://example.com/nl/crm-software/zoho-bigin", "text": ""},
+                            {"href": "https://example.com/nl/crm-software/zoho-crm", "text": ""},
+                            {"href": "https://example.com/nl/crm-software/zoho-desk", "text": ""},
+                        ]
+                    },
+                    "media": {},
+                }
+            ]
+        )
 
     monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_bulk_fetch)
 
@@ -1809,15 +1811,24 @@ async def test_recovery_stops_immediately_on_rate_limited(
     """A confirmed rate-limit during sequential bulk recovery means the
     target site explicitly told us to back off. The recovery loop must stop
     after the FIRST 429 — no second attempt — and mark every remaining URL
-    in the batch RATE_LIMITED (never the abandon-reason default, whatever
-    that default is), with the stop event logged exactly once.
+    in the batch as not-attempted (never the abandon-reason default,
+    whatever that default is), with the stop event logged exactly once.
 
     Extended (fix/bulk-timeout-scales-with-pacing) to pass
-    ``trigger_reason_code=TIMEOUT`` explicitly: the RATE_LIMITED abandon
-    branch MUST win regardless of what triggered recovery (a bulk 5xx or a
-    bulk timeout) — a real 429 is always the more specific, more actionable
-    signal. This is the guard against the trigger_reason_code plumbing
-    accidentally leaking into the one branch that must never use it."""
+    ``trigger_reason_code=TIMEOUT`` explicitly: the abandon branch MUST win
+    regardless of what triggered recovery (a bulk 5xx or a bulk timeout) —
+    a real 429 is always the more specific, more actionable signal. This is
+    the guard against the trigger_reason_code plumbing accidentally leaking
+    into the one branch that must never use it.
+
+    2026-08-18 (bulk-path defects block A / A1): the abandoned URLs (b, c)
+    used to be labelled RATE_LIMITED too, identically to the one URL (a)
+    that was ACTUALLY attempted and really got a 429 back. That inflates a
+    domain-level "how many times did this site really reject us" count
+    with URLs we chose not to even ask. Only ``a`` keeps RATE_LIMITED now;
+    ``b``/``c`` get ``NOT_FETCHED_RATE_LIMIT_STOP`` — this test previously
+    locked in the old, conflating behaviour and is updated here to lock in
+    the fix instead."""
     call_count = 0
 
     async def _fake_crawl_page_with_config(
@@ -1871,8 +1882,11 @@ async def test_recovery_stops_immediately_on_rate_limited(
     assert attempted == 1
 
     by_url = {o["url"]: o["reason_code"] for o in outcomes}
-    for u in urls:
-        assert by_url[u] == FetchReasonCode.RATE_LIMITED.value
+    # Only the URL actually attempted (and really rate-limited) keeps
+    # RATE_LIMITED; the rest were never sent at all.
+    assert by_url["https://example.com/a"] == FetchReasonCode.RATE_LIMITED.value
+    assert by_url["https://example.com/b"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    assert by_url["https://example.com/c"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
     assert crawl_results == []
     assert link_source_results == []
 

--- a/klai-knowledge-ingest/tests/test_extract_domain.py
+++ b/klai-knowledge-ingest/tests/test_extract_domain.py
@@ -1,0 +1,60 @@
+"""``extract_domain`` normalisation (A3, bulk-path defects block A).
+
+``knowledge.crawl_domains`` is keyed by ``extract_domain(url)`` for BOTH
+the CSS-selector cache and the adaptive rate-limit override (see
+``domain_selectors`` module docstring). A bare ``urlparse(url).netloc``
+lets ``Example.com``, ``example.com``, ``example.com:443`` and
+``example.com.`` collide onto four separate rows instead of one — this
+locks in the normalisation that prevents that split.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_ingest.domain_selectors import extract_domain
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_domain"),
+    [
+        # Baseline — already-normalised URL is unchanged.
+        ("https://example.com/page", "example.com"),
+        # Uppercase hostname must lowercase.
+        ("https://Example.com/page", "example.com"),
+        ("https://EXAMPLE.COM/page", "example.com"),
+        # Default port for the URL's own scheme is stripped.
+        ("https://example.com:443/page", "example.com"),
+        ("http://example.com:80/page", "example.com"),
+        # A non-default port is a genuinely different origin and is kept.
+        ("https://example.com:8080/page", "example.com:8080"),
+        # https default port (443) explicitly kept when scheme is http —
+        # it is NOT http's default, so it must NOT be stripped.
+        ("http://example.com:443/page", "example.com:443"),
+        # Trailing dot (absolute DNS name) is stripped.
+        ("https://example.com./page", "example.com"),
+        ("https://Example.com./page", "example.com"),
+        # IDNA normalisation: a Unicode hostname collides with its punycode
+        # form onto the same key.
+        ("https://münchen.example/page", "xn--mnchen-3ya.example"),
+        ("https://xn--mnchen-3ya.example/page", "xn--mnchen-3ya.example"),
+        # Combination: uppercase + default port + trailing dot together.
+        ("https://Example.com.:443/page", "example.com"),
+    ],
+)
+def test_extract_domain_normalises_to_expected_key(url: str, expected_domain: str) -> None:
+    assert extract_domain(url) == expected_domain
+
+
+def test_extract_domain_variants_of_the_same_site_collide_onto_one_key() -> None:
+    """The regression this fix exists for: these four URLs are the SAME
+    site and MUST produce the SAME domain key, or they silently become
+    four independent rate limits / selector rows."""
+    variants = [
+        "https://Example.com/page",
+        "https://example.com/page",
+        "https://example.com:443/page",
+        "https://example.com./page",
+    ]
+    domains = {extract_domain(u) for u in variants}
+    assert domains == {"example.com"}

--- a/klai-knowledge-ingest/tests/test_recover_thin_bulk_results_rate_limit.py
+++ b/klai-knowledge-ingest/tests/test_recover_thin_bulk_results_rate_limit.py
@@ -31,10 +31,10 @@ async def test_recover_thin_bulk_results_forwards_rate_limit(
         cookies: list[dict[str, Any]] | None,
         stealth: bool = False,
         rate_limit: float | None = None,
-    ) -> tuple[list[dict[str, Any]], BaseException | None]:
+    ) -> crawl4ai_client.ChunkedFetchResult:
         seen_rate_limits.append(rate_limit)
-        return (
-            [
+        return crawl4ai_client.ChunkedFetchResult(
+            raw_results=[
                 {
                     "url": u,
                     "success": True,
@@ -45,8 +45,7 @@ async def test_recover_thin_bulk_results_forwards_rate_limit(
                     "media": {},
                 }
                 for u in urls
-            ],
-            None,
+            ]
         )
 
     monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)

--- a/klai-knowledge-ingest/tests/test_sample_linked_pages.py
+++ b/klai-knowledge-ingest/tests/test_sample_linked_pages.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from knowledge_ingest.crawl4ai_client import (
+    ChunkedFetchResult,
     CrawlResult,
     _sample_candidates,
     sample_linked_pages,
@@ -146,7 +147,7 @@ async def test_sample_counts_only_pages_with_real_content() -> None:
     ]
     with patch(
         "knowledge_ingest.crawl4ai_client._chunked_bulk_fetch",
-        new=AsyncMock(return_value=(raw, None)),
+        new=AsyncMock(return_value=ChunkedFetchResult(raw_results=raw)),
     ):
         sample = await sample_linked_pages(seed, max_pages=3)
     assert sample.pages_crawled == 3
@@ -158,7 +159,9 @@ async def test_sample_issues_exactly_one_bulk_request() -> None:
     """The whole point: one parallel batch, no seed re-fetch, no sitemap probe."""
     seed = _seed(*[f"https://example.com/a/b/{i}" for i in range(5)])
     bulk = AsyncMock(
-        return_value=([_page(f"https://example.com/a/b/{i}", 900) for i in range(5)], None)
+        return_value=ChunkedFetchResult(
+            raw_results=[_page(f"https://example.com/a/b/{i}", 900) for i in range(5)]
+        )
     )
     with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
         await sample_linked_pages(seed, max_pages=5)
@@ -168,7 +171,7 @@ async def test_sample_issues_exactly_one_bulk_request() -> None:
 
 @pytest.mark.asyncio
 async def test_seed_without_links_costs_no_request() -> None:
-    bulk = AsyncMock(return_value=([], None))
+    bulk = AsyncMock(return_value=ChunkedFetchResult())
     with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
         sample = await sample_linked_pages(_seed(), max_pages=5)
     assert (sample.pages_crawled, sample.pages_usable) == (0, 0)
@@ -183,7 +186,7 @@ async def test_seed_with_only_template_links_costs_no_request() -> None:
         "https://example.com/euf/themes/standard/{{item.URL}}",
         "https://example.com/euf/themes/standard/{{item.SeoTitle}}",
     )
-    bulk = AsyncMock(return_value=([], None))
+    bulk = AsyncMock(return_value=ChunkedFetchResult())
     with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
         sample = await sample_linked_pages(seed, max_pages=5)
     assert (sample.pages_crawled, sample.pages_usable) == (0, 0)
@@ -200,7 +203,7 @@ async def test_failed_seed_yields_empty_sample() -> None:
         word_count=0,
         success=False,
     )
-    bulk = AsyncMock(return_value=([], None))
+    bulk = AsyncMock(return_value=ChunkedFetchResult())
     with patch("knowledge_ingest.crawl4ai_client._chunked_bulk_fetch", new=bulk):
         sample = await sample_linked_pages(dead, max_pages=5)
     assert (sample.pages_crawled, sample.pages_usable) == (0, 0)
@@ -213,7 +216,11 @@ async def test_transport_error_degrades_to_zero_sample() -> None:
     seed = _seed("https://example.com/a/b/1")
     with patch(
         "knowledge_ingest.crawl4ai_client._chunked_bulk_fetch",
-        new=AsyncMock(return_value=([], RuntimeError("crawl4ai down"))),
+        new=AsyncMock(
+            return_value=ChunkedFetchResult(
+                failed={"https://example.com/a/b/1": RuntimeError("crawl4ai down")}
+            )
+        ),
     ):
         sample = await sample_linked_pages(seed, max_pages=5)
     assert (sample.pages_crawled, sample.pages_usable) == (0, 0)


### PR DESCRIPTION
Three defects in the bulk path, all surfaced by an external architecture review and confirmed against the code before touching anything.

## The site says stop, and we keep sending

`_chunked_bulk_fetch` classified nothing inside its loop. It POSTed each chunk, extended `raw_results`, and only returned after the last one. So when a target answered the first burst with a 429, every remaining burst went out anyway. Immediate abandonment existed only in sequential recovery — the path that runs *after* the damage.

Chunks are now classified as they come back, and an observed `RATE_LIMITED` or `BLOCKED_ANTI_BOT` stops the loop.

The label on the unsent URLs is the part worth arguing about. They do **not** get `rate_limited`. A new `NOT_FETCHED_RATE_LIMIT_STOP` joins the existing `NOT_FETCHED_*` family, because the difference between an *observed* refusal and an *inferred* one has to survive. The next block starts counting how often a host actually pushed back; if 99 abandoned URLs read as 99 observations, that counter is worthless before it exists. `_recover_bulk_5xx_batch` had the identical mislabel after its own 429 abandon and is fixed the same way.

A test pins that the one real observation still triggers the domain rate-limit halving — that is the regression most likely to slip through silently.

Two mechanical guards in this repo caught the change before I did: the cross-service reason-code parity test (the enum is mirrored in `klai-connector`) and an import-time check in `adapters/crawler.py` that raises if any `FetchReasonCode` is uncategorised. Both worked exactly as intended.

## One failed chunk discarded ninety-nine successes

`crawl_site` did `raw_results, transport_error = await _chunked_bulk_fetch(..., stealth=True)` — a reassignment that dropped the first attempt entirely. One failed chunk of 20 in a batch of 100 re-crawled all 100; if the stealth attempt also failed, sequential recovery then walked URLs that had succeeded twice already, at 75s of cooldown each.

`_chunked_bulk_fetch` also kept only the **last** `transport_error`, so with several failed chunks one arbitrary exception drove the caller's classification.

It now returns a `ChunkedFetchResult` — `raw_results`, `failed` keyed by URL with its own exception, `not_attempted`, and `stopped_early`. `crawl_site` retries only the recoverable-failed subset under stealth, merges it back, and hands sequential recovery only what is *still* missing. URLs that were never sent because of a 429 are excluded from both — they are not failures to retry.

`sample_linked_pages` and `_recover_thin_bulk_results` had the same discard-on-partial-failure shape and were fixed alongside.

## Four rate limits for one site

`extract_domain` returned the raw `urlparse(url).netloc`: no lowercasing, no port handling, no trailing dot, no IDNA — while `base_domain` elsewhere in the same file does `.lower()`. So `Example.com`, `example.com`, `example.com:443` and `example.com.` were four independent rate limits for one host, and a site throttled under one key kept being hammered under another.

Now normalised via `urlparse(...).hostname`/`.port`: lowercased, default port stripped for the URL's own scheme (non-default ports kept), trailing dot removed, IDNA-encoded.

No data migration, deliberately. Production rows in `knowledge.crawl_domains` were audited and are already lowercase and port-free, so it would touch zero rows — and that table has RLS with a strict `WITH CHECK`, which makes an unscoped `UPDATE` from alembic fail outright. Documented in the function docstring rather than left implicit. All five call sites use the value purely as a DB key and never compare it against an independently derived string, so normalising is safe.

## Verification

Each defect's tests were run against the pre-fix source and failed for the right reason:

```
A1  calls == [["/1"]]            got [["/1"], ["/2"]]   — chunk 2 sent after chunk 1's 429
A2  ImportError: cannot import name 'ChunkedFetchResult'
A3  assert 'Example.com.:443' == 'example.com'          — 9 of 13 cases
```

1308 → 1329 passed, 4 skipped; 22 new tests. Four existing test files were updated for the new return shape, and one assertion changed on purpose: it previously required *every* URL to be labelled `RATE_LIMITED` after a 429 — the mislabel this PR removes.

`ruff check` and `ruff format --check` clean.

One unrelated failure appears under `-n auto`: `test_simhash_p99_under_5ms_on_100kb`, a wall-clock guard that its own docstring calls out as unreliable on a loaded box. Confirmed it fails identically on `main` at `845e31166`, so it predates this branch. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)