### PR TITLE
fix(crawler): stop deleting live knowledge, and stop storing error pages as knowledge

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -320,6 +320,40 @@ def _build_crawl_outcome_warning(
     }
 
 
+def _crawl_fully_fetched(fetch_outcomes: list[dict]) -> bool:
+    """True only when every discovered candidate URL was actually fetched.
+
+    2026-08-18 stop-the-bleeding fix: the stale-connector-artifact
+    reconciliation below compares ``current_paths`` (the URLs that were
+    successfully fetched THIS run) against everything on record for the
+    connector, and deletes anything missing as "stale". A URL that merely
+    hit a real fetch failure (timeout, 5xx, DNS, ...) this run is absent
+    from ``current_paths`` for a reason that has nothing to do with the
+    page still existing on the site — deleting it destroys live knowledge.
+    ``decide_fetch_failure_terminal_status`` tolerates up to
+    ``ingest_fetch_failure_dirty_trip_rate`` (30% by default) of real
+    failures before it stops the job from reaching ``completed``, so a
+    job well within that tolerance can still have failed some pages.
+
+    Reconciliation may only run when every discovered URL was demonstrably
+    resolved (``success`` or ``non_content_listing_page``) — never on a
+    real fetch failure, and never on a deliberately-unfetched
+    ``not_fetched_*`` scheduling omission (budget/depth/exclude/duplicate).
+    This is intentionally conservative: a crawl with any incompleteness at
+    all skips reconciliation entirely rather than trying to distinguish
+    "gone" from "not reached this run" — the more precise three-way split
+    (present / demonstrably gone / unknown) is a larger design left for a
+    follow-up.
+    """
+    for outcome in fetch_outcomes:
+        reason = str(outcome.get("reason_code") or "")
+        if reason in _FETCH_FAILURE_REASON_CODES:
+            return False
+        if reason.startswith(_NOT_FETCHED_REASON_PREFIX):
+            return False
+    return True
+
+
 def _crawl_warning_terminal_status(crawl_warning: dict | None) -> str:
     """Return the terminal status implied by a crawl warning, if any."""
     if crawl_warning is None:
@@ -898,45 +932,62 @@ async def run_crawl_job(
             await _update_job(conn, job_id, status=terminal_status)
 
         if connector_id and terminal_status == "completed" and pages_done > 0:
-            current_urls = [result.url for result in results]
-            stale_paths = await pg_store.list_stale_connector_artifact_paths(
-                conn,
-                org_id=org_id,
-                kb_slug=kb_slug,
-                connector_id=connector_id,
-                current_paths=current_urls,
-            )
-            if stale_paths:
-                stale_paths_deleted: list[str] = []
-                for path in stale_paths:
-                    try:
-                        await qdrant_store.delete_document(org_id, kb_slug, path)
-                    except Exception as exc:
-                        logger.warning(
-                            "crawl_connector_stale_vector_delete_failed",
+            if not _crawl_fully_fetched(fetch_outcomes):
+                skip_reason_counts = Counter(
+                    reason
+                    for outcome in fetch_outcomes
+                    if (reason := str(outcome.get("reason_code") or ""))
+                    in _FETCH_FAILURE_REASON_CODES
+                    or reason.startswith(_NOT_FETCHED_REASON_PREFIX)
+                )
+                logger.info(
+                    "crawl_connector_stale_reconcile_skipped",
+                    job_id=job_id,
+                    connector_id=connector_id,
+                    kb_slug=kb_slug,
+                    reason="incomplete_crawl",
+                    skip_reason_counts=dict(skip_reason_counts),
+                )
+            else:
+                current_urls = [result.url for result in results]
+                stale_paths = await pg_store.list_stale_connector_artifact_paths(
+                    conn,
+                    org_id=org_id,
+                    kb_slug=kb_slug,
+                    connector_id=connector_id,
+                    current_paths=current_urls,
+                )
+                if stale_paths:
+                    stale_paths_deleted: list[str] = []
+                    for path in stale_paths:
+                        try:
+                            await qdrant_store.delete_document(org_id, kb_slug, path)
+                        except Exception as exc:
+                            logger.warning(
+                                "crawl_connector_stale_vector_delete_failed",
+                                job_id=job_id,
+                                connector_id=connector_id,
+                                kb_slug=kb_slug,
+                                path=path,
+                                error=str(exc),
+                            )
+                        else:
+                            stale_paths_deleted.append(path)
+                    if stale_paths_deleted:
+                        retired_count = await pg_store.soft_delete_stale_connector_artifacts(
+                            conn,
+                            org_id=org_id,
+                            kb_slug=kb_slug,
+                            connector_id=connector_id,
+                            stale_paths=stale_paths_deleted,
+                        )
+                        logger.info(
+                            "crawl_connector_stale_artifacts_retired",
                             job_id=job_id,
                             connector_id=connector_id,
                             kb_slug=kb_slug,
-                            path=path,
-                            error=str(exc),
+                            retired_count=retired_count,
                         )
-                    else:
-                        stale_paths_deleted.append(path)
-                if stale_paths_deleted:
-                    retired_count = await pg_store.soft_delete_stale_connector_artifacts(
-                        conn,
-                        org_id=org_id,
-                        kb_slug=kb_slug,
-                        connector_id=connector_id,
-                        stale_paths=stale_paths_deleted,
-                    )
-                    logger.info(
-                        "crawl_connector_stale_artifacts_retired",
-                        job_id=job_id,
-                        connector_id=connector_id,
-                        kb_slug=kb_slug,
-                        retired_count=retired_count,
-                    )
 
         if terminal_status == "completed" and pages_done > 0:
             await _enqueue_taxonomy_backfill_after_crawl(

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -30,7 +30,11 @@ from knowledge_ingest.domain_selectors import (
     lower_domain_rate_limit,
 )
 from knowledge_ingest.models import IngestRequest
-from knowledge_ingest.reason_codes import FETCH_REASON_VALUES, FetchReasonCode
+from knowledge_ingest.reason_codes import (
+    FETCH_REASON_VALUES,
+    FetchReasonCode,
+    PersistSkipReason,
+)
 from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
 from knowledge_ingest.utils.auth_wall_detector import (
     AuthWallSignal,
@@ -1132,6 +1136,29 @@ async def _ingest_crawl_result(
 
     text = result.fit_markdown or result.raw_markdown or ""
     front_matter = (result.metadata or {}).get("description", "")
+
+    # 2026-08-18 stop-the-bleeding fix: a page that fetched successfully
+    # (HTTP 200) can still be pure boilerplate/error text — e.g.
+    # openapi.eu-production.holodeck.voys.nl served 13 pages of the exact
+    # same 92-char "Failed to parse OpenAPI file" message, and 5 landed in
+    # a customer's knowledge base before the template-cluster detector
+    # (a different mechanism, meant for auth walls, not error pages)
+    # happened to reject the rest once 5 near-identical siblings existed.
+    # There was previously no minimum-content-length check anywhere on
+    # this path — PersistSkipReason.CONTENT_TOO_SHORT existed in
+    # reason_codes.py but was never wired up here.
+    stripped_length = len(text.strip())
+    if stripped_length < settings.ingest_min_content_length:
+        logger.info(
+            "crawl_skipped_content_too_short",
+            url=url,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            content_length=stripped_length,
+            threshold=settings.ingest_min_content_length,
+            reason=PersistSkipReason.CONTENT_TOO_SHORT.value,
+        )
+        return
 
     content_hash = hashlib.sha256(text.encode()).hexdigest()
     if stored is not None:

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -74,6 +74,27 @@ FETCH_FAILURE_DOMINANT_REASON = "fetch_failure_dominant"
 
 _NOT_FETCHED_REASON_PREFIX = "not_fetched_"
 
+# 2026-08-18 stop-the-bleeding fix, corrected same day after production
+# measurement (n=1426, knowledge.crawled_pages) — see the long comment at
+# the short-content-cluster gate in _ingest_crawl_result for the full
+# rationale and tests/test_crawler_content_too_short.py for the measured
+# numbers this is calibrated against.
+#
+# Hard floor: below this length, a page is rejected unconditionally, no
+# cluster lookup needed. Calibrated against the measurement: the only
+# pages below 30 chars in the whole dataset are 3 completely empty
+# (1-char) pages; the shortest legitimate real page measured is ~85
+# chars, far above this floor, so 30 cannot falsely reject real content.
+_HARD_MIN_CONTENT_LENGTH = 30
+
+# Cluster-size requirement for the short-content-cluster gate (soft
+# zone), reusing detect_anonymous_auth_wall's SimHash lookup. Lower than
+# that detector's own DEFAULT_CLUSTER_MIN (5) because the measurement's
+# smallest error-page cluster is 3 total pages (2 OTHERS from any one
+# page's perspective) — cluster_min=5 would silently miss it, letting
+# the 3-page 404 cluster and both 3-page Ascend clusters through.
+_SHORT_CONTENT_CLUSTER_MIN = 2
+
 _DIRTY_CONTENT_SUGGESTION = (
     "Re-run preview from the connector edit page. The site likely now requires "
     "authentication or the content_selector is no longer matching."
@@ -1146,28 +1167,87 @@ async def _ingest_crawl_result(
     text = result.fit_markdown or result.raw_markdown or ""
     front_matter = (result.metadata or {}).get("description", "")
 
-    # 2026-08-18 stop-the-bleeding fix: a page that fetched successfully
-    # (HTTP 200) can still be pure boilerplate/error text — e.g.
-    # openapi.eu-production.holodeck.voys.nl served 13 pages of the exact
-    # same 92-char "Failed to parse OpenAPI file" message, and 5 landed in
-    # a customer's knowledge base before the template-cluster detector
-    # (a different mechanism, meant for auth walls, not error pages)
-    # happened to reject the rest once 5 near-identical siblings existed.
-    # There was previously no minimum-content-length check anywhere on
-    # this path — PersistSkipReason.CONTENT_TOO_SHORT existed in
-    # reason_codes.py but was never wired up here.
+    # SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01 — compute the page's SimHash
+    # once, BEFORE any use (this call site's short-content-cluster gate
+    # below, the login-wall detector further down, and the operator-
+    # triggered backfill / validation script) and store it AFTER the
+    # upsert below so the next crawl can cluster against it. Moved earlier
+    # than its original position (2026-08-18 stop-the-bleeding fix) so the
+    # short-content-cluster gate can reuse it instead of computing a
+    # second SimHash for the same text.
+    #
+    # Empty / whitespace-only content yields ``compute_simhash == 0``. Storing
+    # 0 would let "empty" pages cluster together (all match Hamming 0), which
+    # would falsely flag a tenant whose crawl results were 5+ rendered-but-
+    # empty pages. We treat the missing-content case as "no fingerprint" by
+    # leaving content_simhash NULL, matching the cold-start contract.
+    page_simhash: int | None = compute_simhash(text)
+    if page_simhash == 0:
+        page_simhash = None
+
+    # 2026-08-18 stop-the-bleeding fix, corrected same day after a
+    # production content-length measurement (n=1426,
+    # knowledge.crawled_pages) refuted the original flat 150-char
+    # threshold: two real, unique pages (getklai.com/contact at ~85 chars,
+    # help.voys.nl/help-pages-nl at ~108 chars) sit INSIDE the same length
+    # band as measured error-page clusters (88/92/98/101 chars). Length
+    # alone cannot separate "short and real" from "short and boilerplate"
+    # — see the module docstring in
+    # tests/test_crawler_content_too_short.py for the full measurement.
+    #
+    # Two-tier rule:
+    #
+    # 1. Hard floor: below _HARD_MIN_CONTENT_LENGTH, reject unconditionally
+    #    — no page in the measured dataset that isn't outright empty falls
+    #    this low (only 3 exactly-empty 1-char pages measured below it).
+    # 2. Soft zone: below settings.ingest_min_content_length (150) but at
+    #    or above the hard floor, reject ONLY when the page is a near-
+    #    duplicate of >= _SHORT_CONTENT_CLUSTER_MIN OTHER pages in the same
+    #    KB — reusing the exact SimHash cluster-lookup mechanism from
+    #    detect_anonymous_auth_wall (utils/auth_wall_detector.py), not a
+    #    second implementation of it. cluster_min is lower here than that
+    #    detector's own default (5): the smallest measured error cluster
+    #    is 3 total pages (2 OTHERS from any one page's view), so the
+    #    default would silently miss it.
     stripped_length = len(text.strip())
-    if stripped_length < settings.ingest_min_content_length:
+    if stripped_length < _HARD_MIN_CONTENT_LENGTH:
         logger.info(
             "crawl_skipped_content_too_short",
             url=url,
             org_id=org_id,
             kb_slug=kb_slug,
             content_length=stripped_length,
-            threshold=settings.ingest_min_content_length,
+            gate="hard_floor",
+            threshold=_HARD_MIN_CONTENT_LENGTH,
             reason=PersistSkipReason.CONTENT_TOO_SHORT.value,
         )
         return
+    if stripped_length < settings.ingest_min_content_length:
+        duplicate_signal = await detect_anonymous_auth_wall(
+            result.raw_markdown or "",
+            fit_markdown=result.fit_markdown or None,
+            url=url,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            conn=conn,
+            cluster_min=_SHORT_CONTENT_CLUSTER_MIN,
+            target_simhash=page_simhash,
+        )
+        if duplicate_signal is not None:
+            logger.info(
+                "crawl_skipped_content_too_short",
+                url=url,
+                org_id=org_id,
+                kb_slug=kb_slug,
+                content_length=stripped_length,
+                gate="duplicate_cluster",
+                threshold=settings.ingest_min_content_length,
+                evidence=duplicate_signal.evidence,
+                reason=PersistSkipReason.CONTENT_TOO_SHORT.value,
+            )
+            return
+        # Short but unique (no near-duplicate siblings): fall through and
+        # keep it — this is the case the flat threshold got wrong.
 
     content_hash = hashlib.sha256(text.encode()).hexdigest()
     if stored is not None:
@@ -1190,21 +1270,8 @@ async def _ingest_crawl_result(
             logger.info("crawl_skipped_html_noise", url=url, org_id=org_id, kb_slug=kb_slug)
             return
 
-    # SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-01 — compute the page's SimHash
-    # once, BEFORE the detector call (the detector reuses it for cluster
-    # lookup) and store it AFTER the upsert below so the next crawl can
-    # cluster against it. Computed unconditionally — even with detection
-    # disabled, the fingerprint is needed for the operator-triggered
-    # backfill / validation script.
-    #
-    # Empty / whitespace-only content yields ``compute_simhash == 0``. Storing
-    # 0 would let "empty" pages cluster together (all match Hamming 0), which
-    # would falsely flag a tenant whose crawl results were 5+ rendered-but-
-    # empty pages. We treat the missing-content case as "no fingerprint" by
-    # leaving content_simhash NULL, matching the cold-start contract.
-    page_simhash: int | None = compute_simhash(text)
-    if page_simhash == 0:
-        page_simhash = None
+    # page_simhash was computed earlier (see comment above, near the
+    # short-content-cluster gate) and is reused here unchanged.
 
     # SPEC-CONNECTOR-INPUT-VALIDATION-001 / REQ-4 — shared auth-wall
     # classifier at sync time. This catches single embedded protected-section

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -761,12 +761,21 @@ async def run_crawl_job(
                 # NOT a session-wide failure. Record + continue BFS so sibling
                 # URLs (which may be public) still ingest.
                 auth_wall_pages.append(wall_exc.url)
+                # 2026-08-18 stop-the-bleeding fix: was "crawl_page_login_wall".
+                # The event name asserted the presumed CAUSE (a login wall)
+                # rather than the actual OBSERVATION (near-duplicate content
+                # cluster). On 2026-08-18 this misdirected a live
+                # investigation for an hour — the operator saw "login wall"
+                # in the logs and went looking for credentials, when the
+                # real cause was 13 identical OpenAPI-parser error pages.
+                # Behaviour is unchanged: the page is still skipped, BFS
+                # still continues (REQ-04.1).
                 logger.info(
-                    "crawl_page_login_wall",
+                    "crawl_page_template_cluster_skipped",
                     url=url,
                     job_id=job_id,
                     pattern=wall_exc.signal.pattern,
-                    confidence=wall_exc.signal.confidence,
+                    evidence=wall_exc.signal.evidence,
                 )
             except Exception as exc:
                 logger.warning("crawl_page_failed", url=url, job_id=job_id, error=str(exc))
@@ -1243,9 +1252,25 @@ async def _ingest_crawl_result(
         )
     if login_wall_signal is not None:
         login_wall_mode = _resolve_login_wall_mode()
+        # 2026-08-18 stop-the-bleeding fix — event names below were
+        # "login_wall_reject" / "login_wall_degrade" / "login_wall_detected".
+        # ``login_wall_signal`` can come from TWO different detectors:
+        # ``classify_auth_wall`` (pattern="auth_wall_classifier" — a real
+        # auth signal: redirect/cookie/word-count heuristics) or
+        # ``detect_anonymous_auth_wall`` (pattern="template_cluster" — near-
+        # duplicate content, which does NOT prove an auth wall; an SPA
+        # fallback or a tenant-wide error page produces the same signal).
+        # The old event names asserted "login wall" as the event's identity
+        # regardless of which detector fired, which misdirected a live
+        # investigation for an hour on 2026-08-18 (13 identical OpenAPI-
+        # parser error pages, not a login wall). The renamed events report
+        # the observation neutrally; ``pattern`` in the payload still
+        # distinguishes the two detectors precisely. Behaviour (reject
+        # raises, degrade ingests with quality_score=0.0, audit_only warns
+        # + ingests unchanged) is unchanged.
         if login_wall_mode == "reject":
             logger.info(
-                "login_wall_reject",
+                "content_wall_signal_reject",
                 url=url,
                 org_id=org_id,
                 kb_slug=kb_slug,
@@ -1256,7 +1281,7 @@ async def _ingest_crawl_result(
             raise AnonymousAuthWallDetected(url, login_wall_signal)
         if login_wall_mode == "degrade":
             logger.info(
-                "login_wall_degrade",
+                "content_wall_signal_degrade",
                 url=url,
                 org_id=org_id,
                 kb_slug=kb_slug,
@@ -1266,7 +1291,7 @@ async def _ingest_crawl_result(
             )
         else:  # audit_only
             logger.warning(
-                "login_wall_detected",
+                "content_wall_signal_observed",
                 url=url,
                 org_id=org_id,
                 kb_slug=kb_slug,
@@ -1283,6 +1308,13 @@ async def _ingest_crawl_result(
     # overrides over its hard-coded default of 0.5. The retrieval-side floor
     # filter (Phase E) refuses to serve quality_score < 0.05 chunks, which
     # is the actual exclusion mechanism.
+    # 2026-08-18 stop-the-bleeding fix — deliberately did NOT rename the
+    # "login_wall_detected" string below. Unlike the log EVENT names above
+    # (diagnostic-only, changed), this is persisted DOCUMENT metadata
+    # (``extra["ingest_warning"]``), asserted by
+    # tests/test_ingest_login_wall_integration.py, and out of this fix's
+    # declared scope (log-event naming + confidence claim, not the
+    # document-metadata contract).
     if login_wall_mode == "degrade":
         extra["quality_score"] = 0.0
         extra["ingest_warning"] = "login_wall_detected"

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -28,6 +28,31 @@ class Settings(BaseSettings):
     # due to a config typo.
     ingest_login_wall_detect_enabled: bool = True
     ingest_login_wall_detect_mode: str = "reject"
+    # 2026-08-18 stop-the-bleeding fix — minimum stripped-text length (chars)
+    # for a crawled page to be persisted as knowledge. Below this, the page
+    # is skipped with PersistSkipReason.CONTENT_TOO_SHORT and never reaches
+    # Qdrant or knowledge.artifacts.
+    #
+    # Calibration: NOT derived from a measured production content-length
+    # distribution — this sandboxed dev environment has no Postgres/Grafana
+    # access to query knowledge.crawled_pages.raw_markdown. The only hard
+    # data point is the incident that prompted this fix: 13 pages from
+    # openapi.eu-production.holodeck.voys.nl were exactly ~92 chars of
+    # boilerplate ("Failed to parse OpenAPI file..."). 150 gives ~60%
+    # margin above that measured case (catching near-identical variants of
+    # the same error-page class) while staying far below any real KB
+    # article, which is virtually always multiple sentences. Deliberately
+    # conservative: a real short page is not known to exist below this
+    # bound today, but if one does, it will be dropped silently until
+    # someone raises the exception — better to under-catch (see rule:
+    # "beter te weinig vangen dan echte inhoud weggooien") than delete
+    # real content. Re-calibrate once production content-length data is
+    # available (see rule: allowlist-must-enumerate-all-host-classes for
+    # the same "measure before you gate" principle applied to thresholds).
+    ingest_min_content_length: int = Field(
+        default=150,
+        validation_alias=AliasChoices("KLAI_INGEST_MIN_CONTENT_LENGTH"),
+    )
     # SPEC-INGEST-LOGIN-WALL-DETECT-002 REQ-02 — cluster threshold. A page is
     # flagged as a wall iff this many OR MORE OTHER pages in the same
     # (org_id, kb_slug) have a SimHash within Hamming distance 3 of the page's

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -28,27 +28,30 @@ class Settings(BaseSettings):
     # due to a config typo.
     ingest_login_wall_detect_enabled: bool = True
     ingest_login_wall_detect_mode: str = "reject"
-    # 2026-08-18 stop-the-bleeding fix — minimum stripped-text length (chars)
-    # for a crawled page to be persisted as knowledge. Below this, the page
-    # is skipped with PersistSkipReason.CONTENT_TOO_SHORT and never reaches
-    # Qdrant or knowledge.artifacts.
+    # 2026-08-18 stop-the-bleeding fix, corrected same day after a
+    # production content-length measurement (n=1426,
+    # knowledge.crawled_pages) refuted the original design (a single flat
+    # threshold below which every page is rejected).
     #
-    # Calibration: NOT derived from a measured production content-length
-    # distribution — this sandboxed dev environment has no Postgres/Grafana
-    # access to query knowledge.crawled_pages.raw_markdown. The only hard
-    # data point is the incident that prompted this fix: 13 pages from
-    # openapi.eu-production.holodeck.voys.nl were exactly ~92 chars of
-    # boilerplate ("Failed to parse OpenAPI file..."). 150 gives ~60%
-    # margin above that measured case (catching near-identical variants of
-    # the same error-page class) while staying far below any real KB
-    # article, which is virtually always multiple sentences. Deliberately
-    # conservative: a real short page is not known to exist below this
-    # bound today, but if one does, it will be dropped silently until
-    # someone raises the exception — better to under-catch (see rule:
-    # "beter te weinig vangen dan echte inhoud weggooien") than delete
-    # real content. Re-calibrate once production content-length data is
-    # available (see rule: allowlist-must-enumerate-all-host-classes for
-    # the same "measure before you gate" principle applied to thresholds).
+    # The measurement: two real, unique pages (getklai.com/contact at ~85
+    # chars, help.voys.nl/help-pages-nl at ~108 chars) sit INSIDE the same
+    # length band as measured error-page clusters (5x exactly 92 chars,
+    # 3x exactly 98, 3x exactly 101, 3x exactly 88 — the incident that
+    # prompted this fix, openapi.eu-production.holodeck.voys.nl, is the
+    # 92-char cluster). A flat threshold below 85 lets every measured
+    # error page through; a flat threshold above 118 drops both real
+    # pages. Length alone cannot separate these two classes — only
+    # uniqueness can (see ``_ingest_crawl_result`` in adapters/crawler.py
+    # for the full two-tier rule this setting is now one half of, and
+    # tests/test_crawler_content_too_short.py for the measured numbers).
+    #
+    # This setting is now ONLY the soft-zone ceiling: below it (and at or
+    # above ``_HARD_MIN_CONTENT_LENGTH`` in crawler.py), a page is
+    # persisted UNLESS it is a near-duplicate of >= 2 other pages in the
+    # same KB. At or above this value, a page is always persisted
+    # regardless of clustering. 150 stays far below any real KB article
+    # (virtually always multiple sentences) while giving margin above the
+    # measured 88-118 char error-page band.
     ingest_min_content_length: int = Field(
         default=150,
         validation_alias=AliasChoices("KLAI_INGEST_MIN_CONTENT_LENGTH"),

--- a/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
+++ b/klai-knowledge-ingest/knowledge_ingest/utils/auth_wall_detector.py
@@ -69,9 +69,21 @@ class AuthWallSignal:
             v1; tests pin the new value so a regression is caught.
         evidence: Single-element tuple of the form
             ``("cluster_size={N} hamming<={M}",)`` used for diagnostic logs.
-        confidence: Always ``0.9`` for cluster matches. v1's tiered confidence
-            (0.95 for canonical phrase, 0.7 for weak signal) is gone — v2 has
-            one signal type.
+        confidence: 2026-08-18 stop-the-bleeding fix — no longer hardcoded
+            to 0.9 for cluster matches. Near-duplicate content is a real,
+            deterministic structural observation (hamming distance,
+            cluster size), but it does NOT prove an authentication wall —
+            an SPA fallback, a render error, or a tenant-wide error page
+            produce the identical signal. The old 0.9 was inherited from
+            v1's tiered confidence design (0.95 canonical phrase, 0.7 weak
+            signal) and never actually varied with anything about the
+            observation; reporting it invited callers to read it as "90%
+            sure this is a login wall", which misdirected a live
+            production investigation for an hour (13 near-identical
+            OpenAPI-parser error pages, not a login wall). Defaults to 0.0
+            (dataclass default) for cluster-only detections — the
+            ``evidence`` tuple carries the actual observation
+            (cluster_size, hamming distance) instead.
     """
 
     pattern: str
@@ -206,8 +218,11 @@ async def detect_anonymous_auth_wall(
     if cluster_size < cluster_min:
         return None
 
+    # 2026-08-18 stop-the-bleeding fix: no confidence value set here — a
+    # cluster observation carries no authentication-specific certainty
+    # (see the ``confidence`` attribute docstring above). Falls back to the
+    # dataclass default (0.0). The actual observation is in ``evidence``.
     return AuthWallSignal(
         pattern="template_cluster",
         evidence=(f"cluster_size={cluster_size} hamming<={hamming_max}",),
-        confidence=0.9,
     )

--- a/klai-knowledge-ingest/tests/test_auth_wall_detector.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_detector.py
@@ -92,7 +92,11 @@ class TestClusterDetection:
         assert signal is not None
         assert signal.pattern == "template_cluster"
         assert signal.evidence == ("cluster_size=5 hamming<=3",)
-        assert signal.confidence == 0.9
+        # 2026-08-18 stop-the-bleeding fix: cluster-only detections no
+        # longer report an auth-specific confidence — a near-duplicate
+        # cluster is not proof of an authentication wall. See
+        # tests/test_auth_wall_signal_reporting.py for the regression test.
+        assert signal.confidence == 0.0
 
     @pytest.mark.asyncio
     async def test_no_flag_when_only_4_others_match(self) -> None:
@@ -382,7 +386,9 @@ class TestSignalShape:
         )
         assert signal is not None
         assert signal.pattern == "template_cluster"
-        assert signal.confidence == 0.9
+        # 2026-08-18 stop-the-bleeding fix: no auth-specific confidence for
+        # a cluster-only observation — see test_auth_wall_signal_reporting.py.
+        assert signal.confidence == 0.0
         assert len(signal.evidence) == 1
         assert "cluster_size=" in signal.evidence[0]
         assert "hamming<=3" in signal.evidence[0]

--- a/klai-knowledge-ingest/tests/test_auth_wall_signal_reporting.py
+++ b/klai-knowledge-ingest/tests/test_auth_wall_signal_reporting.py
@@ -1,0 +1,277 @@
+"""Damage 3 (stop-the-bleeding fix): the template-cluster detector must
+report what it observed, not a cause it cannot see.
+
+Near-duplicate content (5+ sibling pages within Hamming distance 3) is a
+real, correctly-detected structural fact. But near-duplicate content does
+NOT prove an authentication wall — an SPA fallback, a render error, or a
+tenant-wide error page produce the exact same signal. On 2026-08-18 this
+mislabeling sent a live investigation down the wrong path for an hour: the
+customer saw "login wall" and went hunting for credentials that had nothing
+to do with the actual problem (13 identical OpenAPI-parser error pages).
+
+This file does NOT change the REJECT behaviour (a rejected page is still
+rejected — see test_crawler_anonymous_auth_wall.py and
+test_ingest_login_wall_integration.py, both of which must stay green). It
+only asserts that:
+
+1. ``detect_anonymous_auth_wall`` no longer reports an auth-specific 0.9
+   confidence for a cluster-only observation.
+2. The log events crawler.py emits when a page is rejected/degraded/
+   audit-only-flagged by the CLUSTER detector no longer name an
+   "inlogmuur" (login wall) as the event identity.
+
+``AUTH_WALL_DETECTED_REASON`` / ``DIRTY_CONTENT_REASON`` (the
+``connector.sync_runs`` / crawl_jobs error_summary top-level ``reason``
+values) are deliberately OUT of scope here — the frontend UI badge switches
+on those exact strings (see klai-portal/frontend
+``-connector-feedback.tsx``), so changing them is a cross-service, UI-
+breaking change outside this damage-limiting fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest.adapters.crawler import AnonymousAuthWallDetected, _ingest_crawl_result
+from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.utils.auth_wall_detector import (
+    AuthWallSignal,
+    detect_anonymous_auth_wall,
+)
+from knowledge_ingest.utils.content_fingerprint import compute_simhash
+
+FIXTURES = Path(__file__).parent / "fixtures"
+WALLS = FIXTURES / "auth_walls"
+
+
+class _FakeConn:
+    """Minimal asyncpg.Connection stub — sibling-cluster fetch only."""
+
+    def __init__(self, simhashes: list[int]) -> None:
+        self._simhashes = simhashes
+
+    async def fetch(self, _query: str, *_args):
+        return [{"content_simhash": h} for h in self._simhashes]
+
+
+def _clean_result(url: str = "https://example.com/error-page") -> CrawlResult:
+    """A page that will NOT trip ``classify_auth_wall`` (no cookie header,
+    no redirect, word_count high enough) so control flow reaches the
+    cluster-only detector.
+    """
+    text = "Ordinary error page content. " * 20
+    return CrawlResult(
+        url=url,
+        fit_markdown=text,
+        raw_markdown=text,
+        html=f"<html><body>{text}</body></html>",
+        word_count=len(text.split()),
+        success=True,
+        links={"internal": []},
+        error_message="",
+        metadata={},
+        response_headers={"content-type": "text/html"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Detector-level: confidence no longer claims auth-specific certainty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cluster_detection_does_not_report_auth_specific_confidence():
+    """A pure cluster observation carries no authentication certainty.
+
+    Cluster membership is a deterministic structural fact (hamming distance,
+    cluster size) — not a probabilistic auth judgement. The old hardcoded
+    0.9 was inherited from v1's tiered confidence design and never actually
+    varied with anything about the observation.
+    """
+    wall_text = (FIXTURES / "auth_walls" / "redcactus_hubspot.md").read_text(encoding="utf-8")
+    target = compute_simhash(wall_text)
+    conn = _FakeConn([target] * 5)
+
+    signal = await detect_anonymous_auth_wall(
+        wall_text,
+        org_id="org-1",
+        kb_slug="kb-1",
+        url="https://x/wall",
+        conn=conn,
+    )
+
+    assert signal is not None
+    assert signal.confidence != 0.9, (
+        "cluster-only detection must not report the old auth-specific 0.9 confidence"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Crawler-level: log events must not name the presumed cause
+# ---------------------------------------------------------------------------
+
+
+def _cluster_signal() -> AuthWallSignal:
+    return AuthWallSignal(
+        pattern="template_cluster",
+        evidence=("cluster_size=5 hamming<=3",),
+        confidence=0.9,
+    )
+
+
+def _logged_event_names(mock_logger: MagicMock) -> list[str]:
+    """Extract the event-name (first positional arg) of every log call.
+
+    NOTE: we assert against a mocked ``crawler.logger`` rather than via
+    pytest's ``caplog`` fixture. Structlog in this codebase only routes
+    through stdlib ``logging`` (which ``caplog`` intercepts) after
+    ``knowledge_ingest.app`` has been imported at least once in the test
+    session (``setup_logging()`` runs at that module's import time — see
+    ``knowledge_ingest/app.py``). Whether that has already happened depends
+    on pytest's collection order across the whole suite, so a ``caplog``-based
+    assertion here would pass or fail depending on which OTHER test files
+    ran first — exactly the kind of order-dependent flake this suite avoids
+    elsewhere. Mocking ``crawler.logger`` directly is order-independent.
+    """
+    names: list[str] = []
+    for method in ("info", "warning", "debug", "error"):
+        for call in getattr(mock_logger, method).call_args_list:
+            if call.args:
+                names.append(str(call.args[0]))
+    return names
+
+
+def _patch_ingest_chain(login_wall_mode: str, mock_logger: MagicMock):
+    from tests.conftest import make_pg_store_mock
+
+    pg = make_pg_store_mock()
+    ingest = AsyncMock(return_value={"chunks": 1})
+    return (
+        pg,
+        ingest,
+        [
+            patch("knowledge_ingest.adapters.crawler.pg_store", pg),
+            patch("knowledge_ingest.adapters.crawler.logger", mock_logger),
+            patch("knowledge_ingest.adapters.crawler._build_image_store", return_value=None),
+            patch("knowledge_ingest.routes.ingest.ingest_document", ingest),
+            patch(
+                "knowledge_ingest.adapters.crawler.classify_auth_wall",
+                return_value=SimpleNamespace(is_walled=False, match_reasons=()),
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.detect_anonymous_auth_wall",
+                new=AsyncMock(return_value=_cluster_signal()),
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_enabled", True
+            ),
+            patch(
+                "knowledge_ingest.adapters.crawler.settings.ingest_login_wall_detect_mode",
+                login_wall_mode,
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_reject_mode_log_event_does_not_name_login_wall():
+    """REJECT mode: exception still raised (behaviour unchanged); the log
+    event identity must no longer assert "login wall" as the cause."""
+    result = _clean_result()
+    pool = MagicMock()
+    mock_logger = MagicMock()
+    _pg, ingest, patches = _patch_ingest_chain("reject", mock_logger)
+
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(AnonymousAuthWallDetected):
+            await _ingest_crawl_result(
+                pool,
+                result,
+                result.url,
+                org_id="org-1",
+                kb_slug="kb-1",
+                stored=None,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    ingest.assert_not_called()  # behaviour: still rejected, not persisted
+    events = _logged_event_names(mock_logger)
+    assert events, "expected at least one log call for the reject path"
+    assert not any("login_wall" in e for e in events), (
+        f"log event still names a login wall as the cause: {events}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_degrade_mode_log_event_does_not_name_login_wall():
+    """DEGRADE mode: page still ingests with quality_score=0.0 (unchanged);
+    the log event identity must no longer assert "login wall"."""
+    result = _clean_result()
+    pool = MagicMock()
+    mock_logger = MagicMock()
+    _pg, ingest, patches = _patch_ingest_chain("degrade", mock_logger)
+
+    for p in patches:
+        p.start()
+    try:
+        await _ingest_crawl_result(
+            pool,
+            result,
+            result.url,
+            org_id="org-1",
+            kb_slug="kb-1",
+            stored=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    ingest.assert_called_once()
+    sent_request = ingest.call_args.args[1]
+    assert sent_request.extra.get("quality_score") == 0.0  # behaviour unchanged
+
+    events = _logged_event_names(mock_logger)
+    assert events, "expected at least one log call for the degrade path"
+    assert not any("login_wall" in e for e in events), (
+        f"log event still names a login wall as the cause: {events}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_audit_only_mode_log_event_does_not_name_login_wall():
+    """AUDIT_ONLY mode: page still ingests unchanged (behaviour unchanged);
+    the WARNING log event identity must no longer assert "login wall"."""
+    result = _clean_result()
+    pool = MagicMock()
+    mock_logger = MagicMock()
+    _pg, ingest, patches = _patch_ingest_chain("audit_only", mock_logger)
+
+    for p in patches:
+        p.start()
+    try:
+        await _ingest_crawl_result(
+            pool,
+            result,
+            result.url,
+            org_id="org-1",
+            kb_slug="kb-1",
+            stored=None,
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    ingest.assert_called_once()  # behaviour unchanged: audit_only never blocks
+    events = _logged_event_names(mock_logger)
+    assert events, "expected at least one log call for the audit_only path"
+    assert not any("login_wall" in e for e in events), (
+        f"log event still names a login wall as the cause: {events}"
+    )

--- a/klai-knowledge-ingest/tests/test_crawl_registry_dedup.py
+++ b/klai-knowledge-ingest/tests/test_crawl_registry_dedup.py
@@ -35,6 +35,14 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+# 2026-08-18 stop-the-bleeding fix: content-length gate
+# (settings.ingest_min_content_length) now skips persistence below
+# threshold. Appended to fixture text below so these dedup tests keep
+# exercising the ingest/upsert paths they were written to test, not the
+# new short-content skip.
+_PAD_ABOVE_MIN_CONTENT_LENGTH = " Filler sentence for length only." * 5
+
+
 def _make_crawl_result(
     text: str = "# Hello\nPage content here.",
     html: str = "<html><body>Hello</body></html>",
@@ -121,7 +129,7 @@ async def test_bulk_crawl_skip_unchanged() -> None:
 async def test_bulk_crawl_reingests_unchanged_connector_when_active_artifact_missing() -> None:
     """Known crawled_pages hashes must not hide a retired connector artifact."""
     html = "<html><body>Hello</body></html>"
-    text = "# Hello\nPage content here."
+    text = "# Hello\nPage content here." + _PAD_ABOVE_MIN_CONTENT_LENGTH
     stored = (_sha256(html), _sha256(text))
 
     result = _make_crawl_result(text=text, html=html)
@@ -166,7 +174,7 @@ async def test_bulk_crawl_reingests_unchanged_connector_when_active_artifact_mis
 @pytest.mark.asyncio
 async def test_bulk_crawl_skip_html_noise() -> None:
     """When raw HTML changed but content hash is identical, skip ingest but update raw_html_hash."""
-    text = "# Article content"
+    text = "# Article content" + _PAD_ABOVE_MIN_CONTENT_LENGTH
     old_html = "<html><body>Article</body></html>"
     new_html = "<html><body>Article<script>analytics()</script></body></html>"
     stored = (_sha256(old_html), _sha256(text))
@@ -203,7 +211,7 @@ async def test_bulk_crawl_skip_html_noise() -> None:
 @pytest.mark.asyncio
 async def test_bulk_crawl_reingest_on_change() -> None:
     """When content hash differs, ingest_document IS called and crawled_pages is updated."""
-    text = "# Updated content"
+    text = "# Updated content" + _PAD_ABOVE_MIN_CONTENT_LENGTH
     html = "<html><body>Updated</body></html>"
     old_stored = (_sha256("old html"), _sha256("# Old content"))
 
@@ -243,7 +251,7 @@ async def test_bulk_crawl_reingest_on_change() -> None:
 @pytest.mark.asyncio
 async def test_bulk_crawl_new_page() -> None:
     """When URL is not in crawled_pages (None), insert + ingest."""
-    text = "# Brand new page"
+    text = "# Brand new page" + _PAD_ABOVE_MIN_CONTENT_LENGTH
     html = "<html><body>New</body></html>"
 
     result = _make_crawl_result(text=text, html=html)

--- a/klai-knowledge-ingest/tests/test_crawler_content_too_short.py
+++ b/klai-knowledge-ingest/tests/test_crawler_content_too_short.py
@@ -1,0 +1,177 @@
+"""Damage 2 (stop-the-bleeding fix): error pages must not be persisted as knowledge.
+
+Production incident (2026-08-18): openapi.eu-production.holodeck.voys.nl
+served 13 pages that all successfully fetched (HTTP 200) and were all
+exactly 92 characters of the same OpenAPI-parser error text:
+
+    #### Failed to parse OpenAPI file
+    Please make sure your OpenAPI file is valid and try again
+
+There was no minimum-content-length check anywhere on the crawl-ingest
+path, so 5 of those 13 pages were persisted into the customer's knowledge
+base with plausible-looking titles (``call``, ``callrecording``, ...) and
+became eligible for retrieval in chat. The other 8 were only rejected once
+the template-cluster detector saw 5 near-identical siblings — a detector
+whose whole job is auth-wall detection, not error-page filtering.
+
+``PersistSkipReason.CONTENT_TOO_SHORT`` already existed in
+``reason_codes.py`` but was wired up nowhere. This test locks in that the
+crawl-ingest path now uses it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest.config import settings
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+# Reconstructed from the incident report (exact production string not
+# available from this environment — no DB/log access). ~91 chars, matching
+# the reported "exactly 92 characters" within reconstruction tolerance.
+_OPENAPI_PARSE_ERROR_TEXT = (
+    "#### Failed to parse OpenAPI file\nPlease make sure your OpenAPI file is valid and try again"
+)
+
+
+def _make_mock_conn():
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
+def _make_crawl_result(url: str, text: str) -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        fit_markdown=text,
+        raw_markdown=text,
+        html=f"<html><body><p>{text}</p></body></html>",
+        word_count=len(text.split()),
+        success=True,
+        links={"internal": []},
+        error_message="",
+        metadata={},
+        response_headers={"content-type": "text/html"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_openapi_error_page_is_not_persisted():
+    """The ~92-char production regression must be skipped, not ingested."""
+    assert len(_OPENAPI_PARSE_ERROR_TEXT) < settings.ingest_min_content_length, (
+        "fixture must stay below the configured threshold to exercise the regression"
+    )
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result(
+        "https://openapi.eu-production.holodeck.voys.nl/call",
+        _OPENAPI_PARSE_ERROR_TEXT,
+    )
+
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    with (
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+    ):
+        from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
+        await _ingest_crawl_result(
+            mock_conn,
+            result,
+            url=result.url,
+            org_id="org-1",
+            kb_slug="docs",
+            stored=None,
+        )
+
+    mock_ingest.assert_not_called()
+    mock_pg.upsert_crawled_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_short_legitimate_page_just_above_threshold_is_persisted():
+    """A short but real page just above the threshold must still be ingested.
+
+    Guards against an overcorrection that would drop legitimate short pages
+    (e.g. the production case of a connector with exactly 1 short document).
+    """
+    text = "x" * (settings.ingest_min_content_length + 1)
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result("https://example.com/short-but-real", text)
+
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    with (
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ) as mock_ingest,
+    ):
+        mock_ingest.return_value = {"chunks": 1}
+
+        from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
+        await _ingest_crawl_result(
+            mock_conn,
+            result,
+            url=result.url,
+            org_id="org-1",
+            kb_slug="docs",
+            stored=None,
+        )
+
+    mock_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_content_too_short_is_logged_with_reason_code():
+    """The skip must be observable, not silent (see rule: silent skips hide for years).
+
+    NOTE: asserts against a mocked ``crawler.logger`` rather than
+    ``caplog`` — structlog in this codebase only routes through stdlib
+    ``logging`` (which ``caplog`` intercepts) after ``knowledge_ingest.app``
+    has been imported at least once in the test session. Whether that has
+    happened depends on pytest's collection order across the whole suite,
+    so a ``caplog``-based assertion here would be order-dependent. Mocking
+    ``crawler.logger`` directly is order-independent.
+    """
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result("https://example.com/junk", _OPENAPI_PARSE_ERROR_TEXT)
+
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_logger = MagicMock()
+    with (
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch("knowledge_ingest.adapters.crawler.logger", mock_logger),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ),
+    ):
+        from knowledge_ingest.adapters.crawler import _ingest_crawl_result
+
+        await _ingest_crawl_result(
+            mock_conn,
+            result,
+            url=result.url,
+            org_id="org-1",
+            kb_slug="docs",
+            stored=None,
+        )
+
+    logged_events = [call.args[0] for call in mock_logger.info.call_args_list if call.args]
+    assert "crawl_skipped_content_too_short" in logged_events

--- a/klai-knowledge-ingest/tests/test_crawler_content_too_short.py
+++ b/klai-knowledge-ingest/tests/test_crawler_content_too_short.py
@@ -10,13 +10,47 @@ exactly 92 characters of the same OpenAPI-parser error text:
 There was no minimum-content-length check anywhere on the crawl-ingest
 path, so 5 of those 13 pages were persisted into the customer's knowledge
 base with plausible-looking titles (``call``, ``callrecording``, ...) and
-became eligible for retrieval in chat. The other 8 were only rejected once
-the template-cluster detector saw 5 near-identical siblings — a detector
-whose whole job is auth-wall detection, not error-page filtering.
+became eligible for retrieval in chat.
 
-``PersistSkipReason.CONTENT_TOO_SHORT`` already existed in
-``reason_codes.py`` but was wired up nowhere. This test locks in that the
-crawl-ingest path now uses it.
+2026-08-18 (correction after production measurement, n=1426, from
+knowledge.crawled_pages): a flat length threshold does NOT work. Two
+legitimate short pages measured in production sit inside the same length
+band as the error pages:
+
+  - getklai.com/contact (85 chars): "# Contact\nHave a question about
+    Klai? Send us a message"
+  - help.voys.nl/help-pages-nl (108 chars): "# Help Pages NL\nFreedom: Je
+    eerste keer\nDe Voys App..."
+
+A flat threshold above 118 would drop both. A flat threshold below 85
+would let every measured error page through (88/92/98/101/118). Length
+alone cannot separate these two classes.
+
+What DOES separate them, per the same measurement: error pages exist in
+IDENTICAL clusters (5x exactly 92 chars, 3x exactly 98, 3x exactly 101,
+3x exactly 88). The two legitimate short pages are each unique — the only
+occurrence of their content in the whole dataset.
+
+The rule is therefore two-tier:
+
+1. Hard floor (``_HARD_MIN_CONTENT_LENGTH`` = 30 chars): below this,
+   reject unconditionally. Justified by the data: the only pages below 30
+   chars in the whole measured set are 3 completely empty (1-char) pages.
+   Every real page -- including the shortest legitimate one at 85 chars --
+   sits far above 30, so 30 cannot falsely catch real content, while it
+   catches the unambiguous empty-page case without needing a cluster
+   lookup at all.
+
+2. Soft zone (30 <= length < ``settings.ingest_min_content_length``, 150):
+   reject ONLY when the page is a near-duplicate (SimHash Hamming <= 3) of
+   >= 2 OTHER pages in the same (org_id, kb_slug) -- reusing the exact
+   cluster-lookup mechanism from ``utils/auth_wall_detector.py``
+   (``detect_anonymous_auth_wall``), with a lower ``cluster_min`` than its
+   default of 5. The lower bound is required by the data: the smallest
+   observed error cluster is 3 total pages (2 OTHERS from any one page's
+   perspective) -- the default cluster_min=5 would silently let the
+   3-page 404 cluster and both 3-page Ascend clusters (98/101 chars)
+   through. A unique short page (0 siblings) is always < 2 and is kept.
 """
 
 from __future__ import annotations
@@ -27,6 +61,7 @@ import pytest
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.utils.content_fingerprint import compute_simhash
 
 # Reconstructed from the incident report (exact production string not
 # available from this environment — no DB/log access). ~91 chars, matching
@@ -35,12 +70,41 @@ _OPENAPI_PARSE_ERROR_TEXT = (
     "#### Failed to parse OpenAPI file\nPlease make sure your OpenAPI file is valid and try again"
 )
 
+# Reconstructed from the production measurement report (2026-08-18,
+# knowledge.crawled_pages, n=1426) — exact production strings not available
+# from this environment (no DB access). Length is an approximate match to
+# the reported ~88-char class ("404 / Page not found"); what matters for
+# the test is that it falls inside the 30-150 soft zone, which it does.
+_NOT_FOUND_TEXT = "# 404\nPage not found. The page you are looking for does not exist on this site."
 
-def _make_mock_conn():
+# Reconstructed, approximate match to the reported ~85-char length — a
+# real, unique page (getklai.com/contact) from the same measurement, in
+# the SAME length band as the error pages above. This is the case a flat
+# length threshold cannot handle.
+_CONTACT_PAGE_TEXT = "# Contact\nHave a question about Klai? Send us a message and we will reply."
+
+# Reconstructed, approximate match to the reported ~108-char length — a
+# real, unique page (help.voys.nl/help-pages-nl) from the same
+# measurement, also inside the error-page length band.
+_HELP_INDEX_TEXT = (
+    "# Help Pages NL\nFreedom: Je eerste keer\nDe Voys App: instellen en gebruiken"
+    "\nMeer hulp nodig? Contact ons."
+)
+
+
+def _make_mock_conn(sibling_simhashes: list[int] | None = None):
+    """Build a mock asyncpg.Connection.
+
+    ``sibling_simhashes`` seeds ``conn.fetch`` with rows shaped like the
+    cluster-lookup query in ``utils/auth_wall_detector.py`` expects
+    (``{"content_simhash": ...}``) so the reused cluster-lookup mechanism
+    sees them as OTHER pages in the same (org_id, kb_slug).
+    """
     conn = MagicMock()
     conn.execute = AsyncMock(return_value=None)
     conn.executemany = AsyncMock(return_value=None)
-    conn.fetch = AsyncMock(return_value=[])
+    rows = [{"content_simhash": h} for h in (sibling_simhashes or [])]
+    conn.fetch = AsyncMock(return_value=rows)
     conn.fetchval = AsyncMock(return_value=0)
     conn.fetchrow = AsyncMock(return_value=None)
     return conn
@@ -61,54 +125,8 @@ def _make_crawl_result(url: str, text: str) -> CrawlResult:
     )
 
 
-@pytest.mark.asyncio
-async def test_openapi_error_page_is_not_persisted():
-    """The ~92-char production regression must be skipped, not ingested."""
-    assert len(_OPENAPI_PARSE_ERROR_TEXT) < settings.ingest_min_content_length, (
-        "fixture must stay below the configured threshold to exercise the regression"
-    )
-    mock_conn = _make_mock_conn()
-    result = _make_crawl_result(
-        "https://openapi.eu-production.holodeck.voys.nl/call",
-        _OPENAPI_PARSE_ERROR_TEXT,
-    )
-
-    from tests.conftest import make_pg_store_mock
-
-    mock_pg = make_pg_store_mock()
-    with (
-        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
-        patch(
-            "knowledge_ingest.routes.ingest.ingest_document",
-            new_callable=AsyncMock,
-        ) as mock_ingest,
-    ):
-        from knowledge_ingest.adapters.crawler import _ingest_crawl_result
-
-        await _ingest_crawl_result(
-            mock_conn,
-            result,
-            url=result.url,
-            org_id="org-1",
-            kb_slug="docs",
-            stored=None,
-        )
-
-    mock_ingest.assert_not_called()
-    mock_pg.upsert_crawled_page.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_short_legitimate_page_just_above_threshold_is_persisted():
-    """A short but real page just above the threshold must still be ingested.
-
-    Guards against an overcorrection that would drop legitimate short pages
-    (e.g. the production case of a connector with exactly 1 short document).
-    """
-    text = "x" * (settings.ingest_min_content_length + 1)
-    mock_conn = _make_mock_conn()
-    result = _make_crawl_result("https://example.com/short-but-real", text)
-
+async def _run_ingest(result: CrawlResult, mock_conn) -> tuple[MagicMock, AsyncMock]:
+    """Run ``_ingest_crawl_result`` and return (pg_store mock, ingest mock)."""
     from tests.conftest import make_pg_store_mock
 
     mock_pg = make_pg_store_mock()
@@ -120,7 +138,145 @@ async def test_short_legitimate_page_just_above_threshold_is_persisted():
         ) as mock_ingest,
     ):
         mock_ingest.return_value = {"chunks": 1}
+        from knowledge_ingest.adapters.crawler import _ingest_crawl_result
 
+        await _ingest_crawl_result(
+            mock_conn,
+            result,
+            url=result.url,
+            org_id="org-1",
+            kb_slug="docs",
+            stored=None,
+        )
+    return mock_pg, mock_ingest
+
+
+@pytest.mark.asyncio
+async def test_empty_page_is_rejected_below_hard_floor():
+    """1-char page (production measurement: 3 completely empty pages) is
+    always rejected -- no cluster lookup needed, no siblings required."""
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result("https://wiki.redcactus.cloud/nl/empty-page", "x")
+
+    mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_not_called()
+    mock_pg.upsert_crawled_page.assert_not_called()
+    # Hard-floor rejection must not even query the cluster lookup.
+    mock_conn.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_openapi_error_page_with_siblings_is_rejected():
+    """92-char OpenAPI error text WITH 4 identical siblings (production:
+    5 total pages) must be rejected -- the exact regression case."""
+    assert len(_OPENAPI_PARSE_ERROR_TEXT) < settings.ingest_min_content_length
+    siblings = [compute_simhash(_OPENAPI_PARSE_ERROR_TEXT)] * 4
+    mock_conn = _make_mock_conn(siblings)
+    result = _make_crawl_result(
+        "https://openapi.eu-production.holodeck.voys.nl/call",
+        _OPENAPI_PARSE_ERROR_TEXT,
+    )
+
+    mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_not_called()
+    mock_pg.upsert_crawled_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_404_page_with_two_siblings_is_rejected():
+    """~88-char (reconstructed) '404 Page not found' WITH 2 identical siblings (production:
+    3 total pages) must be rejected. This is the case that requires
+    cluster_min lower than the auth-wall default of 5 -- a 3-page cluster
+    only has 2 OTHERS from any single page's perspective."""
+    assert len(_NOT_FOUND_TEXT) < settings.ingest_min_content_length
+    siblings = [compute_simhash(_NOT_FOUND_TEXT)] * 2
+    mock_conn = _make_mock_conn(siblings)
+    result = _make_crawl_result("https://getklai.com/en/docs/legal/dpa", _NOT_FOUND_TEXT)
+
+    mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_not_called()
+    mock_pg.upsert_crawled_page.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unique_short_contact_page_is_persisted():
+    """~85-char (reconstructed) contact page WITHOUT siblings must be persisted.
+
+    This is the most important test of the two-tier rule: it locks in
+    that real content is not thrown away. The flat 150-char threshold this
+    replaces would have dropped this page -- it sits at 85 chars, squarely
+    inside the 88-118 char band the measured error pages also occupy.
+    Length alone cannot tell these apart; uniqueness can.
+    """
+    assert len(_CONTACT_PAGE_TEXT) < settings.ingest_min_content_length
+    mock_conn = _make_mock_conn()  # no siblings
+    result = _make_crawl_result("https://getklai.com/contact", _CONTACT_PAGE_TEXT)
+
+    _mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unique_short_help_index_page_is_persisted():
+    """~108-char (reconstructed) Voys help index page WITHOUT siblings must be persisted.
+
+    Second most important test of the two-tier rule -- same rationale as
+    the contact-page test above, at a different point in the error-page
+    length band (88-118 chars).
+    """
+    assert len(_HELP_INDEX_TEXT) < settings.ingest_min_content_length
+    mock_conn = _make_mock_conn()  # no siblings
+    result = _make_crawl_result("https://help.voys.nl/help-pages-nl", _HELP_INDEX_TEXT)
+
+    _mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_short_legitimate_page_just_above_threshold_is_persisted():
+    """A page at/above the 150-char threshold is always persisted,
+    regardless of clustering -- the two-tier rule only applies below it."""
+    text = "x" * (settings.ingest_min_content_length + 1)
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result("https://example.com/short-but-real", text)
+
+    _mock_pg, mock_ingest = await _run_ingest(result, mock_conn)
+
+    mock_ingest.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_hard_floor_rejection_is_logged_with_reason_code():
+    """The empty-page skip must be observable, not silent.
+
+    NOTE: asserts against a mocked ``crawler.logger`` rather than
+    ``caplog`` — structlog in this codebase only routes through stdlib
+    ``logging`` (which ``caplog`` intercepts) after ``knowledge_ingest.app``
+    has been imported at least once in the test session. Whether that has
+    happened depends on pytest's collection order across the whole suite,
+    so a ``caplog``-based assertion here would be order-dependent. Mocking
+    ``crawler.logger`` directly is order-independent.
+    """
+    mock_conn = _make_mock_conn()
+    result = _make_crawl_result("https://example.com/empty", "x")
+
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_logger = MagicMock()
+    with (
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch("knowledge_ingest.adapters.crawler.logger", mock_logger),
+        patch(
+            "knowledge_ingest.routes.ingest.ingest_document",
+            new_callable=AsyncMock,
+        ),
+    ):
         from knowledge_ingest.adapters.crawler import _ingest_crawl_result
 
         await _ingest_crawl_result(
@@ -132,22 +288,15 @@ async def test_short_legitimate_page_just_above_threshold_is_persisted():
             stored=None,
         )
 
-    mock_ingest.assert_called_once()
+    logged_events = [call.args[0] for call in mock_logger.info.call_args_list if call.args]
+    assert "crawl_skipped_content_too_short" in logged_events
 
 
 @pytest.mark.asyncio
-async def test_content_too_short_is_logged_with_reason_code():
-    """The skip must be observable, not silent (see rule: silent skips hide for years).
-
-    NOTE: asserts against a mocked ``crawler.logger`` rather than
-    ``caplog`` — structlog in this codebase only routes through stdlib
-    ``logging`` (which ``caplog`` intercepts) after ``knowledge_ingest.app``
-    has been imported at least once in the test session. Whether that has
-    happened depends on pytest's collection order across the whole suite,
-    so a ``caplog``-based assertion here would be order-dependent. Mocking
-    ``crawler.logger`` directly is order-independent.
-    """
-    mock_conn = _make_mock_conn()
+async def test_duplicate_cluster_rejection_is_logged_with_reason_code():
+    """The short-and-duplicated skip must also be observable."""
+    siblings = [compute_simhash(_OPENAPI_PARSE_ERROR_TEXT)] * 4
+    mock_conn = _make_mock_conn(siblings)
     result = _make_crawl_result("https://example.com/junk", _OPENAPI_PARSE_ERROR_TEXT)
 
     from tests.conftest import make_pg_store_mock

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -29,7 +29,11 @@ def _make_mock_conn():
 def _make_crawl_result(
     url: str = "https://example.com/a",
     success: bool = True,
-    text: str = "Some markdown content for testing",
+    # 2026-08-18 stop-the-bleeding fix: content-length gate
+    # (settings.ingest_min_content_length) now skips persistence below
+    # threshold. Padded well above default (150 chars) so these link-graph
+    # tests keep exercising the ingest path, not the new short-content skip.
+    text: str = "Some markdown content for testing. " * 6,
     links: dict | None = None,
 ) -> CrawlResult:
     return CrawlResult(

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields.py
@@ -16,7 +16,13 @@ from knowledge_ingest.crawl4ai_client import CrawlResult
 
 
 def _make_mock_conn():
-    """SPEC-TI-003-FOLLOWUP-001: helpers take asyncpg.Connection directly."""
+    """SPEC-TI-003-FOLLOWUP-001: helpers take asyncpg.Connection directly.
+
+    ``fetch`` returning ``[]`` also matters for the content-length gate in
+    ``_ingest_crawl_result``: the default fixture text below (33 chars) is
+    inside the gate's soft zone, and with no cluster siblings returned it
+    is treated as unique short content and kept, not rejected.
+    """
     conn = MagicMock()
     conn.execute = AsyncMock(return_value=None)
     conn.executemany = AsyncMock(return_value=None)
@@ -29,11 +35,7 @@ def _make_mock_conn():
 def _make_crawl_result(
     url: str = "https://example.com/a",
     success: bool = True,
-    # 2026-08-18 stop-the-bleeding fix: content-length gate
-    # (settings.ingest_min_content_length) now skips persistence below
-    # threshold. Padded well above default (150 chars) so these link-graph
-    # tests keep exercising the ingest path, not the new short-content skip.
-    text: str = "Some markdown content for testing. " * 6,
+    text: str = "Some markdown content for testing",
     links: dict | None = None,
 ) -> CrawlResult:
     return CrawlResult(

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -16,6 +16,10 @@ from knowledge_ingest.crawl4ai_client import CrawlResult
 
 
 def _make_mock_pool() -> MagicMock:
+    # ``fetch`` returning ``[]`` also matters for the content-length gate
+    # in ``_ingest_crawl_result``: fixture text below (42 chars) is inside
+    # the gate's soft zone, and with no cluster siblings returned it is
+    # treated as unique short content and kept, not rejected.
     pool = MagicMock()
     pool.execute = AsyncMock(return_value=None)
     pool.fetch = AsyncMock(return_value=[])
@@ -28,11 +32,7 @@ def _make_crawl_result(
     internal_links: list[dict] | None = None,
 ) -> CrawlResult:
     """Build a successful CrawlResult with the given internal links."""
-    # 2026-08-18 stop-the-bleeding fix: content-length gate
-    # (settings.ingest_min_content_length) now skips persistence below
-    # threshold. Padded well above default (150 chars) so this fixture
-    # keeps exercising the ingest path.
-    text = f"Markdown content for {url}. " * 6
+    text = f"Markdown content for {url}"
     return CrawlResult(
         url=url,
         fit_markdown=text,

--- a/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
+++ b/klai-knowledge-ingest/tests/test_crawler_link_fields_complete.py
@@ -28,7 +28,11 @@ def _make_crawl_result(
     internal_links: list[dict] | None = None,
 ) -> CrawlResult:
     """Build a successful CrawlResult with the given internal links."""
-    text = f"Markdown content for {url}"
+    # 2026-08-18 stop-the-bleeding fix: content-length gate
+    # (settings.ingest_min_content_length) now skips persistence below
+    # threshold. Padded well above default (150 chars) so this fixture
+    # keeps exercising the ingest path.
+    text = f"Markdown content for {url}. " * 6
     return CrawlResult(
         url=url,
         fit_markdown=text,

--- a/klai-knowledge-ingest/tests/test_crawler_stale_reconcile_safety.py
+++ b/klai-knowledge-ingest/tests/test_crawler_stale_reconcile_safety.py
@@ -1,0 +1,190 @@
+"""Stale-connector-artifact reconciliation must never fire on an incomplete crawl.
+
+Damage 1 (stop-the-bleeding fix): ``run_crawl_job``'s stale-artifact
+reconciliation compared ``current_paths`` (only the URLs that were
+successfully fetched THIS run) against everything on record for the
+connector, and deleted anything missing from ``current_paths`` — including
+Qdrant vectors and the Postgres artifact row.
+
+A URL that merely timed out (or hit any other real fetch failure) this run
+is absent from ``results`` for a reason that has nothing to do with the URL
+still existing on the site. Because ``decide_fetch_failure_terminal_status``
+tolerates up to a 30% fetch-failure rate before flipping the job away from
+``completed``, a crawl with real failures under that threshold reached the
+reconciliation block and retired live knowledge as "stale".
+
+The fix: skip the whole reconciliation whenever the job saw ANY real fetch
+failure or ``not_fetched_*`` outcome. Only a crawl where every discovered
+URL was actually fetched may conclude that a missing path is gone.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import link_graph
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+
+def _make_mock_conn():
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
+def _make_crawl_result(url: str) -> CrawlResult:
+    text = "Some real page content for testing purposes."
+    return CrawlResult(
+        url=url,
+        fit_markdown=text,
+        raw_markdown=text,
+        html="<html><body><p>Test content</p></body></html>",
+        word_count=len(text.split()),
+        success=True,
+        links={"internal": []},
+        error_message="",
+        metadata={},
+        response_headers={"content-type": "text/html"},
+    )
+
+
+def _patch_common(mock_pg, results, fetch_outcomes, ingest_side_effect):
+    return [
+        patch(
+            "knowledge_ingest.adapters.crawler._update_job",
+            new_callable=AsyncMock,
+        ),
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch(
+            "knowledge_ingest.adapters.crawler.qdrant_store.delete_document",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler.crawl_site",
+            new_callable=AsyncMock,
+            return_value=(results, fetch_outcomes),
+        ),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+        patch("knowledge_ingest.routes.ingest.ingest_document", side_effect=ingest_side_effect),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stale_reconcile_skipped_when_any_page_timed_out():
+    """A job that ``completed`` despite one real fetch failure MUST NOT
+    delete stale artifacts.
+
+    4 pages fetched successfully, 1 timed out (20% failure rate — safely
+    under the 30% dirty-trip threshold, so the job legitimately reaches
+    ``completed``). Before the fix, the timed-out URL's existing artifact
+    would be treated as stale and deleted from both Qdrant and Postgres.
+    """
+    mock_conn = _make_mock_conn()
+    results = [
+        _make_crawl_result(f"https://example.com/{letter}") for letter in ("a", "b", "c", "d")
+    ]
+    fetch_outcomes = [{"url": r.url, "reason_code": "success", "status_code": 200} for r in results]
+    fetch_outcomes.append(
+        {"url": "https://example.com/e", "reason_code": "timeout", "status_code": None}
+    )
+
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"chunks": 1}
+
+    mock_pg = MagicMock()
+    mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+    mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
+    mock_pg.has_active_connector_artifact_for_url = AsyncMock(return_value=True)
+    mock_pg.upsert_crawled_page = AsyncMock()
+    mock_pg.update_crawled_page_simhash = AsyncMock()
+    mock_pg.upsert_page_links = AsyncMock()
+    # If reconciliation were to run, it would report /e as stale (it has an
+    # existing artifact but is absent from this run's `current_paths`).
+    mock_pg.list_stale_connector_artifact_paths = AsyncMock(
+        return_value=["https://example.com/e"],
+    )
+    mock_pg.soft_delete_stale_connector_artifacts = AsyncMock(return_value=1)
+
+    patches = _patch_common(mock_pg, results, fetch_outcomes, _fake_ingest)
+    for p in patches:
+        p.start()
+    try:
+        from knowledge_ingest.adapters.crawler import run_crawl_job
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            max_depth=1,
+            rate_limit=100.0,
+            connector_id="conn-1",
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    # The core assertion: an incomplete crawl (any real fetch failure) must
+    # never even ask "what's stale" — let alone delete anything.
+    mock_pg.list_stale_connector_artifact_paths.assert_not_awaited()
+    mock_pg.soft_delete_stale_connector_artifacts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stale_reconcile_still_runs_when_crawl_is_fully_fetched():
+    """The safety guard must not silently disable reconciliation altogether.
+
+    A crawl with zero fetch failures and zero not_fetched_* outcomes is
+    demonstrably complete, so reconciliation must still run — otherwise
+    genuinely removed pages would never be cleaned up.
+    """
+    mock_conn = _make_mock_conn()
+    results = [_make_crawl_result("https://www.getklai.com/")]
+    fetch_outcomes = [{"url": results[0].url, "reason_code": "success", "status_code": 200}]
+
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"chunks": 1}
+
+    mock_pg = MagicMock()
+    mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+    mock_pg.get_crawled_page_stored = AsyncMock(return_value=None)
+    mock_pg.has_active_connector_artifact_for_url = AsyncMock(return_value=True)
+    mock_pg.upsert_crawled_page = AsyncMock()
+    mock_pg.update_crawled_page_simhash = AsyncMock()
+    mock_pg.upsert_page_links = AsyncMock()
+    mock_pg.list_stale_connector_artifact_paths = AsyncMock(
+        return_value=["https://getklai.com/"],
+    )
+    mock_pg.soft_delete_stale_connector_artifacts = AsyncMock(return_value=1)
+
+    patches = _patch_common(mock_pg, results, fetch_outcomes, _fake_ingest)
+    for p in patches:
+        p.start()
+    try:
+        from knowledge_ingest.adapters.crawler import run_crawl_job
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="klai-web-demo",
+            start_url="https://www.getklai.com/",
+            max_depth=1,
+            rate_limit=100.0,
+            connector_id="conn-1",
+        )
+    finally:
+        for p in patches:
+            p.stop()
+
+    mock_pg.list_stale_connector_artifact_paths.assert_awaited_once()
+    mock_pg.soft_delete_stale_connector_artifacts.assert_awaited_once()


### PR DESCRIPTION
Three forms of active harm, found by an external architecture review of the crawler and confirmed against the code before touching anything. This is damage control, not the redesign — that follows.

## A bad network day can delete up to 30% of a knowledge base

`run_crawl_job` reconciles stale artifacts on `completed`, building `current_paths` from **successfully fetched results only**. A URL that merely timed out this run is absent for a reason that has nothing to do with the page still existing — and it gets deleted from Qdrant and retired in Postgres.

This is not theoretical. `decide_fetch_failure_terminal_status` tolerates up to `ingest_fetch_failure_dirty_trip_rate` — **0.30** — of real fetch failures before a job stops reaching `completed`. So a crawl with 29% timeouts is declared healthy and then deletes those 29% of the customer's documents.

Reconciliation now runs only when every discovered URL was demonstrably resolved: no real fetch failure, no `not_fetched_*` omission. Skips are logged with per-reason counts rather than passing silently.

Deliberately conservative. Stale artifacts will linger on sites that fail intermittently; that is far cheaper than deleting live knowledge, and the precise three-way split (present / demonstrably gone / unknown) belongs to the redesign.

Note this guard sits independent of how `terminal_status` was computed, which is the point — it holds even if the status logic changes underneath it.

## Error pages were being stored as knowledge

Today, `openapi.eu-production.holodeck.voys.nl`: 13 pages fetched successfully, every one of them 92 characters reading `#### Failed to parse OpenAPI file`. Five are now artifacts in a customer's KB with correct titles. Chat answers from them.

There was no minimum-content gate on the crawl ingest path at all — `PersistSkipReason.CONTENT_TOO_SHORT` existed as an enum member and nothing used it.

**The threshold is measured, not guessed.** Distribution over 1426 crawled pages: median 5410 characters, p01 99, p05 845. Below 150: 26 pages. The twenty shortest:

```
  1  ×3   empty pages
 85       getklai.com/contact         "# Contact / Have a question about Klai?"     ← real
 88  ×3   getklai.com 404s            "404 / Page not found"
 92  ×5   voys-openapi                "#### Failed to parse OpenAPI file"
 98  ×3   ascend                      "#### Not available"
101  ×3   ascend                      "#### Permission Denied"
108       help.voys.nl/help-pages-nl  "# Help Pages NL / Freedom: Je eerste keer"   ← real
```

Two of them are legitimate content, and they sit **inside** the error band of 88–118. A flat threshold cannot separate these classes — the first attempt at 150 dropped both, and the tests that caught it are the two that matter most.

What does separate them is uniqueness: the error pages arrive in identical clusters (5× exactly 92, 3× 98, 3× 101, 3× 88), the real short pages are unique. So the gate has two rules:

- **Below 30 characters: always reject.** The only pages under 30 in the entire dataset are the three empty ones; the shortest real page is 85, so this cannot touch real content.
- **30–150: reject only when near-identical to siblings.** Reuses the existing SimHash cluster lookup rather than building a second one, at `cluster_min=2` instead of that detector's default of 5 — the smallest measured error cluster is 3 pages, which a threshold of 5 would let straight through.

A good sign the rule is right: two test fixtures that had to be lengthened for the flat threshold were reverted to their original short text, because they are unique. A third stayed lengthened — its text is 16–26 characters, genuinely below the hard floor.

## A near-duplicate cluster is not evidence of a login wall

The template-cluster detector reports `confidence=0.9` and logs `login_wall_reject` when it sees five near-identical siblings. The detection is correct — those pages *are* near-identical — but Hamming distance proves duplication, not authentication. An SPA fallback, a render failure and a tenant-wide error page produce exactly the same signal. Today that label sent the investigation an hour in the wrong direction: the customer sees "login wall" and goes looking for credentials that are irrelevant.

**Behaviour is unchanged on purpose.** Removing the rejection would have stored all 13 OpenAPI error pages instead of 5 — worse, not better. Only the *claim* changes: the auth-specific confidence is gone, and the log events now describe the observation rather than a presumed cause.

Kept deliberately, each with a comment saying why: the exception type, the `template_cluster` pattern string (pinned across tests and `backfill_tasks.py`), and `AUTH_WALL_DETECTED_REASON` / `DIRTY_CONTENT_REASON` — the portal frontend switches on those literals.

## Verification

Each fix's tests were run against the pre-fix source and failed for the right reason. The most important RED run is the threshold correction:

```
FAILED test_unique_short_contact_page_is_persisted    content_length=74  threshold=150
FAILED test_unique_short_help_index_page_is_persisted content_length=105 threshold=150
```

— the two real pages the first attempt would have thrown away.

1329 → 1344 passed, 4 skipped. `ruff check` and `ruff format --check` clean.

## Known and not fixed here

The five error pages already in the Voys KB do not disappear on their own: the content-hash dedup returns before classification, so a re-crawl will not re-assess them. They need explicit removal.

`stopped_early` is set by `_chunked_bulk_fetch` and never read by `crawl_site`, so a rate-limit stop halts the chunk loop but not the BFS loop — the same job can push against a host that already said stop. Left alone because the right fix is to slow down rather than abandon, which is design work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)