### PR TITLE
fix(crawler): four bogus URLs should not end a 460-page crawl

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from html import unescape
 from html.parser import HTMLParser
 from typing import Any, Literal
-from urllib.parse import urldefrag, urlparse, urlunparse
+from urllib.parse import unquote, urldefrag, urlparse, urlunparse
 
 import httpx
 import structlog
@@ -256,6 +256,52 @@ def _url_has_non_html_extension(url: str) -> bool:
         return False
     extension = last_segment.rsplit(".", 1)[-1].lower()
     return extension in _NON_HTML_PATH_EXTENSIONS
+
+
+# 2026-08-18 (support.ascendcloud.com incident) — a site's client-side
+# templating framework can end up in the crawled HTML with its interpolation
+# syntax never rendered, e.g. a search-results widget emitting:
+#
+#   .../themes/standard/{{item.SearchResultURL != '' ?+item.SearchResultURL+...}}
+#
+# crawl4ai extracts ``<a href>`` via lxml's raw attribute text (see the
+# vendored crawl4ai 0.9.2 ``normalize_url``/``normalize_url_for_deep_crawl``,
+# both of which explicitly avoid ``quote(unquote())`` so the path is passed
+# through byte-for-byte) — so a URL reaching ``CrawlLedger.add`` is exactly
+# what the site's HTML attribute contained, un-rendered placeholder syntax
+# included. Such a link is never a real page: fetching it 404s with a tiny
+# error body, and crawl4ai's structural anti-bot heuristic then misreads the
+# small page as a block (see ``_classify_fetch_outcome``), which — because
+# BLOCKED_ANTI_BOT stops the rest of the crawl (``_STOP_CHUNKING_REASON_CODES``)
+# — aborted 192 real pages over four bogus template links in production.
+#
+# Checked against both the raw URL and its percent-decoded form: some sites'
+# JS builds the href through something like ``encodeURIComponent`` before
+# writing it into the HTML source, so the placeholder syntax can arrive
+# percent-encoded (``%7B%7B`` for ``{{``) instead of literal. ``unquote`` is
+# safe to call unconditionally — a URL with no percent-escapes round-trips
+# unchanged.
+_TEMPLATE_PLACEHOLDER_PATTERNS = (
+    "{{",  # Handlebars / Angular / Vue interpolation (open)
+    "}}",  # Handlebars / Angular / Vue interpolation (close)
+    "${",  # JavaScript template literal
+    "<%",  # ERB / JSP / ASP (open)
+    "%>",  # ERB / JSP / ASP (close)
+    "{%",  # Jinja / Django / Liquid tag (open)
+    "%}",  # Jinja / Django / Liquid tag (close)
+)
+
+
+def _url_has_unrendered_template_syntax(url: str) -> bool:
+    """True when ``url`` still contains un-rendered client-side template
+    placeholder syntax — see ``_TEMPLATE_PLACEHOLDER_PATTERNS`` above.
+
+    Checked against the URL as-is AND its percent-decoded form, since it is
+    not guaranteed which one a given site's HTML delivers into
+    ``result.links`` — see the module comment above.
+    """
+    decoded = unquote(url)
+    return any(pattern in url or pattern in decoded for pattern in _TEMPLATE_PLACEHOLDER_PATTERNS)
 
 
 class _HTMLTextCounter(HTMLParser):
@@ -713,6 +759,18 @@ def _is_non_content_listing_page(result: CrawlResult) -> bool:
     return _looks_like_link_listing(result)
 
 
+# 2026-08-18 (support.ascendcloud.com incident) — status codes that mean
+# "this page definitely doesn't exist", which is incompatible with "this
+# page was blocked". A 404/410 alongside crawl4ai's "blocked by anti-bot
+# protection" marker below is not a block: it's a real 404 with a tiny body
+# that happened to trip the STRUCTURAL half of that marker (page-shape
+# heuristics like "minimal_text on small page" rather than a concrete
+# challenge observation like "Cloudflare JS challenge"). 401/403 are
+# deliberately excluded here — a real anti-bot wall commonly answers with
+# exactly one of those, so they stay compatible with the anti-bot marker.
+_DEFINITIVE_NONEXISTENT_STATUS_CODES = frozenset({404, 410})
+
+
 def _classify_fetch_outcome(
     page_result: dict[str, Any] | None,
     *,
@@ -796,7 +854,16 @@ def _classify_fetch_outcome(
     # retired above 2026-08-14). Applies to the bulk per-page result shape
     # and the seed/single-page synthesized shape built in
     # _build_outcome_from_result.
-    if "blocked by anti-bot protection" in err_msg:
+    #
+    # 2026-08-18: a definitive "doesn't exist" status code overrides this
+    # heuristic marker rather than being overridden by it — see
+    # _DEFINITIVE_NONEXISTENT_STATUS_CODES above. Falls through to the
+    # ordinary status-code branches below, which classify 404/410 as
+    # HTTP_4XX.
+    if (
+        "blocked by anti-bot protection" in err_msg
+        and status not in _DEFINITIVE_NONEXISTENT_STATUS_CODES
+    ):
         return FetchReasonCode.BLOCKED_ANTI_BOT.value
 
     if status == 429:
@@ -1368,6 +1435,13 @@ class CrawlLedger:
             # in adapters/crawler.py, which both key off any not_fetched_*
             # prefix and would otherwise mark the whole crawl failed_partial
             # over one PDF link.
+            return False
+        if _url_has_unrendered_template_syntax(url):
+            # Same contract as the extension check above — never a
+            # ``not_fetched_*`` reason code. A link that is un-rendered
+            # template syntax was never a real page to begin with; see
+            # ``_url_has_unrendered_template_syntax`` for why this must be
+            # filtered before a network request is ever made.
             return False
         url = _coerce_same_site_url_to_base_host(url, self.base_domain)
         if not force:

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_404_not_antibot.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_404_not_antibot.py
@@ -1,0 +1,128 @@
+"""2026-08-18 support.ascendcloud.com incident — the storing itself.
+
+Four un-rendered-template-syntax links (see
+``tests/test_crawl_frontier_template_urls.py`` for the frontier-level fix)
+each 404'd with a tiny error body. crawl4ai's structural anti-bot heuristic
+misread each one as ``blocked_anti_bot`` (see
+``tests/test_crawl_site_reconcile.py::TestClassifyFetchOutcome`` for the
+classification-level fix), and because BLOCKED_ANTI_BOT is a
+``_STOP_CHUNKING_REASON_CODES`` member, ``_chunked_bulk_fetch`` stopped
+sending further chunks after the FIRST such 404 — 192 real pages were never
+even attempted.
+
+This test proves the actual incident is fixed, not just its two
+contributing symptoms in isolation: four exact-production-shape 404 pages,
+each in its own chunk, none of them may stop the crawl from fetching the
+real pages that come after them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# URL per chunk, so each URL below produces its own distinct HTTP request
+# (matches the pattern in test_chunked_bulk_fetch_rate_limit_stop.py).
+_ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
+
+
+def _structural_404_page(url: str) -> dict[str, Any]:
+    """Exact production shape (support.ascendcloud.com, 2026-08-18): a 404
+    for a URL built from un-rendered template syntax, whose tiny error page
+    trips crawl4ai's STRUCTURAL anti-bot heuristic."""
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 404,
+        "error_message": (
+            "Blocked by anti-bot protection: Structural: minimal_text "
+            "on small page (482 bytes, 42 chars visible)"
+        ),
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_four_structural_404s_do_not_stop_the_remaining_real_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact incident: four bogus template-syntax URLs 404, three real
+    pages come after them in the frontier — all three must still be
+    fetched."""
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        url = payload["urls"][0]
+        calls.append(list(payload["urls"]))
+        if "bogus-template" in url:
+            return {"results": [_structural_404_page(url)]}
+        return {"results": [_ok_page(url)]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [
+        "https://support.ascendcloud.com/bogus-template-1",
+        "https://support.ascendcloud.com/bogus-template-2",
+        "https://support.ascendcloud.com/bogus-template-3",
+        "https://support.ascendcloud.com/bogus-template-4",
+        "https://support.ascendcloud.com/real/page-a",
+        "https://support.ascendcloud.com/real/page-b",
+        "https://support.ascendcloud.com/real/page-c",
+    ]
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    # Every URL was actually attempted — no chunk was skipped.
+    assert calls == [[u] for u in urls]
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
+
+    reason_by_url = {
+        page["url"]: crawl4ai_client._classify_fetch_outcome(page) for page in fetch.raw_results
+    }
+    for i in range(1, 5):
+        assert (
+            reason_by_url[f"https://support.ascendcloud.com/bogus-template-{i}"]
+            == FetchReasonCode.HTTP_4XX.value
+        )
+    for suffix in ("a", "b", "c"):
+        assert (
+            reason_by_url[f"https://support.ascendcloud.com/real/page-{suffix}"]
+            == FetchReasonCode.SUCCESS.value
+        )

--- a/klai-knowledge-ingest/tests/test_crawl_frontier_template_urls.py
+++ b/klai-knowledge-ingest/tests/test_crawl_frontier_template_urls.py
@@ -1,0 +1,174 @@
+"""A website crawl must not chase un-rendered client-side template syntax.
+
+support.ascendcloud.com's search-results widget emits an ``<a href>``
+whose template placeholder never got interpolated (the templating
+framework's JS never ran, or crawl4ai captured the DOM before it mounted):
+
+    https://support.ascendcloud.com/euf/generated/optimized/1782421674/
+    themes/standard/{{item.SearchResultURL != '' ?+item.SearchResultURL+...}}
+
+That is never a real page. Fetching it 404s with a tiny error body, and
+crawl4ai's structural anti-bot heuristic (``_classify_fetch_outcome``)
+misreads the small page as a block, which — because BLOCKED_ANTI_BOT is a
+``_STOP_CHUNKING_REASON_CODES`` member — aborted the rest of that crawl:
+four template-syntax URLs cost 192 real pages that were never even
+attempted (production incident, 2026-08-18).
+
+These URLs are filtered at the frontier (``CrawlLedger.add``), before a
+single network request is made — same mechanism and same contract as
+``_url_has_non_html_extension`` (test_crawl_frontier_document_extensions.py):
+excluded URLs must never produce a ``not_fetched_*`` outcome, or a single
+template-syntax link anywhere on a site would mark an otherwise-perfect
+crawl ``failed_partial`` (``_build_crawl_outcome_warning`` /
+``_crawl_fully_fetched`` in ``knowledge_ingest/adapters/crawler.py`` both
+key off any ``not_fetched_*``-prefixed reason code).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from knowledge_ingest.adapters.crawler import (
+    _build_crawl_outcome_warning,
+    _crawl_fully_fetched,
+    decide_fetch_failure_terminal_status,
+)
+from knowledge_ingest.crawl4ai_client import CrawlLedger
+
+# The exact production URL (2026-08-18, support.ascendcloud.com).
+_PRODUCTION_TEMPLATE_URL = (
+    "https://support.ascendcloud.com/euf/generated/optimized/1782421674/"
+    "themes/standard/{{item.SearchResultURL != '' ?+item.SearchResultURL+...}}"
+)
+
+# The same URL, percent-encoded the way a site's JS could emit it if its
+# templating layer ran the (un-interpolated) placeholder through
+# encodeURIComponent before writing it into the href attribute.
+_PRODUCTION_TEMPLATE_URL_PERCENT_ENCODED = (
+    "https://support.ascendcloud.com/euf/generated/optimized/1782421674/"
+    "themes/standard/%7B%7Bitem.SearchResultURL%20!%3D%20''%20%3F%2Bitem."
+    "SearchResultURL%2B...%7D%7D"
+)
+
+
+def _ledger(**overrides: Any) -> CrawlLedger:
+    defaults: dict[str, Any] = {
+        "start_url": "https://support.ascendcloud.com",
+        "base_domain": "support.ascendcloud.com",
+        "include_patterns": None,
+        "exclude_patterns": None,
+        "max_depth": 3,
+    }
+    defaults.update(overrides)
+    return CrawlLedger(**defaults)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        _PRODUCTION_TEMPLATE_URL,
+        _PRODUCTION_TEMPLATE_URL_PERCENT_ENCODED,
+    ],
+)
+def test_production_template_placeholder_url_is_never_added_to_the_frontier(url: str) -> None:
+    ledger = _ledger()
+    added = ledger.add(
+        url,
+        depth=1,
+        discovered_from="https://support.ascendcloud.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is False, f"expected {url} to be excluded from the frontier"
+    assert ledger.discovered_count == 0
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Handlebars/Angular/Vue
+        "https://example.com/products/{{product.slug}}",
+        # JavaScript template literal
+        "https://example.com/user/${userId}/profile",
+        # ERB / JSP / ASP
+        "https://example.com/page.jsp?id=<%= id %>",
+        # Jinja / Django / Liquid
+        "https://example.com/{% if user %}dashboard{% endif %}",
+        # percent-encoded Handlebars, lowercase hex digits
+        "https://example.com/products/%7b%7bproduct.slug%7d%7d",
+    ],
+)
+def test_generic_template_placeholder_patterns_are_never_added_to_the_frontier(
+    url: str,
+) -> None:
+    ledger = CrawlLedger(
+        start_url="https://example.com",
+        base_domain="example.com",
+        include_patterns=None,
+        exclude_patterns=None,
+        max_depth=3,
+    )
+    added = ledger.add(
+        url,
+        depth=1,
+        discovered_from="https://example.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is False, f"expected {url} to be excluded from the frontier"
+    assert ledger.discovered_count == 0
+
+
+def test_real_url_next_to_a_template_url_is_still_added() -> None:
+    ledger = _ledger()
+    ledger.add(
+        _PRODUCTION_TEMPLATE_URL,
+        depth=1,
+        discovered_from="https://support.ascendcloud.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    added = ledger.add(
+        "https://support.ascendcloud.com/euf/assets/1782421674/Support",
+        depth=1,
+        discovered_from="https://support.ascendcloud.com",
+        source_kind="page_link",
+        priority=50,
+    )
+    assert added is True
+    assert ledger.discovered_count == 1
+
+
+def test_a_crawl_with_only_skipped_template_urls_is_not_failed_partial() -> None:
+    """The valkuil: a URL we deliberately never wanted to crawl is not
+    'incomplete coverage'. Since the excluded URL never produces an
+    outcome at all (see the ledger-level tests above), the existing
+    not_fetched_* / failure-ratio guards downstream must see a perfectly
+    clean, fully-fetched crawl — mirrors
+    test_a_skipped_pdf_does_not_mark_the_crawl_failed_partial in
+    test_crawl_frontier_document_extensions.py."""
+    fetch_outcomes = [
+        {
+            "url": "https://support.ascendcloud.com",
+            "reason_code": "success",
+            "status_code": 200,
+            "content_length": 500,
+        },
+        {
+            "url": "https://support.ascendcloud.com/euf/assets/1782421674/Support",
+            "reason_code": "success",
+            "status_code": 200,
+            "content_length": 500,
+        },
+    ]
+
+    assert _build_crawl_outcome_warning(fetch_outcomes, max_pages=200) is None
+    assert _crawl_fully_fetched(fetch_outcomes) is True
+    status, summary = decide_fetch_failure_terminal_status(
+        fetch_outcomes=fetch_outcomes,
+        threshold=0.30,
+    )
+    assert status == ""
+    assert summary is None

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -326,6 +326,92 @@ class TestClassifyFetchOutcome:
             == FetchReasonCode.BLOCKED_ANTI_BOT.value
         )
 
+    def test_404_with_structural_antibot_marker_classifies_http_4xx(self) -> None:
+        """2026-08-18 support.ascendcloud.com incident: a 404 (the site
+        genuinely doesn't have this page — it was a link built from
+        un-rendered template syntax) whose tiny error body trips crawl4ai's
+        STRUCTURAL anti-bot heuristic ("minimal_text on small page") must
+        classify honestly as HTTP_4XX, not BLOCKED_ANTI_BOT. A definitive
+        "this page doesn't exist" status code contradicts a heuristic guess
+        and must win. Exact production error_message."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 404,
+                    "error_message": (
+                        "Blocked by anti-bot protection: Structural: minimal_text "
+                        "on small page (482 bytes, 42 chars visible)"
+                    ),
+                }
+            )
+            == FetchReasonCode.HTTP_4XX.value
+        )
+
+    def test_410_with_structural_antibot_marker_classifies_http_4xx(self) -> None:
+        """410 Gone is the same "definitely doesn't exist" signal as 404."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 410,
+                    "error_message": (
+                        "Blocked by anti-bot protection: Structural: minimal_text "
+                        "on small page (200 bytes, 10 chars visible)"
+                    ),
+                }
+            )
+            == FetchReasonCode.HTTP_4XX.value
+        )
+
+    def test_403_with_concrete_antibot_marker_still_classifies_blocked_anti_bot(
+        self,
+    ) -> None:
+        """The sibling case that must NOT change: a 403 (a real anti-bot wall
+        commonly answers with 403) alongside a CONCRETE anti-bot observation
+        (a named challenge, not a structural guess) must keep classifying as
+        BLOCKED_ANTI_BOT — 401/403 are compatible with a block, unlike 404."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 403,
+                    "error_message": "Blocked by anti-bot protection: Cloudflare JS challenge",
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    def test_401_with_concrete_antibot_marker_still_classifies_blocked_anti_bot(
+        self,
+    ) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 401,
+                    "error_message": "Blocked by anti-bot protection: Cloudflare JS challenge",
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    def test_429_with_antibot_marker_still_classifies_rate_limited(self) -> None:
+        """Existing behaviour that must survive the 404/410 override: the
+        429 check runs before the anti-bot marker check regardless of
+        status code, so this is unaffected by the fix — kept here as an
+        explicit regression guard next to the new 404/410/403/401 cases."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 429,
+                    "error_message": "Blocked by anti-bot protection: HTTP 429 Too Many Requests",
+                }
+            )
+            == FetchReasonCode.RATE_LIMITED.value
+        )
+
     def test_unknown_falls_through_to_unknown_exception(self) -> None:
         assert (
             _classify_fetch_outcome({"success": False, "status_code": None, "error_message": ""})


### PR DESCRIPTION
The extension filter shipped earlier worked — crawl4ai's log now shows zero navigation failures, zero "Download is starting", zero line-778 errors. That whole class, 213 of 288 failures, is gone.

The next crawl of support.ascendcloud.com still failed. 265 pages fetched, **192 never sent**, and four outcomes that ended it:

```json
{
  "reason_code": "blocked_anti_bot",
  "status_code": 404,
  "error_message": "Blocked by anti-bot protection: Structural: minimal_text on small page (482 bytes, 42 chars visible)",
  "content_length": 482
}
```

on URLs shaped like:

```
.../themes/standard/{{item.SearchResultURL != '' ?+item.SearchResultURL+...}}
```

Two independent bugs that amplify each other.

## We extract unrendered template placeholders as links

The site ships a client-side template in its HTML. We pull the raw `{{item.SearchResultURL ...}}` placeholder out as a link and go fetch it. It is not a URL, so we get a 404 with a 482-byte page.

Filtered in `CrawlLedger.add`, same place and same contract as the extension filter: a rejected URL produces no outcome at all, so it cannot become missing coverage via `not_fetched_*` → `failed_partial`.

Patterns: `{{`/`}}`, `${`, `<%`/`%>`, `{%`/`%}`. Checked against both the raw and the `unquote()`-decoded form — although the investigation found crawl4ai passes `href` through byte-for-byte (its own `normalize_url` avoids `quote(unquote())` with a comment saying it mangles `+` signs), so the encoded case is defensive rather than observed.

## A 404 is a 404, not a block

`_classify_fetch_outcome` checked for the `"blocked by anti-bot protection"` string before looking at the status code, so a heuristic overrode a hard fact.

crawl4ai uses that same prefix for two very different things:

- `"...: Cloudflare JS challenge"` — a concrete observation. That is a block.
- `"...: Structural: minimal_text on small page"` — a guess from page shape. That is an observation of a small page, not of a block.

A definitive 404 or 410 now wins over the heuristic. **401 and 403 deliberately do not** — a real anti-bot wall commonly answers with exactly those, so the anti-bot classification stays correct there. The existing 429 check already sat above the anti-bot marker and is untouched.

The broader question — whether a structural guess should carry the same weight as a concrete detection even with no contradicting status — is left alone. That is a judgement about acceptable false-positive rate across every anti-bot detection, not a small fix, and 404/410 resolves the reported incident on its own.

## Why four URLs cost 192 pages

`BLOCKED_ANTI_BOT` is in `_STOP_CHUNKING_REASON_CODES`, so those four misclassified 404s halted the rest of the crawl. The incident-level test reproduces it exactly — with the fix reverted it logs the real production line:

```
crawl_bulk_stopped_after_rate_limit_signal not_attempted_urls=6 sent_urls=1 triggering_reason_codes=['blocked_anti_bot']
```

Whether four anti-bot signals out of 460 pages *should* stop a crawl at all is a separate proportionality decision, deliberately not touched here.

## Verification

Both fixes written test-first with the RED runs recorded: 8 of 9 frontier tests failed on template URLs entering the ledger, and the classification tests failed with `assert 'blocked_anti_bot' == 'http_4xx'` while the 401/403/429 regression guards were already green and stayed green.

1396 → 1411 passed, 4 skipped. `ruff check` and `ruff format --check` clean. No new reason code and no migration — `HTTP_4XX` already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)