### PR TITLE
fix(crawler): slow down when the site says 429 instead of giving up

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -234,6 +234,23 @@ class Settings(BaseSettings):
         default=3,
         validation_alias=AliasChoices("KLAI_CRAWL_ANTIBOT_STOP_MIN_COUNT"),
     )
+    # 2026-08-18 (Deel B, "a stop-signal should slow you down, not give up") —
+    # a single, explicit pause after ``crawl_site`` observes a RATE_LIMITED
+    # stop signal and lowers its in-job pacing, before the next (slower)
+    # batch goes out. Deliberately NOT the same value as
+    # ``crawl_sequential_recovery_cooldown_seconds`` (75s) — that cooldown
+    # is calibrated to crawl4ai's browser-pool recycle window (a *browser
+    # session* got flagged and needs a fresh one), a different failure class
+    # from a bulk-level 429 telling us to pace down. A plain rate-limit
+    # signal needs a brief breather, not a full session recycle — short
+    # enough that a temporarily-touchy site doesn't burn its whole crawl
+    # budget on pauses, long enough to be a real backoff rather than a
+    # no-op alongside the inter-chunk pacing gap _chunked_bulk_fetch already
+    # inserts from the (now lower) rate_limit itself.
+    crawl_rate_limit_slowdown_cooldown_seconds: float = Field(
+        default=10.0,
+        validation_alias=AliasChoices("KLAI_CRAWL_RATE_LIMIT_SLOWDOWN_COOLDOWN_SECONDS"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -23,6 +23,7 @@ import httpx
 import structlog
 
 from knowledge_ingest.config import settings
+from knowledge_ingest.domain_rate_limit_control import MIN_DOMAIN_RATE_LIMIT
 from knowledge_ingest.reason_codes import FetchReasonCode
 
 logger = structlog.get_logger()
@@ -1935,6 +1936,18 @@ async def crawl_site(
     sequential_recovery_budget = _MAX_SEQUENTIAL_RECOVERY
     sequential_recovery_time_remaining = settings.crawl_sequential_recovery_max_seconds
 
+    # Deel B (2026-08-18) — the in-job rate_limit actually used for the NEXT
+    # ``_chunked_bulk_fetch`` call. Starts at the caller's ``rate_limit`` and
+    # only ever moves DOWN, via ``_lower_rate_limit_for_slowdown``, after an
+    # observed RATE_LIMITED stop signal — never persisted, never raised back
+    # up within this call (the persisted domain-level AIMD controller in
+    # ``domain_rate_limit_control`` owns raising it back up, once, after the
+    # job completes, for the NEXT crawl). ``consecutive_rate_limit_slowdowns``
+    # bounds how many times in a row that can happen before giving up — see
+    # ``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS``.
+    current_rate_limit = rate_limit
+    consecutive_rate_limit_slowdowns = 0
+
     start_result = await _fetch_seed_page(
         start_url=start_url,
         crawler_config=crawler_config,
@@ -1960,7 +1973,7 @@ async def crawl_site(
             urls=batch,
             crawler_config=crawler_config,
             cookies=cookies,
-            rate_limit=rate_limit,
+            rate_limit=current_rate_limit,
         )
         fetched_count += len(batch)
 
@@ -1970,6 +1983,7 @@ async def crawl_site(
         # stop early on its own chunking) — never retried, never counted
         # as a failure.
         not_attempted_urls: list[str] = list(fetch.not_attempted)
+        stop_trigger_reason_code = fetch.stop_trigger_reason_code
 
         # A2: only the subset of `batch` whose OWN chunk failed to
         # transport is worth a stealth retry — everything else already has
@@ -1992,13 +2006,59 @@ async def crawl_site(
                 crawler_config=crawler_config,
                 cookies=cookies,
                 stealth=True,
-                rate_limit=rate_limit,
+                rate_limit=current_rate_limit,
             )
             fetch.raw_results.extend(stealth_fetch.raw_results)
             for retried_url in retry_urls:
                 fetch.failed.pop(retried_url, None)
             fetch.failed.update(stealth_fetch.failed)
             not_attempted_urls.extend(stealth_fetch.not_attempted)
+            if stealth_fetch.stop_trigger_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
+                stop_trigger_reason_code = FetchReasonCode.BLOCKED_ANTI_BOT.value
+            elif stop_trigger_reason_code is None:
+                stop_trigger_reason_code = stealth_fetch.stop_trigger_reason_code
+
+        # Deel B (2026-08-18, "a stop-signal should slow you down, not give
+        # up") — a RATE_LIMITED stop means "you're going too fast", not
+        # "give up on these URLs forever". They are left QUEUED in the
+        # ledger (never finalised as not_fetched below) so a LATER batch in
+        # this same job retries them, at a lowered ``current_rate_limit``,
+        # after a short cooldown. BLOCKED_ANTI_BOT is the opposite: no rate
+        # exists that fixes a block, so it keeps the old stop-and-give-up
+        # behaviour, immediately. A site that keeps rate-limiting through
+        # ``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS`` halvings in a row is
+        # finally given up on too — see that constant's docstring.
+        carried_over_urls: list[str] = []
+        stop_crawl_after_this_batch = False
+        if not_attempted_urls:
+            if stop_trigger_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
+                stop_crawl_after_this_batch = True
+            elif consecutive_rate_limit_slowdowns < _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS:
+                consecutive_rate_limit_slowdowns += 1
+                current_rate_limit = _lower_rate_limit_for_slowdown(current_rate_limit)
+                carried_over_urls = not_attempted_urls
+                not_attempted_urls = []
+                fetched_count -= len(carried_over_urls)
+                logger.warning(
+                    "crawl_rate_limit_slowdown_retry",
+                    carried_over_urls=len(carried_over_urls),
+                    new_rate_limit=current_rate_limit,
+                    slowdown_count=consecutive_rate_limit_slowdowns,
+                )
+                await _slowdown_sleep(settings.crawl_rate_limit_slowdown_cooldown_seconds)
+            else:
+                stop_crawl_after_this_batch = True
+                logger.warning(
+                    "crawl_rate_limit_slowdown_exhausted",
+                    max_slowdowns=_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS,
+                    abandoned_urls=len(not_attempted_urls),
+                )
+        elif consecutive_rate_limit_slowdowns:
+            # A clean batch (no stop signal at all) proves the site
+            # recovered — give a LATER rate-limit hit in this job a fresh
+            # budget instead of counting toward the give-up threshold
+            # forever.
+            consecutive_rate_limit_slowdowns = 0
 
         recovered_results: list[CrawlResult] = []
         recovered_link_source_results: list[CrawlResult] = []
@@ -2074,11 +2134,15 @@ async def crawl_site(
                 fetch.failed.pop(recovered_url, None)
 
         # Everything NOT sent to sequential recovery, not abandoned as
-        # not-attempted (A1), and not still failed (non-recoverable
-        # transport errors, e.g. DNS/connection/4xx-wrapper) has a real
-        # per-URL result sitting in fetch.raw_results.
+        # not-attempted (A1), not carried over for a slower retry (Deel B),
+        # and not still failed (non-recoverable transport errors, e.g.
+        # DNS/connection/4xx-wrapper) has a real per-URL result sitting in
+        # fetch.raw_results.
         excluded_from_combine = (
-            set(fetch.failed) | set(not_attempted_urls) | set(sequential_recovery_urls)
+            set(fetch.failed)
+            | set(not_attempted_urls)
+            | set(sequential_recovery_urls)
+            | set(carried_over_urls)
         )
         ok_urls = [u for u in batch if u not in excluded_from_combine]
         batch_results, batch_outcomes = _combine_bulk_responses(
@@ -2113,7 +2177,7 @@ async def crawl_site(
                 crawler_config=crawler_config,
                 cookies=cookies,
                 base_domain=base_domain,
-                rate_limit=rate_limit,
+                rate_limit=current_rate_limit,
             )
         for outcome in batch_outcomes:
             ledger.mark_outcome(outcome)
@@ -2126,6 +2190,15 @@ async def crawl_site(
             source_depth = ledger.depth_for_url(result.url)
             if source_depth is not None and source_depth < max_depth:
                 ledger.add_links_from_result(result, source_depth=source_depth)
+
+        if stop_crawl_after_this_batch:
+            # BLOCKED_ANTI_BOT, or a RATE_LIMITED signal that survived
+            # _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS halvings — further
+            # batches would either not help (a block) or keep paying a
+            # cooldown for no progress (an unrecoverable rate limit).
+            # Remaining queued URLs get their honest reason via
+            # ledger.mark_unfetched below, same as any other early stop.
+            break
 
     ledger.mark_unfetched(fetched_count=fetched_count, max_pages=max_pages)
     omitted_outcomes = ledger.omitted_outcomes()
@@ -2947,6 +3020,56 @@ _recovery_monotonic = time.monotonic
 _pacing_sleep = asyncio.sleep
 _pacing_monotonic = time.monotonic
 
+# Deel B (2026-08-18, "a stop-signal should slow you down, not give up") —
+# same test-friendly indirection as the two pairs above, dedicated to the
+# explicit pause ``crawl_site`` takes after lowering its in-job rate_limit,
+# before resuming with the next (slower) batch.
+_slowdown_sleep = asyncio.sleep
+
+# How many times, in a row, ``crawl_site`` will halve its rate_limit and
+# retry the URLs a RATE_LIMITED stop skipped before giving up on them.
+# Mirrors the domain-level AIMD controller's philosophy (halving is
+# reversible, giving up permanently is not) but bounded: a site that is
+# STILL rate-limiting us after three halvings (e.g. 2.0 -> 1.0 -> 0.5 ->
+# 0.25 req/s, hitting MIN_DOMAIN_RATE_LIMIT's floor) is not being slow —
+# something else is wrong (an aggressive WAF, not simple throttling), and
+# burning the rest of the crawl-job's time budget on ever-smaller batches
+# would just replace the old "hammer at full speed" bug with a new
+# "hammer at a snail's pace forever" one. Resets to 0 whenever a batch
+# completes with no stop signal at all, so a site that recovers gets a
+# fresh three attempts if it later relapses, rather than accumulating
+# toward the limit across unrelated incidents in the same job.
+_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS = 3
+
+# Seed rate_limit when a RATE_LIMITED signal is observed on a crawl that
+# was started with no explicit rate_limit at all (``rate_limit=None`` —
+# unpaced, full speed). Matches the value the only production caller
+# (``routes/crawl_sync.py``) already passes for every ordinary crawl, so
+# "start pacing because the site just complained" begins from the same
+# baseline a normal crawl would have used anyway, rather than an
+# arbitrary new number.
+_UNPACED_SLOWDOWN_STARTING_RATE_LIMIT = 2.0
+
+
+def _lower_rate_limit_for_slowdown(current_rate_limit: float | None) -> float:
+    """Halve ``current_rate_limit`` after an observed RATE_LIMITED stop.
+
+    Reuses ``domain_rate_limit_control.MIN_DOMAIN_RATE_LIMIT`` as the floor
+    instead of inventing a second, arbitrary one — keeps this ephemeral,
+    in-job backoff consistent with the persisted domain-level halving that
+    already uses that floor. This one is NEVER persisted: it only affects
+    the rest of THIS ``crawl_site`` call, and the domain-level controller
+    (applied once, after the job completes, for the NEXT crawl) is
+    untouched and unaffected — see ``compute_domain_rate_limit_update``.
+    """
+    baseline = (
+        current_rate_limit
+        if current_rate_limit is not None
+        else _UNPACED_SLOWDOWN_STARTING_RATE_LIMIT
+    )
+    return max(MIN_DOMAIN_RATE_LIMIT, baseline / 2)
+
+
 # Server-side BFS deep crawl polling budget. /crawl/job is async — submit,
 # get task_id, poll status. Voys-support full-depth crawl (~500 pages
 # across 3 levels) completes well under 30 minutes; the cap is a safety
@@ -3189,12 +3312,21 @@ class ChunkedFetchResult:
             chose not to ask".
         stopped_early: True when ``not_attempted`` is non-empty for the
             reason described above.
+        stop_trigger_reason_code: which of ``_STOP_CHUNKING_REASON_CODES``
+            actually caused ``stopped_early`` — ``None`` when
+            ``stopped_early`` is False. Lets a caller (``crawl_site``,
+            Deel B) tell "the site asked us to slow down" (RATE_LIMITED)
+            apart from "the site blocked us outright" (BLOCKED_ANTI_BOT):
+            slowing down helps the former and does nothing for the
+            latter. BLOCKED_ANTI_BOT wins when a single chunk somehow
+            observes both (a block is the more severe signal).
     """
 
     raw_results: list[dict[str, Any]] = field(default_factory=list)
     failed: dict[str, BaseException] = field(default_factory=dict)
     not_attempted: list[str] = field(default_factory=list)
     stopped_early: bool = False
+    stop_trigger_reason_code: str | None = None
 
 
 async def _chunked_bulk_fetch(
@@ -3324,6 +3456,19 @@ async def _chunked_bulk_fetch(
                 triggering_reason_codes = set(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES)
                 if antibot_ratio_exceeded:
                     triggering_reason_codes.add(FetchReasonCode.BLOCKED_ANTI_BOT.value)
+                # Deel B (2026-08-18): a single reason code for crawl_site's
+                # slowdown-vs-give-up branch. Derived from
+                # ``triggering_reason_codes`` (the codes that actually
+                # caused this stop) rather than the raw ``chunk_reason_codes``
+                # — a chunk can carry a BLOCKED_ANTI_BOT-classified page that
+                # never crossed ``crawl_antibot_stop_ratio`` while RATE_LIMITED
+                # is what actually triggered ``stop_triggered`` above; using
+                # the unfiltered set would misreport that stop as a block.
+                result.stop_trigger_reason_code = (
+                    FetchReasonCode.BLOCKED_ANTI_BOT.value
+                    if FetchReasonCode.BLOCKED_ANTI_BOT.value in triggering_reason_codes
+                    else FetchReasonCode.RATE_LIMITED.value
+                )
                 logger.warning(
                     "crawl_bulk_stopped_after_rate_limit_signal",
                     sent_urls=chunk_start + len(chunk_urls),

--- a/klai-knowledge-ingest/tests/conftest.py
+++ b/klai-knowledge-ingest/tests/conftest.py
@@ -307,6 +307,27 @@ def _no_real_recovery_cooldown(monkeypatch):
     monkeypatch.setattr(_crawl_mod, "_recovery_sleep", _instant)
 
 
+@pytest.fixture(autouse=True)
+def _no_real_rate_limit_slowdown_cooldown(monkeypatch):
+    """Never sleep the production rate-limit-slowdown cooldown in tests.
+
+    ``crawl4ai_client.crawl_site`` waits
+    ``crawl_rate_limit_slowdown_cooldown_seconds`` (10s in production)
+    after lowering its in-job rate_limit, before resuming with the next
+    (slower) batch — see Deel B ("a stop-signal should slow you down, not
+    give up"). Same rationale as ``_no_real_recovery_cooldown`` above:
+    honouring that for real in the suite would multiply runtime for every
+    test that exercises a RATE_LIMITED stop signal. Tests that assert ON
+    the cooldown patch this themselves with a recorder.
+    """
+    import knowledge_ingest.crawl4ai_client as _crawl_mod
+
+    async def _instant(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_crawl_mod, "_slowdown_sleep", _instant)
+
+
 @pytest.fixture
 def client(mock_pool):
     """Test client with auth middleware.

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
@@ -295,10 +295,16 @@ async def test_not_attempted_urls_never_enter_retry_or_recovery(
         rate_limit: float | None = None,
     ) -> ChunkedFetchResult:
         calls.append({"urls": list(urls), "stealth": stealth})
-        # Chunk 1 rate-limited, chunk 2 never attempted — no `failed` entry.
+        # Chunk 1 blocked, chunk 2 never attempted — no `failed` entry.
+        # BLOCKED_ANTI_BOT (not RATE_LIMITED) so crawl_site stops
+        # immediately rather than retrying at a lower rate (Deel B) — this
+        # test is about the retry/recovery-path exclusion, not the
+        # slowdown-vs-stop decision itself (see
+        # tests/test_crawl_rate_limit_slowdown.py for that).
         return ChunkedFetchResult(
             not_attempted=["https://example.com/2"],
             stopped_early=True,
+            stop_trigger_reason_code=FetchReasonCode.BLOCKED_ANTI_BOT.value,
         )
 
     monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
@@ -242,11 +242,23 @@ async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Regression guard for the interaction with
-    ``domain_rate_limit_control.count_rate_limit_observations``: even
-    though only ONE chunk's URL was actually rate-limited, that single real
-    observation must still appear in ``crawl_site``'s outcomes as
-    RATE_LIMITED — the NOT_FETCHED_RATE_LIMIT_STOP entries for the skipped
-    URLs must not silently replace it."""
+    ``domain_rate_limit_control.count_rate_limit_observations``: a real
+    RATE_LIMITED observation must always survive into ``crawl_site``'s
+    outcomes and be counted as congestion, however many chunks/retries it
+    takes to get there.
+
+    Deel B (2026-08-18, "a stop-signal should slow you down, not give up")
+    changed what happens to the URLs skipped by the stop signal: they are
+    no longer immediately abandoned as NOT_FETCHED_RATE_LIMIT_STOP — they
+    are retried, at a lowered pace, on a later batch. This fake models a
+    site that is consistently (but not permanently-unrecoverably) 429ing:
+    every URL it actually receives gets a real, observed RATE_LIMITED
+    result — so the retry succeeds at OBSERVING every URL, even though
+    every one of those observations is itself congestion. See
+    ``tests/test_crawl_rate_limit_slowdown.py`` for the dedicated give-up
+    (NOT_FETCHED_RATE_LIMIT_STOP after exhausting the retry budget) and
+    BLOCKED_ANTI_BOT (stop immediately, no retry) coverage.
+    """
 
     async def _fake_sitemap(_base: str) -> list[str]:
         return [
@@ -272,7 +284,12 @@ async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
     async def _fake_crawl_sync(
         _client: httpx.AsyncClient, payload: dict[str, Any]
     ) -> dict[str, Any]:
-        return {"results": [_rate_limited_page(payload["urls"][0])]}
+        # Every URL crawl4ai actually receives gets its own real 429 —
+        # unlike the earlier single-URL-only fake, this must hold across
+        # chunk sizes > 1 (Deel B's slowdown floor can raise the burst
+        # size relative to this test's deliberately tiny starting
+        # rate_limit; see MIN_DOMAIN_RATE_LIMIT).
+        return {"results": [_rate_limited_page(u) for u in payload["urls"]]}
 
     monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
 
@@ -284,15 +301,14 @@ async def test_observed_rate_limit_still_triggers_domain_rate_limit_lowering(
 
     by_url = {o["url"]: o["reason_code"] for o in outcomes}
     assert by_url["https://example.com/1"] == FetchReasonCode.RATE_LIMITED.value
-    assert by_url["https://example.com/2"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
-    assert by_url["https://example.com/3"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    assert by_url["https://example.com/2"] == FetchReasonCode.RATE_LIMITED.value
+    assert by_url["https://example.com/3"] == FetchReasonCode.RATE_LIMITED.value
+    assert FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value not in by_url.values()
 
     # The congestion signal counted by domain_rate_limit_control fires on
-    # RATE_LIMITED / BLOCKED_ANTI_BOT — confirm the one real observation is
+    # RATE_LIMITED / BLOCKED_ANTI_BOT — confirm every real observation is
     # present and would still trip it. The seed page (fetched separately,
-    # SUCCESS) is the only clean observation; the two
-    # NOT_FETCHED_RATE_LIMIT_STOP skips must NOT count as additional clean
-    # or congestion signals.
+    # SUCCESS) is the only clean observation.
     from knowledge_ingest.domain_rate_limit_control import count_rate_limit_observations
 
     observation = count_rate_limit_observations(outcomes)

--- a/klai-knowledge-ingest/tests/test_crawl_rate_limit_slowdown.py
+++ b/klai-knowledge-ingest/tests/test_crawl_rate_limit_slowdown.py
@@ -1,0 +1,263 @@
+"""Deel B — a rate-limit signal should slow the crawl down, not give up on it.
+
+Yesterday's fix (A1, ``_chunked_bulk_fetch.stopped_early``) correctly stops
+the CURRENT chunk-batch the moment a chunk observes RATE_LIMITED /
+BLOCKED_ANTI_BOT. It was half the job: ``crawl_site`` never read
+``stopped_early`` at all, so the outer while-loop just started the next
+batch — of DIFFERENT, still-queued URLs — at the exact same (unreduced)
+pace, hammering the site again. Skipped URLs were also finalised as
+``not_fetched_rate_limit_stop`` immediately, permanently giving up on them
+after a single 429.
+
+This locks in the correct behaviour: RATE_LIMITED lowers the in-job
+rate_limit and retries the skipped URLs on a LATER batch (bounded by
+``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS``, after which giving up is
+correct); BLOCKED_ANTI_BOT stops immediately because no rate exists that
+fixes a block.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
+from knowledge_ingest.crawl4ai_client import ChunkedFetchResult, CrawlResult
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+
+def _rate_limited_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 429,
+        "error_message": "Too Many Requests",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _blocked_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": None,
+        "error_message": "Blocked by anti-bot protection: JS challenge",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _patch_seed_with_links(monkeypatch: pytest.MonkeyPatch, links: list[str]) -> None:
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="Seed",
+            raw_markdown="Seed",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+            links={"internal": [{"href": h, "text": ""} for h in links]},
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    async def _no_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+
+
+def _patch_no_real_slowdown_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    recorded: list[float] = []
+
+    async def _instant(seconds: float) -> None:
+        recorded.append(seconds)
+
+    monkeypatch.setattr(crawl4ai_client, "_slowdown_sleep", _instant)
+    return recorded
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_stop_retries_skipped_urls_at_a_lower_rate_on_the_next_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_seed_with_links(
+        monkeypatch,
+        [
+            "https://example.com/a",
+            "https://example.com/b",
+            "https://example.com/c",
+        ],
+    )
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        if len(calls) == 1:
+            return ChunkedFetchResult(
+                raw_results=[_rate_limited_page(urls[0])],
+                not_attempted=urls[1:],
+                stopped_early=True,
+                stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+            )
+        return ChunkedFetchResult(raw_results=[_ok_page(u) for u in urls])
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+        rate_limit=2.0,
+    )
+
+    assert len(calls) == 2, "the skipped URLs must be retried in a later batch, not abandoned"
+    assert calls[0]["urls"] == [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    assert calls[0]["rate_limit"] == 2.0
+    # The second batch is exactly the URLs skipped by the first — never
+    # abandoned, and demonstrably paced slower than the original rate.
+    assert calls[1]["urls"] == ["https://example.com/b", "https://example.com/c"]
+    assert calls[1]["rate_limit"] < calls[0]["rate_limit"]
+    assert calls[1]["rate_limit"] == pytest.approx(1.0)
+
+    # A short, explicit cooldown happened before resuming — not immediate.
+    assert slowdown_sleeps == [settings.crawl_rate_limit_slowdown_cooldown_seconds]
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/a"] == FetchReasonCode.RATE_LIMITED.value
+    # b and c were RETRIED and succeeded — never permanently marked
+    # not-fetched just because the first attempt hit a 429.
+    assert by_url["https://example.com/b"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/c"] == FetchReasonCode.SUCCESS.value
+    assert "https://example.com/b" not in {
+        o["url"]
+        for o in outcomes
+        if o["reason_code"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    }
+    assert {r.url for r in results} >= {
+        "https://example.com/b",
+        "https://example.com/c",
+    }
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_stop_gives_up_after_max_consecutive_slowdowns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site that stays rate-limited through every slowdown attempt must
+    eventually be abandoned — slowing down forever is not a fix either."""
+    urls = [f"https://example.com/{c}" for c in "abcde"]
+    _patch_seed_with_links(monkeypatch, urls)
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        return ChunkedFetchResult(
+            raw_results=[_rate_limited_page(urls[0])],
+            not_attempted=urls[1:],
+            stopped_early=True,
+            stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=20,
+        rate_limit=2.0,
+    )
+
+    # 1 (initial) + _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS retries, then give up.
+    assert len(calls) == crawl4ai_client._MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS + 1
+    rate_limits = [c["rate_limit"] for c in calls]
+    assert rate_limits == sorted(rate_limits, reverse=True), "rate must monotonically decrease"
+    assert rate_limits[0] == 2.0
+    assert rate_limits[-1] < rate_limits[0]
+    # One cooldown sleep per successful slowdown decision — not on the
+    # final give-up (there is no next batch to wait for).
+    assert len(slowdown_sleeps) == crawl4ai_client._MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    # Every URL that was actually the "first in its chunk" got a real,
+    # observed RATE_LIMITED outcome.
+    for i in range(crawl4ai_client._MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS + 1):
+        assert by_url[urls[i]] == FetchReasonCode.RATE_LIMITED.value
+    # The last URL, never even attempted after the budget ran out, is
+    # honestly marked as a scheduling stop, not a fetch failure.
+    assert by_url[urls[-1]] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+
+
+@pytest.mark.asyncio
+async def test_blocked_anti_bot_stops_immediately_without_any_slowdown_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLOCKED_ANTI_BOT is not a pacing problem — no rate_limit reduction
+    is worth trying, so the crawl must stop after the batch that saw it,
+    exactly like before Deel B."""
+    urls = [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    _patch_seed_with_links(monkeypatch, urls)
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        return ChunkedFetchResult(
+            raw_results=[_blocked_page(urls[0])],
+            not_attempted=urls[1:],
+            stopped_early=True,
+            stop_trigger_reason_code=FetchReasonCode.BLOCKED_ANTI_BOT.value,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+        rate_limit=2.0,
+    )
+
+    assert len(calls) == 1, "an anti-bot block must not trigger any slowdown retry"
+    assert calls[0]["rate_limit"] == 2.0
+    assert slowdown_sleeps == []
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/a"] == FetchReasonCode.BLOCKED_ANTI_BOT.value
+    assert by_url["https://example.com/b"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    assert by_url["https://example.com/c"] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value


### PR DESCRIPTION
## Wat dit verandert

Bij een 429 stopt de crawler nu meteen. De AIMD-regelaar verlaagt daarna het tempo voor de *volgende* crawl, maar de lopende crawl is dan al afgebroken — de gebruiker ziet een mislukte sync en moet handmatig opnieuw beginnen.

Deze wijziging laat een crawl bij een 429 zijn tempo halveren (maximaal drie keer, met tien seconden ertussen) en doorgaan. Het verschil is tussen "de site zegt rustiger aan, dus we stoppen" en "de site zegt rustiger aan, dus we doen rustiger aan".

De domeinbrede AIMD-regelaar blijft ongewijzigd en blijft het startpunt voor volgende crawls bijstellen. Dit is de correctie binnen één run.

## Herkomst

Deze tak lag klaar sinds de non-HTML-fix. Dat eerste deel is inmiddels via #1066 al op main geland, dus daar is niets van overgenomen — alleen de 429-lus was nog nieuw. Geverifieerd tegen main voordat de rebase inging.

## Bewijs

- 374 tests groen, 1 overgeslagen, 0 gefaald
- `ruff check` en `ruff format --check` beide schoon
- Gerebased op `9a7a83ed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)