### PR TITLE
feat(crawler): let a throttled domain earn its speed back

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/0010_crawl_domains_rate_limit_recovery.py
+++ b/klai-knowledge-ingest/alembic/versions/0010_crawl_domains_rate_limit_recovery.py
@@ -1,0 +1,63 @@
+"""Add rate-limit recovery counters to knowledge.crawl_domains
+
+2026-08-18 (block B, follow-up to 0009_crawl_domains_rate_limit):
+``lower_domain_rate_limit`` only ever halved a domain's rate limit —
+nothing ever raised it back up, so a domain that had one bad crawl stayed
+throttled forever. This adds the two columns the additive-recovery
+regelwet needs to track state between crawls:
+
+- ``clean_streak``: consecutive clean (SUCCESS) observations accumulated
+  since the last congestion signal (or since the override was created).
+- ``last_congestion_at``: when the domain last hit RATE_LIMITED or
+  BLOCKED_ANTI_BOT — the hysteresis cooldown is measured from this.
+
+See knowledge_ingest.domain_rate_limit_control.compute_domain_rate_limit_update
+(the pure regelwet) and knowledge_ingest.domain_selectors.
+get_domain_rate_limit_state / save_domain_rate_limit_state (persistence).
+
+Ownership note (unlike some other knowledge.* tables): ``knowledge.
+crawl_domains`` is owned by ``klai``, and knowledge-ingest connects as
+``klai`` itself (see 0009's docstring precedent + this migration's
+DDL-only shape) — so this migration runs as the table owner and needs no
+post-deploy SQL step.
+
+Both columns get a default (0 / NULL) so ``ALTER TABLE ADD COLUMN`` is a
+metadata-only operation on PostgreSQL 11+: no row rewrite, and therefore
+nothing that could collide with the RLS WITH CHECK on this table. No
+``UPDATE`` runs in this migration.
+
+Revision ID: d0fb00b16473
+Revises: a3c9e9286990
+Create Date: 2026-08-18 10:36:48.634580
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d0fb00b16473"
+down_revision: str | Sequence[str] | None = "a3c9e9286990"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE knowledge.crawl_domains
+        ADD COLUMN IF NOT EXISTS clean_streak integer NOT NULL DEFAULT 0
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE knowledge.crawl_domains
+        ADD COLUMN IF NOT EXISTS last_congestion_at timestamp with time zone
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE knowledge.crawl_domains DROP COLUMN IF EXISTS clean_streak")
+    op.execute("ALTER TABLE knowledge.crawl_domains DROP COLUMN IF EXISTS last_congestion_at")

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import time
 from collections import Counter
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 
 import asyncpg
@@ -24,10 +25,14 @@ from klai_image_storage import ImageStore, download_and_upload_crawl_images
 from knowledge_ingest import pg_store, qdrant_store
 from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import CrawlResult, _canonicalise_url, crawl_site
+from knowledge_ingest.domain_rate_limit_control import (
+    compute_domain_rate_limit_update,
+    count_rate_limit_observations,
+)
 from knowledge_ingest.domain_selectors import (
     extract_domain,
-    get_domain_rate_limit,
-    lower_domain_rate_limit,
+    get_domain_rate_limit_state,
+    save_domain_rate_limit_state,
 )
 from knowledge_ingest.models import IngestRequest
 from knowledge_ingest.reason_codes import FETCH_REASON_VALUES, FetchReasonCode
@@ -472,17 +477,15 @@ async def _build_link_graph(
 
 _UNSET = object()  # sentinel: stored_hash not yet fetched from DB
 
-# 2026-08-17 (intermedia.com + support.ascendcloud.com incident): when a
-# crawl hits RATE_LIMITED or BLOCKED_ANTI_BOT, the NEXT crawl of that same
-# domain should start already paced down instead of walking into the same
-# wall again. Halving is a simple, explainable adjustment — no PID
-# controller, no multi-run trend analysis — and the floor keeps a very
-# touchy site making forward progress (1 request every 5s) instead of the
-# halving asymptoting toward zero over repeated bad runs.
-_MIN_DOMAIN_RATE_LIMIT = 0.2
-_RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES = frozenset(
-    {FetchReasonCode.RATE_LIMITED.value, FetchReasonCode.BLOCKED_ANTI_BOT.value}
-)
+# 2026-08-17 (intermedia.com + support.ascendcloud.com incident), extended
+# 2026-08-18 with additive recovery (block B): a crawl that hits
+# RATE_LIMITED or BLOCKED_ANTI_BOT paces the NEXT crawl of that domain down
+# instead of walking into the same wall again, and a domain that has
+# behaved for a while gets its rate limit raised back up. The regelwet
+# (halve on congestion, floor, additive step, hysteresis) lives in
+# ``knowledge_ingest.domain_rate_limit_control`` as a pure function so it
+# is testable without a database; this module only wires observed outcomes
+# into it and persists the result.
 
 
 async def run_crawl_job(
@@ -528,8 +531,9 @@ async def run_crawl_job(
     (see ``build_crawl_config``'s docstring). If ``knowledge.crawl_domains``
     holds a previously-lowered rate for this domain (set after a prior
     RATE_LIMITED/BLOCKED_ANTI_BOT outcome — see
-    ``_RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES`` below), that stored value
-    is used instead of this default.
+    ``knowledge_ingest.domain_rate_limit_control``), that stored value is
+    used instead of this default, and it climbs back toward this default
+    over subsequent clean crawls (same module).
 
     ``login_indicator_selector`` (SPEC-CRAWLER-004 Fase B / REQ-02.3) is
     injected into crawl4ai's wait_for and also re-checked on every returned
@@ -555,10 +559,11 @@ async def run_crawl_job(
         # 2026-08-17 (intermedia.com + support.ascendcloud.com incident): if
         # a PREVIOUS crawl of this domain got rate-limited or anti-bot
         # blocked, start this one already paced down instead of hitting the
-        # same wall again. See _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES
-        # below for where the stored value gets written.
+        # same wall again. See knowledge_ingest.domain_rate_limit_control
+        # for where the stored value gets written (and raised back up).
         domain = extract_domain(start_url)
-        stored_rate_limit = await get_domain_rate_limit(conn, domain, org_id)
+        domain_rate_limit_state = await get_domain_rate_limit_state(conn, domain, org_id)
+        stored_rate_limit = domain_rate_limit_state.rate_limit
         effective_rate_limit = stored_rate_limit if stored_rate_limit is not None else rate_limit
         if stored_rate_limit is not None:
             logger.info(
@@ -641,24 +646,43 @@ async def run_crawl_job(
                 pages=len(results),
             )
 
-        # 2026-08-17 (intermedia.com + support.ascendcloud.com incident):
-        # this crawl told us to back off — halve the rate for next time
-        # (floor _MIN_DOMAIN_RATE_LIMIT) instead of hitting the same wall
-        # again on the next sync. One halving per crawl job that actually
-        # saw the signal; no multi-run trend analysis.
-        if any(
-            outcome.get("reason_code") in _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES
-            for outcome in fetch_outcomes
-        ):
-            lowered_rate_limit = max(_MIN_DOMAIN_RATE_LIMIT, effective_rate_limit / 2)
-            await lower_domain_rate_limit(conn, domain, org_id, lowered_rate_limit)
-            logger.warning(
-                "crawl_domain_rate_limit_lowered",
-                job_id=job_id,
-                domain=domain,
-                previous_rate_limit=effective_rate_limit,
-                lowered_rate_limit=lowered_rate_limit,
-            )
+        # 2026-08-17 (intermedia.com + support.ascendcloud.com incident),
+        # extended 2026-08-18 (block B): fold this job's fetch_outcomes into
+        # the AIMD regelwet — halve on congestion (floor
+        # domain_rate_limit_control.MIN_DOMAIN_RATE_LIMIT), or raise one
+        # step once the domain has stayed clean past the recovery threshold
+        # AND the cooldown since the last congestion. ``updated_state`` is
+        # None when nothing needs writing (a healthy domain with no stored
+        # override stays untouched — see compute_domain_rate_limit_update).
+        rate_limit_observation = count_rate_limit_observations(fetch_outcomes)
+        updated_rate_limit_state = compute_domain_rate_limit_update(
+            domain_rate_limit_state,
+            had_congestion=rate_limit_observation.had_congestion,
+            clean_observations=rate_limit_observation.clean_count,
+            default_rate_limit=rate_limit,
+            step_up=settings.crawl_rate_limit_recovery_step,
+            recovery_threshold=settings.crawl_rate_limit_recovery_clean_threshold,
+            cooldown=timedelta(hours=settings.crawl_rate_limit_recovery_cooldown_hours),
+            now=datetime.now(UTC),
+        )
+        if updated_rate_limit_state is not None:
+            await save_domain_rate_limit_state(conn, domain, org_id, updated_rate_limit_state)
+            if rate_limit_observation.had_congestion:
+                logger.warning(
+                    "crawl_domain_rate_limit_lowered",
+                    job_id=job_id,
+                    domain=domain,
+                    previous_rate_limit=effective_rate_limit,
+                    lowered_rate_limit=updated_rate_limit_state.rate_limit,
+                )
+            elif updated_rate_limit_state.rate_limit != domain_rate_limit_state.rate_limit:
+                logger.info(
+                    "crawl_domain_rate_limit_raised",
+                    job_id=job_id,
+                    domain=domain,
+                    previous_rate_limit=domain_rate_limit_state.rate_limit,
+                    raised_rate_limit=updated_rate_limit_state.rate_limit,
+                )
 
         crawl_outcome_warning = _build_crawl_outcome_warning(
             fetch_outcomes,

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -114,6 +114,39 @@ class Settings(BaseSettings):
         default=240.0,
         validation_alias=AliasChoices("KLAI_CRAWL_SEQUENTIAL_RECOVERY_TIMEOUT_SECONDS"),
     )
+    # 2026-08-18 (block B, AIMD recovery follow-up to the 2026-08-17
+    # halving-only lowering): additive-increase side of the per-domain
+    # rate-limit controller (knowledge_ingest.domain_rate_limit_control).
+    # A domain that hit RATE_LIMITED/BLOCKED_ANTI_BOT once should not stay
+    # throttled forever — but raising too eagerly just repeats the
+    # incident, so all three knobs below are deliberately conservative.
+    #
+    # crawl_rate_limit_recovery_step: fixed additive step (req/s) applied
+    # per ELIGIBLE job — never more than one step, regardless of how far
+    # past the threshold the clean streak has grown.
+    crawl_rate_limit_recovery_step: float = Field(
+        default=0.2,
+        validation_alias=AliasChoices("KLAI_CRAWL_RATE_LIMIT_RECOVERY_STEP"),
+    )
+    # crawl_rate_limit_recovery_clean_threshold: clean (SUCCESS) observations
+    # required before a step is even considered. 50 is roughly one
+    # successful crawl of a small site, so in practice this is at most one
+    # step per day for a domain that crawls daily. From the 0.2 floor back
+    # to a 2.0 default that is 9 steps ~= 9 days — deliberately slow: too
+    # fast repeats the incident, and this is background work where a day
+    # of extra caution is not a real cost.
+    crawl_rate_limit_recovery_clean_threshold: int = Field(
+        default=50,
+        validation_alias=AliasChoices("KLAI_CRAWL_RATE_LIMIT_RECOVERY_CLEAN_THRESHOLD"),
+    )
+    # crawl_rate_limit_recovery_cooldown_hours: minimum time since the last
+    # congestion signal before a raise is allowed, even if the clean
+    # threshold is already met — the hysteresis that stops a single good
+    # crawl right after a bad one from immediately undoing the backoff.
+    crawl_rate_limit_recovery_cooldown_hours: float = Field(
+        default=24.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_RATE_LIMIT_RECOVERY_COOLDOWN_HOURS"),
+    )
     # httpx timeout for one bulk `/crawl` chunk request
     # (crawl4ai_client._chunked_bulk_fetch). With client-side pacing
     # (fix/client-side-crawl-pacing) the wait between chunks happens BEFORE

--- a/klai-knowledge-ingest/knowledge_ingest/domain_rate_limit_control.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_rate_limit_control.py
@@ -1,0 +1,155 @@
+"""Pure AIMD regelwet for per-domain crawl rate-limit recovery.
+
+2026-08-17 (intermedia.com + support.ascendcloud.com incident) added
+``lower_domain_rate_limit``: a domain that hits RATE_LIMITED or
+BLOCKED_ANTI_BOT gets its rate limit halved (floor 0.2 req/s) so the NEXT
+crawl of that domain starts already paced down. That is half of an AIMD
+(Additive-Increase/Multiplicative-Decrease) controller — multiplicative
+decrease with no additive increase. A domain that had one bad crawl stays
+throttled forever, because nothing ever raises the limit back up.
+
+This module adds the missing half: additive increase, with hysteresis so
+a single good crawl right after a bad one does not immediately erase the
+backoff (that would just repeat the incident). The regelwet
+(``compute_domain_rate_limit_update``) is a pure function — no database,
+no wall clock, every time-dependent value is a parameter — so every edge
+case is testable without a Postgres connection. Persistence is a separate,
+thin concern in ``knowledge_ingest.domain_selectors``.
+
+Counting rule (the part most likely to be "simplified" away by a future
+change — see ``count_rate_limit_observations``): only ``SUCCESS`` is a
+clean observation, and only ``RATE_LIMITED`` / ``BLOCKED_ANTI_BOT`` is a
+congestion observation. Everything else (timeouts, 5xx, the
+``NOT_FETCHED_*`` family, ``non_content_listing_page``) is neither. A
+timeout says nothing about whether the site is rate-limiting us, and a URL
+we chose not to send (``NOT_FETCHED_RATE_LIMIT_STOP``) says nothing about
+anything — counting it either way would inflate or deflate the very signal
+this controller reacts to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# Same floor as the original halving-only behaviour — a very touchy site
+# still makes forward progress (1 request every 5s) instead of the halving
+# (and now also the increase step) asymptoting toward zero.
+MIN_DOMAIN_RATE_LIMIT = 0.2
+
+_CONGESTION_REASON_CODES = frozenset(
+    {FetchReasonCode.RATE_LIMITED.value, FetchReasonCode.BLOCKED_ANTI_BOT.value}
+)
+
+
+@dataclass(frozen=True)
+class DomainRateLimitState:
+    """The full AIMD state persisted per ``(domain, org_id)``.
+
+    ``rate_limit`` is ``None`` when no override is stored — the domain is
+    healthy and the caller's own default applies. ``clean_streak`` and
+    ``last_congestion_at`` only matter while an override exists; a healthy
+    domain (``rate_limit is None``) has nothing to recover from and is
+    never written (see ``compute_domain_rate_limit_update``).
+    """
+
+    rate_limit: float | None
+    clean_streak: int
+    last_congestion_at: datetime | None
+
+
+@dataclass(frozen=True)
+class RateLimitObservation:
+    """What this crawl job actually observed, reduced to the two facts the
+    regelwet needs. See the module docstring for the counting rule."""
+
+    had_congestion: bool
+    clean_count: int
+
+
+def count_rate_limit_observations(fetch_outcomes: list[dict]) -> RateLimitObservation:
+    """Reduce a job's ``fetch_outcomes`` to (had_congestion, clean_count).
+
+    See the module docstring's "Counting rule" section — this is
+    deliberately narrow. Do not broaden it to count timeouts, 5xx, or
+    ``NOT_FETCHED_*`` as either signal; none of them observe whether the
+    site is rate-limiting us.
+    """
+    had_congestion = False
+    clean_count = 0
+    for outcome in fetch_outcomes:
+        reason = outcome.get("reason_code")
+        if reason in _CONGESTION_REASON_CODES:
+            had_congestion = True
+        elif reason == FetchReasonCode.SUCCESS.value:
+            clean_count += 1
+    return RateLimitObservation(had_congestion=had_congestion, clean_count=clean_count)
+
+
+def compute_domain_rate_limit_update(
+    state: DomainRateLimitState,
+    *,
+    had_congestion: bool,
+    clean_observations: int,
+    default_rate_limit: float,
+    step_up: float,
+    recovery_threshold: int,
+    cooldown: timedelta,
+    now: datetime,
+) -> DomainRateLimitState | None:
+    """The regelwet: additive up, multiplicative down, with hysteresis.
+
+    Returns the new state to persist, or ``None`` when nothing should be
+    written at all — a healthy domain with no stored override and no
+    congestion this job stays untouched, so ``knowledge.crawl_domains``
+    never gains a row for a site that was never a problem.
+
+    Congestion (``had_congestion``) always wins over any clean observations
+    in the SAME job — halve from whatever rate was actually in effect this
+    run (the stored override if any, else the job's own default), reset
+    the clean streak to zero, and record ``now`` as the last congestion.
+
+    Otherwise, accumulate the clean streak. Only raise when ALL of:
+      - an override is actually stored (nothing to recover otherwise),
+      - the accumulated streak has reached ``recovery_threshold``, and
+      - the cooldown since the last congestion has elapsed (or there was
+        never a recorded congestion for this stored override).
+    The raise is always exactly one step (``step_up``), never scaled by how
+    far past the threshold the streak has grown — a single fixed step per
+    eligible job, capped at ``default_rate_limit``. Once the raise would
+    reach or exceed the default, the override is cleared entirely
+    (``rate_limit=None``) rather than storing the default value, and the
+    streak/congestion-timestamp reset with it — the domain falls back to
+    the normal (no-override) path and the table stays clean.
+    """
+    if had_congestion:
+        effective_rate_limit = (
+            state.rate_limit if state.rate_limit is not None else default_rate_limit
+        )
+        lowered = max(MIN_DOMAIN_RATE_LIMIT, effective_rate_limit / 2)
+        return DomainRateLimitState(rate_limit=lowered, clean_streak=0, last_congestion_at=now)
+
+    if state.rate_limit is None:
+        # Nothing to recover — do not start tracking a healthy domain.
+        return None
+
+    new_streak = state.clean_streak + clean_observations
+    cooldown_elapsed = (
+        state.last_congestion_at is None or now - state.last_congestion_at >= cooldown
+    )
+
+    if new_streak >= recovery_threshold and cooldown_elapsed:
+        raised = min(default_rate_limit, state.rate_limit + step_up)
+        if raised >= default_rate_limit:
+            return DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+        return DomainRateLimitState(
+            rate_limit=raised, clean_streak=0, last_congestion_at=state.last_congestion_at
+        )
+
+    return DomainRateLimitState(
+        rate_limit=state.rate_limit,
+        clean_streak=new_streak,
+        last_congestion_at=state.last_congestion_at,
+    )

--- a/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
@@ -9,7 +9,10 @@ Two independent concerns share ``knowledge.crawl_domains``:
   hit a rate-limit or anti-bot block, so the NEXT crawl starts already
   paced down instead of hitting the same wall again (2026-08-17,
   intermedia.com + support.ascendcloud.com incident — see
-  ``knowledge_ingest.adapters.crawler.run_crawl_job``).
+  ``knowledge_ingest.adapters.crawler.run_crawl_job``), PLUS the additive
+  recovery counters (``clean_streak``, ``last_congestion_at``) that let the
+  rate limit climb back up once the domain has behaved for a while (block
+  B follow-up — see ``knowledge_ingest.domain_rate_limit_control``).
 
 A row may carry either field, both, or neither — ``css_selector`` and
 ``selector_source`` are nullable so a rate-limit-only row (no selector ever
@@ -24,6 +27,8 @@ connection (which would not see the RLS GUC).
 from urllib.parse import urlparse
 
 import asyncpg
+
+from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
 
 # Ports that are implied by the scheme and therefore carry no distinguishing
 # information in the domain key — ``example.com:443`` (https) and
@@ -131,14 +136,19 @@ async def upsert_domain_selector(
     )
 
 
-async def get_domain_rate_limit(conn: asyncpg.Connection, domain: str, org_id: str) -> float | None:
-    """Return the stored lowered rate_limit (requests/second) for (domain,
-    org_id), or None when no override has been recorded — callers fall back
-    to their own default in that case.
+async def get_domain_rate_limit_state(
+    conn: asyncpg.Connection, domain: str, org_id: str
+) -> DomainRateLimitState:
+    """Return the full AIMD state for (domain, org_id) — see
+    ``knowledge_ingest.domain_rate_limit_control.DomainRateLimitState``.
+
+    No row for this (domain, org_id) is the same as a healthy domain with
+    no override: ``rate_limit=None, clean_streak=0, last_congestion_at=None``.
+    Callers fall back to their own default rate_limit in that case.
     """
     row = await conn.fetchrow(
         """
-        SELECT rate_limit
+        SELECT rate_limit, clean_streak, last_congestion_at
         FROM knowledge.crawl_domains
         WHERE domain = $1 AND org_id = $2
         """,
@@ -146,31 +156,53 @@ async def get_domain_rate_limit(conn: asyncpg.Connection, domain: str, org_id: s
         org_id,
     )
     if row is None:
-        return None
-    return row["rate_limit"]
+        return DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+    return DomainRateLimitState(
+        rate_limit=row["rate_limit"],
+        clean_streak=row["clean_streak"],
+        last_congestion_at=row["last_congestion_at"],
+    )
 
 
-async def lower_domain_rate_limit(
+async def save_domain_rate_limit_state(
     conn: asyncpg.Connection,
     domain: str,
     org_id: str,
-    rate_limit: float,
+    state: DomainRateLimitState,
 ) -> None:
-    """Persist a lowered rate_limit (requests/second) for (domain, org_id).
+    """Persist the full AIMD state for (domain, org_id) in one write.
+
+    A single function owns the whole row update (rate_limit, clean_streak,
+    last_congestion_at together) rather than one function per field —
+    two functions independently updating the same row would need to agree
+    on each other's fields on every call, which is exactly the kind of
+    drift ``compute_domain_rate_limit_update`` is designed to prevent by
+    returning one coherent next-state object.
 
     Does not touch css_selector/selector_source (a separate concern — see
     module docstring); a fresh insert leaves them NULL, an update to an
     existing row leaves them untouched.
+
+    Callers MUST only invoke this when
+    ``domain_rate_limit_control.compute_domain_rate_limit_update`` returned
+    a non-``None`` state — a healthy domain with no stored override has
+    nothing to persist, and calling this unconditionally would create a
+    row for every domain ever crawled.
     """
     await conn.execute(
         """
-        INSERT INTO knowledge.crawl_domains (domain, org_id, rate_limit, created_at, updated_at)
-        VALUES ($1, $2, $3, now(), now())
+        INSERT INTO knowledge.crawl_domains
+            (domain, org_id, rate_limit, clean_streak, last_congestion_at, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, now(), now())
         ON CONFLICT (domain, org_id) DO UPDATE
-            SET rate_limit = EXCLUDED.rate_limit,
-                updated_at = now()
+            SET rate_limit         = EXCLUDED.rate_limit,
+                clean_streak       = EXCLUDED.clean_streak,
+                last_congestion_at = EXCLUDED.last_congestion_at,
+                updated_at         = now()
         """,
         domain,
         org_id,
-        rate_limit,
+        state.rate_limit,
+        state.clean_streak,
+        state.last_congestion_at,
     )

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
@@ -221,7 +221,7 @@ async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression guard for the interaction with
-    ``adapters.crawler._RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES``: even
+    ``domain_rate_limit_control.count_rate_limit_observations``: even
     though only ONE chunk's URL was actually rate-limited, that single real
     observation must still appear in ``crawl_site``'s outcomes as
     RATE_LIMITED — the NOT_FETCHED_RATE_LIMIT_STOP entries for the skipped
@@ -266,9 +266,14 @@ async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
     assert by_url["https://example.com/2"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
     assert by_url["https://example.com/3"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
 
-    # The lowering trigger set in adapters/crawler.py fires on RATE_LIMITED
-    # / BLOCKED_ANTI_BOT — confirm the one real observation is present and
-    # would still trip it.
-    from knowledge_ingest.adapters.crawler import _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES
+    # The congestion signal counted by domain_rate_limit_control fires on
+    # RATE_LIMITED / BLOCKED_ANTI_BOT — confirm the one real observation is
+    # present and would still trip it. The seed page (fetched separately,
+    # SUCCESS) is the only clean observation; the two
+    # NOT_FETCHED_RATE_LIMIT_STOP skips must NOT count as additional clean
+    # or congestion signals.
+    from knowledge_ingest.domain_rate_limit_control import count_rate_limit_observations
 
-    assert any(o["reason_code"] in _RATE_LIMIT_LOWERING_TRIGGER_REASON_CODES for o in outcomes)
+    observation = count_rate_limit_observations(outcomes)
+    assert observation.had_congestion is True
+    assert observation.clean_count == 1  # the seed page only

--- a/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
+++ b/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
@@ -1,31 +1,47 @@
-"""Per-domain adaptive rate-limit lowering (2026-08-17 incident).
+"""Per-domain adaptive rate-limit control, wired through ``run_crawl_job``
+(2026-08-17 halving incident + 2026-08-18 block B additive recovery).
 
 A domain that returns RATE_LIMITED or BLOCKED_ANTI_BOT outcomes should not
-get hammered again at the same pace on the next crawl. ``run_crawl_job``
-stores a halved rate_limit in ``knowledge.crawl_domains`` for that domain
-(``domain_selectors.lower_domain_rate_limit``) and applies a previously
-stored value on the NEXT crawl instead of the caller's default
-(``domain_selectors.get_domain_rate_limit``).
+get hammered again at the same pace on the next crawl — and a domain that
+has since behaved should not stay throttled forever. ``run_crawl_job``:
+
+- reads the full AIMD state for the domain
+  (``domain_selectors.get_domain_rate_limit_state``) and applies its
+  ``rate_limit`` INSTEAD OF the caller's default when one is stored,
+- counts this job's fetch_outcomes into congestion/clean signals
+  (``domain_rate_limit_control.count_rate_limit_observations``),
+- runs the pure regelwet
+  (``domain_rate_limit_control.compute_domain_rate_limit_update``), and
+- persists the result in one write
+  (``domain_selectors.save_domain_rate_limit_state``) — unless the
+  regelwet says nothing needs persisting.
 
 These tests mock ``crawl_site`` entirely — the crawl4ai wiring itself is
 covered by tests/test_build_crawl_config.py and
-tests/test_crawl_site_reconcile.py. Here the concern is purely: does
-run_crawl_job read the stored override, and does it write one back when the
-signal fires.
+tests/test_crawl_site_reconcile.py. The pure regelwet itself (hysteresis,
+floor, ceiling, table-cleanliness edge cases) is covered exhaustively,
+without any mocking, in tests/test_domain_rate_limit_control.py. Here the
+concern is purely the wiring: does run_crawl_job read the stored state,
+does it feed the right observations into the regelwet, and does it persist
+exactly what the regelwet returned.
 """
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from knowledge_ingest.adapters.crawler import run_crawl_job
 from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
 from knowledge_ingest.reason_codes import FetchReasonCode
 
 START_URL = "https://intermedia.com/support"
 DOMAIN = "intermedia.com"
+
+_NO_OVERRIDE = DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
 
 
 def _mock_conn() -> MagicMock:
@@ -51,19 +67,19 @@ def _page(url: str) -> CrawlResult:
 async def _run(
     *,
     crawl_site_mock: AsyncMock,
-    get_domain_rate_limit_mock: AsyncMock,
-    lower_domain_rate_limit_mock: AsyncMock,
+    get_state_mock: AsyncMock,
+    save_state_mock: AsyncMock,
     rate_limit: float = 2.0,
 ) -> None:
     with (
         patch("knowledge_ingest.adapters.crawler.crawl_site", new=crawl_site_mock),
         patch(
-            "knowledge_ingest.adapters.crawler.get_domain_rate_limit",
-            new=get_domain_rate_limit_mock,
+            "knowledge_ingest.adapters.crawler.get_domain_rate_limit_state",
+            new=get_state_mock,
         ),
         patch(
-            "knowledge_ingest.adapters.crawler.lower_domain_rate_limit",
-            new=lower_domain_rate_limit_mock,
+            "knowledge_ingest.adapters.crawler.save_domain_rate_limit_state",
+            new=save_state_mock,
         ),
         patch(
             "knowledge_ingest.adapters.crawler.pg_store.get_crawled_page_hashes",
@@ -88,6 +104,18 @@ async def _run(
         )
 
 
+def _outcomes(*reason_codes: str) -> list[dict]:
+    return [
+        {
+            "url": f"https://intermedia.com/support/{i}",
+            "reason_code": reason_code,
+            "status_code": 200 if reason_code == FetchReasonCode.SUCCESS.value else None,
+            "content_length": 100 if reason_code == FetchReasonCode.SUCCESS.value else 0,
+        }
+        for i, reason_code in enumerate(reason_codes)
+    ]
+
+
 @pytest.mark.asyncio
 async def test_rate_limited_outcome_lowers_the_domain_rate_limit() -> None:
     """A crawl whose outcomes include RATE_LIMITED must halve and persist
@@ -96,37 +124,27 @@ async def test_rate_limited_outcome_lowers_the_domain_rate_limit() -> None:
     crawl_site = AsyncMock(
         return_value=(
             [_page(START_URL)],
-            [
-                {
-                    "url": START_URL,
-                    "reason_code": FetchReasonCode.SUCCESS.value,
-                    "status_code": 200,
-                    "content_length": 100,
-                },
-                {
-                    "url": "https://intermedia.com/support/a",
-                    "reason_code": FetchReasonCode.RATE_LIMITED.value,
-                    "status_code": None,
-                    "content_length": 0,
-                },
-            ],
+            _outcomes(FetchReasonCode.SUCCESS.value, FetchReasonCode.RATE_LIMITED.value),
         )
     )
-    get_domain_rate_limit = AsyncMock(return_value=None)  # no prior override
-    lower_domain_rate_limit = AsyncMock(return_value=None)
+    get_state = AsyncMock(return_value=_NO_OVERRIDE)  # no prior override
+    save_state = AsyncMock(return_value=None)
 
     await _run(
         crawl_site_mock=crawl_site,
-        get_domain_rate_limit_mock=get_domain_rate_limit,
-        lower_domain_rate_limit_mock=lower_domain_rate_limit,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
         rate_limit=2.0,
     )
 
-    lower_domain_rate_limit.assert_awaited_once()
-    args = lower_domain_rate_limit.await_args
+    save_state.assert_awaited_once()
+    args = save_state.await_args
     assert args.args[1] == DOMAIN
     assert args.args[2] == "org-1"
-    assert args.args[3] == pytest.approx(1.0)  # 2.0 / 2
+    new_state = args.args[3]
+    assert new_state.rate_limit == pytest.approx(1.0)  # 2.0 / 2
+    assert new_state.clean_streak == 0
+    assert new_state.last_congestion_at is not None
 
 
 @pytest.mark.asyncio
@@ -134,58 +152,38 @@ async def test_blocked_anti_bot_outcome_also_lowers_the_domain_rate_limit() -> N
     """BLOCKED_ANTI_BOT is the sibling trigger to RATE_LIMITED — a site
     that anti-bot-blocked us should also be paced down next time."""
     crawl_site = AsyncMock(
-        return_value=(
-            [_page(START_URL)],
-            [
-                {
-                    "url": "https://intermedia.com/support/b",
-                    "reason_code": FetchReasonCode.BLOCKED_ANTI_BOT.value,
-                    "status_code": None,
-                    "content_length": 0,
-                },
-            ],
-        )
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.BLOCKED_ANTI_BOT.value))
     )
-    get_domain_rate_limit = AsyncMock(return_value=None)
-    lower_domain_rate_limit = AsyncMock(return_value=None)
+    get_state = AsyncMock(return_value=_NO_OVERRIDE)
+    save_state = AsyncMock(return_value=None)
 
     await _run(
         crawl_site_mock=crawl_site,
-        get_domain_rate_limit_mock=get_domain_rate_limit,
-        lower_domain_rate_limit_mock=lower_domain_rate_limit,
-        rate_limit=2.0,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
     )
 
-    lower_domain_rate_limit.assert_awaited_once()
+    save_state.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_healthy_crawl_does_not_touch_the_domain_rate_limit() -> None:
-    """No RATE_LIMITED / BLOCKED_ANTI_BOT signal → nothing written. A
-    healthy site is never touched by the adaptive throttle."""
+async def test_healthy_crawl_with_no_override_does_not_touch_the_domain_rate_limit() -> None:
+    """No RATE_LIMITED / BLOCKED_ANTI_BOT signal, no stored override →
+    nothing written. A healthy site is never touched by the adaptive
+    throttle, and no row is created for it."""
     crawl_site = AsyncMock(
-        return_value=(
-            [_page(START_URL)],
-            [
-                {
-                    "url": START_URL,
-                    "reason_code": FetchReasonCode.SUCCESS.value,
-                    "status_code": 200,
-                    "content_length": 100,
-                },
-            ],
-        )
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.SUCCESS.value))
     )
-    get_domain_rate_limit = AsyncMock(return_value=None)
-    lower_domain_rate_limit = AsyncMock(return_value=None)
+    get_state = AsyncMock(return_value=_NO_OVERRIDE)
+    save_state = AsyncMock(return_value=None)
 
     await _run(
         crawl_site_mock=crawl_site,
-        get_domain_rate_limit_mock=get_domain_rate_limit,
-        lower_domain_rate_limit_mock=lower_domain_rate_limit,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
     )
 
-    lower_domain_rate_limit.assert_not_awaited()
+    save_state.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -193,25 +191,17 @@ async def test_a_previously_lowered_rate_is_applied_on_the_next_crawl() -> None:
     """A stored override for this domain must be used INSTEAD OF the
     caller's default rate_limit, on both crawl_site call sites."""
     crawl_site = AsyncMock(
-        return_value=(
-            [_page(START_URL)],
-            [
-                {
-                    "url": START_URL,
-                    "reason_code": FetchReasonCode.SUCCESS.value,
-                    "status_code": 200,
-                    "content_length": 100,
-                },
-            ],
-        )
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.SUCCESS.value))
     )
-    get_domain_rate_limit = AsyncMock(return_value=0.5)  # stored override
-    lower_domain_rate_limit = AsyncMock(return_value=None)
+    get_state = AsyncMock(
+        return_value=DomainRateLimitState(rate_limit=0.5, clean_streak=0, last_congestion_at=None)
+    )
+    save_state = AsyncMock(return_value=None)
 
     await _run(
         crawl_site_mock=crawl_site,
-        get_domain_rate_limit_mock=get_domain_rate_limit,
-        lower_domain_rate_limit_mock=lower_domain_rate_limit,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
         rate_limit=2.0,  # caller's default — must be overridden
     )
 
@@ -224,27 +214,82 @@ async def test_lowering_never_goes_below_the_floor() -> None:
     """Repeated lowering on an already-low stored rate must not asymptote
     toward zero — floor is 0.2 req/s."""
     crawl_site = AsyncMock(
-        return_value=(
-            [_page(START_URL)],
-            [
-                {
-                    "url": "https://intermedia.com/support/a",
-                    "reason_code": FetchReasonCode.RATE_LIMITED.value,
-                    "status_code": None,
-                    "content_length": 0,
-                },
-            ],
-        )
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.RATE_LIMITED.value))
     )
-    get_domain_rate_limit = AsyncMock(return_value=0.3)  # already low
-    lower_domain_rate_limit = AsyncMock(return_value=None)
+    get_state = AsyncMock(
+        return_value=DomainRateLimitState(rate_limit=0.3, clean_streak=0, last_congestion_at=None)
+    )
+    save_state = AsyncMock(return_value=None)
 
     await _run(
         crawl_site_mock=crawl_site,
-        get_domain_rate_limit_mock=get_domain_rate_limit,
-        lower_domain_rate_limit_mock=lower_domain_rate_limit,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
         rate_limit=2.0,
     )
 
-    lower_domain_rate_limit.assert_awaited_once()
-    assert lower_domain_rate_limit.await_args.args[3] == pytest.approx(0.2)  # floor, not 0.15
+    save_state.assert_awaited_once()
+    assert save_state.await_args.args[3].rate_limit == pytest.approx(0.2)  # floor, not 0.15
+
+
+@pytest.mark.asyncio
+async def test_a_clean_job_that_clears_recovery_threshold_and_cooldown_raises_and_persists() -> (
+    None
+):
+    """Integration-level (block B): a domain with a stored override, a
+    clean streak already past the recovery threshold, and a last
+    congestion outside the cooldown window gets raised by exactly one step
+    and the raised state is actually written back — not just computed."""
+    crawl_site = AsyncMock(
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.SUCCESS.value))
+    )
+    get_state = AsyncMock(
+        return_value=DomainRateLimitState(
+            rate_limit=0.5,
+            clean_streak=60,
+            last_congestion_at=datetime.now(UTC) - timedelta(hours=48),
+        )
+    )
+    save_state = AsyncMock(return_value=None)
+
+    await _run(
+        crawl_site_mock=crawl_site,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
+        rate_limit=2.0,
+    )
+
+    save_state.assert_awaited_once()
+    new_state = save_state.await_args.args[3]
+    assert new_state.rate_limit == pytest.approx(0.7)  # 0.5 + one 0.2 step
+    assert new_state.clean_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_a_clean_job_within_cooldown_does_not_raise_despite_a_large_streak() -> None:
+    """Hysteresis wired end-to-end: even with a clean streak already past
+    the threshold, a congestion inside the cooldown window blocks the
+    raise — the persisted state keeps the same (lowered) rate_limit."""
+    crawl_site = AsyncMock(
+        return_value=([_page(START_URL)], _outcomes(FetchReasonCode.SUCCESS.value))
+    )
+    get_state = AsyncMock(
+        return_value=DomainRateLimitState(
+            rate_limit=0.5,
+            clean_streak=60,
+            last_congestion_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+    )
+    save_state = AsyncMock(return_value=None)
+
+    await _run(
+        crawl_site_mock=crawl_site,
+        get_state_mock=get_state,
+        save_state_mock=save_state,
+        rate_limit=2.0,
+    )
+
+    save_state.assert_awaited_once()
+    new_state = save_state.await_args.args[3]
+    assert new_state.rate_limit == pytest.approx(0.5)  # unchanged — still throttled
+    assert new_state.clean_streak == 61  # 60 stored + 1 SUCCESS this job

--- a/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
+++ b/klai-knowledge-ingest/tests/test_crawler_anonymous_auth_wall.py
@@ -18,6 +18,7 @@ from knowledge_ingest.adapters.crawler import (
     run_crawl_job,
 )
 from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
 from knowledge_ingest.utils.auth_wall_detector import AuthWallSignal
 
 
@@ -79,14 +80,19 @@ def _patch_crawler_externals(crawl_results: list[CrawlResult], ingest_side_effec
             "knowledge_ingest.adapters.crawler._ingest_crawl_result",
             new=AsyncMock(side_effect=ingest_side_effect),
         ),
-        # 2026-08-17 per-domain adaptive rate limit: no stored override, no
-        # signal to persist — not the concern of these auth-wall tests.
+        # 2026-08-17/08-18 per-domain adaptive rate limit: no stored
+        # override, no signal to persist — not the concern of these
+        # auth-wall tests.
         patch(
-            "knowledge_ingest.adapters.crawler.get_domain_rate_limit",
-            new=AsyncMock(return_value=None),
+            "knowledge_ingest.adapters.crawler.get_domain_rate_limit_state",
+            new=AsyncMock(
+                return_value=DomainRateLimitState(
+                    rate_limit=None, clean_streak=0, last_congestion_at=None
+                )
+            ),
         ),
         patch(
-            "knowledge_ingest.adapters.crawler.lower_domain_rate_limit",
+            "knowledge_ingest.adapters.crawler.save_domain_rate_limit_state",
             new=AsyncMock(return_value=None),
         ),
     ]

--- a/klai-knowledge-ingest/tests/test_domain_rate_limit_control.py
+++ b/klai-knowledge-ingest/tests/test_domain_rate_limit_control.py
@@ -1,0 +1,243 @@
+"""Pure AIMD regelwet for per-domain crawl rate-limit recovery (block B).
+
+``lower_domain_rate_limit`` (2026-08-17) halves a domain's rate limit on
+congestion but never raises it back — a domain that had one bad day stays
+throttled forever. This module adds the missing half: additive-increase
+with hysteresis (a cooldown + a minimum run of clean observations before
+any increase), so a site that has genuinely recovered gets its rate limit
+back over time, without oscillating on a single good crawl right after a
+bad one.
+
+``compute_domain_rate_limit_update`` is a pure function: no database, no
+wall clock — every time-dependent value is a parameter. This lets every
+edge case (hysteresis, floor, ceiling, table-cleanliness-on-recovery) be
+tested without a Postgres connection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from knowledge_ingest.domain_rate_limit_control import (
+    DomainRateLimitState,
+    compute_domain_rate_limit_update,
+    count_rate_limit_observations,
+)
+
+NOW = datetime(2026, 8, 18, 12, 0, 0, tzinfo=UTC)
+STEP_UP = 0.2
+RECOVERY_THRESHOLD = 50
+COOLDOWN = timedelta(hours=24)
+DEFAULT_RATE_LIMIT = 2.0
+
+
+def _update(
+    state: DomainRateLimitState,
+    *,
+    had_congestion: bool = False,
+    clean_observations: int = 0,
+    default_rate_limit: float = DEFAULT_RATE_LIMIT,
+    step_up: float = STEP_UP,
+    recovery_threshold: int = RECOVERY_THRESHOLD,
+    cooldown: timedelta = COOLDOWN,
+    now: datetime = NOW,
+) -> DomainRateLimitState | None:
+    return compute_domain_rate_limit_update(
+        state,
+        had_congestion=had_congestion,
+        clean_observations=clean_observations,
+        default_rate_limit=default_rate_limit,
+        step_up=step_up,
+        recovery_threshold=recovery_threshold,
+        cooldown=cooldown,
+        now=now,
+    )
+
+
+def test_congestion_halves_resets_streak_and_records_the_timestamp() -> None:
+    """1. Congestie halveert, zet de teller op nul en legt het tijdstip vast."""
+    state = DomainRateLimitState(rate_limit=1.0, clean_streak=30, last_congestion_at=None)
+
+    result = _update(state, had_congestion=True, clean_observations=0)
+
+    assert result == DomainRateLimitState(rate_limit=0.5, clean_streak=0, last_congestion_at=NOW)
+
+
+def test_congestion_never_halves_below_the_floor() -> None:
+    """2. Congestie halveert nooit onder de bodem van 0.2."""
+    state = DomainRateLimitState(rate_limit=0.3, clean_streak=0, last_congestion_at=None)
+
+    result = _update(state, had_congestion=True, clean_observations=0)
+
+    assert result is not None
+    assert result.rate_limit == pytest.approx(0.2)
+
+
+def test_congestion_from_default_when_no_override_stored_yet() -> None:
+    """Congestion on a domain with no stored override halves the job's
+    default rate — the 'effective rate actually used this run'."""
+    state = DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+
+    result = _update(state, had_congestion=True, clean_observations=0, default_rate_limit=2.0)
+
+    assert result is not None
+    assert result.rate_limit == pytest.approx(1.0)
+
+
+def test_clean_job_below_threshold_does_not_raise_and_accumulates_streak() -> None:
+    """3. Schone job onder de drempel: geen verhoging, teller telt op."""
+    state = DomainRateLimitState(rate_limit=0.5, clean_streak=10, last_congestion_at=None)
+
+    result = _update(state, had_congestion=False, clean_observations=5)
+
+    assert result == DomainRateLimitState(rate_limit=0.5, clean_streak=15, last_congestion_at=None)
+
+
+def test_clean_job_above_threshold_but_within_cooldown_does_not_raise() -> None:
+    """4. Schone job boven de drempel maar binnen de afkoelperiode: geen
+    verhoging. This is the hysteresis case — the streak keeps accumulating
+    so a later job (once the cooldown elapses) can still trigger the raise
+    without needing fresh clean observations from scratch."""
+    state = DomainRateLimitState(
+        rate_limit=0.5,
+        clean_streak=45,
+        last_congestion_at=NOW - timedelta(hours=1),
+    )
+
+    result = _update(state, had_congestion=False, clean_observations=10)
+
+    assert result == DomainRateLimitState(
+        rate_limit=0.5,
+        clean_streak=55,
+        last_congestion_at=NOW - timedelta(hours=1),
+    )
+
+
+def test_clean_job_above_threshold_and_outside_cooldown_raises_one_step() -> None:
+    """5. Schone job boven de drempel én buiten de afkoelperiode: precies
+    één stap omhoog, teller terug op nul."""
+    state = DomainRateLimitState(
+        rate_limit=0.5,
+        clean_streak=60,
+        last_congestion_at=NOW - timedelta(hours=25),
+    )
+
+    result = _update(state, had_congestion=False, clean_observations=0)
+
+    assert result == DomainRateLimitState(
+        rate_limit=pytest.approx(0.7),
+        clean_streak=0,
+        last_congestion_at=NOW - timedelta(hours=25),
+    )
+
+
+def test_raise_never_exceeds_the_job_default() -> None:
+    """6. Verhoging plafonneert op de default van de job en gaat er nooit
+    overheen."""
+    state = DomainRateLimitState(
+        rate_limit=1.9,
+        clean_streak=60,
+        last_congestion_at=NOW - timedelta(hours=25),
+    )
+
+    result = _update(state, had_congestion=False, clean_observations=0, default_rate_limit=2.0)
+
+    assert result is not None
+    assert result.rate_limit is None  # reached/exceeded default -> override cleared
+
+
+def test_reaching_default_clears_the_override_instead_of_storing_it() -> None:
+    """7. Bereikt de verhoging de default, dan wordt de opgeslagen override
+    verwijderd in plaats van de default opgeslagen. Also resets the streak
+    and congestion timestamp so the table is genuinely clean again."""
+    state = DomainRateLimitState(
+        rate_limit=1.8,  # +0.2 step lands exactly on the 2.0 default
+        clean_streak=60,
+        last_congestion_at=NOW - timedelta(hours=25),
+    )
+
+    result = _update(state, had_congestion=False, clean_observations=0, default_rate_limit=2.0)
+
+    assert result == DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+
+
+def test_healthy_domain_with_no_stored_override_is_left_untouched() -> None:
+    """8. Een domein zonder opgeslagen verlaging blijft ongemoeid — geen
+    rijen aanmaken voor gezonde domeinen. Returning None signals the caller
+    to skip persistence entirely."""
+    state = DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+
+    result = _update(state, had_congestion=False, clean_observations=1)
+
+    assert result is None
+
+
+def test_congestion_after_a_run_of_clean_jobs_resets_the_streak_immediately() -> None:
+    """9. Congestie ná een reeks schone jobs zet de teller onmiddellijk
+    terug op nul (even though the streak was already large)."""
+    state = DomainRateLimitState(
+        rate_limit=0.5,
+        clean_streak=49,  # one observation away from the threshold
+        last_congestion_at=NOW - timedelta(hours=30),
+    )
+
+    result = _update(state, had_congestion=True, clean_observations=0)
+
+    assert result == DomainRateLimitState(rate_limit=0.25, clean_streak=0, last_congestion_at=NOW)
+
+
+def test_count_rate_limit_observations_congestion_and_not_fetched_stop() -> None:
+    """10. Een job met 1 waargenomen 429 en 99 NOT_FETCHED_RATE_LIMIT_STOP
+    telt als één congestiesignaal en NUL schone waarnemingen — the
+    not-fetched URLs were never sent, so they are not an observation of
+    anything."""
+    outcomes = [
+        {"url": "https://example.com/a", "reason_code": "rate_limited"},
+        *(
+            {"url": f"https://example.com/skip-{i}", "reason_code": "not_fetched_rate_limit_stop"}
+            for i in range(99)
+        ),
+    ]
+
+    result = count_rate_limit_observations(outcomes)
+
+    assert result.had_congestion is True
+    assert result.clean_count == 0
+
+
+def test_count_rate_limit_observations_timeouts_count_as_neither() -> None:
+    """A job with only timeouts says nothing about whether the site rate-
+    limits us — it counts toward neither congestion nor a clean run."""
+    outcomes = [
+        {"url": "https://example.com/a", "reason_code": "timeout"},
+        {"url": "https://example.com/b", "reason_code": "http_5xx"},
+        {"url": "https://example.com/c", "reason_code": "non_content_listing_page"},
+    ]
+
+    result = count_rate_limit_observations(outcomes)
+
+    assert result.had_congestion is False
+    assert result.clean_count == 0
+
+
+def test_count_rate_limit_observations_blocked_anti_bot_is_congestion() -> None:
+    outcomes = [{"url": "https://example.com/a", "reason_code": "blocked_anti_bot"}]
+
+    result = count_rate_limit_observations(outcomes)
+
+    assert result.had_congestion is True
+    assert result.clean_count == 0
+
+
+def test_count_rate_limit_observations_success_is_clean() -> None:
+    outcomes = [
+        {"url": "https://example.com/a", "reason_code": "success"},
+        {"url": "https://example.com/b", "reason_code": "success"},
+    ]
+
+    result = count_rate_limit_observations(outcomes)
+
+    assert result.had_congestion is False
+    assert result.clean_count == 2


### PR DESCRIPTION
## Half a control loop

`lower_domain_rate_limit` halves a domain's rate on a rate-limit or anti-bot signal, down to a floor of 0.2/s. Nothing ever raises it again. A site that had one bad day stayed slow for that tenant permanently.

Four bad jobs walk a host 2.0 → 1.0 → 0.5 → 0.25 → 0.2. At 0.2 the burst is 2 with 10s between, so a 200-page crawl starts its last batch at ~990s instead of ~90s. One transient incident costs a quarter of an hour on every future crawl, forever. Two production domains are sitting at 0.25 and 0.5 right now with no path back.

This is multiplicative decrease without the increase half — AIMD with one wing.

## The law

Additive up, multiplicative down, with hysteresis so it cannot oscillate.

Congestion always wins: halve from whatever was in effect, floor at 0.2, reset the clean streak, stamp the time. Otherwise accumulate clean observations and raise by exactly one step — never scaled by how much evidence accrued — but only when the streak clears its threshold **and** the cooldown since the last congestion has elapsed. That second condition is the hysteresis, and it is the one most likely to get dropped as redundant; there is a test whose only job is to fail if it is.

A domain with no stored override and no congestion is left alone entirely — the function returns `None` and no row is created, so `crawl_domains` stays a table of exceptions rather than a table of everything. When a raise would reach the job's default, the override is deleted rather than storing the default, and the domain falls back to the ordinary path.

Defaults: +0.2 per step, 50 clean observations, 24h cooldown. Fifty is roughly one successful crawl of a small site, so in practice at most one step per day; from the floor back to 2.0 takes nine days. Deliberately slow — raising fast just re-runs the incident, and this is background work where a day costs nothing. All three are settings.

Existing throttled rows have `last_congestion_at = NULL`, so they become eligible as soon as they accumulate clean evidence. That is the intended migration path for the two domains currently sitting below default.

## Counting only what was actually observed

This is where it would quietly go wrong. Since the previous PR, `NOT_FETCHED_RATE_LIMIT_STOP` marks URLs we chose not to send after a 429. Those are not observations of anything.

- congestion: `RATE_LIMITED`, `BLOCKED_ANTI_BOT`
- clean: `SUCCESS`
- neither: timeouts, 5xx, every `NOT_FETCHED_*`, `non_content_listing_page`

A timeout says nothing about whether the site finds us too fast, and a URL that was never sent says nothing by definition. A job with one observed 429 and 99 stopped URLs counts as one congestion signal and zero clean observations — there is a test for exactly that shape, because "simplifying" this is how the denominator gets poisoned.

## Shape

The law is a pure function in its own module: current state plus this job's observations plus `now` as a parameter, returning the new state or `None`. No database, no clock. It is the part worth reviewing, so it is fully testable without either.

`get_domain_rate_limit` and `lower_domain_rate_limit` are replaced by `get_domain_rate_limit_state` / `save_domain_rate_limit_state`, reading and writing the whole row in one upsert. Two functions updating the same row while needing to know each other's fields is how drift starts.

A `crawl_domain_rate_limit_raised` log line mirrors the existing `_lowered` one, so recovery is visible in VictoriaLogs without extra instrumentation.

## Migration

`d0fb00b16473`, on `a3c9e9286990`. Two `ADD COLUMN IF NOT EXISTS` with defaults — metadata-only in PG11+, so no row rewrite and no collision with the strict `WITH CHECK` on that table's RLS policy. No `UPDATE` anywhere in it. `alembic heads` returns exactly one.

## Verification

Fourteen tests on the law, covering both floor and ceiling, hysteresis, streak reset on congestion, the no-row-for-healthy-domains case, and the counting shapes above. Tests written first; the run before implementation failed with `ModuleNotFoundError: No module named 'knowledge_ingest.domain_rate_limit_control'`.

1329 → 1345 passed, 4 skipped, excluding the known flaky wall-clock test that predates this branch. `ruff check` and `ruff format --check` clean.

Not done, deliberately: severity tiers (×0.8 for an isolated 429 vs ×0.5 for a sustained one). It is defensible, but it adds tuning knobs to a system with a dozen connectors, and the counting split above is the part that has to be right first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)