### PR TITLE
fix(portal-frontend): a long sync no longer shows as permanently stuck

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -59,9 +59,29 @@ function elapsedMinutes(iso: string | null | undefined): number | null {
 }
 
 export function shouldPollSource(source: Source): boolean {
-  if (mapSourceStatus(source) !== 'pending') return false
-  const minutes = elapsedMinutes(source.last_sync_at ?? source.created_at)
-  return minutes === null || minutes < STUCK_THRESHOLD_MINUTES
+  return mapSourceStatus(source) === 'pending'
+}
+
+/**
+ * Poll interval (ms) for the sources list, or `false` to stop polling.
+ *
+ * Polling must never fully stop while a source is 'pending' — a sync that
+ * outlives STUCK_THRESHOLD_MINUTES is still a real sync that will eventually
+ * complete, and the UI needs to notice. What changes at the threshold is only
+ * the cadence: fresh pending sources are polled quickly (4s) so a normal sync
+ * feels responsive; sources past the "stuck" threshold are polled slowly
+ * (30s) since a poll now is about eventually noticing completion, not
+ * immediacy. Sources without a usable timestamp are treated as fresh, since
+ * we can't tell how long they've been running.
+ */
+export function sourcesPollIntervalMs(sources: Source[]): number | false {
+  const pending = sources.filter((s) => mapSourceStatus(s) === 'pending')
+  if (pending.length === 0) return false
+  const anyFresh = pending.some((s) => {
+    const minutes = elapsedMinutes(s.last_sync_at ?? s.created_at)
+    return minutes === null || minutes < STUCK_THRESHOLD_MINUTES
+  })
+  return anyFresh ? 4000 : 30_000
 }
 
 /**

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-helpers.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/paraglide/messages', () => ({
   kb_status_failed_tooltip: () => 'Verwerking mislukt',
 }))
 
-import { mapSourceStatus, shouldPollSource } from '../-sources-helpers'
+import { mapSourceStatus, shouldPollSource, sourcesPollIntervalMs } from '../-sources-helpers'
 import type { Source } from '../-sources-types'
 
 function uploadSource(overrides: Partial<Source> = {}): Source {
@@ -36,14 +36,19 @@ describe('sources helpers', () => {
     vi.useRealTimers()
   })
 
-  it('keeps stale pending sources visible as pending without endless polling', () => {
+  it('keeps stale pending sources visible as pending and still polls', () => {
+    // Regression: shouldPollSource used to stop polling once a pending
+    // source crossed STUCK_THRESHOLD_MINUTES. The badge kept re-rendering
+    // every 30s off a growing elapsed-time calculation, but the underlying
+    // data never refreshed again — so a sync that actually finished stayed
+    // stuck on "Stuck for Nm" forever. Status alone now drives polling.
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-05T15:10:00Z'))
 
     const source = uploadSource({ created_at: '2026-06-05T14:55:00Z' })
 
     expect(mapSourceStatus(source)).toBe('pending')
-    expect(shouldPollSource(source)).toBe(false)
+    expect(shouldPollSource(source)).toBe(true)
   })
 
   it('polls fresh pending sources', () => {
@@ -75,5 +80,52 @@ describe('sources helpers', () => {
 
   it('maps failed uploads to not_synced', () => {
     expect(mapSourceStatus(uploadSource({ index_status: 'failed' }))).toBe('not_synced')
+  })
+
+  describe('sourcesPollIntervalMs', () => {
+    it('keeps polling after the stuck threshold so a completed long sync is picked up', () => {
+      // Regression: a 66-minute crawl completed in the database at 05:45,
+      // but the sources list had stopped polling at the 10-minute stuck
+      // mark and never fetched the update. The page showed "Stuck for 66m"
+      // forever. Polling must never fully stop while a source is pending —
+      // only the cadence should slow down.
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-05T16:00:00Z'))
+
+      const stuck = uploadSource({ created_at: '2026-06-05T14:54:00Z' })
+
+      expect(sourcesPollIntervalMs([stuck])).toBe(30_000)
+    })
+
+    it('polls quickly when a fresh pending source is present', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-05T15:10:00Z'))
+
+      const fresh = uploadSource({ created_at: '2026-06-05T15:05:30Z' })
+
+      expect(sourcesPollIntervalMs([fresh])).toBe(4000)
+    })
+
+    it('polls quickly when a mix of fresh and stuck pending sources are present', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-06-05T16:00:00Z'))
+
+      const fresh = uploadSource({ id: 'art-fresh', created_at: '2026-06-05T15:58:00Z' })
+      const stuck = uploadSource({ id: 'art-stuck', created_at: '2026-06-05T14:54:00Z' })
+
+      expect(sourcesPollIntervalMs([fresh, stuck])).toBe(4000)
+    })
+
+    it('stops polling when no source is pending', () => {
+      const synced = uploadSource({ index_status: 'synced', chunks_count: 4 })
+
+      expect(sourcesPollIntervalMs([synced])).toBe(false)
+    })
+
+    it('polls quickly for a pending source with no usable timestamp', () => {
+      const unknown = uploadSource({ last_sync_at: null, created_at: null })
+
+      expect(sourcesPollIntervalMs([unknown])).toBe(4000)
+    })
   })
 })

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/sources.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/sources.tsx
@@ -19,7 +19,7 @@ import { apiFetch } from '@/lib/apiFetch'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { DOCS_BASE, getOrgSlug } from '@/lib/kb-editor/tree-utils'
 import * as m from '@/paraglide/messages'
-import { editablePageIdForSource, shouldPollSource } from './-sources-helpers'
+import { editablePageIdForSource, sourcesPollIntervalMs } from './-sources-helpers'
 import { SourcesActionBar } from './-sources-actionbar'
 import { SourceRow } from './-sources-row'
 import { kbQueryKeys } from '@/lib/kb-query-keys'
@@ -37,12 +37,8 @@ function SourcesTab() {
     queryKey: kbQueryKeys.sources(kbSlug),
     queryFn: () => apiFetch<SourcesResponse>(`/api/app/knowledge-bases/${kbSlug}/sources`),
     retry: false,
-    // Poll while any connector is syncing so the badge updates without refresh.
-    refetchInterval: (query) => {
-      const list = query.state.data?.sources ?? []
-      const anyPending = list.some(shouldPollSource)
-      return anyPending ? 4000 : false
-    },
+    // Poll while any source is syncing so the badge updates without refresh.
+    refetchInterval: (query) => sourcesPollIntervalMs(query.state.data?.sources ?? []),
   })
 
   const sources = data?.sources ?? []


### PR DESCRIPTION
## Wat er misging

De bronnenlijst stopte na tien minuten volledig met verversen:

```ts
shouldPollSource(source)   // false zodra pending > 10 minuten
refetchInterval: anyPending ? 4000 : false
```

Daardoor bevroor de status op "bezig", terwijl `StatusBadge` elke 30 seconden opnieuw rendert en het aantal minuten blijft ophogen op verouderde gegevens. Elke sync die langer dan tien minuten duurt toonde dus voor altijd "Stuck for {N}m" — ook als hij allang geslaagd was. De enige manier eruit was een andere actie aanklikken, want die haalt de query opnieuw op.

Waargenomen op productie: een crawl van 54 minuten stond om 05:45 in de database op `completed` met 455 van de 456 pagina's; het scherm toonde om 05:57 nog steeds "Stuck for 66m".

## Wat er nu gebeurt

Twee dingen die door elkaar liepen zijn gescheiden. De drempel van tien minuten bepaalt nog steeds wannéér je waarschuwt — dat was altijd al goed. Maar hij bepaalt niet langer wanneer je stopt met vragen. In plaats van zwijgen gaat de pagina trager door:

- niets in behandeling → niet verversen
- iets vers in behandeling → elke 4 seconden
- alleen nog oude in behandeling → elke 30 seconden

De afronding van een lange sync wordt dus altijd opgepikt.

## Bewijs

- `npx tsc --noEmit` schoon
- `npm run lint` schoon
- 47 tests in 7 bestanden groen, waaronder een regressietest die vastlegt dat een bron die 60 minuten bezig is `30_000` oplevert en niet `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)