### PR TITLE
feat(feedback): attach reporter's recent chat conversations to /app/chat reports

### DIFF
--- a/klai-portal/backend/app/api/admin/platform.py
+++ b/klai-portal/backend/app/api/admin/platform.py
@@ -172,6 +172,7 @@ class PlatformFeedbackSubmission(BaseModel):
     route_id: str | None
     locale: str | None
     viewport: str | None
+    chat_context: dict | None = None
     created_at: datetime
     triage_suggestion: PlatformFeedbackTriageSuggestion | None = None
     linked_item_id: int | None = None
@@ -461,6 +462,7 @@ def _platform_feedback_submission(
         route_id=row.route_id,
         locale=row.locale,
         viewport=row.viewport,
+        chat_context=row.chat_context,
         created_at=row.created_at,
         triage_suggestion=triage_suggestions.get(row.id),
         linked_item_id=linked.id if linked is not None else None,
@@ -1131,6 +1133,7 @@ async def platform_feedback_submissions(
 
     feedback_type = FeedbackSubmission.metadata_json["feedback_type"].astext
     severity = FeedbackSubmission.metadata_json["severity"].astext
+    chat_context = FeedbackSubmission.metadata_json["chat_context"]
 
     query = (
         select(
@@ -1150,6 +1153,7 @@ async def platform_feedback_submissions(
             FeedbackSubmission.route_id.label("route_id"),
             FeedbackSubmission.locale.label("locale"),
             FeedbackSubmission.viewport.label("viewport"),
+            chat_context.label("chat_context"),
             FeedbackSubmission.created_at.label("created_at"),
         )
         .select_from(FeedbackSubmission)
@@ -1216,6 +1220,7 @@ async def platform_feedback_submission_detail(
     await _audit(perms, "feedback:submission_detail", str(submission_id))
     feedback_type = FeedbackSubmission.metadata_json["feedback_type"].astext
     severity = FeedbackSubmission.metadata_json["severity"].astext
+    chat_context = FeedbackSubmission.metadata_json["chat_context"]
     query = (
         select(
             FeedbackSubmission.id.label("id"),
@@ -1234,6 +1239,7 @@ async def platform_feedback_submission_detail(
             FeedbackSubmission.route_id.label("route_id"),
             FeedbackSubmission.locale.label("locale"),
             FeedbackSubmission.viewport.label("viewport"),
+            chat_context.label("chat_context"),
             FeedbackSubmission.created_at.label("created_at"),
         )
         .select_from(FeedbackSubmission)
@@ -1309,6 +1315,7 @@ async def platform_feedback_item_detail(
     await _audit(perms, "feedback:item_detail", str(item_id))
     feedback_type = FeedbackSubmission.metadata_json["feedback_type"].astext
     severity = FeedbackSubmission.metadata_json["severity"].astext
+    chat_context = FeedbackSubmission.metadata_json["chat_context"]
     async with cross_org_session() as db:
         try:
             item = await get_feedback_item(db, item_id)
@@ -1331,6 +1338,7 @@ async def platform_feedback_item_detail(
                         FeedbackSubmission.route_id.label("route_id"),
                         FeedbackSubmission.locale.label("locale"),
                         FeedbackSubmission.viewport.label("viewport"),
+                        chat_context.label("chat_context"),
                         FeedbackSubmission.created_at.label("created_at"),
                         FeedbackItemLink.link_type.label("link_type"),
                         FeedbackItemLink.created_at.label("linked_at"),
@@ -1373,6 +1381,7 @@ async def platform_feedback_item_detail(
                     route_id=r.route_id,
                     locale=r.locale,
                     viewport=r.viewport,
+                    chat_context=r.chat_context,
                     created_at=r.created_at,
                     link_type=r.link_type,
                     linked_at=r.linked_at,

--- a/klai-portal/backend/app/api/app_assistant.py
+++ b/klai-portal/backend/app/api/app_assistant.py
@@ -9,15 +9,21 @@ from __future__ import annotations
 from typing import Literal
 from urllib.parse import urlsplit, urlunsplit
 
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.database import get_db
+from app.core.database import cross_org_session, get_db
 from app.core.permissions import UserPermissions, get_caller
-from app.klai_feedback.service import create_feedback_submission
+from app.klai_feedback.service import create_feedback_submission, get_feedback_submission
 from app.klai_feedback.triage import run_feedback_triage_for_submission
 from app.services.events import emit_event
+from app.services.librechat_chat_context import recent_chat_conversations
+
+logger = structlog.get_logger()
+
+CHAT_ROUTE_PATH = "/app/chat"
 
 router = APIRouter(prefix="/api/app/assistant", tags=["app-assistant"])
 
@@ -76,6 +82,57 @@ def _feedback_metadata(
         "client_host": request_context.get("client_host"),
         **extra,
     }
+
+
+def _is_chat_route(body: AssistantContextIn) -> bool:
+    if body.route_id and body.route_id.rstrip("/") == CHAT_ROUTE_PATH:
+        return True
+    return urlsplit(body.page_url).path.rstrip("/") == CHAT_ROUTE_PATH
+
+
+def _schedule_followup(
+    background_tasks: BackgroundTasks,
+    *,
+    body: AssistantContextIn,
+    perms: UserPermissions,
+    submission_id: int,
+) -> None:
+    """Queue post-persist work: chat-context enrichment (chat route only), then triage.
+
+    The Mongo lookup runs AFTER the submission is durably stored so a slow or
+    unreachable Mongo can never delay or fail the feedback POST itself.
+    """
+    if _is_chat_route(body) and perms.org_slug:
+        background_tasks.add_task(enrich_chat_context_and_triage, submission_id, perms.org_slug, perms.user_id)
+    else:
+        background_tasks.add_task(run_feedback_triage_for_submission, submission_id)
+
+
+async def enrich_chat_context_and_triage(
+    submission_id: int,
+    org_slug: str,
+    zitadel_user_id: str,
+) -> None:
+    """Attach the reporter's recent LibreChat conversations, then run triage.
+
+    The chat lives in a cross-origin iframe, so ``page_url`` can never carry
+    the conversation; this server-side lookup is the only way to link a
+    report to conversation candidates. Best-effort: any failure is logged and
+    triage still runs.
+    """
+    conversations = await recent_chat_conversations(org_slug, zitadel_user_id)
+    if conversations:
+        try:
+            async with cross_org_session() as db:
+                submission = await get_feedback_submission(db, submission_id)
+                submission.metadata_json = {
+                    **(submission.metadata_json or {}),
+                    "chat_context": {"recent_conversations": conversations},
+                }
+                await db.commit()
+        except Exception:
+            logger.warning("feedback_chat_context_persist_failed", submission_id=submission_id, exc_info=True)
+    await run_feedback_triage_for_submission(submission_id)
 
 
 def _base_properties(
@@ -169,7 +226,7 @@ async def submit_feedback(
             "feedback_type": body.type,
         },
     )
-    background_tasks.add_task(run_feedback_triage_for_submission, submission.id)
+    _schedule_followup(background_tasks, body=body, perms=perms, submission_id=submission.id)
     return AssistantSubmitResponse()
 
 
@@ -214,5 +271,5 @@ async def submit_problem_report(
             "severity": body.severity,
         },
     )
-    background_tasks.add_task(run_feedback_triage_for_submission, submission.id)
+    _schedule_followup(background_tasks, body=body, perms=perms, submission_id=submission.id)
     return AssistantSubmitResponse()

--- a/klai-portal/backend/app/services/librechat_chat_context.py
+++ b/klai-portal/backend/app/services/librechat_chat_context.py
@@ -1,0 +1,127 @@
+"""Recent LibreChat conversations for a feedback reporter.
+
+Feedback submitted from ``/app/chat`` lacks the conversation the reporter was
+looking at: the portal embeds LibreChat in a cross-origin iframe, so the
+portal page URL never contains a conversation id. As enrichment we look up
+the reporter's most recent conversations in the tenant's LibreChat MongoDB
+(users are matched on ``openidId`` = the Zitadel ``sub``).
+
+The result is a RECENCY-BASED CANDIDATE LIST, not a proven link: a reporter
+can complain about an older conversation without touching it, in which case
+``updatedAt`` stays old and the conversation may not appear here. Consumers
+(admin prompt, triage LLM) must treat these as candidates.
+
+Connection note: this uses the Mongo root credentials because portal-api has
+no runtime access to per-tenant Mongo passwords (those live in the LibreChat
+container env only). Scoping is enforced in code instead: the database name
+is derived from the authenticated caller's org slug and the query filters on
+the caller's own ``openidId``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pymongo
+import structlog
+
+from app.core.config import settings
+from app.core.provisioning_names import provisioning_names_for_slug
+
+logger = structlog.get_logger()
+
+MAX_CONVERSATIONS = 3
+_TITLE_MAX_LENGTH = 200
+_MONGO_TIMEOUT_MS = 2000
+
+
+def _sync_recent_conversations(
+    db_name: str,
+    zitadel_user_id: str,
+    limit: int,
+) -> list[dict] | None:
+    """Return the reporter's most recent LibreChat conversations, or ``None``
+    when no LibreChat user exists for this identity (user never opened chat)."""
+    with pymongo.MongoClient(
+        host=settings.mongodb_container_name,
+        port=27017,
+        username=settings.mongo_root_username,
+        password=settings.mongo_root_password,
+        authSource="admin",
+        serverSelectionTimeoutMS=_MONGO_TIMEOUT_MS,
+        connectTimeoutMS=_MONGO_TIMEOUT_MS,
+        socketTimeoutMS=_MONGO_TIMEOUT_MS,
+    ) as client:
+        db = client[db_name]
+        user = db.users.find_one({"openidId": zitadel_user_id}, {"_id": 1})
+        if user is None:
+            return None
+        cursor = (
+            db.conversations.find(
+                # LibreChat stores the owning user's ``_id`` as a string.
+                {"user": str(user["_id"])},
+                {"conversationId": 1, "title": 1, "model": 1, "createdAt": 1, "updatedAt": 1, "_id": 0},
+            )
+            .sort("updatedAt", pymongo.DESCENDING)
+            .limit(limit)
+        )
+        return list(cursor)
+
+
+def _iso(value: object) -> str | None:
+    if not isinstance(value, datetime):
+        return None
+    # MongoDB stores datetimes in UTC but pymongo returns them naive by
+    # default; attach UTC so the timestamp is unambiguous next to the
+    # (timezone-aware) feedback submission time.
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _as_str(value: object, max_length: int | None = None) -> str | None:
+    # Mongo fields are unvalidated external data; on schema drift (ObjectId,
+    # nested document) a non-string value would later fail PostgreSQL JSONB
+    # serialization outside our error handling. Only accept plain strings.
+    if not isinstance(value, str):
+        return None
+    return value[:max_length] if max_length else value
+
+
+def _conversation_entry(raw: dict, chat_origin: str) -> dict[str, str | None]:
+    conversation_id = _as_str(raw.get("conversationId"))
+    return {
+        "conversation_id": conversation_id,
+        "title": _as_str(raw.get("title"), _TITLE_MAX_LENGTH),
+        "model": _as_str(raw.get("model")),
+        "url": f"{chat_origin}/c/{conversation_id}" if conversation_id else None,
+        "created_at": _iso(raw.get("createdAt")),
+        "updated_at": _iso(raw.get("updatedAt")),
+    }
+
+
+async def recent_chat_conversations(
+    org_slug: str,
+    zitadel_user_id: str,
+) -> list[dict[str, str | None]] | None:
+    """Best-effort lookup of the reporter's recent conversations.
+
+    Returns ``None`` on any failure or when the reporter has no LibreChat
+    account; feedback handling must never fail on this enrichment.
+    """
+    try:
+        names = provisioning_names_for_slug(org_slug, domain=settings.domain)
+        raw = await asyncio.to_thread(
+            _sync_recent_conversations,
+            names.mongodb_database,
+            zitadel_user_id,
+            MAX_CONVERSATIONS,
+        )
+    except Exception:
+        logger.warning("feedback_chat_context_lookup_failed", org_slug=org_slug, exc_info=True)
+        return None
+    if raw is None:
+        logger.info("feedback_chat_context_no_librechat_user", org_slug=org_slug)
+        return None
+    return [_conversation_entry(entry, names.chat_origin) for entry in raw]

--- a/klai-portal/backend/tests/test_app_assistant.py
+++ b/klai-portal/backend/tests/test_app_assistant.py
@@ -110,9 +110,11 @@ async def test_submit_feedback_schedules_triage(monkeypatch):
     monkeypatch.setattr(app_assistant, "create_feedback_submission", fake_create_feedback_submission)
 
     background_tasks = BackgroundTasks()
+    # Non-chat page: schedules plain triage. Chat-page submissions schedule
+    # the chat-context enrichment wrapper instead (test_feedback_chat_context).
     body = app_assistant.AssistantFeedbackIn(
         raw_text="Maak het makkelijker om feedback te geven.",
-        page_url="https://app.getklai.com/app/chat",
+        page_url="https://app.getklai.com/app/knowledge",
     )
 
     response = await app_assistant.submit_feedback(

--- a/klai-portal/backend/tests/test_feedback_chat_context.py
+++ b/klai-portal/backend/tests/test_feedback_chat_context.py
@@ -1,0 +1,270 @@
+"""Chat-context enrichment for /app/chat feedback submissions.
+
+Contract: feedback submitted from the chat page gets the reporter's most
+recent LibreChat conversations attached to ``metadata_json["chat_context"]``
+as recency-based candidates, because the cross-origin chat iframe makes the
+conversation unreachable client-side. The enrichment runs as a background
+task AFTER the submission is durably stored and is best-effort: it must
+never delay or fail the feedback POST, and triage always runs.
+
+All identifiers below are synthetic fixtures.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import BackgroundTasks
+
+from app.api import app_assistant
+from app.services import librechat_chat_context
+
+
+def _perms():
+    return SimpleNamespace(
+        org_id=42,
+        org_slug="acme",
+        user_id="1000000000000000001",
+        effective_role=SimpleNamespace(value="member"),
+    )
+
+
+def _request():
+    return SimpleNamespace(
+        headers={"user-agent": "pytest", "referer": "https://acme.getklai.com/app/chat"},
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+
+
+class TestRecentChatConversations:
+    @pytest.mark.asyncio
+    async def test_maps_mongo_documents_to_metadata_entries(self, monkeypatch):
+        def fake_sync(db_name, zitadel_user_id, limit):
+            assert db_name == "librechat-acme"
+            assert zitadel_user_id == "1000000000000000001"
+            return [
+                {
+                    "conversationId": "00000000-0000-4000-8000-000000000001",
+                    "title": "Routing question",
+                    "model": "klai-primary",
+                    "createdAt": datetime(2026, 1, 10, 9, 12, 29, tzinfo=UTC),
+                    "updatedAt": datetime(2026, 1, 10, 11, 54, 32, tzinfo=UTC),
+                }
+            ]
+
+        monkeypatch.setattr(librechat_chat_context, "_sync_recent_conversations", fake_sync)
+        result = await librechat_chat_context.recent_chat_conversations("acme", "1000000000000000001")
+
+        assert result == [
+            {
+                "conversation_id": "00000000-0000-4000-8000-000000000001",
+                "title": "Routing question",
+                "model": "klai-primary",
+                "url": "https://chat-acme.getklai.com/c/00000000-0000-4000-8000-000000000001",
+                "created_at": "2026-01-10T09:12:29+00:00",
+                "updated_at": "2026-01-10T11:54:32+00:00",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_titles_and_tolerates_missing_fields(self, monkeypatch):
+        monkeypatch.setattr(
+            librechat_chat_context,
+            "_sync_recent_conversations",
+            lambda *args: [{"conversationId": "abc", "title": "x" * 500}],
+        )
+        result = await librechat_chat_context.recent_chat_conversations("acme", "sub")
+
+        assert result is not None
+        assert len(result[0]["title"]) == 200
+        assert result[0]["model"] is None
+        assert result[0]["created_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_naive_mongo_datetimes_are_normalized_to_utc(self, monkeypatch):
+        # pymongo returns naive datetimes by default; the stored ISO strings
+        # must still carry an explicit UTC offset.
+        monkeypatch.setattr(
+            librechat_chat_context,
+            "_sync_recent_conversations",
+            lambda *args: [
+                {
+                    "conversationId": "abc",
+                    "createdAt": datetime(2026, 1, 10, 9, 12, 29),
+                    "updatedAt": datetime(2026, 1, 10, 11, 54, 32),
+                }
+            ],
+        )
+        result = await librechat_chat_context.recent_chat_conversations("acme", "sub")
+
+        assert result is not None
+        assert result[0]["created_at"] == "2026-01-10T09:12:29+00:00"
+        assert result[0]["updated_at"] == "2026-01-10T11:54:32+00:00"
+
+    @pytest.mark.asyncio
+    async def test_non_string_bson_values_are_dropped(self, monkeypatch):
+        # On LibreChat schema drift a field may come back as an ObjectId or
+        # embedded document; those must never reach the JSONB column where
+        # they would fail serialization outside our error handling.
+        class FakeObjectId:
+            pass
+
+        monkeypatch.setattr(
+            librechat_chat_context,
+            "_sync_recent_conversations",
+            lambda *args: [
+                {
+                    "conversationId": FakeObjectId(),
+                    "title": {"nested": "doc"},
+                    "model": 42,
+                }
+            ],
+        )
+        result = await librechat_chat_context.recent_chat_conversations("acme", "sub")
+
+        assert result == [
+            {
+                "conversation_id": None,
+                "title": None,
+                "model": None,
+                "url": None,
+                "created_at": None,
+                "updated_at": None,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_reporter_has_no_librechat_user(self, monkeypatch):
+        monkeypatch.setattr(librechat_chat_context, "_sync_recent_conversations", lambda *args: None)
+        assert await librechat_chat_context.recent_chat_conversations("acme", "sub") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_mongo_failure(self, monkeypatch):
+        def boom(*args):
+            raise ConnectionError("mongo unreachable")
+
+        monkeypatch.setattr(librechat_chat_context, "_sync_recent_conversations", boom)
+        assert await librechat_chat_context.recent_chat_conversations("acme", "sub") is None
+
+
+class TestFollowupScheduling:
+    async def _submit_problem(self, monkeypatch, *, route_id, page_url):
+        async def fake_create(db, **kwargs):
+            return SimpleNamespace(id=7)
+
+        monkeypatch.setattr(app_assistant, "emit_event", lambda *a, **k: None)
+        monkeypatch.setattr(app_assistant, "create_feedback_submission", fake_create)
+
+        body = app_assistant.AssistantProblemReportIn(
+            raw_text="De assistent geeft verkeerde antwoorden.",
+            page_url=page_url,
+            route_id=route_id,
+            severity="workaround",
+        )
+        background_tasks = BackgroundTasks()
+        response = await app_assistant.submit_problem_report(body, _request(), background_tasks, _perms(), object())
+        assert response.ok is True
+        return background_tasks.tasks
+
+    @pytest.mark.asyncio
+    async def test_chat_route_schedules_enrichment_then_triage(self, monkeypatch):
+        tasks = await self._submit_problem(
+            monkeypatch,
+            route_id="/app/chat",
+            page_url="https://acme.getklai.com/app/chat",
+        )
+        assert [t.func for t in tasks] == [app_assistant.enrich_chat_context_and_triage]
+        assert tasks[0].args == (7, "acme", "1000000000000000001")
+
+    @pytest.mark.asyncio
+    async def test_non_chat_route_schedules_plain_triage(self, monkeypatch):
+        tasks = await self._submit_problem(
+            monkeypatch,
+            route_id="/app/knowledge",
+            page_url="https://acme.getklai.com/app/knowledge",
+        )
+        assert [t.func for t in tasks] == [app_assistant.run_feedback_triage_for_submission]
+        assert tasks[0].args == (7,)
+
+    @pytest.mark.asyncio
+    async def test_feedback_endpoint_also_schedules_enrichment(self, monkeypatch):
+        async def fake_create(db, **kwargs):
+            return SimpleNamespace(id=8)
+
+        monkeypatch.setattr(app_assistant, "emit_event", lambda *a, **k: None)
+        monkeypatch.setattr(app_assistant, "create_feedback_submission", fake_create)
+
+        body = app_assistant.AssistantFeedbackIn(
+            raw_text="Chat geeft rare antwoorden.",
+            page_url="https://acme.getklai.com/app/chat",
+            route_id="/app/chat",
+            type="confusing",
+        )
+        background_tasks = BackgroundTasks()
+        response = await app_assistant.submit_feedback(body, _request(), background_tasks, _perms(), object())
+        assert response.ok is True
+        assert [t.func for t in background_tasks.tasks] == [app_assistant.enrich_chat_context_and_triage]
+
+
+class TestEnrichChatContextAndTriage:
+    def _wire(self, monkeypatch, *, conversations, submission):
+        async def fake_recent(org_slug, zitadel_user_id):
+            return conversations
+
+        db = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_session():
+            yield db
+
+        async def fake_get_submission(_db, submission_id):
+            return submission
+
+        triage_calls = []
+
+        async def fake_triage(submission_id):
+            triage_calls.append(submission_id)
+
+        monkeypatch.setattr(app_assistant, "recent_chat_conversations", fake_recent)
+        monkeypatch.setattr(app_assistant, "cross_org_session", fake_session)
+        monkeypatch.setattr(app_assistant, "get_feedback_submission", fake_get_submission)
+        monkeypatch.setattr(app_assistant, "run_feedback_triage_for_submission", fake_triage)
+        return db, triage_calls
+
+    @pytest.mark.asyncio
+    async def test_attaches_conversations_and_runs_triage(self, monkeypatch):
+        submission = SimpleNamespace(metadata_json={"org_slug": "acme"})
+        conversations = [{"conversation_id": "abc", "title": "t"}]
+        db, triage_calls = self._wire(monkeypatch, conversations=conversations, submission=submission)
+
+        await app_assistant.enrich_chat_context_and_triage(7, "acme", "sub")
+
+        assert submission.metadata_json == {
+            "org_slug": "acme",
+            "chat_context": {"recent_conversations": conversations},
+        }
+        db.commit.assert_awaited_once()
+        assert triage_calls == [7]
+
+    @pytest.mark.asyncio
+    async def test_no_conversations_skips_write_but_runs_triage(self, monkeypatch):
+        submission = SimpleNamespace(metadata_json={"org_slug": "acme"})
+        db, triage_calls = self._wire(monkeypatch, conversations=None, submission=submission)
+
+        await app_assistant.enrich_chat_context_and_triage(7, "acme", "sub")
+
+        assert submission.metadata_json == {"org_slug": "acme"}
+        db.commit.assert_not_awaited()
+        assert triage_calls == [7]
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_still_runs_triage(self, monkeypatch):
+        submission = SimpleNamespace(metadata_json={})
+        db, triage_calls = self._wire(monkeypatch, conversations=[{"conversation_id": "abc"}], submission=submission)
+        db.commit.side_effect = RuntimeError("db down")
+
+        await app_assistant.enrich_chat_context_and_triage(7, "acme", "sub")
+
+        assert triage_calls == [7]

--- a/klai-portal/backend/tests/test_platform_feedback_submissions.py
+++ b/klai-portal/backend/tests/test_platform_feedback_submissions.py
@@ -138,6 +138,7 @@ async def test_platform_feedback_submissions_reads_assistant_events(monkeypatch)
             route_id="/app/knowledge",
             locale="nl",
             viewport="1440x900",
+            chat_context=None,
             created_at="2026-05-27T10:00:00Z",
         )
     ]
@@ -196,6 +197,7 @@ async def test_platform_feedback_submissions_includes_ai_suggestion(monkeypatch)
             route_id="/admin/platform",
             locale="nl",
             viewport="1440x900",
+            chat_context=None,
             created_at=created_at,
         )
     ]
@@ -269,6 +271,7 @@ async def test_platform_feedback_submission_detail_returns_one_submission(monkey
             route_id="/admin/platform",
             locale="nl",
             viewport="1440x900",
+            chat_context=None,
             created_at=created_at,
         )
     ]
@@ -600,6 +603,7 @@ async def test_platform_feedback_item_detail_returns_linked_customer_evidence(mo
             route_id="/admin/platform",
             locale="nl",
             viewport="1440x900",
+            chat_context=None,
             created_at=datetime(2026, 5, 27, 10, 30, tzinfo=UTC),
             link_type="evidence",
             linked_at=linked_at,

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { buildFeedbackDebugInstructions } from './-feedback-helpers'
+import type {
+  PlatformFeedbackItem,
+  PlatformFeedbackLinkedSubmission,
+} from '../../-types'
+
+function makeItem(): PlatformFeedbackItem {
+  return {
+    id: 24,
+    kind: 'bug',
+    title: 'Assistent geeft verkeerde antwoorden',
+    summary: 'Assistent geeft verkeerde antwoorden.',
+    status: 'open',
+    area: 'assistant_core',
+    priority_score: 11,
+    org_count: 1,
+    user_count: 1,
+    shipped_at: null,
+    resolution_summary: null,
+    resolved_at: null,
+    resolved_by: null,
+    notification_state: null,
+    reporter_orgs: [],
+    created_at: '2026-08-17T12:00:00Z',
+    updated_at: '2026-08-17T12:00:00Z',
+  }
+}
+
+function makeSubmission(
+  overrides: Partial<PlatformFeedbackLinkedSubmission> = {},
+): PlatformFeedbackLinkedSubmission {
+  return {
+    id: 29,
+    org_id: 8,
+    org_name: 'Acme',
+    org_slug: 'acme',
+    user_id: '1000000000000000001',
+    user_email: 'ada@example.test',
+    user_display_name: 'Ada Acme',
+    event_type: 'klai_assistant.problem_report',
+    status: 'open',
+    raw_text: 'Assistent geeft verkeerde antwoorden.',
+    feedback_type: 'confusing',
+    severity: null,
+    page_url: 'https://acme.getklai.com/app/chat',
+    route_id: '/app/chat',
+    locale: 'en',
+    viewport: '3440x1271',
+    chat_context: null,
+    created_at: '2026-08-17T12:00:08Z',
+    triage_suggestion: null,
+    linked_item_id: 24,
+    linked_item_title: null,
+    linked_item_status: null,
+    link_type: 'evidence',
+    linked_at: '2026-08-17T12:00:08Z',
+    ...overrides,
+  }
+}
+
+describe('buildFeedbackDebugInstructions chat context', () => {
+  it('lists the reporter conversations captured at report time', () => {
+    const prompt = buildFeedbackDebugInstructions(
+      makeItem(),
+      [
+        makeSubmission({
+          chat_context: {
+            recent_conversations: [
+              {
+                conversation_id: '00000000-0000-4000-8000-000000000001',
+                title: 'Routing question',
+                model: 'klai-primary',
+                url: 'https://chat-acme.getklai.com/c/00000000-0000-4000-8000-000000000001',
+                created_at: '2026-01-10T09:12:29+00:00',
+                updated_at: '2026-01-10T11:54:32+00:00',
+              },
+            ],
+          },
+        }),
+      ],
+      (value) => value ?? '-',
+    )
+
+    expect(prompt).toContain('Recent chat conversations at report time (recency-based candidates; the report may concern an older conversation not listed here):')
+    expect(prompt).toContain('"Routing question"')
+    expect(prompt).toContain('last activity 2026-01-10T11:54:32+00:00')
+    expect(prompt).toContain(
+      'https://chat-acme.getklai.com/c/00000000-0000-4000-8000-000000000001',
+    )
+  })
+
+  it('omits the chat section when no chat context was captured', () => {
+    const prompt = buildFeedbackDebugInstructions(
+      makeItem(),
+      [makeSubmission()],
+      (value) => value ?? '-',
+    )
+
+    expect(prompt).not.toContain('Recent chat conversations at report time')
+    expect(prompt).toContain('Assistent geeft verkeerde antwoorden.')
+  })
+})

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.tsx
@@ -235,6 +235,44 @@ export function FeedbackMetaRow({
   )
 }
 
+function submissionChatContextLines(submission: PlatformFeedbackLinkedSubmission): string[] {
+  const conversations = submission.chat_context?.recent_conversations ?? []
+  if (!conversations.length) return []
+  return [
+    '   Recent chat conversations at report time (recency-based candidates; the report may concern an older conversation not listed here):',
+    ...conversations.map((conversation) => {
+      const title = (conversation.title || 'untitled').replace(/\s+/g, ' ')
+      const details = [
+        conversation.updated_at ? `last activity ${conversation.updated_at}` : null,
+        conversation.url,
+      ].filter(Boolean)
+      return `     - "${title}"${details.length ? ` (${details.join(', ')})` : ''}`
+    }),
+  ]
+}
+
+function buildSubmissionEvidence(
+  submissions: PlatformFeedbackLinkedSubmission[],
+  fmtDate: (s: string | null) => string,
+) {
+  if (!submissions.length) return 'No linked feedback evidence yet.'
+  return submissions
+    .map((submission, index) =>
+      [
+        `${index + 1}. ${submission.raw_text || '(empty)'}`,
+        `   Org: ${submission.org_name ?? submission.org_slug ?? 'unknown'}`,
+        `   Reporter: ${feedbackSubmissionReporterLabel(submission) || submission.user_id || 'unknown'}`,
+        `   Type/severity: ${[submission.feedback_type, submission.severity].filter(Boolean).join(' / ') || 'unknown'}`,
+        `   URL: ${submission.page_url || 'unknown'}`,
+        `   Route: ${submission.route_id || 'unknown'}`,
+        `   Locale/viewport: ${[submission.locale, submission.viewport].filter(Boolean).join(' / ') || 'unknown'}`,
+        `   Submitted: ${fmtDate(submission.created_at)}`,
+        ...submissionChatContextLines(submission),
+      ].join('\n'),
+    )
+    .join('\n\n')
+}
+
 export function buildFeedbackDebugInstructions(
   item: PlatformFeedbackItem,
   submissions: PlatformFeedbackLinkedSubmission[],
@@ -254,22 +292,7 @@ export function buildFeedbackDebugInstructions(
     `- Locales seen: ${locales.length ? locales.join(', ') : 'unknown'}`,
   ].join('\n')
 
-  const evidence = submissions.length
-    ? submissions
-        .map((submission, index) =>
-          [
-            `${index + 1}. ${submission.raw_text || '(empty)'}`,
-            `   Org: ${submission.org_name ?? submission.org_slug ?? 'unknown'}`,
-            `   Reporter: ${feedbackSubmissionReporterLabel(submission) || submission.user_id || 'unknown'}`,
-            `   Type/severity: ${[submission.feedback_type, submission.severity].filter(Boolean).join(' / ') || 'unknown'}`,
-            `   URL: ${submission.page_url || 'unknown'}`,
-            `   Route: ${submission.route_id || 'unknown'}`,
-            `   Locale/viewport: ${[submission.locale, submission.viewport].filter(Boolean).join(' / ') || 'unknown'}`,
-            `   Submitted: ${fmtDate(submission.created_at)}`,
-          ].join('\n'),
-        )
-        .join('\n\n')
-    : 'No linked feedback evidence yet.'
+  const evidence = buildSubmissionEvidence(submissions, fmtDate)
 
   return [
     'You are fixing a Klai production bug from the Platform feedback workflow.',
@@ -331,22 +354,7 @@ export function buildFeedbackFeatureInstructions(
     `- Locales seen: ${locales.length ? locales.join(', ') : 'unknown'}`,
   ].join('\n')
 
-  const evidence = submissions.length
-    ? submissions
-        .map((submission, index) =>
-          [
-            `${index + 1}. ${submission.raw_text || '(empty)'}`,
-            `   Org: ${submission.org_name ?? submission.org_slug ?? 'unknown'}`,
-            `   Reporter: ${feedbackSubmissionReporterLabel(submission) || submission.user_id || 'unknown'}`,
-            `   Type/severity: ${[submission.feedback_type, submission.severity].filter(Boolean).join(' / ') || 'unknown'}`,
-            `   URL: ${submission.page_url || 'unknown'}`,
-            `   Route: ${submission.route_id || 'unknown'}`,
-            `   Locale/viewport: ${[submission.locale, submission.viewport].filter(Boolean).join(' / ') || 'unknown'}`,
-            `   Submitted: ${fmtDate(submission.created_at)}`,
-          ].join('\n'),
-        )
-        .join('\n\n')
-    : 'No linked feedback evidence yet.'
+  const evidence = buildSubmissionEvidence(submissions, fmtDate)
 
   return [
     'You are implementing a Klai product feature request from the Platform feedback workflow.',

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackSubmissionDetailPanel.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackSubmissionDetailPanel.test.tsx
@@ -114,6 +114,7 @@ function submissionWithCandidate(): PlatformFeedbackSubmission {
     route_id: '/app/chat',
     locale: 'en',
     viewport: '1362x895',
+    chat_context: null,
     created_at: '2026-06-06T09:18:00Z',
     triage_suggestion: {
       classification: 'bug',

--- a/klai-portal/frontend/src/routes/admin/platform/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-types.ts
@@ -200,6 +200,19 @@ export interface PlatformFeedbackTriageSuggestion {
   created_at: string | null
 }
 
+export interface PlatformFeedbackChatConversation {
+  conversation_id: string | null
+  title: string | null
+  model: string | null
+  url: string | null
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface PlatformFeedbackChatContext {
+  recent_conversations: PlatformFeedbackChatConversation[]
+}
+
 export interface PlatformFeedbackSubmission {
   id: number
   org_id: number | null
@@ -217,6 +230,7 @@ export interface PlatformFeedbackSubmission {
   route_id: string | null
   locale: string | null
   viewport: string | null
+  chat_context: PlatformFeedbackChatContext | null
   created_at: string
   triage_suggestion: PlatformFeedbackTriageSuggestion | null
   linked_item_id: number | null


### PR DESCRIPTION
## Why

Feedback from `/app/chat` (e.g. platform feedback item #24) carried no conversation context: the chat is a cross-origin LibreChat iframe, so the portal page URL never contains the conversation id. The generated debug prompt and the triage LLM had nothing to work from.

## What

- New `app/services/librechat_chat_context.py`: after a chat-page submission is durably stored, a background task looks up the reporter's most recent LibreChat conversations in the tenant Mongo (`users.openidId` = Zitadel `sub`) and stores them as recency-based candidates in `metadata_json.chat_context`, then runs triage.
- Admin platform API exposes `chat_context` on submissions; the admin debug/feature prompts list the candidates with title, last-activity timestamp and a direct `chat-<slug>…/c/<id>` URL. The triage LLM receives them via the existing metadata pass-through.
- Persist-first: Mongo can never delay or fail the feedback POST; lookup has 2s timeouts and is fail-soft (logged), triage always runs.
- Only plain-string fields are accepted from Mongo (BSON schema drift cannot break JSONB persistence); naive Mongo datetimes are normalized to UTC.
- Candidates are explicitly labeled recency-based — a report can concern an older conversation; scoping of the root-credential read is documented in the service (db name from the caller's org, filter on the caller's own openidId).

The lookup approach was verified read-only against the real production case before implementation (report matched the reporter's conversation last updated 5.5 minutes before submission; runner-up months older). Production evidence lives in the internal thread, not in code — all test fixtures are synthetic.

## Tests

- backend: `tests/test_feedback_chat_context.py` (13 tests: mapping, truncation, UTC-normalization, BSON-drift, scheduling, enrichment/triage ordering, failure paths) + updated existing suites — 39 passed; ruff + format clean; pyright 0 errors
- frontend: `-feedback-helpers.test.ts` prompt coverage — vitest 9 passed; eslint + `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)