### PR TITLE
fix(crawler): an anti-bot signal we can trust, and a threshold instead of a hair trigger

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -199,6 +199,41 @@ class Settings(BaseSettings):
         default=360.0,
         validation_alias=AliasChoices("KLAI_CRAWL_BULK_BASE_TIMEOUT_SECONDS"),
     )
+    # 2026-08-18 — ``_chunked_bulk_fetch`` used to stop the WHOLE remaining
+    # crawl the moment a single page classified BLOCKED_ANTI_BOT
+    # (`_STOP_CHUNKING_REASON_CODES`). A production audit of 60 crawl jobs
+    # found the false-positive rate this reacted to: 48 jobs had zero
+    # anti-bot signals, 7 stayed under 2%, 5 sat between 2% and 10%, and
+    # ZERO landed between 10% and 100% — the highest observed noise ratio
+    # across all 60 jobs was 5.9%. Three jobs paid for the single-signal
+    # trigger directly: 216, 192, and 17 URLs never even attempted, caused
+    # by only 4, 4, and 5 misclassified signals respectively. A genuine
+    # site-wide block, by contrast, drives this ratio toward 100% (the
+    # target rejects nearly everything), not into the 10-100% gap that has
+    # zero production observations.
+    #
+    # ``crawl_antibot_stop_ratio`` (0.25): chosen inside that empty 10-100%
+    # gap, more than 4x above the worst observed noise (5.9%) so ordinary
+    # misclassification noise never trips it, while still intervening well
+    # before a crawl burns through most of its remaining pages against a
+    # site that is genuinely blocking us.
+    crawl_antibot_stop_ratio: float = Field(
+        default=0.25,
+        validation_alias=AliasChoices("KLAI_CRAWL_ANTIBOT_STOP_RATIO"),
+    )
+    # ``crawl_antibot_stop_min_count`` (3): absolute floor protecting SMALL
+    # crawls, where the ratio alone is too noisy to trust — a 3-page crawl
+    # with one signal is already 33%, comfortably above the 25% ratio
+    # above, yet a single stray signal is exactly the noise this fix
+    # exists to stop reacting to. Requiring at least 3 confirmed signals
+    # before the ratio gate can fire means a crawl under ~12 pages
+    # (3 / 0.25) needs to see MOST of its pages blocked before stopping —
+    # deliberately conservative for small sites, where losing even a
+    # handful of pages to a false stop is proportionally expensive.
+    crawl_antibot_stop_min_count: int = Field(
+        default=3,
+        validation_alias=AliasChoices("KLAI_CRAWL_ANTIBOT_STOP_MIN_COUNT"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -759,16 +759,89 @@ def _is_non_content_listing_page(result: CrawlResult) -> bool:
     return _looks_like_link_listing(result)
 
 
-# 2026-08-18 (support.ascendcloud.com incident) — status codes that mean
-# "this page definitely doesn't exist", which is incompatible with "this
-# page was blocked". A 404/410 alongside crawl4ai's "blocked by anti-bot
-# protection" marker below is not a block: it's a real 404 with a tiny body
-# that happened to trip the STRUCTURAL half of that marker (page-shape
-# heuristics like "minimal_text on small page" rather than a concrete
-# challenge observation like "Cloudflare JS challenge"). 401/403 are
-# deliberately excluded here — a real anti-bot wall commonly answers with
-# exactly one of those, so they stay compatible with the anti-bot marker.
-_DEFINITIVE_NONEXISTENT_STATUS_CODES = frozenset({404, 410})
+# 2026-08-18 (production audit of every historical BLOCKED_ANTI_BOT outcome,
+# 100 rows): 91 of 100 carried a status code that itself contradicts "this
+# was a block" — 51x 200 (server delivered content), 26x 404 (+4 more with
+# the new "Structural: minimal_text" wording — nonexistent page, the exact
+# support.ascendcloud.com incident this subsumes), 10x 307 (redirect, not a
+# block), 5x 500 (server error, not a block). Only 4x 403 — a status a real
+# anti-bot wall commonly answers with — looked genuinely consistent with a
+# block. Root cause: crawl4ai's "Blocked by anti-bot protection: <reason>"
+# prefix (async_webcrawler.py:633) wraps TWO fundamentally different kinds
+# of <reason>, sourced from crawl4ai.antibot_detector (pinned 0.9.2, see
+# deploy/crawl4ai/Dockerfile):
+#
+#   - Tier 1 structural markers (_TIER1_PATTERNS): a concrete, named
+#     vendor/challenge signature (e.g. "Cloudflare JS challenge", "Akamai
+#     block (Reference #)") matched anywhere on the page regardless of
+#     status code or page size. A real observation, not a guess — kept as
+#     BLOCKED_ANTI_BOT even when the status code would otherwise contradict
+#     it (a challenge page is very often served with a plain 200).
+#   - Tier 2/3 heuristics (generic short-page terms, and the
+#     "Structural: minimal_text on small page (...)" / "no <body> tag" /
+#     "Near-empty content ... with HTTP 200" / "HTTP {status} with
+#     near-empty response" fallbacks): page-SHAPE guesses with no vendor
+#     signature at all — exactly the class that misfired on 91 of the 100
+#     production rows above. A guess loses to a status code that itself
+#     proves this wasn't a block.
+#
+# ``_CONCRETE_ANTI_BOT_MARKERS`` below is the exact, pinned-version set of
+# Tier 1 reason strings (crawl4ai.antibot_detector._TIER1_PATTERNS, second
+# element of each tuple) — anything else reaching this prefix is a Tier 2/3
+# guess. 401/403 are deliberately NOT in the "contradicts" set: a real
+# anti-bot wall commonly answers with exactly one of those (the 4 production
+# rows above), so a guess stays trusted there.
+#
+# Supersedes a narrower, 404/410-only "definitively nonexistent" status set
+# from the support.ascendcloud.com incident fix (single-signal precedent):
+# every 2xx/3xx/5xx status code contradicts a structural guess just as much
+# as 404/410 does, and a concrete detection needs to survive a contradicting
+# status code too (a Cloudflare challenge on a 200 is real). One mechanism,
+# not two overlapping ones — see ``_status_contradicts_structural_anti_bot_guess``.
+_CONCRETE_ANTI_BOT_MARKERS = frozenset(
+    {
+        "akamai block (reference #)",
+        "akamai challenge (pardon our interruption)",
+        "cloudflare challenge form",
+        "cloudflare firewall block",
+        "cloudflare js challenge",
+        "perimeterx block",
+        "perimeterx captcha",
+        "datadome captcha",
+        "imperva/incapsula block",
+        "imperva/incapsula incident",
+        "sucuri firewall block",
+        "kasada challenge",
+        "network security block",
+    }
+)
+
+
+def _is_concrete_anti_bot_detection(err_msg: str) -> bool:
+    """True when ``err_msg`` (already lower-cased) names a specific,
+    known anti-bot vendor/challenge signature — as opposed to a generic
+    page-shape guess. See the module comment above ``_classify_fetch_outcome``
+    for the full rationale and the crawl4ai source this is derived from.
+    """
+    return any(marker in err_msg for marker in _CONCRETE_ANTI_BOT_MARKERS)
+
+
+def _status_contradicts_structural_anti_bot_guess(status: Any) -> bool:
+    """True when ``status`` is a status code that is incompatible with a
+    STRUCTURAL anti-bot guess (never with a concrete detection — see
+    ``_is_concrete_anti_bot_detection``). Subsumes the narrower
+    404/410-only "definitively nonexistent" case: 404/410 (nonexistent),
+    every 2xx (content was actually delivered), every 3xx (a redirect, not
+    a block), and every 5xx (a server error, not a block). 401/403 are
+    intentionally excluded — see the module comment above.
+    """
+    if not isinstance(status, int):
+        return False
+    if 200 <= status < 400:
+        return True
+    if status in (404, 410):
+        return True
+    return 500 <= status < 600
 
 
 def _classify_fetch_outcome(
@@ -855,14 +928,18 @@ def _classify_fetch_outcome(
     # and the seed/single-page synthesized shape built in
     # _build_outcome_from_result.
     #
-    # 2026-08-18: a definitive "doesn't exist" status code overrides this
-    # heuristic marker rather than being overridden by it — see
-    # _DEFINITIVE_NONEXISTENT_STATUS_CODES above. Falls through to the
-    # ordinary status-code branches below, which classify 404/410 as
-    # HTTP_4XX.
-    if (
-        "blocked by anti-bot protection" in err_msg
-        and status not in _DEFINITIVE_NONEXISTENT_STATUS_CODES
+    # 2026-08-18: a concrete detection (named vendor/challenge signature)
+    # always wins — see _is_concrete_anti_bot_detection. A structural GUESS
+    # only wins when the status code does not itself contradict a block —
+    # see _status_contradicts_structural_anti_bot_guess and the module
+    # comment above for the production evidence (91 of 100 historical
+    # BLOCKED_ANTI_BOT outcomes carried a contradicting status code).
+    # Falls through to the ordinary status-code branches below on a
+    # contradicted guess, which classify e.g. 404/410 as HTTP_4XX, 200 has
+    # already returned SUCCESS above, and 5xx as HTTP_5XX.
+    if "blocked by anti-bot protection" in err_msg and (
+        _is_concrete_anti_bot_detection(err_msg)
+        or not _status_contradicts_structural_anti_bot_guess(status)
     ):
         return FetchReasonCode.BLOCKED_ANTI_BOT.value
 
@@ -3059,9 +3136,18 @@ async def _bfs_deep_crawl(
 # stop ``_chunked_bulk_fetch`` from sending any further chunk (A1): sending
 # chunk 2..N after chunk 1 already saw this signal is precisely the
 # "ignore the 429, keep hammering" bug this fixes.
-_STOP_CHUNKING_REASON_CODES = frozenset(
-    {FetchReasonCode.RATE_LIMITED.value, FetchReasonCode.BLOCKED_ANTI_BOT.value}
-)
+#
+# 2026-08-18 (antibot-classification-and-threshold): RATE_LIMITED stays an
+# IMMEDIATE stop — a 429 is the target site explicitly telling us to slow
+# down, not a guess. BLOCKED_ANTI_BOT is deliberately NOT in this set any
+# more: it only comes from a per-URL page result (never from the
+# exception path — see ``_classify_fetch_outcome``'s error branch, which
+# never checks the "blocked by anti-bot protection" marker), and a single
+# such signal is exactly the disproportionate trigger this fix removes —
+# see ``crawl_antibot_stop_ratio`` / ``crawl_antibot_stop_min_count``
+# (config.py) for the production evidence and the replacement, crawl-wide
+# ratio+floor gate applied further down in this function.
+_STOP_CHUNKING_REASON_CODES = frozenset({FetchReasonCode.RATE_LIMITED.value})
 
 
 @dataclass
@@ -3094,7 +3180,9 @@ class ChunkedFetchResult:
         not_attempted: URLs belonging to chunks that were never submitted
             at all because an earlier chunk's outcome (page-level
             classification, or the chunk's own transport exception)
-            classified as RATE_LIMITED or BLOCKED_ANTI_BOT and the loop
+            classified as RATE_LIMITED — or the crawl-wide BLOCKED_ANTI_BOT
+            ratio crossed its threshold (see ``crawl_antibot_stop_ratio`` /
+            ``crawl_antibot_stop_min_count``, config.py) — and the loop
             stopped sending further chunks (A1, see ``stopped_early``).
             These made ZERO network calls — kept out of ``failed`` so a
             caller never conflates "the site rejected this URL" with "we
@@ -3144,19 +3232,33 @@ async def _chunked_bulk_fetch(
     server-side ``timeouts.batch_process``. The pacing gap above happens
     BEFORE a chunk's request starts, so it never eats into that timeout.
 
-    A1 (2026-08-18): once a chunk's outcome classifies as RATE_LIMITED or
-    BLOCKED_ANTI_BOT — either a per-URL page result within a successfully
-    transported chunk, or the chunk's own transport exception — every
-    later, not-yet-submitted chunk is skipped entirely instead of being
-    sent anyway. The chunk that produced the signal still fully completes
-    (its own request already went out; we cannot un-send it), only chunks
-    AFTER it are affected. See ``ChunkedFetchResult.not_attempted``.
+    A1 (2026-08-18): once a chunk's outcome classifies as RATE_LIMITED —
+    either a per-URL page result within a successfully transported chunk,
+    or the chunk's own transport exception — every later, not-yet-submitted
+    chunk is skipped entirely instead of being sent anyway. The chunk that
+    produced the signal still fully completes (its own request already
+    went out; we cannot un-send it), only chunks AFTER it are affected.
+    See ``ChunkedFetchResult.not_attempted``.
+
+    2026-08-18 (antibot-classification-and-threshold): BLOCKED_ANTI_BOT is
+    a SEPARATE, ratio-gated trigger, not an immediate stop like
+    RATE_LIMITED. A running tally of anti-bot signals and total attempted
+    URLs is kept across every chunk processed by THIS call (crawl-wide,
+    not per-chunk — a 1-URL chunk that itself classifies BLOCKED_ANTI_BOT
+    is trivially 100% locally, which is meaningless in isolation).
+    Chunking stops only once BOTH ``settings.crawl_antibot_stop_min_count``
+    (absolute floor, protects small crawls from one stray signal) AND
+    ``settings.crawl_antibot_stop_ratio`` (share of attempted URLs so far)
+    are met. See config.py for the production evidence behind both
+    defaults (0.25 / 3).
     """
     result = ChunkedFetchResult()
     if not urls:
         return result
     chunk_size = _burst_size_for(rate_limit)
     previous_chunk_start: float | None = None
+    attempted_count = 0
+    antibot_signal_count = 0
     for chunk_start in range(0, len(urls), chunk_size):
         if rate_limit is not None and previous_chunk_start is not None:
             gap_seconds = chunk_size / rate_limit
@@ -3182,11 +3284,22 @@ async def _chunked_bulk_fetch(
                 data = await _crawl_sync(client, payload)
             chunk_pages = _normalise_results_block(data)
             result.raw_results.extend(chunk_pages)
+            attempted_count += len(chunk_pages)
             for page in chunk_pages:
-                chunk_reason_codes.add(_classify_fetch_outcome(page))
+                page_reason_code = _classify_fetch_outcome(page)
+                chunk_reason_codes.add(page_reason_code)
+                if page_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
+                    antibot_signal_count += 1
         except Exception as exc:
+            # A chunk-level transport exception can never itself classify
+            # BLOCKED_ANTI_BOT (see _classify_fetch_outcome's error branch:
+            # it never checks the "blocked by anti-bot protection" body
+            # marker) — attempted_count still advances by the whole chunk
+            # (a network call WAS made for every URL in it), but the
+            # anti-bot tally is untouched here.
             for chunk_url in chunk_urls:
                 result.failed[chunk_url] = exc
+            attempted_count += len(chunk_urls)
             chunk_reason_codes.add(_classify_fetch_outcome(None, error=exc))
             logger.warning(
                 "crawl_site_bulk_chunk_failed",
@@ -3195,18 +3308,29 @@ async def _chunked_bulk_fetch(
                 error=str(exc),
             )
 
-        if chunk_reason_codes & _STOP_CHUNKING_REASON_CODES:
+        antibot_ratio_exceeded = (
+            antibot_signal_count >= settings.crawl_antibot_stop_min_count
+            and attempted_count > 0
+            and (antibot_signal_count / attempted_count) >= settings.crawl_antibot_stop_ratio
+        )
+        stop_triggered = bool(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES) or (
+            FetchReasonCode.BLOCKED_ANTI_BOT.value in chunk_reason_codes and antibot_ratio_exceeded
+        )
+        if stop_triggered:
             remaining_urls = urls[chunk_start + chunk_size :]
             if remaining_urls:
                 result.stopped_early = True
                 result.not_attempted = remaining_urls
+                triggering_reason_codes = set(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES)
+                if antibot_ratio_exceeded:
+                    triggering_reason_codes.add(FetchReasonCode.BLOCKED_ANTI_BOT.value)
                 logger.warning(
                     "crawl_bulk_stopped_after_rate_limit_signal",
                     sent_urls=chunk_start + len(chunk_urls),
                     not_attempted_urls=len(remaining_urls),
-                    triggering_reason_codes=sorted(
-                        chunk_reason_codes & _STOP_CHUNKING_REASON_CODES
-                    ),
+                    triggering_reason_codes=sorted(triggering_reason_codes),
+                    antibot_signal_count=antibot_signal_count,
+                    antibot_attempted_count=attempted_count,
                 )
             break
 

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_antibot_ratio_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_antibot_ratio_stop.py
@@ -1,0 +1,231 @@
+"""2026-08-18 (antibot-classification-and-threshold) — BLOCKED_ANTI_BOT must
+stop ``_chunked_bulk_fetch`` on a crawl-wide RATIO, not on the first signal.
+
+Production evidence that motivated this fix:
+
+- Every historical ``blocked_anti_bot`` outcome (100 rows) broken down by
+  status code showed 91 were noise (see
+  ``TestClassifyFetchOutcomeStructuralGuessVsStatusCode`` in
+  ``test_crawl_site_reconcile.py`` for the wijziging-1 half of this fix).
+- 60 crawl jobs broken down by anti-bot signal share: 48 had zero signals,
+  7 stayed under 2%, 5 sat between 2% and 10%, and ZERO landed between 10%
+  and 100% — the worst observed noise ratio across all 60 jobs was 5.9%.
+- Three real jobs paid for the old single-signal stop directly: 216, 192,
+  and 17 URLs never even attempted, caused by only 4, 4, and 5 signals
+  respectively.
+
+``RATE_LIMITED`` is deliberately NOT touched by this fix — a 429 is the
+target site explicitly telling us to slow down, a fundamentally different,
+reliable signal from a heuristic anti-bot guess. It still stops
+``_chunked_bulk_fetch`` on the very first observation (see
+``test_chunked_bulk_fetch_rate_limit_stop.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
+from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
+
+# Same derivation as test_chunked_bulk_fetch_rate_limit_stop.py:
+# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# URL per chunk, so N urls produce N distinct HTTP requests we can fail
+# independently and observe the running crawl-wide tally accumulate.
+_ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
+
+_ANTIBOT_MESSAGE = "Blocked by anti-bot protection: Cloudflare JS challenge"
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _antibot_page(url: str) -> dict[str, Any]:
+    # 403 + a concrete Tier-1 vendor signature — classifies BLOCKED_ANTI_BOT
+    # regardless of the wijziging-1 status-code fix, so this test file
+    # exercises the wijziging-2 threshold logic in isolation.
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 403,
+        "error_message": _ANTIBOT_MESSAGE,
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _disable_real_pacing_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same virtual-clock pattern as the rate-limit-stop test module: a
+    multi-chunk fetch with ``rate_limit`` set would otherwise really sleep
+    between chunks."""
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_four_antibot_signals_on_400_plus_pages_does_not_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact storyline from production: four misclassified anti-bot
+    signals scattered across a 460-page crawl (well under the default 25%
+    ratio / 3-signal floor) must NOT abort the remaining pages — this is
+    precisely the failure mode that lost 216/192/17 real pages."""
+    urls = [f"https://example.com/page-{i}" for i in range(460)]
+    antibot_urls = {
+        "https://example.com/page-50",
+        "https://example.com/page-150",
+        "https://example.com/page-250",
+        "https://example.com/page-350",
+    }
+
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        chunk_urls = payload["urls"]
+        calls.append(list(chunk_urls))
+        pages = [_antibot_page(u) if u in antibot_urls else _ok_page(u) for u in chunk_urls]
+        return {"results": pages}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    # rate_limit=None -> fixed _BULK_CHUNK_SIZE (100) chunking, no pacing
+    # sleep is ever invoked (see _chunked_bulk_fetch: the inter-chunk sleep
+    # is gated on `rate_limit is not None`).
+    fetch = await _chunked_bulk_fetch(urls=urls, crawler_config={}, cookies=None)
+
+    # Every URL was actually requested — nothing skipped.
+    assert sum(len(c) for c in calls) == 460
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
+    assert len(fetch.raw_results) == 460
+
+
+@pytest.mark.asyncio
+async def test_majority_blocked_crawl_stops_early(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crawl where the anti-bot ratio genuinely crosses both gates (ratio
+    >= 25% AND count >= 3) must still stop — the fix narrows WHEN we stop,
+    it does not disable stopping. Also demonstrates the ratio is tracked
+    CUMULATIVELY across the whole crawl, not per current (1-URL) chunk:
+    the 7th URL alone is 100% anti-bot for its own chunk, yet the crawl
+    keeps going because the crawl-wide count (2) is still under the floor
+    (3); only the 8th URL's cumulative tally (3 signals / 8 attempted =
+    37.5%) crosses both thresholds."""
+    _disable_real_pacing_sleep(monkeypatch)
+
+    # 5 clean, then 3 anti-bot in a row, then 2 URLs that must never be sent.
+    urls = [f"https://example.com/{i}" for i in range(1, 11)]
+    antibot_urls = {urls[5], urls[6], urls[7]}  # index 6, 7, 8 (1-based /6 /7 /8)
+
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        url = payload["urls"][0]
+        calls.append([url])
+        page = _antibot_page(url) if url in antibot_urls else _ok_page(url)
+        return {"results": [page]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    # Only the first 8 URLs were ever requested (5 clean + 3 anti-bot); the
+    # crawl-wide ratio only crosses the floor+ratio gate after the 8th.
+    assert calls == [[u] for u in urls[:8]]
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted == urls[8:]
+    assert len(fetch.raw_results) == 8
+
+
+@pytest.mark.asyncio
+async def test_small_crawl_below_absolute_floor_does_not_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The task's specified edge case: a 3-page crawl where 1 page signals
+    anti-bot is already 33% — well above the 25% ratio gate — yet must NOT
+    stop, because the absolute floor (default 3) protects small crawls
+    from a single stray signal."""
+    urls = [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        pages = [
+            _antibot_page(u) if u == "https://example.com/b" else _ok_page(u)
+            for u in payload["urls"]
+        ]
+        return {"results": pages}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    # rate_limit=None -> all 3 URLs fit in a single 100-URL chunk, so the
+    # 33% ratio is computed over the whole crawl in one pass.
+    fetch = await _chunked_bulk_fetch(urls=urls, crawler_config={}, cookies=None)
+
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
+    assert len(fetch.raw_results) == 3
+
+
+@pytest.mark.asyncio
+async def test_thresholds_are_read_from_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ratio and floor must be configurable, matching the existing
+    crawl_* settings pattern (config.py) — not hardcoded constants."""
+    monkeypatch.setattr(settings, "crawl_antibot_stop_ratio", 0.5)
+    monkeypatch.setattr(settings, "crawl_antibot_stop_min_count", 1)
+    _disable_real_pacing_sleep(monkeypatch)
+
+    urls = ["https://example.com/1", "https://example.com/2"]
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        url = payload["urls"][0]
+        return {"results": [_antibot_page(url)]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    # With min_count=1 and ratio=0.5, the very first signal (1/1 = 100%)
+    # already crosses both lowered gates.
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted == ["https://example.com/2"]

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
@@ -96,11 +96,31 @@ async def test_per_url_429_in_chunk_one_stops_chunk_two_and_three(
 
 
 @pytest.mark.asyncio
-async def test_blocked_anti_bot_signal_also_stops_further_chunks(
+async def test_single_blocked_anti_bot_signal_no_longer_stops_further_chunks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """BLOCKED_ANTI_BOT is the sibling trigger to RATE_LIMITED — both mean
-    "stop asking this site right now"."""
+    """2026-08-18 (antibot-classification-and-threshold): BLOCKED_ANTI_BOT
+    used to be RATE_LIMITED's sibling immediate-stop trigger — a single
+    signal aborted every remaining chunk. A production audit of 100
+    historical BLOCKED_ANTI_BOT outcomes (91 misclassifications) and 60
+    crawl jobs (three lost 216/192/17 URLs each to only 4-5 false
+    signals) proved that reaction disproportionate. BLOCKED_ANTI_BOT now
+    only stops once a crawl-wide ratio threshold is crossed (see
+    tests/test_chunked_bulk_fetch_antibot_ratio_stop.py) — RATE_LIMITED
+    is unaffected and still stops on the very first signal, since a 429
+    is the target site explicitly telling us to back off, not a guess.
+    One signal on two URLs (50%) stays well under the default
+    ``crawl_antibot_stop_min_count`` floor (3), so chunking continues."""
+    # Chunking no longer stops after chunk 1, so a second chunk's pacing
+    # gap would otherwise really sleep — same virtual-clock pattern as
+    # test_no_stop_when_no_chunk_observes_rate_limit below.
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
     calls: list[list[str]] = []
 
     async def _fake_crawl_sync(
@@ -133,8 +153,9 @@ async def test_blocked_anti_bot_signal_also_stops_further_chunks(
         rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
     )
 
-    assert calls == [["https://example.com/1"]]
-    assert fetch.not_attempted == ["https://example.com/2"]
+    assert calls == [["https://example.com/1"], ["https://example.com/2"]]
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -438,6 +438,115 @@ class TestClassifyFetchOutcome:
         )
 
 
+class TestClassifyFetchOutcomeStructuralGuessVsStatusCode:
+    """2026-08-18 — production audit of 100 historical BLOCKED_ANTI_BOT
+    outcomes: 91 carried a status code that itself contradicts a block
+    (51x 200, 26x 404 [+4 "Structural: minimal_text"], 10x 307, 5x 500).
+    Only 4x 403 looked genuinely consistent. Root cause: crawl4ai's
+    "Blocked by anti-bot protection: <reason>" prefix wraps both a
+    concrete vendor/challenge signature (Tier 1 — trusted regardless of
+    status) and a generic page-shape GUESS (Tier 2/3 — a structural guess
+    that a contradicting status code should override). See the module
+    comment above ``_classify_fetch_outcome`` in crawl4ai_client.py."""
+
+    _STRUCTURAL_GUESS_MESSAGE = (
+        "Blocked by anti-bot protection: Structural: minimal_text on small page "
+        "(940 bytes, 12 chars visible)"
+    )
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            # 2xx — the server delivered content; never a block.
+            (200, FetchReasonCode.UNKNOWN_EXCEPTION.value),
+            # 3xx — a redirect; never a block.
+            (307, FetchReasonCode.UNKNOWN_EXCEPTION.value),
+            # 5xx — a server error; never a block.
+            (500, FetchReasonCode.HTTP_5XX.value),
+            # 404/410 — definitively nonexistent, subsumes the narrower
+            # 404/410-only branch from fix/crawl-template-urls-and-404-classification.
+            (404, FetchReasonCode.HTTP_4XX.value),
+            (410, FetchReasonCode.HTTP_4XX.value),
+        ],
+    )
+    def test_structural_guess_loses_to_a_contradicting_status_code(
+        self, status: int, expected: str
+    ) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": status,
+                    "error_message": self._STRUCTURAL_GUESS_MESSAGE,
+                }
+            )
+            == expected
+        )
+
+    def test_structural_guess_on_403_stays_blocked_anti_bot(self) -> None:
+        """401/403 remain compatible with anti-bot — a real wall commonly
+        answers with exactly one of those (the 4 genuine production rows)."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 403,
+                    "error_message": self._STRUCTURAL_GUESS_MESSAGE,
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    def test_structural_guess_on_401_stays_blocked_anti_bot(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 401,
+                    "error_message": self._STRUCTURAL_GUESS_MESSAGE,
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    @pytest.mark.parametrize("status", [200, 307, 404, 410, 500, 403, None])
+    def test_concrete_cloudflare_challenge_always_stays_blocked_anti_bot(
+        self, status: int | None
+    ) -> None:
+        """A concrete challenge observation is a real detection, not a
+        guess — it must never be overridden by a contradicting status
+        code, unlike the structural guess above. Challenge pages are
+        commonly served with a plain HTTP 200."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": status,
+                    "error_message": "Blocked by anti-bot protection: Cloudflare JS challenge",
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    def test_429_wrapped_in_anti_bot_prefix_stays_rate_limited_not_structural_guess(
+        self,
+    ) -> None:
+        """Regression guard: the pre-existing 429-wrapper check (checked
+        before this fix's status-code logic) must still win — a rate-limit
+        signal is not a structural anti-bot guess and must never fall
+        through to it."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 200,
+                    "error_message": ("Blocked by anti-bot protection: HTTP 429 Too Many Requests"),
+                }
+            )
+            == FetchReasonCode.RATE_LIMITED.value
+        )
+
+
 class TestBuildCandidateSetExcludeStartUrl:
     def test_excludes_start_url_from_output(self) -> None:
         candidates = _build_candidate_set(


### PR DESCRIPTION
Four bogus URLs ended a 460-page crawl and left 192 pages unfetched. The 404 half of that is already fixed; this is the rest, and the measurement behind it changes what the problem actually is.

## 91 of 100 anti-bot signals contradict themselves

Every outcome ever classified `blocked_anti_bot`, by status code:

| status | count |
|---|---|
| **200** | **51** |
| 404 | 30 |
| 307 | 10 |
| 500 | 5 |
| **403** | **4** |

Fifty-one of them returned **HTTP 200** — the server sent us content. Four have a 403, the status that actually indicates a block.

So this was never a proportionality problem first. The signal itself is wrong 96 times out of 100.

## Which messages are observations, and which are guesses

crawl4ai wraps both in the same prefix, so the distinction was invisible. Rather than infer it, the pinned `crawl4ai==0.9.2` wheel was downloaded and `antibot_detector.py` read:

- **Tier 1** — thirteen fixed vendor signatures (Cloudflare JS challenge, Akamai `Reference #`, PerimeterX, DataDome captcha, …), matched regardless of status or page size. That is an observation.
- **Tier 2/3** — generic short-page terms and the `Structural: …` / `no <body> tag` / `Near-empty content … with HTTP 200` fallback, derived from page shape alone. That is a guess.

A status code that contradicts the guess now wins: 2xx, 3xx, 404, 410, 5xx. **401 and 403 deliberately still qualify** — a real wall commonly answers with exactly those, and they are the four genuine cases in the data. A concrete Tier-1 detection stays a block regardless of status, because a challenge page is frequently served with 200. The existing 429 check sits above all of this and is untouched.

This subsumes the narrower `_DEFINITIVE_NONEXISTENT_STATUS_CODES = {404, 410}` from the previous PR, which is removed. One mechanism rather than two overlapping ones — the shape that has damaged this codebase four times this week.

## A handful of signals should not end a crawl

`BLOCKED_ANTI_BOT` sat in `_STOP_CHUNKING_REASON_CODES`, so the first signal stopped everything. Across 60 crawl jobs:

| share of anti-bot outcomes | jobs |
|---|---|
| none | 48 |
| under 2% | 7 |
| 2–10% | 5 |
| **over 10%** | **0** |

Observed noise never exceeds 5.9%. A site genuinely refusing us would sit near 100%. Nothing has ever been observed between 10% and 100%, so the threshold lands in a wide empty gap rather than being guessed: **25%**, with a **minimum of 3** signals so a three-page crawl cannot trip on one. Both are settings.

The share is counted cumulatively across the whole `_chunked_bulk_fetch` call, not per chunk — within a two-URL chunk a percentage is meaningless.

`RATE_LIMITED` stays on a hair trigger, deliberately. A 429 is the site telling us in plain language that we are too fast; that deserves a response from the first occurrence, and the right response is to slow down rather than stop. That work lives on its own branch.

## Verification

Both changes written test-first. Change 1's RED run failed on exactly the five status codes being corrected while the ten already-correct cases stayed green. Change 2's RED run reproduced the incident: one signal, `crawl_bulk_stopped_after_rate_limit_signal … triggering_reason_codes=['blocked_anti_bot']`.

One existing test encoded the old behaviour — one signal on two URLs stopping everything — and was inverted with a comment recording the change and why.

1415 → 1430 passed after rebasing onto the merged 404/410 work; the +15 is exactly that branch's own tests, all verified green against the broader implementation. `ruff check` and `ruff format --check` clean.

## Noted, not fixed

After change 1, a 307 falls through to `UNKNOWN_EXCEPTION` — there is no 3xx branch in `_classify_fetch_outcome`. It is no longer wrongly called a block, but a redirect deserves its own reason code. Out of scope here since it would mean inventing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)