### PR TITLE
fix(rag): third review round — sub-question coref, zero-chunks coverage, bypass aggregate, splitter guards

### DIFF
--- a/deploy/litellm/klai_kb_confidence_policy.py
+++ b/deploy/litellm/klai_kb_confidence_policy.py
@@ -98,11 +98,15 @@ def split_sub_questions(query: object, max_questions: int | None = None) -> list
     per line, so line-shaped questions win; inline prose falls back to
     ``?``-terminated segments; a numbered/bulleted list with no ``?`` anywhere
     in the message falls back to list-marker lines (e.g. a pasted procedure
-    written as imperative steps). The list-marker fallback only fires when NO
-    line in the message ends with ``?`` — a genuine mixed message (one real
-    question plus unrelated list lines) must never be split. Returns ``[]``
-    unless at least two usable questions are found — single questions keep
-    the normal retrieval path.
+    written as imperative steps). The list-marker fallback only fires when the
+    message contains NO ``?`` character AT ALL — not merely "no line ends
+    with ?". A message like "Can you help? Details:\n1. First\n2. Second" has
+    its one real question mid-line (not line-terminal), so a line-terminal-
+    only check would wrongly treat this as list-shaped and split it, losing
+    the real question. Checking the whole message for any ``?`` keeps a
+    genuine mixed message (one real question plus unrelated list lines)
+    intact. Returns ``[]`` unless at least two usable questions are found —
+    single questions keep the normal retrieval path.
 
     ``max_questions`` caps the returned list. ``None`` (the default) returns
     every usable question found, uncapped: callers that need a bounded subset
@@ -128,10 +132,7 @@ def split_sub_questions(query: object, max_questions: int | None = None) -> list
             if len(segment) >= _MIN_SUB_QUESTION_CHARS
         ]
     if len(questions) < 2:
-        any_question_mark_line = any(
-            line.strip().endswith("?") for line in query.splitlines()
-        )
-        if not any_question_mark_line:
+        if "?" not in query:
             list_marker_questions: list[str] = []
             for line in query.splitlines():
                 raw = line.strip()

--- a/deploy/litellm/klai_kb_context_prompt.py
+++ b/deploy/litellm/klai_kb_context_prompt.py
@@ -59,6 +59,12 @@ KB_ANSWER_FORMAT_INSTRUCTION = (
 
 _QUESTION_ECHO_MAX_CHARS = 150
 
+# A message with dozens of "unchecked" sub-questions (e.g. a pasted FAQ list)
+# would otherwise render one full marker block per question and dominate the
+# prompt. Show individual markers for at most this many; the rest collapse
+# into one summary line.
+MAX_UNCHECKED_QUESTIONS_SHOWN = 6
+
 
 def _sanitize_question_echo(text: str) -> str:
     """Sanitize a user-supplied sub-question before echoing it verbatim into
@@ -151,7 +157,9 @@ def _sub_query_grouped_context(
             )
     if unchecked_questions:
         start_index = len(entries) + 1
-        for offset, question in enumerate(unchecked_questions):
+        shown = unchecked_questions[:MAX_UNCHECKED_QUESTIONS_SHOWN]
+        remainder = len(unchecked_questions) - len(shown)
+        for offset, question in enumerate(shown):
             index = start_index + offset
             header = f"[Question {index}: {_sanitize_question_echo(question)}]"
             blocks.append(
@@ -159,6 +167,12 @@ def _sub_query_grouped_context(
                 "(question limit reached) — answer it only if the evidence "
                 "above clearly covers it; otherwise say you could not fully "
                 "check it. Do NOT say it is not in the knowledge base.]"
+            )
+        if remainder > 0:
+            blocks.append(
+                f"[Plus {remainder} more questions were not separately "
+                "searched — tell the user you could not check them all and "
+                "suggest splitting the message into smaller parts.]"
             )
     if ungrouped:
         rendered = render_evidence_context(ungrouped, include_source_urls=False)

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -1376,6 +1376,9 @@ class KlaiKnowledgeHook(CustomLogger):
                             if isinstance(evidence_pack, dict)
                             else None
                         ),
+                        multi_question=multi_question,
+                        sub_query_coverage=sub_query_results,
+                        unchecked_questions=unchecked_questions or None,
                         original_stream=original_stream,
                         render_mode=render_strategy.mode,
                         retrieval_request_id=retrieval_request_id,

--- a/deploy/litellm/tests/test_sub_question_fanout_hook.py
+++ b/deploy/litellm/tests/test_sub_question_fanout_hook.py
@@ -146,6 +146,18 @@ class TestSplitSubQuestions:
         )
         assert questions == []
 
+    def test_mid_line_question_mark_blocks_list_fallback(self, monkeypatch):
+        """Round-3 Fix 4: the list-marker fallback must only fire when the
+        message has NO '?' anywhere — not merely 'no line ends with ?'. A
+        question mid-line ('Can you help? Details:') would pass the old
+        line-terminal-only check and wrongly get list-split, losing the real
+        question."""
+        klai_knowledge = _load_hook(monkeypatch)
+        questions = klai_knowledge._split_sub_questions(
+            "Can you help? Details:\n1. First instruction\n2. Second instruction"
+        )
+        assert questions == []
+
 
 class TestRetrieveBodyCarriesSubQueries:
     def test_body_includes_sub_queries_when_present(self, monkeypatch):
@@ -372,6 +384,77 @@ class TestGroupedContext:
         q2_pos = block.index("[Question 2:")
         q3_pos = block.index("[Question 3:")
         assert q2_pos < q3_pos
+
+    def test_unchecked_questions_beyond_display_cap_collapse_to_summary_line(
+        self, monkeypatch
+    ):
+        """Round-3 Fix 5: a message with dozens of unchecked questions (e.g.
+        a pasted 100-item FAQ) must render at most MAX_UNCHECKED_QUESTIONS_SHOWN
+        individual markers, with the rest collapsed into one summary line —
+        otherwise the prompt is dominated by near-identical marker blocks."""
+        _load_hook(monkeypatch)
+        from klai_kb_context_prompt import (
+            MAX_UNCHECKED_QUESTIONS_SHOWN,
+            _sub_query_grouped_context,
+        )
+
+        assert MAX_UNCHECKED_QUESTIONS_SHOWN == 6
+
+        unchecked = [f"Vraag {i}?" for i in range(1, 95)]  # 94 unchecked
+        rendered = _sub_query_grouped_context(
+            context_chunks=[
+                {
+                    "chunk_id": "c1",
+                    "text": "Antwoord.",
+                    "title": "Titel",
+                    "sub_query_index": 1,
+                }
+            ],
+            sub_query_results=[
+                {"index": 1, "query": "Hoofdvraag?", "evidence_count": 1},
+            ],
+            unchecked_questions=unchecked,
+        )
+
+        # Exactly 6 individual unchecked markers, numbered 2..7 (continuing
+        # from the 1 searched question).
+        for n in range(2, 8):
+            assert f"[Question {n}: Vraag {n - 1}?]" in rendered
+        assert "[Question 8:" not in rendered
+
+        summary_line = (
+            "[Plus 88 more questions were not separately searched — tell "
+            "the user you could not check them all and suggest splitting "
+            "the message into smaller parts.]"
+        )
+        assert summary_line in rendered
+
+        # The whole unchecked section (6 individual markers + the summary
+        # line) stays well under ~2000 chars despite 94 unchecked questions.
+        unchecked_section_start = rendered.index("[Question 2:")
+        assert len(rendered[unchecked_section_start:]) < 2000
+
+    def test_unchecked_questions_at_or_below_cap_show_no_summary_line(
+        self, monkeypatch
+    ):
+        prompt = self._build(
+            monkeypatch,
+            sub_query_results=[
+                {"index": 1, "query": "Hoofdvraag?", "evidence_count": 1},
+            ],
+            chunks=[
+                {
+                    "chunk_id": "c1",
+                    "text": "Antwoord.",
+                    "title": "Titel",
+                    "sub_query_index": 1,
+                }
+            ],
+            unchecked_questions=[f"Vraag {i}?" for i in range(1, 7)],  # exactly 6
+        )
+        block = prompt.context_block
+        assert "more questions were not separately searched" not in block
+        assert "[Question 7: Vraag 6?]" in block
 
     def test_retrieval_bypassed_question_gets_gate_skipped_marker(self, monkeypatch):
         """Fix B: a gate-bypassed sub-question (Open mode) must render a
@@ -870,3 +953,76 @@ class TestHookFanoutEndToEnd:
         coverage = {entry["index"]: entry for entry in meta["sub_query_coverage"]}
         assert coverage[1]["evidence_count"] == 0
         assert coverage[2]["evidence_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_zero_chunks_branch_carries_sub_query_coverage(self, monkeypatch):
+        """Round-3 Fix 2: the zero-chunks route must be fan-out-aware. Strict
+        mode still refuses deterministically (mock_response), but
+        kb_meta['sub_query_coverage'] must carry BOTH sub-question entries
+        (the error and the genuinely-empty one) so the 'Deelvragen' footer
+        reflects reality even when the fan-out found nothing at all."""
+        from tests.test_klai_knowledge_hook import (
+            _make_cache,
+            _make_resp,
+            _make_user_api_key,
+            _patch_http,
+        )
+
+        mod = _load_hook(monkeypatch)
+        hook = mod.KlaiKnowledgeHook()
+        cache = _make_cache()
+
+        data = {
+            "user": "aabbcc112233445566778899",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Wat is de responstijd?\nWat is de SLA?",
+                }
+            ],
+        }
+        retrieval_resp = _make_resp(
+            {
+                "chunks": [],
+                "retrieval_bypassed": False,
+                "confidence_band": "unknown",
+                "sub_results": [
+                    {
+                        "index": 1,
+                        "query": "Wat is de responstijd?",
+                        "error": "RuntimeError",
+                    },
+                    {
+                        "index": 2,
+                        "query": "Wat is de SLA?",
+                        "evidence_count": 0,
+                    },
+                ],
+            }
+        )
+        portal_resp = _make_resp(
+            {
+                "enabled": True,
+                "kb_retrieval_enabled": True,
+                "kb_personal_enabled": True,
+                "kb_slugs_filter": None,
+                "kb_narrow": True,
+                "kb_pref_version": 12,
+                "zitadel_user_id": "300000000000000002",
+            }
+        )
+
+        with _patch_http(
+            monkeypatch, portal_resp=portal_resp, retrieval_resp=retrieval_resp
+        ):
+            result = await hook.async_pre_call_hook(
+                _make_user_api_key(), cache, data, "completion"
+            )
+
+        assert "mock_response" in result
+
+        meta = result["metadata"]["_klai_kb_meta"]
+        coverage = {entry["index"]: entry for entry in meta["sub_query_coverage"]}
+        assert set(coverage) == {1, 2}
+        assert coverage[1]["error"] == "RuntimeError"
+        assert coverage[2]["evidence_count"] == 0

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -176,10 +176,15 @@ async def _retrieve_sub_queries(
         sub_req = req.model_copy(
             update={
                 "query": sub_query,
-                # Sub-questions are standalone by contract; skip per-question
-                # coreference LLM calls and raw-query RRF legs.
+                # Sub-questions are standalone TEXT (splitting never rewrites
+                # them), but a question like "En hoe lang duurt het?" still
+                # needs coreference resolution against conversation_history
+                # (already carried on ``req`` and preserved by model_copy)
+                # to resolve "het". ``None`` lets retrieval-api's own
+                # coreference step run per sub-question instead of treating
+                # the raw text as already-resolved.
                 "raw_query": None,
-                "coreference_resolved": True,
+                "coreference_resolved": None,
                 "sub_queries": None,
                 "top_k": per_query_top_k,
             }
@@ -206,6 +211,7 @@ async def _retrieve_sub_queries(
     candidates_total = 0
     reranked_total = 0
     failures = 0
+    successful_bypassed_flags: list[bool] = []
     for (index, query), result in zip(sub_queries, results, strict=True):
         if isinstance(result, BaseException):
             # A 4xx from a sub-call is an auth/validation failure of the
@@ -229,6 +235,7 @@ async def _retrieve_sub_queries(
         pack = result.evidence_pack
         evidence_count = len(pack.items) if pack is not None else 0
         indexed_packs.append((index, pack))
+        successful_bypassed_flags.append(result.retrieval_bypassed)
         sub_results.append(
             SubQueryResult(
                 index=index,
@@ -253,6 +260,13 @@ async def _retrieve_sub_queries(
     overall_band = (
         max(covered_bands, key=lambda band: _BAND_RANK.get(band, 0)) if covered_bands else "unknown"
     )
+    # Aggregate retrieval_bypassed: True only when there is at least one
+    # successful sub-response AND every successful sub-response was
+    # gate-bypassed. A parent False with zero successes (all failed) is
+    # already unreachable here — the all-failures branch above raises 502
+    # first. Mixed bypassed/non-bypassed correctly stays False: real
+    # retrieval happened for at least one question.
+    all_bypassed = bool(successful_bypassed_flags) and all(successful_bypassed_flags)
     merged_pack = merge_evidence_packs(indexed_packs)
     retrieval_ms = (time.perf_counter() - t0) * 1000
     logger.info(
@@ -302,7 +316,7 @@ async def _retrieve_sub_queries(
 
     return RetrieveResponse(
         query_resolved=req.query,
-        retrieval_bypassed=False,
+        retrieval_bypassed=all_bypassed,
         chunks=merged_chunks,
         metadata=RetrieveMetadata(
             candidates_retrieved=candidates_total,

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -260,13 +260,22 @@ async def _retrieve_sub_queries(
     overall_band = (
         max(covered_bands, key=lambda band: _BAND_RANK.get(band, 0)) if covered_bands else "unknown"
     )
-    # Aggregate retrieval_bypassed: True only when there is at least one
-    # successful sub-response AND every successful sub-response was
-    # gate-bypassed. A parent False with zero successes (all failed) is
-    # already unreachable here — the all-failures branch above raises 502
-    # first. Mixed bypassed/non-bypassed correctly stays False: real
-    # retrieval happened for at least one question.
-    all_bypassed = bool(successful_bypassed_flags) and all(successful_bypassed_flags)
+    # Aggregate retrieval_bypassed: True only when there are ZERO failures
+    # AND at least one successful sub-response AND every successful
+    # sub-response was gate-bypassed. The failures==0 guard matters even
+    # though a mix of "some bypassed, some failed" still has
+    # bool(successful_bypassed_flags) and all(...) both true — without it,
+    # a partially-failed fan-out (e.g. 1 bypassed success + 1 error) would
+    # report bypassed=True at the parent level. The litellm hook treats
+    # retrieval_bypassed=True as an early-return "gate bypassed" branch that
+    # never reaches sub_query_coverage/unchecked_questions, so that failed
+    # sub-question would silently vanish from what the user sees instead of
+    # surfacing as "could not check this one". All-failures (failures ==
+    # len(sub_queries)) is already unreachable here — that branch raises 502
+    # above — so this guard only affects the partial-failure case.
+    all_bypassed = (
+        failures == 0 and bool(successful_bypassed_flags) and all(successful_bypassed_flags)
+    )
     merged_pack = merge_evidence_packs(indexed_packs)
     retrieval_ms = (time.perf_counter() - t0) * 1000
     logger.info(

--- a/klai-retrieval-api/tests/test_sub_query_fanout.py
+++ b/klai-retrieval-api/tests/test_sub_query_fanout.py
@@ -275,9 +275,13 @@ class TestRetrieveSubQueries:
 
     @pytest.mark.asyncio
     async def test_parent_retrieval_bypassed_false_when_one_sub_query_failed(self, monkeypatch):
-        """A failed sub-question is not a 'successful bypass' — the parent
-        must not report bypassed=True just because the only SUCCESSFUL
-        sub-response happened to be bypassed while another one errored."""
+        """Round-4 fix: a failed sub-question must block the aggregate
+        bypass, even when the only SUCCESSFUL sub-response was itself
+        gate-bypassed. The litellm hook treats retrieval_bypassed=True as
+        an early-return 'gate bypassed' branch that never reaches
+        sub_query_coverage/unchecked_questions — so a bypassed=True here
+        would make the failed sub-question silently vanish from what the
+        user sees instead of surfacing as 'could not check this one'."""
 
         async def fake_retrieve(sub_req, request, _auth=None):
             if sub_req.query == "kapotte vraag":
@@ -290,9 +294,9 @@ class TestRetrieveSubQueries:
             _request(["goede vraag", "kapotte vraag"]), MagicMock(), MagicMock()
         )
 
-        # Only one successful sub-response and it WAS bypassed — per the
-        # spec (>=1 success AND all successes bypassed), this is True.
-        assert result.retrieval_bypassed is True
+        # One sub-question failed — the aggregate must stay False even
+        # though the sole successful sub-response was bypassed.
+        assert result.retrieval_bypassed is False
 
 
 class TestSubQueryFourXXPassthrough:

--- a/klai-retrieval-api/tests/test_sub_query_fanout.py
+++ b/klai-retrieval-api/tests/test_sub_query_fanout.py
@@ -146,7 +146,11 @@ class TestRetrieveSubQueries:
         assert result.retrieval_bypassed is False
 
     @pytest.mark.asyncio
-    async def test_sub_query_uses_bounded_top_k_and_standalone_flags(self, monkeypatch):
+    async def test_sub_query_uses_bounded_top_k_and_lets_coreference_run(self, monkeypatch):
+        """Round-3 Fix 1: coreference_resolved is None (not True) so
+        retrieval-api's own coreference step runs per sub-question against
+        the carried conversation_history — a sub-question like "En hoe lang
+        duurt het?" needs that resolution to know what "het" refers to."""
         captured = []
 
         async def fake_retrieve(sub_req, request, _auth=None):
@@ -160,7 +164,7 @@ class TestRetrieveSubQueries:
         )
 
         assert all(sub_req.sub_queries is None for sub_req in captured)
-        assert all(sub_req.coreference_resolved is True for sub_req in captured)
+        assert all(sub_req.coreference_resolved is None for sub_req in captured)
         assert all(sub_req.raw_query is None for sub_req in captured)
         assert all(
             sub_req.top_k == retrieve_module.settings.sub_query_top_k for sub_req in captured
@@ -221,6 +225,74 @@ class TestRetrieveSubQueries:
 
         assert result.sub_results[0].retrieval_bypassed is False
         assert result.sub_results[1].retrieval_bypassed is True
+
+    @pytest.mark.asyncio
+    async def test_parent_retrieval_bypassed_true_when_all_sub_queries_bypassed(self, monkeypatch):
+        """Round-3 Fix 3: the merged RetrieveResponse's own retrieval_bypassed
+        must aggregate the sub-responses instead of being hardcoded False —
+        a fully gate-skipped fan-out (Open mode, no sub-question needed KB
+        lookup) must report bypassed=True at the parent level too."""
+
+        async def fake_retrieve(sub_req, request, _auth=None):
+            return _response("unknown", [], [], retrieval_bypassed=True)
+
+        monkeypatch.setattr(retrieve_module, "retrieve", fake_retrieve)
+
+        result = await retrieve_module._retrieve_sub_queries(
+            _request(["vraag een", "vraag twee"]), MagicMock(), MagicMock()
+        )
+
+        assert result.retrieval_bypassed is True
+
+    @pytest.mark.asyncio
+    async def test_parent_retrieval_bypassed_false_when_mixed(self, monkeypatch):
+        async def fake_retrieve(sub_req, request, _auth=None):
+            bypassed = sub_req.query == "meta vraag"
+            return _response(
+                "unknown" if bypassed else "medium", [], [], retrieval_bypassed=bypassed
+            )
+
+        monkeypatch.setattr(retrieve_module, "retrieve", fake_retrieve)
+
+        result = await retrieve_module._retrieve_sub_queries(
+            _request(["gewone vraag", "meta vraag"]), MagicMock(), MagicMock()
+        )
+
+        assert result.retrieval_bypassed is False
+
+    @pytest.mark.asyncio
+    async def test_parent_retrieval_bypassed_false_when_none_bypassed(self, monkeypatch):
+        async def fake_retrieve(sub_req, request, _auth=None):
+            return _response("medium", [], [], retrieval_bypassed=False)
+
+        monkeypatch.setattr(retrieve_module, "retrieve", fake_retrieve)
+
+        result = await retrieve_module._retrieve_sub_queries(
+            _request(["vraag een", "vraag twee"]), MagicMock(), MagicMock()
+        )
+
+        assert result.retrieval_bypassed is False
+
+    @pytest.mark.asyncio
+    async def test_parent_retrieval_bypassed_false_when_one_sub_query_failed(self, monkeypatch):
+        """A failed sub-question is not a 'successful bypass' — the parent
+        must not report bypassed=True just because the only SUCCESSFUL
+        sub-response happened to be bypassed while another one errored."""
+
+        async def fake_retrieve(sub_req, request, _auth=None):
+            if sub_req.query == "kapotte vraag":
+                raise RuntimeError("down")
+            return _response("unknown", [], [], retrieval_bypassed=True)
+
+        monkeypatch.setattr(retrieve_module, "retrieve", fake_retrieve)
+
+        result = await retrieve_module._retrieve_sub_queries(
+            _request(["goede vraag", "kapotte vraag"]), MagicMock(), MagicMock()
+        )
+
+        # Only one successful sub-response and it WAS bypassed — per the
+        # spec (>=1 success AND all successes bypassed), this is True.
+        assert result.retrieval_bypassed is True
 
 
 class TestSubQueryFourXXPassthrough:


### PR DESCRIPTION
## Summary
Third review round on the sub-question retrieval fan-out (previously PR #1060, merged as `edaafcd6f`). All 5 findings accepted and fixed here:

1. **Sub-question coreference** — `_retrieve_sub_queries` now sets `coreference_resolved=None` (not `True`) on sub-requests, so retrieval-api's own coreference step runs per sub-question against the carried `conversation_history` (e.g. "En hoe lang duurt het?" now resolves "het").
2. **Zero-chunks fan-out coverage** — the zero-chunks branch in the litellm hook now passes `sub_query_coverage`/`unchecked_questions` to `to_kb_meta`, mirroring the chunks-present branch, so the "Deelvragen" footer is accurate even on a strict refusal.
3. **Aggregate `retrieval_bypassed`** — the merged `RetrieveResponse` now reports `retrieval_bypassed = (>=1 successful sub-response) AND (all successful sub-responses were bypassed)`, instead of a hardcoded `False`.
4. **Splitter list-fallback guard** — `split_sub_questions`'s list-marker fallback now requires NO `?` anywhere in the message (not just "no line ends with `?`"), so a mid-line question ("Can you help? Details:\n1. ...") is never wrongly split.
5. **Unchecked-questions display cap** — grouped-prompt markers for unchecked questions are capped at `MAX_UNCHECKED_QUESTIONS_SHOWN = 6`; anything beyond collapses into one "Plus N more" summary line.

## Test plan
- [x] LiteLLM hook suite: 562 passed (`test_sub_query_uses_bounded_top_k_and_lets_coreference_run`, `test_zero_chunks_branch_carries_sub_query_coverage`, `test_mid_line_question_mark_blocks_list_fallback`, `test_unchecked_questions_beyond_display_cap_collapse_to_summary_line`, `test_unchecked_questions_at_or_below_cap_show_no_summary_line`)
- [x] Retrieval-api: `ruff check` clean, `ruff format --check` clean, 610 passed / 1 skipped (`test_parent_retrieval_bypassed_true_when_all_sub_queries_bypassed`, `test_parent_retrieval_bypassed_false_when_mixed`, `test_parent_retrieval_bypassed_false_when_none_bypassed`, `test_parent_retrieval_bypassed_false_when_one_sub_query_failed`)
- [x] `git diff origin/main...HEAD --stat` touches only `deploy/litellm/**` and `klai-retrieval-api/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)