### PR TITLE
fix(citations): numbered prose lines with inline bold must survive citation stripping

### DIFF
--- a/klai-libs/citations/klai_citations/__init__.py
+++ b/klai-libs/citations/klai_citations/__init__.py
@@ -97,6 +97,11 @@ _ACTIVITY_HEADING_RE = re.compile(
 )
 _SOURCE_LIST_LINE_RE = re.compile(r"^\s*(?:\(\s*\d{1,3}\s*\)|\[\s*\d{1,3}\s*\]|\d{1,3}[.)])\s*(.+)$")
 _BULLET_LINE_RE = re.compile(r"^\s*[-*+•]\s+(.+?)\s*$")
+# A numbered line whose content is ENTIRELY one bold/italic-wrapped span
+# ("**Klai Handleiding**", optionally with trailing punctuation) — the shape
+# of a fabricated source-list entry. Inline emphasis inside prose does NOT
+# match; see _looks_like_source_list_line.
+_FULLY_EMPHASISED_LINE_RE = re.compile(r"^(?:\*{1,3}|_{1,3})[^*_]+(?:\*{1,3}|_{1,3})[.,;:!?]?$")
 _DEFAULT_MAX_SOURCES = 4
 _SIMPLE_ANSWER_SOURCE_TOKEN_LIMIT = 20
 _COMPLEX_ANSWER_SOURCE_TOKEN_LIMIT = 30
@@ -470,7 +475,15 @@ def _looks_like_source_list_line(line: str) -> bool:
     rest = match.group(1).strip()
     if _RAW_URL_RE.search(rest):
         return True
-    if "*" in rest or "http" in rest.lower():
+    # A fabricated source-list line is a bare bold-wrapped title
+    # ("1. **Klai Handleiding**"), not any numbered line that happens to
+    # contain inline bold. The previous `"*" in rest` check deleted whole
+    # numbered PROSE sections from bold-heavy model answers (Voys replay,
+    # 2026-08-18: "Vragen voor Voys" and a cause-list vanished wholesale,
+    # leaving dangling headings) — content loss far worse than an occasional
+    # surviving fake source line, which the footer-heading pass upstream
+    # already catches in its usual list shape.
+    if _FULLY_EMPHASISED_LINE_RE.match(rest) or "http" in rest.lower():
         return True
     return bool(re.search(r"\b(?:bron|source|stichting|privacy|policy|docs?)\b", rest, re.IGNORECASE))
 

--- a/klai-libs/citations/tests/test_citations.py
+++ b/klai-libs/citations/tests/test_citations.py
@@ -1521,3 +1521,46 @@ def test_evidence_label_ids_does_not_model_max_chars_truncation() -> None:
 
     # The divergence this test pins: E2 was never shown, yet is strippable.
     assert evidence_label_ids(chunks) == {"E1", "E2"}
+
+
+def test_numbered_prose_lines_with_inline_bold_survive_stripping() -> None:
+    """Regression (Voys replay, 2026-08-18): _looks_like_source_list_line
+    treated ANY numbered line containing '*' as a fabricated source-list
+    line and deleted it wholesale. Models write bold-heavy Dutch answers,
+    so entire numbered sections ("Vragen voor Voys", "Dit kan komen door:")
+    silently vanished from a grounded production answer, leaving dangling
+    headings and colons. A numbered PROSE line with inline bold is content,
+    not a source reference — only a line that is entirely a bold-wrapped
+    title (fabricated source-list shape) or carries a URL/source keyword
+    may be dropped."""
+    from klai_citations import strip_model_citation_artifacts
+
+    answer = (
+        "### Vragen voor Voys\n"
+        "De volgende vragen zijn essentieel:\n"
+        "1. Kunnen jullie in de **VGUA-logs** kijken naar dit Call-ID?\n"
+        "2. Staat er een **fraude- of beveiligingsblokkade** op het account?\n"
+        "3. Is er verschil in behandeling tussen bestemmingen?\n"
+    )
+
+    cleaned = strip_model_citation_artifacts(answer)
+
+    assert "1. Kunnen jullie in de **VGUA-logs** kijken naar dit Call-ID?" in cleaned
+    assert "2. Staat er een **fraude- of beveiligingsblokkade** op het account?" in cleaned
+    # Numbering intact: with lines 1-2 kept, the renumber pass no longer
+    # sees an isolated run starting at 3 and leaves the list untouched.
+    assert "3. Is er verschil in behandeling tussen bestemmingen?" in cleaned
+
+
+def test_fully_bold_numbered_title_line_still_stripped() -> None:
+    """The shape the '*' heuristic was FOR: a fabricated source list whose
+    numbered lines are entirely a bold-wrapped title. Still stripped."""
+    from klai_citations import strip_model_citation_artifacts
+
+    answer = "Zie de documentatie.\n1. **Klai Handleiding**\n2. **Voys Freedom Portal**\n"
+
+    cleaned = strip_model_citation_artifacts(answer)
+
+    assert "Klai Handleiding" not in cleaned
+    assert "Voys Freedom Portal" not in cleaned
+    assert "Zie de documentatie." in cleaned


### PR DESCRIPTION
## What

The live replay of the Voys pasted-emails incident (post #1072) produced a grounded answer with two silently-deleted sections. Reproduced deterministically: `_looks_like_source_list_line` dropped ANY numbered line containing `*` as a "fabricated source list" line. Bold-heavy model answers therefore lose whole numbered prose sections; dash-bulleted lists survive — exactly the observed damage, including the follow-on renumbering glitch.

Fix: the emphasis heuristic now only matches a line that is entirely one bold/italic-wrapped span (`1. **Klai Handleiding**` — the fabricated source-title shape). URL/keyword rules and the footer-heading pass unchanged.

## Testing

- TDD: repro test failed pre-fix (both bold prose lines deleted + numbering mangled), passes post-fix; counter-test pins that fully-bold title lines are still stripped.
- klai-libs/citations: 67 passed; deploy/litellm consumer suite: 637 passed.
- Post-merge: replay the incident conversation again and confirm the sections render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)