### PR TITLE
fix(crawler): skip document links before they ever enter the frontier

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -170,6 +170,93 @@ _PRIORITY_PAGE_LINK = 50
 _LISTING_LINK_THRESHOLD = 50
 _THIN_CONTENT_WORD_COUNT = 100
 
+# 2026-08-18 (intermedia.com incident) — a website crawl exists to fetch
+# HTML pages, not documents. crawl4ai's browser tries to *navigate* to
+# every discovered same-domain link; pointed at a PDF (or any other
+# document/archive/media/binary), the browser starts a download instead
+# of rendering and the request fails.
+#
+# This is NOT about a bad URL poisoning a whole bulk chunk — measured
+# directly against the running crawl4ai container (2026-08-18): a PDF
+# submitted together with a good URL in one bulk ``/crawl`` request comes
+# back HTTP 200 with two results, the PDF's own ``success: false`` and an
+# error message, the good page fetched normally. crawl4ai's REST API
+# dispatches bulk requests to ``crawler.arun_many``, which isolates
+# failures per URL — exactly as it should. A single-URL request is a
+# different code path (``crawler.arun``, chosen by crawl4ai's own
+# ``api.py`` whenever ``len(urls) == 1``) that does NOT isolate the
+# failure and returns a bare HTTP 500 instead.
+#
+# That single-URL path is exactly what the sequential-recovery route
+# (``_recover_bulk_5xx_batch``) and the seed fetch (``_fetch_seed_page``)
+# use — one URL at a time, each attempt preceded by a real
+# ``crawl_sequential_recovery_cooldown_seconds`` (75s) wait and counted
+# against the crawl-job-wide ``_MAX_SEQUENTIAL_RECOVERY`` budget. A PDF
+# can never become fetchable HTML no matter how many times or how slowly
+# it is retried, so letting one reach that route wastes a guaranteed-to-
+# fail 75-second attempt and a budget slot that a genuinely recoverable
+# HTML page (a real transient 5xx or timeout) needed instead.
+#
+# This is also not a workaround for a crawler limitation: Klai already
+# has a dedicated document connector for exactly this content class. The
+# web crawler's job is web pages; PDFs, spreadsheets, archives and media
+# belong to that other connector, not to this one's frontier. Filtering
+# them out here, before a single network request is made, costs nothing
+# and is deterministic — unlike a HEAD request or content-type sniff.
+_NON_HTML_PATH_EXTENSIONS = frozenset(
+    {
+        # documents
+        "pdf",
+        "doc",
+        "docx",
+        "xls",
+        "xlsx",
+        "ppt",
+        "pptx",
+        "odt",
+        # archives
+        "zip",
+        "tar",
+        "gz",
+        "rar",
+        "7z",
+        # media
+        "jpg",
+        "jpeg",
+        "png",
+        "gif",
+        "svg",
+        "webp",
+        "ico",
+        "mp4",
+        "mp3",
+        "avi",
+        "mov",
+        "wav",
+        # binaries
+        "exe",
+        "dmg",
+        "pkg",
+        "deb",
+    }
+)
+
+
+def _url_has_non_html_extension(url: str) -> bool:
+    """True when ``url``'s PATH (query params ignored) ends in a
+    document/archive/media/binary extension — see
+    ``_NON_HTML_PATH_EXTENSIONS`` above.
+
+    ``.../rapport.pdf?download=1`` matches: only ``urlparse(url).path`` is
+    inspected, so a query string can never hide the extension or trigger a
+    false positive on a path segment that merely contains a dot.
+    """
+    last_segment = urlparse(url).path.rsplit("/", 1)[-1]
+    if "." not in last_segment:
+        return False
+    extension = last_segment.rsplit(".", 1)[-1].lower()
+    return extension in _NON_HTML_PATH_EXTENSIONS
+
 
 class _HTMLTextCounter(HTMLParser):
     """Cheap rendered-HTML text signal for deciding whether a crawl was over-pruned."""
@@ -1272,6 +1359,15 @@ class CrawlLedger:
         if not url:
             return False
         if not _same_site_domain(urlparse(url).netloc.lower(), self.base_domain):
+            return False
+        if _url_has_non_html_extension(url):
+            # Deliberately produces NO outcome at all (same contract as the
+            # domain check above) — never a ``not_fetched_*`` reason code.
+            # A URL we correctly never wanted to crawl is not incomplete
+            # coverage; see _build_crawl_outcome_warning / _crawl_fully_fetched
+            # in adapters/crawler.py, which both key off any not_fetched_*
+            # prefix and would otherwise mark the whole crawl failed_partial
+            # over one PDF link.
             return False
         url = _coerce_same_site_url_to_base_host(url, self.base_domain)
         if not force:

--- a/klai-knowledge-ingest/tests/test_crawl_frontier_document_extensions.py
+++ b/klai-knowledge-ingest/tests/test_crawl_frontier_document_extensions.py
@@ -1,0 +1,251 @@
+"""A website crawl must not treat document files as pages.
+
+crawl4ai's browser tries to *navigate* to every discovered same-domain
+link. Pointed at a PDF (or any other document/archive/media/binary),
+navigation starts a download instead of rendering, and the request fails.
+
+This is NOT about one bad URL poisoning a whole bulk batch — measured
+directly against the running crawl4ai container (2026-08-18): a PDF
+submitted together with a good URL in one bulk request comes back HTTP
+200 with two results, the PDF's own ``success: false`` and an error
+message, the good page fetched normally. crawl4ai's bulk endpoint
+(``crawler.arun_many``) isolates per-URL failures correctly.
+
+The real cost is downstream: a PDF that reaches the crawl frontier can
+end up in Klai's own sequential-recovery route
+(``knowledge_ingest.crawl4ai_client._recover_bulk_5xx_batch``) or the
+seed fetch (``_fetch_seed_page``) — both single-URL requests, which
+crawl4ai dispatches to ``crawler.arun`` instead of ``arun_many``, and
+which does NOT isolate the failure the same way. A PDF can never become
+fetchable HTML no matter how many times or how slowly it is retried, so
+letting one reach that route burns a real 75-second cooldown
+(``crawl_sequential_recovery_cooldown_seconds``) and a
+``_MAX_SEQUENTIAL_RECOVERY`` budget slot that a genuinely recoverable
+HTML page needed instead.
+
+These URLs are filtered at the frontier (``CrawlLedger.add``), before a
+single network request is made — same mechanism as ``exclude_patterns``,
+deliberately: excluded-by-extension URLs must never produce a
+``not_fetched_*`` outcome, or a single PDF link anywhere on a site would
+mark an otherwise-perfect crawl ``failed_partial``
+(``_build_crawl_outcome_warning`` / ``_crawl_fully_fetched`` in
+``knowledge_ingest/adapters/crawler.py`` both key off any
+``not_fetched_*``-prefixed reason code).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.adapters.crawler import (
+    _build_crawl_outcome_warning,
+    _crawl_fully_fetched,
+    decide_fetch_failure_terminal_status,
+)
+from knowledge_ingest.crawl4ai_client import CrawlLedger, CrawlResult
+
+
+def _ledger(**overrides: Any) -> CrawlLedger:
+    defaults: dict[str, Any] = {
+        "start_url": "https://example.com",
+        "base_domain": "example.com",
+        "include_patterns": None,
+        "exclude_patterns": None,
+        "max_depth": 3,
+    }
+    defaults.update(overrides)
+    return CrawlLedger(**defaults)
+
+
+def test_pdf_link_is_never_added_to_the_frontier() -> None:
+    ledger = _ledger()
+    added = ledger.add(
+        "https://example.com/assets/pdf/report.pdf",
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is False
+    assert ledger.discovered_count == 0
+
+
+def test_html_link_next_to_a_pdf_link_is_still_added() -> None:
+    ledger = _ledger()
+    ledger.add(
+        "https://example.com/assets/pdf/report.pdf",
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    added = ledger.add(
+        "https://example.com/products/widget",
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is True
+    assert ledger.discovered_count == 1
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/assets/pdf/report.pdf?download=1",
+        "https://example.com/whitepaper.PDF?utm_source=newsletter",
+        "https://example.com/downloads/manual.docx",
+        "https://example.com/archive/backup.zip",
+        "https://example.com/images/logo.png",
+        "https://example.com/media/demo.mp4",
+        "https://example.com/installers/setup.exe",
+    ],
+)
+def test_non_html_extensions_are_excluded_including_with_query_params(url: str) -> None:
+    ledger = _ledger()
+    added = ledger.add(
+        url,
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is False, f"expected {url} to be excluded from the frontier"
+    assert ledger.discovered_count == 0
+
+
+def test_path_segment_containing_a_dot_but_no_recognised_extension_is_kept() -> None:
+    """A path with a dot that is not a document/archive/media/binary extension
+    (e.g. a versioned doc path) must not be swept up by an overly broad filter."""
+    ledger = _ledger()
+    added = ledger.add(
+        "https://example.com/docs/v1.2/getting-started",
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is True
+
+
+def test_add_links_from_result_skips_pdf_hrefs() -> None:
+    ledger = _ledger()
+    result = CrawlResult(
+        url="https://example.com/support",
+        fit_markdown="Support",
+        raw_markdown="Support",
+        html="<html></html>",
+        word_count=2,
+        success=True,
+        links={
+            "internal": [
+                {"href": "https://example.com/assets/pdf/report.pdf", "text": "Report"},
+                {"href": "https://example.com/support/faq", "text": "FAQ"},
+            ]
+        },
+    )
+    ledger.add_links_from_result(result, source_depth=1)
+    assert ledger.discovered_count == 1
+    assert ledger.next_batch(remaining_budget=10) == ["https://example.com/support/faq"]
+
+
+@pytest.mark.asyncio
+async def test_crawl_site_never_submits_pdf_links_to_crawl4ai(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a PDF discovered on the seed page must never reach the
+    bulk /crawl request, or (more importantly) the single-URL sequential
+    recovery route it would otherwise be retried through."""
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="Seed",
+            raw_markdown="Seed",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+            links={
+                "internal": [
+                    {"href": "https://example.com/assets/pdf/report.pdf", "text": "Report"},
+                    {"href": "https://example.com/products/widget", "text": "Widget"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    async def _no_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+
+    submitted: list[list[str]] = []
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        urls = payload["urls"]
+        submitted.append(urls)
+        return {
+            "results": [
+                {
+                    "url": u,
+                    "success": True,
+                    "status_code": 200,
+                    "html": "<html><body>Real content, several words here.</body></html>",
+                    "markdown": "Real content, several words here.",
+                    "links": {"internal": []},
+                    "media": {},
+                }
+                for u in urls
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+    )
+
+    for batch in submitted:
+        assert "https://example.com/assets/pdf/report.pdf" not in batch
+
+    urls_in_outcomes = {o["url"] for o in outcomes}
+    assert "https://example.com/assets/pdf/report.pdf" not in urls_in_outcomes
+    assert "https://example.com/products/widget" in urls_in_outcomes
+    assert any(r.url == "https://example.com/products/widget" for r in results)
+
+
+def test_a_skipped_pdf_does_not_mark_the_crawl_failed_partial() -> None:
+    """The valkuil: a URL we deliberately never wanted to crawl is not
+    'incomplete coverage'. Since the excluded URL never produces an
+    outcome at all (see the ledger-level tests above), the existing
+    not_fetched_* / failure-ratio guards downstream must see a perfectly
+    clean, fully-fetched crawl."""
+    fetch_outcomes = [
+        {
+            "url": "https://example.com",
+            "reason_code": "success",
+            "status_code": 200,
+            "content_length": 500,
+        },
+        {
+            "url": "https://example.com/products/widget",
+            "reason_code": "success",
+            "status_code": 200,
+            "content_length": 500,
+        },
+    ]
+
+    assert _build_crawl_outcome_warning(fetch_outcomes, max_pages=200) is None
+    assert _crawl_fully_fetched(fetch_outcomes) is True
+    status, summary = decide_fetch_failure_terminal_status(
+        fetch_outcomes=fetch_outcomes,
+        threshold=0.30,
+    )
+    assert status == ""
+    assert summary is None


### PR DESCRIPTION
A production crawl of www.intermedia.com produced zero pages in twenty minutes. Every failing URL was a PDF under `/assets/pdf/`.

## Nothing filtered on file type

`CrawlLedger.add` checks same-site domain and URL patterns only, so `<a href=".../SLA.pdf">` entered the frontier like any other link. `_default_exclude_patterns` fires only when `path_prefix == "/blog"` — for a general site nothing was excluded at all.

URLs whose path extension is evidently not an HTML page now never enter the frontier: documents, archives, media, binaries. Matched on the path so `report.pdf?download=1` is caught too.

This is not a workaround. There is already a separate file connector for documents; a web crawler should crawl web pages. The comment on the list says so, because otherwise the next reader deletes it as a hack.

## Why it costs so much, measured rather than assumed

My first version of this claimed one PDF poisons its whole chunk. That is wrong, and testing it against the running crawl4ai says so:

| request | result |
|---|---|
| good URL alone | 200, one result, success |
| **broken PDF alone** | **500, zero results** |
| **both together in one batch** | **200, two results** — PDF `success=False` with its error, good page succeeds |

`arun_many` isolates per-URL failures correctly. The 500 appears only for a single-URL request, and the mechanism is in crawl4ai's `api.py`: `func = getattr(crawler, "arun" if len(urls) == 1 else "arun_many")`. `arun` re-raises; `arun_many` goes through the dispatcher with `return_exceptions=True`.

So the real cost is in the paths that send one URL at a time — the seed fetch, and above all the sequential recovery route. That route retries each failed URL individually with a 75s cooldown, and every one of those single-URL requests against a PDF returns 500. It was manufacturing the failures it was trying to recover from, burning the full 1200s job budget for zero pages.

The fix is the same either way; the reason is different. It is not about avoiding batch poisoning, it is about never handing the recovery path a URL that can only ever fail. The code comments carry the corrected reasoning, because leaving a refuted rationale in the codebase is precisely how three patches got built on a false premise this week.

## The trap this avoids

Skipped URLs must not count as missing coverage. `_build_crawl_outcome_warning` turns any `not_fetched_*` outcome into `crawl_frontier_incomplete` → `failed_partial`, so recording a skipped PDF naively would report every site with one PDF link as failed — the same politeness-is-failure shape fixed earlier today. Excluded URLs never enter the ledger and produce no outcome at all, exactly like `exclude_patterns` does now.

## Honest limitation

Extension matching misses a PDF served on an extensionless URL. Jina calls extension detection unreliable for exactly this reason, and crawl4ai's own `ContentTypeFilter` waves extensionless URLs through automatically. Content-type sniffing is more robust and costs a request per URL; not worth it until we see the case.

## Verification

Written test-first; the initial run failed with the PDF still present in the frontier. 1396 passed, 4 skipped. `ruff check` and `ruff format --check` clean.

The 429-slowdown work is deliberately held back to a separate PR so the next production crawl shows what this change alone does.

## Found while investigating, not fixed here

`FetchReasonCode.NOT_FETCHED_EXCLUDED` exists, is correctly categorised, and is produced nowhere — `exclude_patterns` skips vanish silently too. Fourth instance this week of a path that is configured and never wired.

Upstream: [crawl4ai#2127](https://github.com/unclecode/crawl4ai/issues/2127), open since 2026-08-06. Their guard catches `net::ERR_ABORTED` but not `Page.goto: Download is starting`, which Playwright closed as expected behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)