### PR TITLE
feat(crawler): make failures say what went wrong, and stop reporting a total ingest failure as success

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -77,6 +77,16 @@ AUTH_WALL_DETECTED_REASON = "auth_wall_detected"
 # error_summary" contract as the other *_REASON constants above.
 FETCH_FAILURE_DOMINANT_REASON = "fetch_failure_dominant"
 
+# SPEC-CRAWLER-FAILURE-EVIDENCE Deel B: ``pages_failed`` (incremented on
+# every ``_ingest_crawl_result`` exception) was tracked but never read —
+# a job where every fetched page's ingest raised (embedding provider down,
+# database gone, ...) still reported ``completed``. This guard is
+# deliberately narrow: it only fires on TOTAL ingest failure (zero pages
+# actually persisted despite at least one ingest attempt). See
+# ``decide_ingest_failure_terminal_status`` for why a ratio threshold is
+# NOT used here.
+INGEST_FAILURE_TOTAL_REASON = "ingest_failure_total"
+
 _NOT_FETCHED_REASON_PREFIX = "not_fetched_"
 
 # 2026-08-18 stop-the-bleeding fix, corrected same day after production
@@ -295,6 +305,63 @@ def decide_fetch_failure_terminal_status(
         "total_count": total_count,
         "top_reason_codes": dict(failure_counts.most_common(5)),
         "suggestion": _FETCH_FAILURE_SUGGESTION,
+    }
+    return ("failed_partial", summary)
+
+
+def decide_ingest_failure_terminal_status(
+    *,
+    pages_done: int,
+    pages_failed: int,
+) -> tuple[str, dict | None]:
+    """Pure decision function — sibling of :func:`decide_fetch_failure_terminal_status`.
+
+    ``pages_failed`` counts every ``_ingest_crawl_result`` exception
+    (embedding provider unreachable, database gone, a malformed document,
+    ...) in ``run_crawl_job``'s per-page ingest loop. Before this guard, the
+    counter was incremented and then never read again — a harness
+    reproduction confirmed one successful fetch whose ingest raised a bare
+    ``RuntimeError`` still finished with ``pages_done=0 pages_failed=1
+    status=completed``.
+
+    Scope, deliberately narrow: this fires ONLY when EVERY ingest attempt in
+    the job failed (``pages_done == 0 and pages_failed > 0``) — not a
+    trip-rate threshold. Two reasons:
+
+    1. A ratio threshold needs a documented, defensible cutoff — and this
+       codebase has direct evidence that guessing one is dangerous:
+       ``ingest_fetch_failure_dirty_trip_rate = 0.30`` meant a job with 29%
+       failures still reported healthy. Picking a new ratio without the
+       same calibration work (see ``decide_terminal_status``'s calibration
+       comment) would repeat that mistake instead of fixing it.
+    2. The full accounting this deserves — indexed / unchanged / rejected /
+       skipped / failed as distinct, countable outcomes — requires
+       ``_ingest_crawl_result`` to return an explicit result instead of
+       raising-or-not. That is out of scope for this fix; here we only make
+       the EXISTING counter count, so the status stops lying on a total
+       failure. Partial-failure tolerance is the next step, not this one.
+
+    Args:
+        pages_done: pages whose ingest completed without raising (existing
+            ``run_crawl_job`` counter — an early-return "unchanged"/"skipped"
+            page still counts as done; see the caller's docstring for that
+            pre-existing caveat, unchanged by this guard).
+        pages_failed: pages whose ingest raised (existing counter).
+
+    Returns:
+        ``(terminal_status, summary_dict_or_None)`` — same contract as
+        :func:`decide_fetch_failure_terminal_status`: ``("", None)`` when
+        the guard does not fire, so the caller falls through to its
+        existing terminal-status logic.
+    """
+    if pages_failed <= 0:
+        return ("", None)
+    if pages_done > 0:
+        return ("", None)
+    summary: dict = {
+        "reason": INGEST_FAILURE_TOTAL_REASON,
+        "pages_attempted": pages_done + pages_failed,
+        "pages_failed": pages_failed,
     }
     return ("failed_partial", summary)
 
@@ -858,9 +925,20 @@ async def run_crawl_job(
             threshold=settings.ingest_fetch_failure_dirty_trip_rate,
         )
 
+        # SPEC-CRAWLER-FAILURE-EVIDENCE Deel B: fetch succeeding is not the
+        # same as ingest succeeding — a fetch-failure trip-rate of 0% can
+        # still hide a job where every single ingest attempt raised (see
+        # decide_ingest_failure_terminal_status's docstring for the
+        # reproduction and why this is a total-failure guard, not a ratio).
+        ingest_failure_status, ingest_failure_summary = decide_ingest_failure_terminal_status(
+            pages_done=pages_done,
+            pages_failed=pages_failed,
+        )
+
         # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-04.2/04.3 — terminal status:
         # - failed_partial when REQ-4 dirty-content guard tripped (loud failure)
         # - failed_partial when the fetch-failure guard tripped (loud failure)
+        # - failed_partial when every ingest attempt failed (loud failure)
         # - failed_partial when 0 pages ingested AND >= 1 wall skipped
         # - completed otherwise
         #
@@ -870,7 +948,9 @@ async def run_crawl_job(
         # login-gated); a fetch-failure trip often means Klai could not
         # reach the site at all. The auth-wall summary is the more
         # actionable of the two when both signals are present, so it
-        # takes priority.
+        # takes priority. The ingest-failure guard sits right after the
+        # fetch-failure guard: both are "Klai reached the site but the job
+        # still produced nothing", just at a different pipeline stage.
         if dirty_status:
             terminal_status = dirty_status
             summary_payload = dirty_summary or {}
@@ -891,6 +971,19 @@ async def run_crawl_job(
         elif fetch_failure_status:
             terminal_status = fetch_failure_status
             summary_payload = fetch_failure_summary or {}
+            _attach_crawl_warning(summary_payload, crawl_outcome_warning)
+            summary_json = json.dumps(summary_payload)
+            await conn.execute(
+                "UPDATE knowledge.crawl_jobs SET status=$1, error_summary=$2::jsonb, "
+                "updated_at=$3 WHERE id=$4",
+                terminal_status,
+                summary_json,
+                int(time.time()),
+                job_id,
+            )
+        elif ingest_failure_status:
+            terminal_status = ingest_failure_status
+            summary_payload = ingest_failure_summary or {}
             _attach_crawl_warning(summary_payload, crawl_outcome_warning)
             summary_json = json.dumps(summary_payload)
             await conn.execute(

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -899,12 +899,32 @@ def _with_evidence(
     """Merge evidence fields into an outcome dict — additive to the existing
     ``{url, reason_code, status_code, content_length}`` shape.
 
-    ``observed`` distinguishes a real per-URL fetch result (success, a
-    page-level failure, or a transport exception directly tied to sending a
-    request for THIS url — including a chunk-level bulk request that bundled
-    this URL with others) from a label assigned to a URL we never
-    individually sent (batch fallout with no matching response, abandoned on
-    budget/circuit-breaker/deadline, or a previous rate-limit stop signal).
+    ``observed`` answers one narrow question: for THIS url, did we get our
+    own individual result back, or is the outcome a label we assigned
+    without one?
+
+    ``True`` — a per-URL result exists for this exact URL: a page-level
+    response from a successfully transported bulk request (even a failed
+    one — 404, 500, ...), or a single-page fetch via
+    ``_crawl_page_with_config``/the seed path.
+
+    ``False`` — no per-URL result exists. This includes a chunk-level
+    transport failure attributed to every URL in that chunk: the CHUNK's
+    request genuinely failed, but that is one observation about the
+    request, not N observations about N URLs. Also false for anything we
+    never individually sent (budget/circuit-breaker/deadline abandonment,
+    a previous rate-limit stop signal) and for a bulk response with no
+    matching entry for this candidate.
+
+    Why this matters: the field exists so a question like "how many times
+    did intermedia.com actually give us a timeout?" has a real answer.
+    Counting a chunk of 20 URLs that failed together as 20 observations
+    inflates that count 20x — exactly the polluted-counter failure mode
+    this field was added to prevent. Do not "simplify" this to
+    `has an error is observed` without re-reading this comment; the whole
+    point is that a URL can have reason_code=TIMEOUT and evidence attached
+    while still being unobserved, because the evidence describes the
+    request, not a confirmed per-URL result.
     """
     outcome.update(evidence)
     outcome["observed"] = observed
@@ -2437,10 +2457,14 @@ def _outcome_for_failed_url(url: str, error: BaseException) -> FetchOutcome:
     """Outcome for a URL whose OWN chunk failed to transport (A2).
 
     Classified from THAT chunk's actual exception — never borrowed from a
-    different chunk's failure, and never a guess. ``observed=True``: the
-    chunk containing this URL was genuinely submitted over the network and
-    the exception is the real result of that attempt (even though the same
-    chunk-level exception is shared across every URL bundled in it).
+    different chunk's failure, and never a guess. ``observed=False``: the
+    exception is a genuine observation about the CHUNK's request (which may
+    have bundled many URLs), not a confirmed per-URL result — we do not
+    know whether the site would have failed this specific URL if it had
+    been sent alone. Attributing the chunk's single failure as `observed`
+    for every URL in it would inflate "how many times did this domain
+    actually fail" by the chunk size. See ``_with_evidence``'s docstring
+    for the full rationale.
     """
     outcome: FetchOutcome = {
         "url": url,
@@ -2448,7 +2472,7 @@ def _outcome_for_failed_url(url: str, error: BaseException) -> FetchOutcome:
         "status_code": _status_code_from_exception(error),
         "content_length": 0,
     }
-    return _with_evidence(outcome, _evidence_from_exception(error), observed=True)
+    return _with_evidence(outcome, _evidence_from_exception(error), observed=False)
 
 
 def _outcome_for_not_attempted_url(url: str) -> FetchOutcome:

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -123,6 +123,18 @@ class CrawlResult:
     # honestly instead of falling through to UNKNOWN_EXCEPTION — see the
     # bulk-5xx sequential-recovery rework in ``crawl_site`` / adapters/crawler.py.
     status_code: int | None = None
+    # 2026-08-18 (SPEC-CRAWLER-FAILURE-EVIDENCE): populated ONLY by the
+    # single-page fetch paths (``_fetch_seed_page`` / ``_crawl_page_with_config``)
+    # when they catch a raised Python exception, BEFORE it is collapsed into
+    # the bare ``str(exc)`` stored in ``error_message`` above. Lets the
+    # fetch_outcomes evidence builder (``_evidence_for_crawl_result``) recover
+    # the real exception type + response body (which may carry crawl4ai's
+    # ``correlation_id``) instead of only the flattened string. Both additive
+    # and None for every other CrawlResult (success, page-level failure with
+    # no raised exception, bulk-path results) — never read outside the
+    # evidence builder.
+    error_type: str | None = None
+    raw_error_text: str | None = None
 
 
 DiscoverySourceKind = Literal["start", "sitemap", "page_link"]
@@ -721,6 +733,184 @@ def _classify_fetch_outcome(
     return FetchReasonCode.UNKNOWN_EXCEPTION.value
 
 
+# ---------------------------------------------------------------------------
+# Fetch-failure evidence (SPEC-CRAWLER-FAILURE-EVIDENCE)
+#
+# ``reason_code`` alone collapses every fetch failure that doesn't map to a
+# recognised status/keyword straight into UNKNOWN_EXCEPTION — production's
+# single largest failure category (349 occurrences across 23 jobs, all-time —
+# more jobs than any other non-success reason). These helpers attach the
+# underlying exception type, a truncated+sanitised error message, and a
+# crawl4ai ``correlation_id`` (when the failure body carries one) to every
+# outcome, so an UNKNOWN_EXCEPTION entry is diagnosable instead of a dead
+# end. Purely additive to the existing ``{url, reason_code, status_code,
+# content_length}`` shape — see ``_with_evidence``.
+# ---------------------------------------------------------------------------
+
+# Hard cap on how much raw error text is persisted per outcome into
+# crawl_jobs.fetch_outcomes JSONB. Bounds storage/log volume and rules out
+# ever writing an entire HTML error page (or a URL carrying an auth token)
+# into the database unbounded. 300 chars keeps an exception message or a
+# crawl4ai error body legible while staying well clear of "content".
+_ERROR_MESSAGE_MAX_LEN = 300
+_TRUNCATION_MARKER = "…[truncated]"
+
+# Redact common secret-bearing query-param VALUES before anything is
+# truncated and persisted. A failing URL can be echoed back verbatim inside
+# crawl4ai's own error body, and that URL may carry an auth/session token —
+# fetch_outcomes goes into the database and into logs, so the token must
+# never survive into either.
+_SENSITIVE_QUERY_PARAM_RE = re.compile(
+    r"(?i)\b(token|access_token|api[_-]?key|secret|password|auth)=([^&\s\"'<>]+)"
+)
+
+# crawl4ai's opaque bulk-5xx body is
+# ``{"error": "Internal server error", "correlation_id": "188834187d7d"}``
+# (see the module comment on ``_classify_fetch_outcome``) — the only handle
+# operators have to cross-reference a failure against crawl4ai's own logs.
+_CORRELATION_ID_RE = re.compile(r'correlation_id"?\s*[:=]\s*"?([a-zA-Z0-9_-]+)"?', re.IGNORECASE)
+
+_NO_EVIDENCE: dict[str, Any] = {
+    "error_type": None,
+    "error_message": None,
+    "correlation_id": None,
+}
+
+
+def _mask_sensitive_query_params(text: str) -> str:
+    """Redact token/secret/password/api-key/auth query-param VALUES."""
+    return _SENSITIVE_QUERY_PARAM_RE.sub(lambda m: f"{m.group(1)}=***", text)
+
+
+def _truncate_error_message(text: str, *, max_len: int = _ERROR_MESSAGE_MAX_LEN) -> str:
+    """Sanitise then bound raw error text before it is persisted.
+
+    Masking runs BEFORE truncation so a secret sitting near the cut point
+    cannot survive partially exposed.
+    """
+    masked = _mask_sensitive_query_params(text.strip())
+    if len(masked) <= max_len:
+        return masked
+    keep = max(max_len - len(_TRUNCATION_MARKER), 0)
+    return masked[:keep].rstrip() + _TRUNCATION_MARKER
+
+
+def _extract_correlation_id(text: str) -> str | None:
+    """Pull crawl4ai's ``correlation_id`` out of an error body, when present."""
+    match = _CORRELATION_ID_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _error_type_name(error: BaseException) -> str:
+    """Stable ``module.ClassName`` label — e.g. ``httpx.ReadTimeout``.
+
+    Builtin exceptions (``RuntimeError``, ...) report just the class name,
+    since ``builtins.RuntimeError`` adds nothing a reader doesn't already
+    know.
+    """
+    cls = type(error)
+    module = cls.__module__
+    if module in ("builtins", "__main__"):
+        return cls.__qualname__
+    return f"{module}.{cls.__qualname__}"
+
+
+def _raw_error_text(error: BaseException) -> str:
+    """Prefer the HTTP response body over ``str(error)``.
+
+    crawl4ai's own error detail (including ``correlation_id``) lives in the
+    response body, not in httpx's exception message — ``str(HTTPStatusError)``
+    is just ``"crawl4ai failed"`` regardless of what the server actually said.
+    """
+    if isinstance(error, httpx.HTTPStatusError):
+        try:
+            body = error.response.text
+        except Exception:
+            body = ""
+        if body:
+            return body
+    return str(error)
+
+
+def _evidence_from_exception_text(*, error_type: str | None, raw_text: str) -> dict[str, Any]:
+    return {
+        "error_type": error_type,
+        "error_message": _truncate_error_message(raw_text) if raw_text else None,
+        "correlation_id": _extract_correlation_id(raw_text) if raw_text else None,
+    }
+
+
+def _evidence_from_exception(error: BaseException) -> dict[str, Any]:
+    """Evidence bundle for a fetch whose Python exception is directly in hand."""
+    return _evidence_from_exception_text(
+        error_type=_error_type_name(error), raw_text=_raw_error_text(error)
+    )
+
+
+def _evidence_from_page_result(
+    page_result: dict[str, Any] | None, *, reason_code: str
+) -> dict[str, Any]:
+    """Evidence for a crawl4ai page-level failure (``success: false``) with
+    no raised Python exception — ``error_type`` falls back to the
+    crawl4ai-side failure category (its own ``reason_code``) since there is
+    no exception class to report. A page carrying ``success: true`` (even
+    when ``reason_code`` was overridden to NON_CONTENT_LISTING_PAGE) is not
+    a failure — no evidence to report."""
+    if not page_result or page_result.get("success"):
+        return dict(_NO_EVIDENCE)
+    raw_text = str(page_result.get("error_message") or "")
+    if not raw_text:
+        return {
+            "error_type": f"crawl4ai:{reason_code}",
+            "error_message": None,
+            "correlation_id": None,
+        }
+    return {
+        "error_type": f"crawl4ai:{reason_code}",
+        "error_message": _truncate_error_message(raw_text),
+        "correlation_id": _extract_correlation_id(raw_text),
+    }
+
+
+def _evidence_for_crawl_result(result: CrawlResult, *, reason_code: str) -> dict[str, Any]:
+    """Evidence for a CrawlResult from the single-page fetch path
+    (``_fetch_seed_page`` / ``_crawl_page_with_config``) — shared by the seed
+    fetch and the sequential bulk-5xx/timeout recovery loop.
+
+    Prefers ``result.raw_error_text``/``result.error_type`` (the exception
+    caught at the transport boundary, before it was collapsed into the bare
+    ``error_message`` string) when present; falls back to classifying
+    crawl4ai's own reported ``error_message`` otherwise.
+    """
+    if result.success:
+        return dict(_NO_EVIDENCE)
+    if result.raw_error_text is not None:
+        return _evidence_from_exception_text(
+            error_type=result.error_type, raw_text=result.raw_error_text
+        )
+    return _evidence_from_page_result(
+        {"error_message": result.error_message or ""}, reason_code=reason_code
+    )
+
+
+def _with_evidence(
+    outcome: FetchOutcome, evidence: dict[str, Any], *, observed: bool
+) -> FetchOutcome:
+    """Merge evidence fields into an outcome dict — additive to the existing
+    ``{url, reason_code, status_code, content_length}`` shape.
+
+    ``observed`` distinguishes a real per-URL fetch result (success, a
+    page-level failure, or a transport exception directly tied to sending a
+    request for THIS url — including a chunk-level bulk request that bundled
+    this URL with others) from a label assigned to a URL we never
+    individually sent (batch fallout with no matching response, abandoned on
+    budget/circuit-breaker/deadline, or a previous rate-limit stop signal).
+    """
+    outcome.update(evidence)
+    outcome["observed"] = observed
+    return outcome
+
+
 async def _crawl_sync(
     client: httpx.AsyncClient,
     payload: dict[str, Any],
@@ -956,6 +1146,8 @@ async def _crawl_page_with_config(
                 success=False,
                 error_message=str(exc),
                 status_code=_status_code_from_exception(exc),
+                error_type=_error_type_name(exc),
+                raw_error_text=_raw_error_text(exc),
             )
 
     results = data.get("results", [])
@@ -1130,13 +1322,19 @@ class CrawlLedger:
             if item.status == "omitted" and item.reason_code
         ]
         omitted.sort(key=lambda i: (i.priority, i.depth, i.order))
+        # Deliberate scheduling omissions (budget/depth/discovery limit) —
+        # never attempted over the network, so never observed.
         return [
-            {
-                "url": item.url,
-                "reason_code": item.reason_code,
-                "status_code": None,
-                "content_length": 0,
-            }
+            _with_evidence(
+                {
+                    "url": item.url,
+                    "reason_code": item.reason_code,
+                    "status_code": None,
+                    "content_length": 0,
+                },
+                dict(_NO_EVIDENCE),
+                observed=False,
+            )
             for item in omitted
         ]
 
@@ -1740,6 +1938,8 @@ async def _fetch_seed_page(
             success=False,
             error_message=str(exc),
             status_code=_status_code_from_exception(exc),
+            error_type=_error_type_name(exc),
+            raw_error_text=_raw_error_text(exc),
         )
 
     pages = _normalise_results_block(data)
@@ -1833,12 +2033,16 @@ def _build_outcome_from_result(url: str, result: CrawlResult) -> FetchOutcome:
                 "error_message": result.error_message or "",
             },
         )
-    return {
+    outcome: FetchOutcome = {
         "url": url,
         "reason_code": reason_code,
         "status_code": result.status_code,
         "content_length": len(result.html or ""),
     }
+    evidence = _evidence_for_crawl_result(result, reason_code=reason_code)
+    # A seed fetch is always individually attempted — it is the ONE URL
+    # _fetch_seed_page ever sends, never a batch fallout label.
+    return _with_evidence(outcome, evidence, observed=True)
 
 
 def _result_is_ingestable(result: CrawlResult, *, base_domain: str) -> bool:
@@ -1935,12 +2139,16 @@ async def _recover_bulk_5xx_batch(
         """
         for leftover_url in urls[index:]:
             outcomes.append(
-                {
-                    "url": leftover_url,
-                    "reason_code": reason_code,
-                    "status_code": None,
-                    "content_length": 0,
-                }
+                _with_evidence(
+                    {
+                        "url": leftover_url,
+                        "reason_code": reason_code,
+                        "status_code": None,
+                        "content_length": 0,
+                    },
+                    dict(_NO_EVIDENCE),
+                    observed=False,
+                )
             )
         return len(urls) - index
 
@@ -2022,13 +2230,19 @@ async def _recover_bulk_5xx_batch(
         is_non_content_listing = result.success and _is_non_content_listing_page(result)
         if reason_code == FetchReasonCode.SUCCESS.value and is_non_content_listing:
             reason_code = FetchReasonCode.NON_CONTENT_LISTING_PAGE.value
+        # This URL was individually attempted over the network (unlike the
+        # abandoned/not-yet-attempted URLs above) — a real observation.
         outcomes.append(
-            {
-                "url": url,
-                "reason_code": reason_code,
-                "status_code": result.status_code,
-                "content_length": len(result.html or ""),
-            }
+            _with_evidence(
+                {
+                    "url": url,
+                    "reason_code": reason_code,
+                    "status_code": result.status_code,
+                    "content_length": len(result.html or ""),
+                },
+                _evidence_for_crawl_result(result, reason_code=reason_code),
+                observed=True,
+            )
         )
 
         # A confirmed rate-limit (429, including crawl4ai's "Blocked by
@@ -2129,13 +2343,20 @@ def _combine_bulk_responses(
 
     for i, url in enumerate(candidates):
         if transport_error is not None:
+            # The whole-batch request failed transport-wide — this
+            # candidate's own outcome was never individually confirmed, even
+            # though the same exception genuinely applies to the batch.
             outcomes.append(
-                {
-                    "url": url,
-                    "reason_code": _classify_fetch_outcome(None, error=transport_error),
-                    "status_code": None,
-                    "content_length": 0,
-                }
+                _with_evidence(
+                    {
+                        "url": url,
+                        "reason_code": _classify_fetch_outcome(None, error=transport_error),
+                        "status_code": None,
+                        "content_length": 0,
+                    },
+                    _evidence_from_exception(transport_error),
+                    observed=False,
+                )
             )
             continue
 
@@ -2169,13 +2390,21 @@ def _combine_bulk_responses(
                     claimed_response_indices.add(i)
 
         if page is None:
+            # The bulk request itself transported fine, but no response in
+            # it matches this candidate (and the redirect fallback above
+            # didn't resolve it either) — this URL's own outcome was never
+            # confirmed.
             outcomes.append(
-                {
-                    "url": url,
-                    "reason_code": _classify_fetch_outcome(page),
-                    "status_code": None,
-                    "content_length": 0,
-                }
+                _with_evidence(
+                    {
+                        "url": url,
+                        "reason_code": _classify_fetch_outcome(page),
+                        "status_code": None,
+                        "content_length": 0,
+                    },
+                    dict(_NO_EVIDENCE),
+                    observed=False,
+                )
             )
             continue
 
@@ -2184,13 +2413,18 @@ def _combine_bulk_responses(
         is_non_content_listing = _is_non_content_listing_page(result)
         if reason_code == FetchReasonCode.SUCCESS.value and is_non_content_listing:
             reason_code = FetchReasonCode.NON_CONTENT_LISTING_PAGE.value
+        # A real per-URL page result came back from crawl4ai's bulk response.
         outcomes.append(
-            {
-                "url": url,
-                "reason_code": reason_code,
-                "status_code": page.get("status_code"),
-                "content_length": len(page.get("html", "") or ""),
-            }
+            _with_evidence(
+                {
+                    "url": url,
+                    "reason_code": reason_code,
+                    "status_code": page.get("status_code"),
+                    "content_length": len(page.get("html", "") or ""),
+                },
+                _evidence_from_page_result(page, reason_code=reason_code),
+                observed=True,
+            )
         )
 
         if _result_is_ingestable(result, base_domain=base_domain) and not is_non_content_listing:
@@ -2203,14 +2437,18 @@ def _outcome_for_failed_url(url: str, error: BaseException) -> FetchOutcome:
     """Outcome for a URL whose OWN chunk failed to transport (A2).
 
     Classified from THAT chunk's actual exception — never borrowed from a
-    different chunk's failure, and never a guess.
+    different chunk's failure, and never a guess. ``observed=True``: the
+    chunk containing this URL was genuinely submitted over the network and
+    the exception is the real result of that attempt (even though the same
+    chunk-level exception is shared across every URL bundled in it).
     """
-    return {
+    outcome: FetchOutcome = {
         "url": url,
         "reason_code": _classify_fetch_outcome(None, error=error),
         "status_code": _status_code_from_exception(error),
         "content_length": 0,
     }
+    return _with_evidence(outcome, _evidence_from_exception(error), observed=True)
 
 
 def _outcome_for_not_attempted_url(url: str) -> FetchOutcome:
@@ -2221,14 +2459,17 @@ def _outcome_for_not_attempted_url(url: str) -> FetchOutcome:
     Deliberately NOT ``FetchReasonCode.RATE_LIMITED`` — that value stays
     reserved for a URL we actually asked and got that answer from, so a
     "how many times did this domain really reject us" count is not
-    inflated by URLs we chose not to send.
+    inflated by URLs we chose not to send. ``observed=False``: no network
+    call was ever made for this URL, so there is nothing to report as
+    evidence.
     """
-    return {
+    outcome: FetchOutcome = {
         "url": url,
         "reason_code": FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
         "status_code": None,
         "content_length": 0,
     }
+    return _with_evidence(outcome, dict(_NO_EVIDENCE), observed=False)
 
 
 async def _recover_thin_bulk_results(

--- a/klai-knowledge-ingest/tests/test_crawl_job_ingest_failure_status.py
+++ b/klai-knowledge-ingest/tests/test_crawl_job_ingest_failure_status.py
@@ -1,0 +1,216 @@
+"""Tests for Deel B: an ingest failure must not report ``completed`` (SPEC-
+CRAWLER-FAILURE-EVIDENCE).
+
+``run_crawl_job`` increments ``pages_failed`` on every ``_ingest_crawl_result``
+exception (embedding provider down, database gone, ...) but never reads that
+counter again — a job where every single ingest attempt failed still ends
+with ``status="completed"``. This was reproduced with a harness: one
+successful fetch + a ``RuntimeError`` from ``_ingest_crawl_result`` yields
+``pages_done=0 pages_failed=1 status=completed``.
+
+Scope for this fix (explicitly NOT the full materialization accounting):
+a job in which EVERY ingest attempt failed (``pages_done == 0 and
+pages_failed > 0``) must never be reported as ``completed``. Partial-failure
+tolerance (a ratio threshold) is deliberately out of scope here — see
+``decide_ingest_failure_terminal_status``'s docstring for the rationale.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import link_graph
+from knowledge_ingest.crawl4ai_client import CrawlResult
+
+
+def _make_mock_conn():
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
+def _make_crawl_result(url: str = "https://example.com/a") -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        fit_markdown="Some markdown content for testing",
+        raw_markdown="Some markdown content for testing",
+        html="<html><body><p>Test content</p></body></html>",
+        word_count=5,
+        success=True,
+        links={"internal": []},
+        error_message="",
+        metadata={},
+        response_headers={"content-type": "text/html"},
+    )
+
+
+def _last_status_call(mock_conn: MagicMock) -> str | None:
+    """Return the ``status`` argument of the LAST ``crawl_jobs`` status
+    UPDATE issued on ``mock_conn`` — every branch in ``run_crawl_job``'s
+    terminal-status chain writes ``SET status=$1, ...`` with the status as
+    the first bound parameter, whether via ``_update_job`` or a direct
+    ``conn.execute`` call."""
+    status_calls = [
+        call for call in mock_conn.execute.call_args_list if "SET status=$1" in call.args[0]
+    ]
+    if not status_calls:
+        return None
+    return status_calls[-1].args[1]
+
+
+@pytest.mark.asyncio
+async def test_job_with_total_ingest_failure_is_not_reported_completed() -> None:
+    """One successful fetch, its ingest raises — pages_done=0, pages_failed=1.
+    The job MUST NOT be reported as completed."""
+    mock_conn = _make_mock_conn()
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_result = _make_crawl_result()
+
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new_callable=AsyncMock) as mock_crawl,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("embedding provider unreachable"),
+        ),
+    ):
+        mock_crawl.return_value = (
+            [mock_result],
+            [
+                {
+                    "url": mock_result.url,
+                    "reason_code": "success",
+                    "status_code": 200,
+                    "content_length": len(mock_result.html or ""),
+                }
+            ],
+        )
+        mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+        mock_pg.list_stale_connector_artifact_paths = AsyncMock(return_value=[])
+
+        from knowledge_ingest.adapters.crawler import run_crawl_job
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            max_depth=1,
+            rate_limit=100.0,
+        )
+
+    status = _last_status_call(mock_conn)
+    assert status is not None, "no crawl_jobs status UPDATE was issued at all"
+    assert status != "completed", (
+        f"job with pages_done=0 pages_failed=1 (every ingest failed) reported "
+        f"status={status!r} — a total ingest failure must never be 'completed'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_job_with_all_ingests_succeeding_is_still_completed() -> None:
+    """Counterpart: the new guard must not break the existing happy path."""
+    mock_conn = _make_mock_conn()
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_result = _make_crawl_result()
+
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new_callable=AsyncMock) as mock_crawl,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new_callable=AsyncMock,
+            side_effect=_fake_ingest,
+        ),
+    ):
+        mock_crawl.return_value = (
+            [mock_result],
+            [
+                {
+                    "url": mock_result.url,
+                    "reason_code": "success",
+                    "status_code": 200,
+                    "content_length": len(mock_result.html or ""),
+                }
+            ],
+        )
+        mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+        mock_pg.list_stale_connector_artifact_paths = AsyncMock(return_value=[])
+
+        from knowledge_ingest.adapters.crawler import run_crawl_job
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            max_depth=1,
+            rate_limit=100.0,
+        )
+
+    status = _last_status_call(mock_conn)
+    assert status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# decide_ingest_failure_terminal_status — pure decision function
+# ---------------------------------------------------------------------------
+
+
+class TestDecideIngestFailureTerminalStatus:
+    def test_total_ingest_failure_trips_the_guard(self) -> None:
+        from knowledge_ingest.adapters.crawler import decide_ingest_failure_terminal_status
+
+        status, summary = decide_ingest_failure_terminal_status(pages_done=0, pages_failed=3)
+        assert status == "failed_partial"
+        assert summary is not None
+        assert summary["pages_failed"] == 3
+        assert summary["pages_attempted"] == 3
+
+    def test_partial_failure_does_not_trip_the_guard(self) -> None:
+        """Explicitly out of scope for this fix — at least one page ingested
+        successfully means the guard does not fire (no ratio tolerance
+        introduced here)."""
+        from knowledge_ingest.adapters.crawler import decide_ingest_failure_terminal_status
+
+        status, summary = decide_ingest_failure_terminal_status(pages_done=1, pages_failed=5)
+        assert status == ""
+        assert summary is None
+
+    def test_no_ingest_attempts_does_not_trip_the_guard(self) -> None:
+        """No fetches reached the ingest loop at all — a different guard
+        (fetch-failure / crawl-outcome-warning) owns that case."""
+        from knowledge_ingest.adapters.crawler import decide_ingest_failure_terminal_status
+
+        status, summary = decide_ingest_failure_terminal_status(pages_done=0, pages_failed=0)
+        assert status == ""
+        assert summary is None
+
+    def test_all_succeeded_does_not_trip_the_guard(self) -> None:
+        from knowledge_ingest.adapters.crawler import decide_ingest_failure_terminal_status
+
+        status, summary = decide_ingest_failure_terminal_status(pages_done=4, pages_failed=0)
+        assert status == ""
+        assert summary is None

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -512,9 +512,20 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
         assert by_url[url]["reason_code"] == FetchReasonCode.TIMEOUT.value
         assert by_url[url]["status_code"] is None
 
-    # Shape sanity — all four required keys present on every outcome.
+    # Shape sanity — all required keys present on every outcome.
+    # SPEC-CRAWLER-FAILURE-EVIDENCE added error_type/error_message/
+    # correlation_id/observed, additive to the original four.
     for outcome in outcomes:
-        assert set(outcome.keys()) == {"url", "reason_code", "status_code", "content_length"}
+        assert set(outcome.keys()) == {
+            "url",
+            "reason_code",
+            "status_code",
+            "content_length",
+            "error_type",
+            "error_message",
+            "correlation_id",
+            "observed",
+        }
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_fetch_outcome_evidence.py
+++ b/klai-knowledge-ingest/tests/test_fetch_outcome_evidence.py
@@ -1,0 +1,230 @@
+"""Tests for fetch-outcome failure evidence (Deel A).
+
+Production has ~1119 failed fetches (unknown_exception + timeout, all-time)
+whose ``crawl_jobs.fetch_outcomes`` entries carry nothing beyond
+``{"url", "reason_code", "status_code", "content_length"}`` — no exception
+type, no error message, no correlation_id. These tests pin the additive
+evidence fields (``error_type``, ``error_message``, ``correlation_id``,
+``observed``) that let an ``unknown_exception`` outcome be diagnosed instead
+of being a dead end.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from knowledge_ingest.crawl4ai_client import (
+    _ERROR_MESSAGE_MAX_LEN,
+    CrawlResult,
+    _build_outcome_from_result,
+    _error_type_name,
+    _extract_correlation_id,
+    _mask_sensitive_query_params,
+    _outcome_for_failed_url,
+    _outcome_for_not_attempted_url,
+    _truncate_error_message,
+)
+
+
+def _http_status_error(*, status: int = 500, body: dict | None = None) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+    response = httpx.Response(status, json=body or {}, request=request)
+    return httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# _outcome_for_failed_url — a fetch that actually raised an exception
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeForFailedUrlPreservesExceptionEvidence:
+    def test_read_timeout_preserves_exception_type_and_truncated_message(self) -> None:
+        error = httpx.ReadTimeout("simulated read timeout after 90s")
+        outcome = _outcome_for_failed_url("https://example.com/a", error)
+
+        assert outcome["error_type"] == "httpx.ReadTimeout"
+        assert outcome["error_message"] == "simulated read timeout after 90s"
+        assert outcome["correlation_id"] is None
+        assert outcome["observed"] is True
+
+    def test_5xx_with_correlation_id_body_preserves_correlation_id(self) -> None:
+        """2026-08-14 intermedia.com shape: opaque 500 body carrying only
+        an 'error' string and a correlation_id — the only handle to cross-
+        reference the failure against crawl4ai's own logs."""
+        error = _http_status_error(
+            status=500,
+            body={"error": "Internal server error", "correlation_id": "188834187d7d"},
+        )
+        outcome = _outcome_for_failed_url("https://example.com/a", error)
+
+        assert outcome["error_type"] == "httpx.HTTPStatusError"
+        assert outcome["correlation_id"] == "188834187d7d"
+        assert outcome["error_message"] is not None
+        assert "188834187d7d" in outcome["error_message"]
+        assert outcome["observed"] is True
+
+    def test_connection_error_preserves_exception_type(self) -> None:
+        error = httpx.ConnectError("Connection refused")
+        outcome = _outcome_for_failed_url("https://example.com/a", error)
+
+        assert outcome["error_type"] == "httpx.ConnectError"
+        assert outcome["observed"] is True
+
+
+# ---------------------------------------------------------------------------
+# _outcome_for_not_attempted_url — a URL we deliberately never sent
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeForNotAttemptedUrlIsDerivedNotObserved:
+    def test_not_attempted_url_is_marked_derived(self) -> None:
+        outcome = _outcome_for_not_attempted_url("https://example.com/never-sent")
+
+        assert outcome["observed"] is False
+        assert outcome["error_type"] is None
+        assert outcome["error_message"] is None
+        assert outcome["correlation_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# _build_outcome_from_result — the seed-page path
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOutcomeFromResultSeedPath:
+    def test_successful_seed_fetch_is_observed_with_no_evidence(self) -> None:
+        result = CrawlResult(
+            url="https://example.com",
+            fit_markdown="hello",
+            raw_markdown="hello",
+            html="<html>hello</html>",
+            word_count=1,
+            success=True,
+        )
+        outcome = _build_outcome_from_result("https://example.com", result)
+
+        assert outcome["observed"] is True
+        assert outcome["error_type"] is None
+        assert outcome["error_message"] is None
+        assert outcome["correlation_id"] is None
+
+    def test_seed_fetch_exception_preserves_type_and_correlation_id(self) -> None:
+        """The seed path (_fetch_seed_page) catches the raised exception and
+        collapses it into CrawlResult.error_message (a bare str(exc)) — but
+        also now carries the raw exception type + body on
+        CrawlResult.error_type / .raw_error_text so the evidence survives."""
+        result = CrawlResult(
+            url="https://example.com",
+            fit_markdown="",
+            raw_markdown="",
+            html="",
+            word_count=0,
+            success=False,
+            error_message="crawl4ai failed",
+            error_type="httpx.HTTPStatusError",
+            raw_error_text='{"error": "Internal server error", "correlation_id": "abc123"}',
+        )
+        outcome = _build_outcome_from_result("https://example.com", result)
+
+        assert outcome["observed"] is True
+        assert outcome["error_type"] == "httpx.HTTPStatusError"
+        assert outcome["correlation_id"] == "abc123"
+        assert "abc123" in outcome["error_message"]
+
+    def test_seed_fetch_page_level_failure_without_exception_uses_crawl4ai_category(
+        self,
+    ) -> None:
+        """crawl4ai itself reported success=False (no Python exception raised) —
+        error_type falls back to the crawl4ai-side failure category since
+        there is no exception class to report."""
+        result = CrawlResult(
+            url="https://example.com",
+            fit_markdown="",
+            raw_markdown="",
+            html="",
+            word_count=0,
+            success=False,
+            error_message="Blocked by anti-bot protection: Cloudflare JS challenge",
+        )
+        outcome = _build_outcome_from_result("https://example.com", result)
+
+        assert outcome["observed"] is True
+        assert outcome["error_type"] == "crawl4ai:blocked_anti_bot"
+        assert outcome["error_message"] == "Blocked by anti-bot protection: Cloudflare JS challenge"
+
+
+# ---------------------------------------------------------------------------
+# Truncation + masking
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateErrorMessage:
+    def test_short_message_is_unchanged(self) -> None:
+        assert _truncate_error_message("short error") == "short error"
+
+    def test_long_message_is_truncated_at_documented_limit(self) -> None:
+        long_message = "x" * (_ERROR_MESSAGE_MAX_LEN * 3)
+        truncated = _truncate_error_message(long_message)
+
+        assert len(truncated) <= _ERROR_MESSAGE_MAX_LEN
+        assert truncated != long_message
+        assert truncated.startswith("x")
+
+    def test_truncation_limit_is_bounded_and_documented(self) -> None:
+        # Pin the actual number so a future accidental change is visible
+        # in a diff, not silently absorbed by a symbolic-only assertion.
+        assert 200 <= _ERROR_MESSAGE_MAX_LEN <= 500
+
+    def test_masks_token_query_param_before_truncating(self) -> None:
+        text = "fetch failed for https://example.com/x?access_token=SUPERSECRET123&y=1"
+        masked = _mask_sensitive_query_params(text)
+
+        assert "SUPERSECRET123" not in masked
+        assert "access_token=***" in masked
+
+    def test_outcome_for_failed_url_masks_token_in_url_within_error_body(self) -> None:
+        error = _http_status_error(
+            status=500,
+            body={
+                "error": "upstream fetch failed for https://example.com/x?api_key=SUPERSECRET123"
+            },
+        )
+        outcome = _outcome_for_failed_url("https://example.com/a", error)
+
+        assert "SUPERSECRET123" not in outcome["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# _extract_correlation_id / _error_type_name — pure helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCorrelationId:
+    def test_extracts_from_json_body_shape(self) -> None:
+        text = '{"error": "Internal server error", "correlation_id": "188834187d7d"}'
+        assert _extract_correlation_id(text) == "188834187d7d"
+
+    def test_returns_none_when_absent(self) -> None:
+        assert _extract_correlation_id("plain timeout error, no structured body") is None
+
+
+class TestErrorTypeName:
+    def test_httpx_exception_type_name(self) -> None:
+        assert _error_type_name(httpx.ReadTimeout("x")) == "httpx.ReadTimeout"
+
+    def test_builtin_exception_type_name_has_no_module_prefix(self) -> None:
+        assert _error_type_name(RuntimeError("x")) == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Shape sanity — every outcome dict carries the new additive keys
+# ---------------------------------------------------------------------------
+
+
+def test_all_outcome_builders_include_evidence_keys() -> None:
+    outcomes = [
+        _outcome_for_failed_url("https://example.com/a", httpx.ReadTimeout("x")),
+        _outcome_for_not_attempted_url("https://example.com/b"),
+    ]
+    for outcome in outcomes:
+        assert {"error_type", "error_message", "correlation_id", "observed"} <= set(outcome.keys())

--- a/klai-knowledge-ingest/tests/test_fetch_outcome_evidence.py
+++ b/klai-knowledge-ingest/tests/test_fetch_outcome_evidence.py
@@ -34,6 +34,13 @@ def _http_status_error(*, status: int = 500, body: dict | None = None) -> httpx.
 
 # ---------------------------------------------------------------------------
 # _outcome_for_failed_url — a fetch that actually raised an exception
+#
+# The exception belongs to the CHUNK's transport request, not to any single
+# URL in it — a chunk can bundle many URLs, and one failed request does not
+# mean every one of those URLs was individually confirmed to fail. That is
+# exactly why ``observed`` is False here even though real evidence (type,
+# message, correlation_id) is attached: evidence and "confirmed per-URL
+# result" are independent axes. See ``_with_evidence``'s docstring.
 # ---------------------------------------------------------------------------
 
 
@@ -45,7 +52,9 @@ class TestOutcomeForFailedUrlPreservesExceptionEvidence:
         assert outcome["error_type"] == "httpx.ReadTimeout"
         assert outcome["error_message"] == "simulated read timeout after 90s"
         assert outcome["correlation_id"] is None
-        assert outcome["observed"] is True
+        # A chunk-level transport exception is real evidence about the
+        # request, but not a confirmed per-URL result — see class docstring.
+        assert outcome["observed"] is False
 
     def test_5xx_with_correlation_id_body_preserves_correlation_id(self) -> None:
         """2026-08-14 intermedia.com shape: opaque 500 body carrying only
@@ -61,14 +70,37 @@ class TestOutcomeForFailedUrlPreservesExceptionEvidence:
         assert outcome["correlation_id"] == "188834187d7d"
         assert outcome["error_message"] is not None
         assert "188834187d7d" in outcome["error_message"]
-        assert outcome["observed"] is True
+        assert outcome["observed"] is False
 
     def test_connection_error_preserves_exception_type(self) -> None:
         error = httpx.ConnectError("Connection refused")
         outcome = _outcome_for_failed_url("https://example.com/a", error)
 
         assert outcome["error_type"] == "httpx.ConnectError"
-        assert outcome["observed"] is True
+        assert outcome["observed"] is False
+
+    def test_chunk_transport_failure_attributed_to_multiple_urls_is_unobserved_for_each(
+        self,
+    ) -> None:
+        """A single chunk request bundling many URLs fails once — that is
+        ONE observation about the request, not N observations about N
+        URLs. Every URL in the chunk must report observed=False, so a
+        'how many times did this domain actually time out' count is not
+        inflated by chunk size. This is the exact scenario the review
+        flagged: without this, one failed request counted as a hundred
+        observations."""
+        chunk_urls = [f"https://example.com/page-{i}" for i in range(20)]
+        error = httpx.ReadTimeout("simulated chunk-wide timeout")
+
+        outcomes = [_outcome_for_failed_url(url, error) for url in chunk_urls]
+
+        assert len(outcomes) == 20
+        for outcome in outcomes:
+            assert outcome["observed"] is False
+            # Evidence is still attached per-URL — the exception is real,
+            # just not an individually-confirmed per-URL result.
+            assert outcome["error_type"] == "httpx.ReadTimeout"
+            assert outcome["reason_code"] == "timeout"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two places where we discard the evidence of a failure, which is why three days of crawler work were spent designing on guesses.

## The largest failure class records nothing

Across all 65 crawl jobs ever run:

```
success             4811   (45 jobs)
timeout              770   (11 jobs)
unknown_exception    349   (23 jobs)   ← in more jobs than any other failure
http_5xx             266   ( 6 jobs)
blocked_anti_bot      96   (11 jobs)
rate_limited           4   ( 1 job)
```

And this is everything we keep about one:

```json
{"url": "https://www.intermedia.com/products/ai", "reason_code": "unknown_exception", "status_code": null, "content_length": 0}
```

No exception type, no message, no correlation id. A taxonomy of fifteen precise reason codes with a catch-all that is a black hole — and the catch-all is the biggest bucket. 1119 failed fetches currently tell us nothing.

Outcomes now carry `error_type`, a truncated `error_message`, `correlation_id`, and `observed`.

**`correlation_id` is the one that unlocks the rest.** crawl4ai's 5xx body is `{"error":"Internal server error","correlation_id":"..."}` and that id is the only way to find the matching entry in *its* logs. It is read from the response body rather than `str(exc)`, because the latter is always the literal string `"crawl4ai failed"`.

Messages are truncated at 300 characters, and token-shaped query parameters are masked first — a failing URL can come back inside crawl4ai's own error body, and that URL may carry a token. `fetch_outcomes` goes to the database and into logs.

**`observed` distinguishes evidence from attribution**, and the semantics are deliberate: it means "we got a result back for *this* URL". A chunk of 20 URLs that dies on one shared `ReadTimeout` yields `observed=False` for all 20 — we observed one request failing, not twenty URLs failing. Marking them observed would let a single failed request read as a hundred observations later, which is exactly the poisoned denominator this field exists to prevent. There is a test for that shape and a comment on the field, because this is the kind of distinction that gets "simplified" away.

No migration needed: the shape guard on `fetch_outcomes` is `CHECK (jsonb_typeof(...) = 'array')` with no per-element constraint, so the fields are purely additive. Every existing reader accesses by `.get("reason_code")` and is unaffected; one test pinned the exact key set and was updated.

## Every ingest can fail while the job reports success

```python
try:
    await _ingest_crawl_result(...)
    pages_done += 1
except Exception as exc:
    logger.warning("crawl_page_failed", ...)
    pages_failed += 1
```

`pages_failed` is incremented and read nowhere — it appears on the line that initialises it, the line that increments it, and nowhere else. So embeddings can be down, the database can be unreachable, every single page can fail to persist, and the job reports `completed`. Confirmed with a harness: one successful fetch plus a `RuntimeError` from `_ingest_crawl_result` gave `pages_done=0 pages_failed=1 status=completed`.

A job where every ingest failed can no longer be `completed`.

**The rule is deliberately narrow**: `failed_partial` only when `pages_failed > 0 and pages_done == 0`. No ratio threshold — this codebase has fresh evidence that a guessed one is dangerous, since `ingest_fetch_failure_dirty_trip_rate = 0.30` is how 29% failures came to count as healthy. Inventing a second guessed threshold would repeat that. Proper partial accounting needs `_ingest_crawl_result` to return an explicit result instead of raise-or-not, and that is the next step, not this one.

Worth noting for that next step: `pages_done` counts "no exception raised", not "document stored". An early return for unchanged content, an empty document, or an inactive connector all count as done.

## Verification

Both parts written test-first. Part A's initial run failed on `ImportError: cannot import name '_ERROR_MESSAGE_MAX_LEN'`; part B's harness reproduced the status lie verbatim before the fix.

1359 → 1383 passed, 4 skipped, 24 new tests. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)