### PR TITLE
fix(frontend): remove deprecated TypeScript baseUrl

### DIFF
--- a/klai-portal/frontend/tsconfig.json
+++ b/klai-portal/frontend/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Removes the obsolete root `baseUrl` setting so the standard TypeScript 6 check no longer fails on TS5101. The existing `paths` mapping remains valid and the app config already owns the runtime alias.\n\nVerified in a fresh Conductor-style worktree:\n- `make setup`\n- `make check`\n- `make lint`\n- `npm run build`\n- Claude TypeScript LSP go-to-definition/find-references\n- Claude Pyright LSP go-to-definition/find-references\n- independent Codex review: no findings