### PR TITLE
fix(crawler): stop when the whole conversation with a host is failing

### DIFF
--- a/klai-connector/app/reason_codes.py
+++ b/klai-connector/app/reason_codes.py
@@ -55,6 +55,13 @@ class FetchReasonCode(StrEnum):
     # Mirror of knowledge-ingest's FetchReasonCode; the parity test
     # (tests/test_reason_codes_parity.py) keeps both copies in lockstep.
     BLOCKED_ANTI_BOT = "blocked_anti_bot"
+    # 2026-08-19 mirror (weigering/refusal + host circuit breaker fix,
+    # klai-knowledge-ingest crawl4ai_client.py) — the connector does not
+    # itself produce these values today, but the parity test requires both
+    # copies to carry the same value set regardless of which side
+    # currently emits it.
+    REFUSED = "refused"
+    NOT_FETCHED_CIRCUIT_BREAKER_STOP = "not_fetched_circuit_breaker_stop"
 
 
 class PersistSkipReason(StrEnum):

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -157,6 +157,9 @@ _FETCH_FAILURE_REASON_CODES: frozenset[str] = frozenset(
         FetchReasonCode.RATE_LIMITED.value,
         FetchReasonCode.UNKNOWN_EXCEPTION.value,
         FetchReasonCode.BLOCKED_ANTI_BOT.value,
+        # 2026-08-19: the site explicitly refused automated access — a
+        # real fetch failure, same as an anti-bot block.
+        FetchReasonCode.REFUSED.value,
     }
 )
 _FETCH_NON_FAILURE_REASON_CODES: frozenset[str] = frozenset(
@@ -174,6 +177,9 @@ _FETCH_NON_FAILURE_REASON_CODES: frozenset[str] = frozenset(
         # fetch_failure_dominant the way the real RATE_LIMITED observation
         # correctly does.
         FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+        # 2026-08-19: same rationale — a URL the host circuit breaker
+        # deliberately never sent, not a fetch failure.
+        FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value,
     }
 )
 _uncategorized_fetch_reason_codes = (

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -251,6 +251,54 @@ class Settings(BaseSettings):
         default=10.0,
         validation_alias=AliasChoices("KLAI_CRAWL_RATE_LIMIT_SLOWDOWN_COOLDOWN_SECONDS"),
     )
+    # 2026-08-19 (host circuit breaker, knowledge_ingest.host_circuit_breaker)
+    # — the intermedia.com "20 minutes, zero pages" incident: neither the
+    # RATE_LIMITED immediate-stop nor the BLOCKED_ANTI_BOT ratio gate
+    # (crawl_antibot_stop_ratio/min_count above) reacts to a site that
+    # simply fails every request for an unrelated reason (5xx, timeout,
+    # unknown_exception) — none of those reason codes trip either existing
+    # mechanism. This breaker is a general-purpose, cause-independent
+    # backstop, evaluated once per bulk-fetch chunk (not per URL) so it can
+    # intervene within tens of seconds instead of the crawl's full page
+    # budget. See host_circuit_breaker.evaluate_chunk for the three
+    # triggers these four knobs configure.
+    #
+    # crawl_circuit_breaker_consecutive_failures: N whole-chunk failures in
+    # a row (any single success resets to zero) — 5 mirrors
+    # crawl_sequential_recovery_max_consecutive_failures's philosophy
+    # (give an intermittently-failing site room to recover) while still
+    # capping the damage of a truly dead site to a handful of chunks.
+    crawl_circuit_breaker_consecutive_failures: int = Field(
+        default=5,
+        validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_CONSECUTIVE_FAILURES"),
+    )
+    # crawl_circuit_breaker_min_attempts: the ratio trigger below never
+    # fires before this many URLs have actually been attempted (crawl-wide,
+    # within ONE _chunked_bulk_fetch call) — protects small crawls from a
+    # noisy early ratio the same way crawl_antibot_stop_min_count does.
+    crawl_circuit_breaker_min_attempts: int = Field(
+        default=10,
+        validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_MIN_ATTEMPTS"),
+    )
+    # crawl_circuit_breaker_failure_ratio: once min_attempts is reached,
+    # abort when MORE than this share of all attempted URLs failed. 0.5 —
+    # a site failing a genuine majority of requests is not intermittent
+    # trouble, it is broken or unreachable for the rest of the crawl too.
+    crawl_circuit_breaker_failure_ratio: float = Field(
+        default=0.5,
+        validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_FAILURE_RATIO"),
+    )
+    # crawl_circuit_breaker_refusal_count: N observed REFUSED outcomes
+    # (FetchReasonCode.REFUSED — see reason_codes.py) abort immediately,
+    # never reset by an interleaved success. A refusal is the site telling
+    # us "no", not "not right now" — slowing down does not fix it, so this
+    # trigger is independent of (and does not wait for) the ratio/
+    # consecutive counters above. 3 mirrors crawl_antibot_stop_min_count's
+    # floor against a single stray misclassification.
+    crawl_circuit_breaker_refusal_count: int = Field(
+        default=3,
+        validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_REFUSAL_COUNT"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -24,6 +24,12 @@ import structlog
 
 from knowledge_ingest.config import settings
 from knowledge_ingest.domain_rate_limit_control import MIN_DOMAIN_RATE_LIMIT
+from knowledge_ingest.host_circuit_breaker import (
+    BreakerVerdict,
+    ChunkObservation,
+    HostCircuitBreakerState,
+    evaluate_chunk,
+)
 from knowledge_ingest.reason_codes import FetchReasonCode
 
 logger = structlog.get_logger()
@@ -845,6 +851,102 @@ def _status_contradicts_structural_anti_bot_guess(status: Any) -> bool:
     return 500 <= status < 600
 
 
+# ---------------------------------------------------------------------------
+# 2026-08-19 (intermedia.com / support.ascendcloud.com "weigering" incident)
+#
+# A rate-limit signal was previously derived purely from the HTTP status
+# code (429), which misses crawl4ai wrapping a real 429 inside a DIFFERENT
+# transport status (its bulk endpoint's opaque 500 wrapper) or inside a
+# response header (``Retry-After``) instead of the body. These two helpers
+# judge status + error text + response headers TOGETHER, in one place, so
+# every caller (the raised-exception path and the page-result dict path)
+# sees the same signal regardless of which of the three carries it.
+#
+# ``_is_refused_signal`` is a SEPARATE, narrower concept: the site is not
+# asking us to slow down, it is refusing automated access outright (a
+# Cloudflare/anti-bot challenge or deny page). Deliberately checked ONLY on
+# the page-result (dict) path — see
+# ``test_antibot_marker_500_transport_error_also_classifies_http_5xx`` in
+# test_crawl_site_reconcile.py: crawl4ai's real bulk-request 500 body is
+# opaque (2026-08-14), so body-text markers are not a reliable signal on
+# the raised-exception path and must not be trusted there. It is also
+# deliberately independent of ``_is_concrete_anti_bot_detection`` /
+# the "blocked by anti-bot protection" prefix below: those stay
+# BLOCKED_ANTI_BOT (crawl4ai's OWN detector output, a congestion signal
+# that lowers the domain's stored rate_limit — see
+# domain_rate_limit_control.py). This produces a DIFFERENT reason code
+# (FetchReasonCode.REFUSED) precisely so a refusal does NOT feed that
+# congestion signal — no rate fixes a site that refuses us outright.
+# ---------------------------------------------------------------------------
+
+
+def _find_header(headers: Any, name: str) -> str | None:
+    """Case-insensitive header lookup.
+
+    Accepts ``httpx.Headers`` (from a raised ``HTTPStatusError`` — already
+    case-insensitive natively) or a plain ``dict[str, str]`` (crawl4ai's
+    page-result ``response_headers``, not guaranteed to be lower-cased).
+    """
+    if not headers:
+        return None
+    getter = getattr(headers, "get", None)
+    if not callable(getter):
+        return None
+    value = getter(name)
+    if value is not None or not isinstance(headers, dict):
+        return value
+    lname = name.lower()
+    for key, val in headers.items():
+        if key.lower() == lname:
+            return val
+    return None
+
+
+def _is_rate_limit_signal(*, status: Any, err_msg: str, headers: Any) -> bool:
+    """True when status, error text, or headers indicate rate-limiting —
+    regardless of which of the three actually carries the signal. See the
+    module comment above for why a single status-code check is not enough
+    (crawl4ai's bulk endpoint can wrap a real 429 inside an opaque 500)."""
+    if status == 429:
+        return True
+    if "429" in err_msg or "too many requests" in err_msg:
+        return True
+    return _find_header(headers, "retry-after") is not None
+
+
+# Onderdeel 1 (2026-08-19) — concrete refusal markers, independent of
+# crawl4ai's own "blocked by anti-bot protection" prefix. "challenge" is
+# deliberately broad (a real Cloudflare/DataDome interstitial's title or
+# body commonly contains it) — checked AFTER the existing Tier-1 vendor
+# markers (``_is_concrete_anti_bot_detection``) in ``_classify_fetch_outcome``
+# so an already-covered case (e.g. "Cloudflare JS challenge") keeps
+# classifying BLOCKED_ANTI_BOT, never REFUSED.
+_REFUSAL_TEXT_MARKERS = frozenset(
+    {
+        "just a moment",
+        "attention required",
+        "access denied",
+        "challenge",
+    }
+)
+
+
+def _has_refusal_text_marker(text: str) -> bool:
+    return any(marker in text for marker in _REFUSAL_TEXT_MARKERS)
+
+
+def _is_refused_signal(*, err_msg: str, headers: Any) -> bool:
+    """True when a concrete signal shows the site refuses automated access
+    outright. Status-independent by design: a challenge/deny page can be
+    served with 200, 403, or another status — unlike rate-limiting, no
+    bare status code alone is trusted as a refusal signal (a plain 403
+    with no marker stays AUTH_ERROR, the historically calibrated
+    auth-wall signal — see test_auth_codes_classify_auth_error)."""
+    if _find_header(headers, "cf-mitigated") is not None:
+        return True
+    return _has_refusal_text_marker(err_msg)
+
+
 def _classify_fetch_outcome(
     page_result: dict[str, Any] | None,
     *,
@@ -870,23 +972,26 @@ def _classify_fetch_outcome(
         # ``_is_minimal_content_antibot_error``) for the retired approach.
         if isinstance(error, httpx.HTTPStatusError):
             status_code = error.response.status_code
-            # 2026-08-17 (intermedia.com rate-limit incident): crawl4ai can
-            # wrap a target-site 429 inside its own wrapper status/body —
-            # e.g. "Blocked by anti-bot protection: HTTP 429 Too Many
-            # Requests" — regardless of the wrapper's own transport status
-            # code. Checked before the status-code branches below so a
-            # rate-limit signal is honoured even when the wrapper reports a
-            # different status, and drives the sequential-recovery breaker
-            # (see _recover_bulk_5xx_batch) to stop instead of continuing
-            # to hammer a site that already told us to back off. This is
-            # narrower than the retired generic anti-bot body match above
-            # (which never fired in production) — it only matches the
-            # specific 429 / "too many requests" signal, not any anti-bot
-            # wording.
+            # 2026-08-17 (intermedia.com rate-limit incident), extended
+            # 2026-08-19: crawl4ai can wrap a target-site 429 inside its
+            # own wrapper status/body — e.g. "Blocked by anti-bot
+            # protection: HTTP 429 Too Many Requests" — regardless of the
+            # wrapper's own transport status code, or signal it purely via
+            # a ``Retry-After`` response header. Checked before the
+            # status-code branches below so a rate-limit signal is
+            # honoured no matter which of the three carries it, and drives
+            # the sequential-recovery breaker (see _recover_bulk_5xx_batch)
+            # to stop instead of continuing to hammer a site that already
+            # told us to back off. Deliberately NOT extended to also check
+            # for a refusal marker here (cf-mitigated/challenge/...) — see
+            # the module comment above ``_is_refused_signal``: crawl4ai's
+            # real bulk-request 500 body is opaque, so a body-text marker
+            # on THIS path is not trustworthy the way it is on the
+            # page-result dict path below.
             body = error.response.text.lower()
-            if "429" in body or "too many requests" in body:
-                return FetchReasonCode.RATE_LIMITED.value
-            if status_code == 429:
+            if _is_rate_limit_signal(
+                status=status_code, err_msg=body, headers=error.response.headers
+            ):
                 return FetchReasonCode.RATE_LIMITED.value
             if status_code in (401, 403):
                 return FetchReasonCode.AUTH_ERROR.value
@@ -911,15 +1016,18 @@ def _classify_fetch_outcome(
 
     status = page_result.get("status_code")
     err_msg = (page_result.get("error_message") or "").lower()
+    headers = page_result.get("response_headers")
 
-    # 2026-08-17 (intermedia.com rate-limit incident): crawl4ai wraps a real
-    # 429 inside the SAME "Blocked by anti-bot protection: ..." prefix used
-    # for genuine anti-bot challenges — e.g. "Blocked by anti-bot
-    # protection: HTTP 429 Too Many Requests". Checked BEFORE the generic
-    # anti-bot marker below so a rate-limit signal drives the
-    # sequential-recovery breaker (see _recover_bulk_5xx_batch) instead of
-    # being treated as an ordinary anti-bot block worth retrying.
-    if "429" in err_msg or "too many requests" in err_msg:
+    # 2026-08-17 (intermedia.com rate-limit incident), extended 2026-08-19:
+    # crawl4ai wraps a real 429 inside the SAME "Blocked by anti-bot
+    # protection: ..." prefix used for genuine anti-bot challenges — e.g.
+    # "Blocked by anti-bot protection: HTTP 429 Too Many Requests" — or
+    # signals it purely via status 429 or a ``Retry-After`` header. Checked
+    # BEFORE the generic anti-bot marker below so a rate-limit signal
+    # drives the sequential-recovery breaker (see _recover_bulk_5xx_batch)
+    # instead of being treated as an ordinary anti-bot block worth
+    # retrying.
+    if _is_rate_limit_signal(status=status, err_msg=err_msg, headers=headers):
         return FetchReasonCode.RATE_LIMITED.value
 
     # Checked before the status-code branches: crawl4ai can return HTTP 200
@@ -943,6 +1051,18 @@ def _classify_fetch_outcome(
         or not _status_contradicts_structural_anti_bot_guess(status)
     ):
         return FetchReasonCode.BLOCKED_ANTI_BOT.value
+
+    # Onderdeel 1/3 (2026-08-19, "weigering"): a concrete refusal signal
+    # crawl4ai's own detector did not surface via the prefix above — a
+    # cf-mitigated header, or "Just a moment"/"Attention Required"/"Access
+    # denied"/"challenge" in the body. Checked AFTER the branch above so a
+    # case already covered by a Tier-1 vendor marker (e.g. "Cloudflare JS
+    # challenge") keeps classifying BLOCKED_ANTI_BOT, never REFUSED — see
+    # the module comment above _is_refused_signal for why the two reason
+    # codes are kept separate (only BLOCKED_ANTI_BOT feeds the domain
+    # rate-limit congestion signal).
+    if _is_refused_signal(err_msg=err_msg, headers=headers):
+        return FetchReasonCode.REFUSED.value
 
     if status == 429:
         return FetchReasonCode.RATE_LIMITED.value
@@ -1006,6 +1126,11 @@ _NO_EVIDENCE: dict[str, Any] = {
     "error_type": None,
     "error_message": None,
     "correlation_id": None,
+    # 2026-08-19 (onderdeel 1): a Retry-After header, surfaced onto the
+    # outcome when present — see _is_rate_limit_signal's module comment.
+    # No backoff logic reads this yet; it is deliberately just delivered
+    # here for a future caller to use.
+    "retry_after": None,
 }
 
 
@@ -1064,18 +1189,26 @@ def _raw_error_text(error: BaseException) -> str:
     return str(error)
 
 
-def _evidence_from_exception_text(*, error_type: str | None, raw_text: str) -> dict[str, Any]:
+def _evidence_from_exception_text(
+    *, error_type: str | None, raw_text: str, retry_after: str | None = None
+) -> dict[str, Any]:
     return {
         "error_type": error_type,
         "error_message": _truncate_error_message(raw_text) if raw_text else None,
         "correlation_id": _extract_correlation_id(raw_text) if raw_text else None,
+        "retry_after": retry_after,
     }
 
 
 def _evidence_from_exception(error: BaseException) -> dict[str, Any]:
     """Evidence bundle for a fetch whose Python exception is directly in hand."""
+    retry_after = (
+        _find_header(error.response.headers, "retry-after")
+        if isinstance(error, httpx.HTTPStatusError)
+        else None
+    )
     return _evidence_from_exception_text(
-        error_type=_error_type_name(error), raw_text=_raw_error_text(error)
+        error_type=_error_type_name(error), raw_text=_raw_error_text(error), retry_after=retry_after
     )
 
 
@@ -1091,16 +1224,19 @@ def _evidence_from_page_result(
     if not page_result or page_result.get("success"):
         return dict(_NO_EVIDENCE)
     raw_text = str(page_result.get("error_message") or "")
+    retry_after = _find_header(page_result.get("response_headers"), "retry-after")
     if not raw_text:
         return {
             "error_type": f"crawl4ai:{reason_code}",
             "error_message": None,
             "correlation_id": None,
+            "retry_after": retry_after,
         }
     return {
         "error_type": f"crawl4ai:{reason_code}",
         "error_message": _truncate_error_message(raw_text),
         "correlation_id": _extract_correlation_id(raw_text),
+        "retry_after": retry_after,
     }
 
 
@@ -1118,10 +1254,13 @@ def _evidence_for_crawl_result(result: CrawlResult, *, reason_code: str) -> dict
         return dict(_NO_EVIDENCE)
     if result.raw_error_text is not None:
         return _evidence_from_exception_text(
-            error_type=result.error_type, raw_text=result.raw_error_text
+            error_type=result.error_type,
+            raw_text=result.raw_error_text,
+            retry_after=_find_header(result.response_headers, "retry-after"),
         )
     return _evidence_from_page_result(
-        {"error_message": result.error_message or ""}, reason_code=reason_code
+        {"error_message": result.error_message or "", "response_headers": result.response_headers},
+        reason_code=reason_code,
     )
 
 
@@ -1984,6 +2123,10 @@ async def crawl_site(
         # as a failure.
         not_attempted_urls: list[str] = list(fetch.not_attempted)
         stop_trigger_reason_code = fetch.stop_trigger_reason_code
+        # 2026-08-19: which FetchReasonCode ``crawl_site`` should use for
+        # ``not_attempted_urls`` when it finalises them below — mirrors
+        # ``stop_trigger_reason_code``'s own merge with the stealth retry.
+        not_attempted_reason_code = fetch.not_attempted_reason_code
 
         # A2: only the subset of `batch` whose OWN chunk failed to
         # transport is worth a stealth retry — everything else already has
@@ -2017,6 +2160,8 @@ async def crawl_site(
                 stop_trigger_reason_code = FetchReasonCode.BLOCKED_ANTI_BOT.value
             elif stop_trigger_reason_code is None:
                 stop_trigger_reason_code = stealth_fetch.stop_trigger_reason_code
+            if stealth_fetch.not_attempted:
+                not_attempted_reason_code = stealth_fetch.not_attempted_reason_code
 
         # Deel B (2026-08-18, "a stop-signal should slow you down, not give
         # up") — a RATE_LIMITED stop means "you're going too fast", not
@@ -2162,7 +2307,9 @@ async def crawl_site(
             batch_outcomes.append(_outcome_for_failed_url(failed_url, failed_exc))
         # A1: URLs whose chunk was deliberately never sent.
         for skipped_url in not_attempted_urls:
-            batch_outcomes.append(_outcome_for_not_attempted_url(skipped_url))
+            batch_outcomes.append(
+                _outcome_for_not_attempted_url(skipped_url, reason_code=not_attempted_reason_code)
+            )
 
         batch_results.extend(recovered_results)
         batch_outcomes.extend(recovered_outcomes)
@@ -2795,21 +2942,27 @@ def _outcome_for_failed_url(url: str, error: BaseException) -> FetchOutcome:
     return _with_evidence(outcome, _evidence_from_exception(error), observed=False)
 
 
-def _outcome_for_not_attempted_url(url: str) -> FetchOutcome:
+def _outcome_for_not_attempted_url(
+    url: str,
+    *,
+    reason_code: str = FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+) -> FetchOutcome:
     """Outcome for a URL whose chunk was never even sent (A1).
 
-    An earlier chunk already observed RATE_LIMITED/BLOCKED_ANTI_BOT, so
-    ``_chunked_bulk_fetch`` stopped before this URL's chunk went out.
-    Deliberately NOT ``FetchReasonCode.RATE_LIMITED`` — that value stays
-    reserved for a URL we actually asked and got that answer from, so a
-    "how many times did this domain really reject us" count is not
-    inflated by URLs we chose not to send. ``observed=False``: no network
-    call was ever made for this URL, so there is nothing to report as
-    evidence.
+    An earlier chunk already observed RATE_LIMITED/BLOCKED_ANTI_BOT, or the
+    host circuit breaker tripped (2026-08-19 — see ``ChunkedFetchResult.
+    not_attempted_reason_code``), so ``_chunked_bulk_fetch`` stopped before
+    this URL's chunk went out. ``reason_code`` is deliberately NOT
+    ``FetchReasonCode.RATE_LIMITED`` (the default) or ``REFUSED`` — those
+    values stay reserved for a URL we actually asked and got that answer
+    from, so a "how many times did this domain really reject us" count is
+    not inflated by URLs we chose not to send. ``observed=False``: no
+    network call was ever made for this URL, so there is nothing to
+    report as evidence.
     """
     outcome: FetchOutcome = {
         "url": url,
-        "reason_code": FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+        "reason_code": reason_code,
         "status_code": None,
         "content_length": 0,
     }
@@ -3319,7 +3472,22 @@ class ChunkedFetchResult:
             apart from "the site blocked us outright" (BLOCKED_ANTI_BOT):
             slowing down helps the former and does nothing for the
             latter. BLOCKED_ANTI_BOT wins when a single chunk somehow
-            observes both (a block is the more severe signal).
+            observes both (a block is the more severe signal). Also set
+            to BLOCKED_ANTI_BOT when ``circuit_breaker_triggered`` is True
+            (see below) — both breaker verdicts mean "further attempts
+            will not help", the same give-up semantics as a confirmed
+            block.
+        circuit_breaker_triggered: True when
+            ``knowledge_ingest.host_circuit_breaker`` (onderdeel 2, the
+            general-purpose "everything is failing" backstop — see that
+            module's docstring) is why chunking stopped, as opposed to the
+            RATE_LIMITED/BLOCKED_ANTI_BOT triggers above.
+        not_attempted_reason_code: the FetchReasonCode value ``crawl_site``
+            should use for every URL in ``not_attempted`` — NOT_FETCHED_
+            RATE_LIMIT_STOP by default (existing behaviour, unchanged),
+            or NOT_FETCHED_CIRCUIT_BREAKER_STOP when
+            ``circuit_breaker_triggered`` is True, so "how many times did
+            the breaker actually intervene" has an honest answer.
     """
 
     raw_results: list[dict[str, Any]] = field(default_factory=list)
@@ -3327,6 +3495,8 @@ class ChunkedFetchResult:
     not_attempted: list[str] = field(default_factory=list)
     stopped_early: bool = False
     stop_trigger_reason_code: str | None = None
+    circuit_breaker_triggered: bool = False
+    not_attempted_reason_code: str = FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
 
 
 async def _chunked_bulk_fetch(
@@ -3383,6 +3553,15 @@ async def _chunked_bulk_fetch(
     ``settings.crawl_antibot_stop_ratio`` (share of attempted URLs so far)
     are met. See config.py for the production evidence behind both
     defaults (0.25 / 3).
+
+    2026-08-19 (host circuit breaker, onderdeel 2 — see
+    ``knowledge_ingest.host_circuit_breaker``): a THIRD, independent stop
+    trigger for the case neither RATE_LIMITED nor the BLOCKED_ANTI_BOT
+    ratio gate reacts to — a site that fails every request for an
+    unrelated reason (5xx, timeout, unknown_exception). Evaluated once per
+    chunk (never per URL), same as the anti-bot ratio tally above, so it
+    can intervene within tens of seconds instead of the crawl's full page
+    budget.
     """
     result = ChunkedFetchResult()
     if not urls:
@@ -3391,6 +3570,7 @@ async def _chunked_bulk_fetch(
     previous_chunk_start: float | None = None
     attempted_count = 0
     antibot_signal_count = 0
+    breaker_state = HostCircuitBreakerState()
     for chunk_start in range(0, len(urls), chunk_size):
         if rate_limit is not None and previous_chunk_start is not None:
             gap_seconds = chunk_size / rate_limit
@@ -3409,6 +3589,15 @@ async def _chunked_bulk_fetch(
             payload["browser_config"] = bc
 
         chunk_reason_codes: set[str] = set()
+        # Fed to host_circuit_breaker.evaluate_chunk below — a whole-chunk
+        # transport exception counts every URL it covered (attempted AND
+        # failed), but is still ONE observation for the consecutive-streak
+        # (see that module's docstring); a transported chunk counts each
+        # page's own outcome independently.
+        chunk_attempted = 0
+        chunk_failed = 0
+        chunk_any_success = False
+        chunk_refused = 0
         try:
             async with httpx.AsyncClient(
                 timeout=settings.crawl_bulk_base_timeout_seconds
@@ -3417,21 +3606,30 @@ async def _chunked_bulk_fetch(
             chunk_pages = _normalise_results_block(data)
             result.raw_results.extend(chunk_pages)
             attempted_count += len(chunk_pages)
+            chunk_attempted = len(chunk_pages)
             for page in chunk_pages:
                 page_reason_code = _classify_fetch_outcome(page)
                 chunk_reason_codes.add(page_reason_code)
-                if page_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
-                    antibot_signal_count += 1
+                if page_reason_code == FetchReasonCode.SUCCESS.value:
+                    chunk_any_success = True
+                else:
+                    chunk_failed += 1
+                    if page_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
+                        antibot_signal_count += 1
+                    elif page_reason_code == FetchReasonCode.REFUSED.value:
+                        chunk_refused += 1
         except Exception as exc:
             # A chunk-level transport exception can never itself classify
-            # BLOCKED_ANTI_BOT (see _classify_fetch_outcome's error branch:
-            # it never checks the "blocked by anti-bot protection" body
-            # marker) — attempted_count still advances by the whole chunk
-            # (a network call WAS made for every URL in it), but the
-            # anti-bot tally is untouched here.
+            # BLOCKED_ANTI_BOT or REFUSED (see _classify_fetch_outcome's
+            # error branch, which never checks anti-bot/refusal body
+            # markers on the raised-exception path) — attempted_count
+            # still advances by the whole chunk (a network call WAS made
+            # for every URL in it), but neither tally is touched here.
             for chunk_url in chunk_urls:
                 result.failed[chunk_url] = exc
             attempted_count += len(chunk_urls)
+            chunk_attempted = len(chunk_urls)
+            chunk_failed = len(chunk_urls)
             chunk_reason_codes.add(_classify_fetch_outcome(None, error=exc))
             logger.warning(
                 "crawl_site_bulk_chunk_failed",
@@ -3445,8 +3643,27 @@ async def _chunked_bulk_fetch(
             and attempted_count > 0
             and (antibot_signal_count / attempted_count) >= settings.crawl_antibot_stop_ratio
         )
-        stop_triggered = bool(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES) or (
-            FetchReasonCode.BLOCKED_ANTI_BOT.value in chunk_reason_codes and antibot_ratio_exceeded
+        breaker_state, breaker_verdict = evaluate_chunk(
+            breaker_state,
+            ChunkObservation(
+                attempted=chunk_attempted,
+                failed=chunk_failed,
+                any_success=chunk_any_success,
+                refused=chunk_refused,
+            ),
+            consecutive_failure_threshold=settings.crawl_circuit_breaker_consecutive_failures,
+            min_attempts_for_ratio=settings.crawl_circuit_breaker_min_attempts,
+            failure_ratio_threshold=settings.crawl_circuit_breaker_failure_ratio,
+            refusal_threshold=settings.crawl_circuit_breaker_refusal_count,
+        )
+        breaker_tripped = breaker_verdict != BreakerVerdict.CONTINUE
+        stop_triggered = (
+            bool(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES)
+            or (
+                FetchReasonCode.BLOCKED_ANTI_BOT.value in chunk_reason_codes
+                and antibot_ratio_exceeded
+            )
+            or breaker_tripped
         )
         if stop_triggered:
             remaining_urls = urls[chunk_start + chunk_size :]
@@ -3464,11 +3681,21 @@ async def _chunked_bulk_fetch(
                 # never crossed ``crawl_antibot_stop_ratio`` while RATE_LIMITED
                 # is what actually triggered ``stop_triggered`` above; using
                 # the unfiltered set would misreport that stop as a block.
+                # 2026-08-19: the host circuit breaker's verdict (either
+                # persistent-failure or refusal) gets the SAME give-up
+                # treatment as BLOCKED_ANTI_BOT — neither is fixed by
+                # slowing down.
                 result.stop_trigger_reason_code = (
                     FetchReasonCode.BLOCKED_ANTI_BOT.value
-                    if FetchReasonCode.BLOCKED_ANTI_BOT.value in triggering_reason_codes
+                    if breaker_tripped
+                    or FetchReasonCode.BLOCKED_ANTI_BOT.value in triggering_reason_codes
                     else FetchReasonCode.RATE_LIMITED.value
                 )
+                if breaker_tripped:
+                    result.circuit_breaker_triggered = True
+                    result.not_attempted_reason_code = (
+                        FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
+                    )
                 logger.warning(
                     "crawl_bulk_stopped_after_rate_limit_signal",
                     sent_urls=chunk_start + len(chunk_urls),
@@ -3476,6 +3703,7 @@ async def _chunked_bulk_fetch(
                     triggering_reason_codes=sorted(triggering_reason_codes),
                     antibot_signal_count=antibot_signal_count,
                     antibot_attempted_count=attempted_count,
+                    circuit_breaker_verdict=(breaker_verdict.value if breaker_tripped else None),
                 )
             break
 

--- a/klai-knowledge-ingest/knowledge_ingest/host_circuit_breaker.py
+++ b/klai-knowledge-ingest/knowledge_ingest/host_circuit_breaker.py
@@ -1,0 +1,128 @@
+"""Pure per-host circuit breaker for the crawl bulk-fetch loop.
+
+2026-08-19 (intermedia.com incident #3 — "20 minutes, zero pages"): a
+RATE_LIMITED signal already stops ``_chunked_bulk_fetch`` immediately (see
+``crawl4ai_client._STOP_CHUNKING_REASON_CODES``), and a BLOCKED_ANTI_BOT
+signal stops it once a crawl-wide ratio+floor gate trips
+(``settings.crawl_antibot_stop_ratio`` / ``crawl_antibot_stop_min_count``).
+Neither mechanism reacts to "everything is failing" in general — a site
+that 500s, times out, or DNS-fails on every request keeps getting hammered
+for the crawl's full page budget, because none of those individual reason
+codes is RATE_LIMITED or BLOCKED_ANTI_BOT. That gap is what let the morning
+crawl of intermedia.com burn ~20 minutes and ingest zero pages.
+
+This module is the missing general-purpose breaker: three independent
+triggers, evaluated once per bulk-fetch CHUNK (never per URL — see
+``crawl4ai_client._chunked_bulk_fetch``'s docstring for why per-chunk
+granularity is what lets this intervene within tens of seconds instead of
+minutes):
+
+- Consecutive: N chunk-level failures in a row abort. A chunk counts as
+  exactly ONE observation for this counter regardless of how many URLs it
+  covered (a 20-URL chunk that fails wholesale is one failed *request*,
+  not twenty) — see ``ChunkObservation``. A single success anywhere resets
+  the counter to zero.
+- Ratio: once at least ``min_attempts_for_ratio`` URLs have been attempted
+  (crawl-wide, within ONE ``_chunked_bulk_fetch`` call), abort once MORE
+  than ``failure_ratio_threshold`` of them failed. Unlike the consecutive
+  trigger, this one counts real per-URL attempts/failures, not
+  chunk-as-one-observation.
+- Refusal: ``refusal_threshold`` observed REFUSED outcomes (see
+  ``knowledge_ingest.reason_codes.FetchReasonCode.REFUSED``) abort
+  immediately. The site is explicitly refusing automated access — slowing
+  down does not fix that, unlike real rate-limiting — so this counter is
+  never reset by an interleaved success and is checked independently of
+  the other two.
+
+Pure function, no I/O, no wall clock — every caller-observable value is a
+parameter, matching ``domain_rate_limit_control.compute_domain_rate_limit_
+update``'s shape. State is scoped to ONE ``_chunked_bulk_fetch`` call
+(never persisted across calls) — a fresh ``HostCircuitBreakerState()``
+starts at the top of every call, since crawl4ai_client itself has no
+memory across invocations today.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class BreakerVerdict(StrEnum):
+    """The three outcomes ``evaluate_chunk`` can return."""
+
+    CONTINUE = "continue"
+    ABORT_PERSISTENT_FAILURE = "abort_persistent_failure"
+    ABORT_REFUSAL = "abort_refusal"
+
+
+@dataclass(frozen=True)
+class HostCircuitBreakerState:
+    """Counters accumulated across chunk boundaries within one
+    ``_chunked_bulk_fetch`` call."""
+
+    consecutive_failures: int = 0
+    attempted: int = 0
+    failed: int = 0
+    refused: int = 0
+
+
+@dataclass(frozen=True)
+class ChunkObservation:
+    """What ONE chunk contributed, reduced to the four facts the breaker
+    needs.
+
+    ``attempted``/``failed`` are real per-URL counts — a whole-chunk
+    transport failure counts every URL it covered (the request really was
+    made, and every one of those URLs really did fail), matching how
+    ``crawl4ai_client._chunked_bulk_fetch`` already accounts chunk-level
+    transport exceptions against ``failed``/``not_attempted``.
+
+    ``any_success`` and ``refused`` drive the consecutive-streak and
+    refusal-count respectively — see the module docstring for why a
+    wholly-failed chunk is still only ONE observation for the streak
+    regardless of ``attempted``.
+    """
+
+    attempted: int
+    failed: int
+    any_success: bool
+    refused: int
+
+
+def evaluate_chunk(
+    state: HostCircuitBreakerState,
+    observation: ChunkObservation,
+    *,
+    consecutive_failure_threshold: int,
+    min_attempts_for_ratio: int,
+    failure_ratio_threshold: float,
+    refusal_threshold: int,
+) -> tuple[HostCircuitBreakerState, BreakerVerdict]:
+    """Fold ``observation`` into ``state`` and decide continue vs. abort.
+
+    Refusal is checked first — it is never undone by a success in the same
+    or an earlier chunk, unlike the consecutive-failure streak. Either the
+    consecutive-failure trigger or the ratio trigger is independently
+    sufficient to abort once refusal does not already apply.
+    """
+    new_state = HostCircuitBreakerState(
+        consecutive_failures=(0 if observation.any_success else state.consecutive_failures + 1),
+        attempted=state.attempted + observation.attempted,
+        failed=state.failed + observation.failed,
+        refused=state.refused + observation.refused,
+    )
+
+    if new_state.refused >= refusal_threshold:
+        return new_state, BreakerVerdict.ABORT_REFUSAL
+
+    if new_state.consecutive_failures >= consecutive_failure_threshold:
+        return new_state, BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+    if (
+        new_state.attempted >= min_attempts_for_ratio
+        and new_state.failed / new_state.attempted > failure_ratio_threshold
+    ):
+        return new_state, BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+    return new_state, BreakerVerdict.CONTINUE

--- a/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
+++ b/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
@@ -71,6 +71,25 @@ class FetchReasonCode(StrEnum):
     # "Shape guard only"); validation of individual reason codes is
     # application-side only.
     BLOCKED_ANTI_BOT = "blocked_anti_bot"
+    # 2026-08-19 (intermedia.com / support.ascendcloud.com "weigering"
+    # incident): the site explicitly refuses automated access — a 403 (or
+    # any status) carrying a concrete refusal marker crawl4ai's own
+    # "blocked by anti-bot protection" detector does not surface (a
+    # ``cf-mitigated`` header, or "Just a moment"/"Attention
+    # Required"/"Access denied"/"challenge" in the body). Deliberately
+    # separate from BLOCKED_ANTI_BOT (crawl4ai's OWN detector output):
+    # BLOCKED_ANTI_BOT stays a congestion signal that lowers the domain's
+    # stored rate_limit (knowledge_ingest.domain_rate_limit_control), but a
+    # refusal is not fixed by going slower, so REFUSED is deliberately NOT
+    # in that congestion set — see the module comment there.
+    REFUSED = "refused"
+    # 2026-08-19 (host circuit breaker, knowledge_ingest.host_circuit_
+    # breaker): a URL abandoned because the breaker tripped (persistent
+    # failure or repeated refusal) partway through a
+    # ``_chunked_bulk_fetch`` call — distinct from
+    # NOT_FETCHED_RATE_LIMIT_STOP so "how many times did the breaker
+    # actually intervene" has an honest, uninflated answer.
+    NOT_FETCHED_CIRCUIT_BREAKER_STOP = "not_fetched_circuit_breaker_stop"
 
 
 class PersistSkipReason(StrEnum):

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
@@ -1,0 +1,318 @@
+"""Onderdeel 2 (2026-08-19, intermedia.com incident #3 — "20 minutes, zero
+pages") — the host circuit breaker (knowledge_ingest.host_circuit_breaker)
+wired into ``_chunked_bulk_fetch``.
+
+Neither the pre-existing RATE_LIMITED immediate-stop nor the BLOCKED_ANTI_BOT
+ratio gate reacts to a site that fails every request for an UNRELATED reason
+(plain 5xx, no anti-bot marker) — none of those reason codes trip either
+mechanism. These tests lock in the new backstop for exactly that gap, and
+the refusal trigger for the "site explicitly refuses us" case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# URL per chunk, so N urls produce N distinct HTTP requests we can fail
+# independently and observe the breaker's running tally accumulate.
+_ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _server_error_page(url: str) -> dict[str, Any]:
+    """A plain 5xx with no rate-limit or anti-bot marker at all — the class
+    of failure neither existing stop mechanism reacts to."""
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 503,
+        "error_message": "Service Unavailable",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _refused_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 403,
+        "error_message": "Access Denied",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _morning_incident_500_error_page(url: str) -> dict[str, Any]:
+    """The literal shape from this morning's crawl4ai container log,
+    delivered as a page-level result (success=False, HTTP 200 transport)
+    rather than a raised exception — classifies RATE_LIMITED via the
+    existing (pre-breaker) immediate stop."""
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 500,
+        "error_message": (
+            "Crawl request failed: Blocked by anti-bot protection: HTTP 429 Too Many Requests"
+        ),
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _disable_real_pacing_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_five_consecutive_plain_5xx_chunks_stop_the_crawl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither RATE_LIMITED nor BLOCKED_ANTI_BOT ever appears here — a
+    plain 503 with no marker classifies HTTP_5XX, which trips neither
+    existing mechanism. Ten URLs, every one 503s: the breaker must stop
+    sending after the 5th consecutive failure, leaving 5 URLs never
+    attempted."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_server_error_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(10)]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert len(calls) == 5
+    assert fetch.stopped_early is True
+    assert fetch.circuit_breaker_triggered is True
+    assert fetch.not_attempted == urls[5:]
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
+    # Give-up semantics, same as a confirmed block — crawl_site must not
+    # retry these at a slower pace (see the crawl_site-level test below).
+    assert fetch.stop_trigger_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value
+
+
+@pytest.mark.asyncio
+async def test_a_success_between_5xx_failures_prevents_the_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """4 failures, 1 success, 4 more failures — the consecutive-failure
+    streak never reaches 5, so every chunk still ships."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+
+    def _page_for(url: str, index: int) -> dict[str, Any]:
+        return _ok_page(url) if index == 4 else _server_error_page(url)
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        index = len(calls)
+        calls.append(list(payload["urls"]))
+        return {"results": [_page_for(payload["urls"][0], index)]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(9)]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert len(calls) == 9
+    assert fetch.stopped_early is False
+    assert fetch.circuit_breaker_triggered is False
+    assert fetch.not_attempted == []
+
+
+@pytest.mark.asyncio
+async def test_majority_failure_ratio_stops_the_crawl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Alternating fail/success so the consecutive-streak keeps resetting
+    (never reaches 5), but the crawl-wide ratio crosses 50% once at least
+    10 URLs have been attempted — this isolates the ratio trigger from the
+    consecutive-failure trigger."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+    # 11 urls: F,S,F,S,F,S,F,S,F,S,F — after url #11 (the 11th attempt),
+    # 6 of 11 have failed (0.545 > 0.5) with attempted=11 >= 10.
+    pattern = [_server_error_page if i % 2 == 0 else _ok_page for i in range(11)]
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        index = len(calls)
+        calls.append(list(payload["urls"]))
+        return {"results": [pattern[index](payload["urls"][0])]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(15)]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert len(calls) == 11
+    assert fetch.stopped_early is True
+    assert fetch.circuit_breaker_triggered is True
+    assert fetch.not_attempted == urls[11:]
+
+
+@pytest.mark.asyncio
+async def test_three_refusals_stop_the_crawl_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three REFUSED observations abort even with a success interleaved —
+    the refusal counter is never reset, unlike the consecutive streak."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+    pattern = [_refused_page, _ok_page, _refused_page, _ok_page, _refused_page]
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        index = len(calls)
+        calls.append(list(payload["urls"]))
+        return {"results": [pattern[index](payload["urls"][0])]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(10)]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert len(calls) == 5
+    assert fetch.stopped_early is True
+    assert fetch.circuit_breaker_triggered is True
+    assert fetch.not_attempted == urls[5:]
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
+
+    # The three real REFUSED observations survive in raw_results, distinct
+    # from the abandoned URLs — "how many times did this domain actually
+    # refuse us" is not inflated by URLs never sent.
+    refused_urls = [
+        p["url"]
+        for p in fetch.raw_results
+        if crawl4ai_client._classify_fetch_outcome(p) == FetchReasonCode.REFUSED.value
+    ]
+    assert len(refused_urls) == 3
+
+
+@pytest.mark.asyncio
+async def test_morning_incident_simulation_stops_within_a_handful_of_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every block fails with the exact 500-shape from this morning's
+    crawl4ai container log — the crawl must break off within the first
+    handful of blocks, never hammer through all of them."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_morning_incident_500_error_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://www.intermedia.com/{i}" for i in range(50)]
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    assert len(calls) <= 5, f"expected a handful of blocks, got {len(calls)}"
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_stop_gives_up_immediately_in_crawl_site(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """crawl_site must NOT retry breaker-abandoned URLs at a slower pace
+    (Deel B's RATE_LIMITED-only retry path) — it must give up on them the
+    same way it already does for a confirmed BLOCKED_ANTI_BOT."""
+    _disable_real_pacing_sleep(monkeypatch)
+
+    async def _fake_sitemap(_base: str) -> list[str]:
+        return [f"https://example.com/{i}" for i in range(10)]
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _fake_sitemap)
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> crawl4ai_client.CrawlResult:
+        return crawl4ai_client.CrawlResult(
+            url=start_url,
+            fit_markdown="seed",
+            raw_markdown="seed",
+            html="<html></html>",
+            word_count=1,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_server_error_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=20,
+        rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
+    )
+
+    # 5 real 503 observations, then the breaker trips — the remaining
+    # sitemap URLs are abandoned as NOT_FETCHED_CIRCUIT_BREAKER_STOP, not
+    # silently retried forever (no "crawl_rate_limit_slowdown_retry" loop).
+    by_reason: dict[str, int] = {}
+    for outcome in outcomes:
+        by_reason[outcome["reason_code"]] = by_reason.get(outcome["reason_code"], 0) + 1
+
+    assert by_reason.get(FetchReasonCode.HTTP_5XX.value, 0) == 5
+    assert by_reason.get(FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value, 0) == 5
+    # Only the 5 real 503 attempts were ever sent to the failing batch —
+    # crawl_site did not retry the abandoned tail at a slower pace.
+    assert sum(len(c) for c in calls) == 5

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -438,6 +438,136 @@ class TestClassifyFetchOutcome:
         )
 
 
+class TestClassifyFetchOutcomeRateLimitAndRefusal:
+    """2026-08-19 (intermedia.com incident #3 / support.ascendcloud.com) —
+    onderdeel 1: one place judges the WHOLE response (status + error text
+    + headers) for rate-limiting and refusal signals, regardless of which
+    of the three actually carries the signal."""
+
+    def test_opaque_500_wrapping_429_text_classifies_rate_limited(self) -> None:
+        """The exact regression from this morning's crawl4ai container log:
+
+            server - ERROR - server error 500 [cid=635f89a6]: Crawl request
+            failed: Blocked by anti-bot protection: HTTP 429 Too Many Requests
+
+        A bulk chunk transport failure whose response carries status 500
+        and this exact body text must still classify RATE_LIMITED, not
+        HTTP_5XX — this is the signal that should trip the sequential-
+        recovery breaker and the host circuit breaker's refusal-vs-
+        congestion distinction, not just get counted as an ordinary
+        server error."""
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(
+            500,
+            text="Crawl request failed: Blocked by anti-bot protection: HTTP 429 Too Many Requests",
+            request=request,
+        )
+        exc = httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.RATE_LIMITED.value
+
+    def test_retry_after_header_alone_classifies_rate_limited(self) -> None:
+        """A Retry-After header is a rate-limit signal even with no 429
+        text anywhere and a non-429 status."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 503,
+                    "error_message": "Service Unavailable",
+                    "response_headers": {"Retry-After": "30"},
+                }
+            )
+            == FetchReasonCode.RATE_LIMITED.value
+        )
+
+    def test_403_with_cf_mitigated_header_classifies_refused_not_rate_limited(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 403,
+                    "error_message": "Forbidden",
+                    "response_headers": {"cf-mitigated": "challenge"},
+                }
+            )
+            == FetchReasonCode.REFUSED.value
+        )
+
+    def test_just_a_moment_body_text_classifies_refused(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 200,
+                    "error_message": "Just a moment...",
+                }
+            )
+            == FetchReasonCode.REFUSED.value
+        )
+
+    def test_attention_required_body_text_classifies_refused(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 403,
+                    "error_message": "Attention Required! | Cloudflare",
+                }
+            )
+            == FetchReasonCode.REFUSED.value
+        )
+
+    def test_access_denied_body_text_classifies_refused(self) -> None:
+        assert (
+            _classify_fetch_outcome(
+                {"success": False, "status_code": 403, "error_message": "Access Denied"}
+            )
+            == FetchReasonCode.REFUSED.value
+        )
+
+    def test_bare_403_with_no_marker_still_classifies_auth_error(self) -> None:
+        """Existing, deliberately calibrated behaviour that must NOT change:
+        a plain 403 with no concrete refusal marker stays AUTH_ERROR (a
+        real auth wall commonly answers with a bare 403 too) — see
+        test_auth_codes_classify_auth_error above."""
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": 403})
+            == FetchReasonCode.AUTH_ERROR.value
+        )
+
+    def test_404_with_no_marker_stays_http_4xx(self) -> None:
+        assert (
+            _classify_fetch_outcome({"success": False, "status_code": 404})
+            == FetchReasonCode.HTTP_4XX.value
+        )
+
+    def test_concrete_antibot_marker_still_wins_over_new_refused_code(self) -> None:
+        """A Tier-1 vendor marker (e.g. "Cloudflare JS challenge", which
+        contains the substring "challenge") must keep classifying
+        BLOCKED_ANTI_BOT, never the new REFUSED code — the existing
+        concrete-detection branch is checked first."""
+        assert (
+            _classify_fetch_outcome(
+                {
+                    "success": False,
+                    "status_code": 403,
+                    "error_message": "Blocked by anti-bot protection: Cloudflare JS challenge",
+                }
+            )
+            == FetchReasonCode.BLOCKED_ANTI_BOT.value
+        )
+
+    def test_refusal_marker_on_raised_exception_path_does_not_classify_refused(self) -> None:
+        """Mirrors test_antibot_marker_500_transport_error_also_classifies_
+        http_5xx below: crawl4ai's real bulk-500 body is opaque, so a
+        refusal-marker body match is only trusted on the page-result dict
+        path, never on the raised-exception path."""
+        request = httpx.Request("POST", "http://crawl4ai:11235/crawl")
+        response = httpx.Response(403, text="Access Denied", request=request)
+        exc = httpx.HTTPStatusError("crawl4ai failed", request=request, response=response)
+        assert _classify_fetch_outcome(None, error=exc) == FetchReasonCode.AUTH_ERROR.value
+
+
 class TestClassifyFetchOutcomeStructuralGuessVsStatusCode:
     """2026-08-18 — production audit of 100 historical BLOCKED_ANTI_BOT
     outcomes: 91 carried a status code that itself contradicts a block
@@ -710,6 +840,7 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
     # Shape sanity — all required keys present on every outcome.
     # SPEC-CRAWLER-FAILURE-EVIDENCE added error_type/error_message/
     # correlation_id/observed, additive to the original four.
+    # 2026-08-19 (onderdeel 1) added retry_after, additive again.
     for outcome in outcomes:
         assert set(outcome.keys()) == {
             "url",
@@ -720,6 +851,7 @@ async def test_crawl_site_bulk_transport_failure_records_one_outcome_per_candida
             "error_message",
             "correlation_id",
             "observed",
+            "retry_after",
         }
 
 

--- a/klai-knowledge-ingest/tests/test_domain_rate_limit_control.py
+++ b/klai-knowledge-ingest/tests/test_domain_rate_limit_control.py
@@ -231,6 +231,23 @@ def test_count_rate_limit_observations_blocked_anti_bot_is_congestion() -> None:
     assert result.clean_count == 0
 
 
+def test_count_rate_limit_observations_refused_is_not_congestion() -> None:
+    """2026-08-19 (onderdeel 3, intermedia.com / support.ascendcloud.com
+    "weigering" incident): a REFUSED outcome (the site explicitly refuses
+    automated access — see reason_codes.py) must NOT lower the domain's
+    stored rate_limit. Slowing down does not fix a refusal, unlike real
+    429 congestion — the support.ascendcloud.com incident's rate got
+    halved all the way to the floor for exactly this reason before this
+    fix. REFUSED counts toward neither congestion nor a clean run, same
+    treatment as a timeout or a 5xx."""
+    outcomes = [{"url": "https://example.com/a", "reason_code": "refused"}]
+
+    result = count_rate_limit_observations(outcomes)
+
+    assert result.had_congestion is False
+    assert result.clean_count == 0
+
+
 def test_count_rate_limit_observations_success_is_clean() -> None:
     outcomes = [
         {"url": "https://example.com/a", "reason_code": "success"},

--- a/klai-knowledge-ingest/tests/test_host_circuit_breaker.py
+++ b/klai-knowledge-ingest/tests/test_host_circuit_breaker.py
@@ -1,0 +1,169 @@
+"""Pure unit tests for knowledge_ingest.host_circuit_breaker.evaluate_chunk.
+
+Onderdeel 2 of the 2026-08-19 intermedia.com "20 minutes, zero pages"
+fix — see the module docstring in host_circuit_breaker.py for the full
+rationale. Defaults used throughout mirror settings.py's:
+consecutive_failure_threshold=5, min_attempts_for_ratio=10,
+failure_ratio_threshold=0.5, refusal_threshold=3.
+"""
+
+from __future__ import annotations
+
+from knowledge_ingest.host_circuit_breaker import (
+    BreakerVerdict,
+    ChunkObservation,
+    HostCircuitBreakerState,
+    evaluate_chunk,
+)
+
+_DEFAULT_KWARGS = {
+    "consecutive_failure_threshold": 5,
+    "min_attempts_for_ratio": 10,
+    "failure_ratio_threshold": 0.5,
+    "refusal_threshold": 3,
+}
+
+
+def _failure(*, attempted: int = 1, refused: int = 0) -> ChunkObservation:
+    return ChunkObservation(
+        attempted=attempted, failed=attempted, any_success=False, refused=refused
+    )
+
+
+def _success(*, attempted: int = 1) -> ChunkObservation:
+    return ChunkObservation(attempted=attempted, failed=0, any_success=True, refused=0)
+
+
+def _run(observations: list[ChunkObservation]) -> tuple[HostCircuitBreakerState, BreakerVerdict]:
+    state = HostCircuitBreakerState()
+    verdict = BreakerVerdict.CONTINUE
+    for observation in observations:
+        state, verdict = evaluate_chunk(state, observation, **_DEFAULT_KWARGS)
+    return state, verdict
+
+
+class TestConsecutiveFailures:
+    def test_five_failures_in_a_row_aborts(self) -> None:
+        _state, verdict = _run([_failure() for _ in range(5)])
+        assert verdict == BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+    def test_four_failures_then_a_success_then_four_more_does_not_abort(self) -> None:
+        observations = (
+            [_failure() for _ in range(4)] + [_success()] + [_failure() for _ in range(4)]
+        )
+        _state, verdict = _run(observations)
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_a_success_resets_the_streak_to_zero(self) -> None:
+        state = HostCircuitBreakerState()
+        for _ in range(4):
+            state, verdict = evaluate_chunk(state, _failure(), **_DEFAULT_KWARGS)
+        assert state.consecutive_failures == 4
+        state, verdict = evaluate_chunk(state, _success(), **_DEFAULT_KWARGS)
+        assert state.consecutive_failures == 0
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_a_wholly_failed_20_url_chunk_counts_as_one_observation_for_the_streak(
+        self,
+    ) -> None:
+        """A block of twenty URLs that fails wholesale must only advance the
+        consecutive-failure streak by one — not twenty. The ratio trigger is
+        disabled here (a very high min_attempts_for_ratio) so this test
+        isolates the streak counter from the independent ratio gate, which
+        a 20/20-failed observation would otherwise also cross on its own."""
+        kwargs = {**_DEFAULT_KWARGS, "min_attempts_for_ratio": 1_000_000}
+        state, verdict = evaluate_chunk(HostCircuitBreakerState(), _failure(attempted=20), **kwargs)
+        assert state.consecutive_failures == 1
+        assert verdict == BreakerVerdict.CONTINUE
+
+        # Five such 20-url blocks in a row (100 failed URLs total) is only
+        # five OBSERVATIONS for the streak — enough to trip it exactly
+        # because the threshold is 5, not because of the URL count.
+        state = HostCircuitBreakerState()
+        verdict = BreakerVerdict.CONTINUE
+        for _ in range(5):
+            state, verdict = evaluate_chunk(state, _failure(attempted=20), **kwargs)
+        assert state.consecutive_failures == 5
+        assert verdict == BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+
+class TestFailureRatio:
+    def test_nine_attempts_six_failed_does_not_abort_too_few_observations(self) -> None:
+        """6/9 = 0.667 > 0.5, but only 9 attempts — below min_attempts_for_ratio
+        (10) — so the ratio gate must not fire yet."""
+        observations = [_failure() for _ in range(6)] + [_success() for _ in range(3)]
+        state, verdict = _run(observations)
+        assert state.attempted == 9
+        assert state.failed == 6
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_twelve_attempts_seven_failed_aborts(self) -> None:
+        """7/12 = 0.583 > 0.5 and 12 >= min_attempts_for_ratio (10) — aborts."""
+        observations = [_failure() for _ in range(7)] + [_success() for _ in range(5)]
+        state, verdict = _run(observations)
+        assert state.attempted == 12
+        assert state.failed == 7
+        assert verdict == BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+    def test_exactly_half_failed_does_not_abort(self) -> None:
+        """'meer dan de helft' (MORE than half) — exactly 50% must not trip."""
+        observations = [_failure() for _ in range(5)] + [_success() for _ in range(5)]
+        state, verdict = _run(observations)
+        assert state.attempted == 10
+        assert verdict == BreakerVerdict.CONTINUE
+
+
+class TestRefusal:
+    def test_three_refusals_aborts_immediately(self) -> None:
+        observations = [
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1) for _ in range(3)
+        ]
+        _state, verdict = _run(observations)
+        assert verdict == BreakerVerdict.ABORT_REFUSAL
+
+    def test_three_refusals_with_interleaved_successes_still_aborts(self) -> None:
+        """A refusal is never undone by a success — unlike the consecutive
+        streak, the refusal counter is monotonic."""
+        observations = [
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1),
+            _success(),
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1),
+            _success(),
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1),
+        ]
+        state, verdict = _run(observations)
+        assert state.refused == 3
+        # The interleaved successes DID reset the consecutive-failure streak...
+        assert state.consecutive_failures == 1
+        # ...but the refusal trigger fires anyway, independent of the streak.
+        assert verdict == BreakerVerdict.ABORT_REFUSAL
+
+    def test_two_refusals_does_not_abort(self) -> None:
+        observations = [
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1) for _ in range(2)
+        ]
+        _state, verdict = _run(observations)
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_refusal_takes_priority_over_persistent_failure_verdict(self) -> None:
+        """When both the consecutive-failure and refusal thresholds are
+        crossed by the same observation, the more specific ABORT_REFUSAL
+        verdict wins."""
+        observations = [
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1) for _ in range(5)
+        ]
+        _state, verdict = _run(observations)
+        assert verdict == BreakerVerdict.ABORT_REFUSAL
+
+
+class TestContinue:
+    def test_all_successes_never_aborts(self) -> None:
+        _state, verdict = _run([_success() for _ in range(50)])
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_fresh_state_is_all_zero(self) -> None:
+        state = HostCircuitBreakerState()
+        assert state.consecutive_failures == 0
+        assert state.attempted == 0
+        assert state.failed == 0
+        assert state.refused == 0


### PR DESCRIPTION
## Wat er vanochtend gebeurde

Een crawl van www.intermedia.com draaide twintig minuten, haalde nul pagina's op, en niets greep in. Elk verzoek mislukte. De site zit achter Cloudflare-botbeheer en antwoordde met 429 — ook op 0,2 verzoeken per seconde, één per vijf seconden.

Drie fouten die elkaar versterkten:

**De 429 was onzichtbaar.** crawl4ai vertaalt een 429 van de doelsite naar een eigen 500. De echte reden staat alleen in crawl4ai's containerlog; het antwoord dat wij krijgen is ondoorzichtig — geverifieerd tegen echte productiedata: `{"error":"Internal server error","correlation_id":"..."}`. De bestaande stop-op-rate-limiting reageert op de redencode `rate_limited` en kwam er dus nooit aan te pas.

**Er was geen rem op "alles mislukt".** Er bestond een stop voor rate-limiting en een stop op een anti-bot-verhouding, maar niets dat zegt: honderd procent faalt, kap ermee.

**Een weigering werd behandeld als drukte.** Het opgeslagen tempo voor het domein werd verlaagd tot de bodem van 0,2 — voor een probleem dat niets met snelheid te maken had. Zowel intermedia als support.ascendcloud.com staan daardoor op die bodem.

## Wat er nu gebeurt

**Eén plek beoordeelt het hele antwoord** — status, fouttekst en headers — in plaats van alleen de statuscode. Een 429 wordt herkend of hij nu in de status zit, in de tekst, of alleen in een `Retry-After`. Voor het ondoorzichtige bulk-500 helpt dat niet, en dat is precies waarom het volgende punt bestaat.

**Een stroomonderbreker per host** die niet naar de reden kijkt. Vijf mislukkingen op rij, of meer dan de helft mislukt over minstens tien pogingen: afbreken. Een volledig mislukt blok van twintig URL's telt als één waarneming voor de reeks — één verzoek dat faalt is één waarneming, geen twintig.

**Weigering is geen drukte.** Bij een blokkade of Cloudflare-uitdaging stoppen we meteen met een eigen reden, en verlagen we het domeintempo níét. Langzamer crawlen lost een weigering per definitie niet op; het tempo omlaag schroeven is dan schade zonder baat.

## Bewijs

- 1464 tests geslaagd, 4 overgeslagen, 0 gefaald
- `ruff check` en `ruff format --check` beide schoon
- 41 tests op het nieuwe gedrag, waaronder `test_morning_incident_simulation_stops_within_a_handful_of_blocks` — het scenario van vanochtend breekt nu af binnen een handvol blokken
- De ondoorzichtige 500-vorm is geverifieerd tegen echte opgeslagen productiedata, niet aangenomen
- Bestaand gedrag geborgd: een kale 403 blijft `auth_error`, een 404 blijft een 404 en wordt geen anti-bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)