### PR TITLE
fix(crawler): cancelling a running crawl actually stops it

### DIFF
--- a/klai-connector/app/reason_codes.py
+++ b/klai-connector/app/reason_codes.py
@@ -62,6 +62,11 @@ class FetchReasonCode(StrEnum):
     # currently emits it.
     REFUSED = "refused"
     NOT_FETCHED_CIRCUIT_BREAKER_STOP = "not_fetched_circuit_breaker_stop"
+    # 2026-08-19 mirror (crawl-cancel, klai-knowledge-ingest
+    # crawl4ai_client.py) — the connector does not itself produce this
+    # value today, but the parity test requires both copies to carry the
+    # same value set regardless of which side currently emits it.
+    NOT_FETCHED_CANCELLED = "not_fetched_cancelled"
 
 
 class PersistSkipReason(StrEnum):

--- a/klai-knowledge-ingest/alembic/versions/0011_crawl_jobs_cancel.py
+++ b/klai-knowledge-ingest/alembic/versions/0011_crawl_jobs_cancel.py
@@ -1,0 +1,112 @@
+"""crawl-cancel — add knowledge.crawl_jobs.cancel_requested + 'cancelled' status.
+
+The existing ``POST /ingest/v1/crawl/sync/{job_id}/cancel`` endpoint only
+signalled Procrastinate's own ``abort_requested`` column — the ``run_crawl``
+task never checked it, so a cancel request on an in-flight crawl was a
+silent no-op (observed 2026-08-19: 204 returned, crawl kept fetching pages
+for minutes afterward). This migration adds the DB-backed flag the crawl
+loop now polls cooperatively between bulk-fetch chunks
+(``crawl4ai_client._chunked_bulk_fetch``), and a ``'cancelled'`` terminal
+status distinct from ``'failed'`` — an operator-requested stop is not a
+failure.
+
+Two changes to ``knowledge.crawl_jobs``:
+
+1. ADD COLUMN ``cancel_requested boolean NOT NULL DEFAULT false`` — set by
+   the cancel endpoint, polled by ``adapters.crawler.run_crawl_job`` via a
+   ``cancel_check`` closure passed down into ``crawl_site``.
+2. EXTEND the status CHECK constraint to allow ``'cancelled'``, alongside
+   the existing ``pending``/``running``/``completed``/``failed``/
+   ``failed_partial`` values.
+
+Idempotent: ADD COLUMN uses IF NOT EXISTS; the CHECK swap drops by name and
+re-adds, both wrapped so re-running on a partially-migrated DB is safe —
+same pattern as 0004_crawl_jobs_error_summary.py.
+
+Revision ID: dafd7070493d
+Revises: d0fb00b16473
+Create Date: 2026-08-19
+SPEC: crawl-cancel (ad hoc — cancel a running crawl actually stops it)
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "dafd7070493d"
+down_revision: str | None = "d0fb00b16473"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE knowledge.crawl_jobs "
+        "ADD COLUMN IF NOT EXISTS cancel_requested boolean NOT NULL DEFAULT false"
+    )
+
+    # Drop the old CHECK constraint and re-add with 'cancelled'. Wrapped in
+    # DO blocks so re-running on a partially-migrated DB is safe.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'crawl_jobs_status_check'
+                  AND conrelid = 'knowledge.crawl_jobs'::regclass
+            ) THEN
+                ALTER TABLE knowledge.crawl_jobs
+                DROP CONSTRAINT crawl_jobs_status_check;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE knowledge.crawl_jobs
+        ADD CONSTRAINT crawl_jobs_status_check
+        CHECK (status = ANY (ARRAY[
+            'pending'::text,
+            'running'::text,
+            'completed'::text,
+            'failed'::text,
+            'failed_partial'::text,
+            'cancelled'::text
+        ]))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'crawl_jobs_status_check'
+                  AND conrelid = 'knowledge.crawl_jobs'::regclass
+            ) THEN
+                ALTER TABLE knowledge.crawl_jobs
+                DROP CONSTRAINT crawl_jobs_status_check;
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE knowledge.crawl_jobs
+        ADD CONSTRAINT crawl_jobs_status_check
+        CHECK (status = ANY (ARRAY[
+            'pending'::text,
+            'running'::text,
+            'completed'::text,
+            'failed'::text,
+            'failed_partial'::text
+        ]))
+        """
+    )
+    op.execute("ALTER TABLE knowledge.crawl_jobs DROP COLUMN IF EXISTS cancel_requested")

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -180,6 +180,11 @@ _FETCH_NON_FAILURE_REASON_CODES: frozenset[str] = frozenset(
         # 2026-08-19: same rationale — a URL the host circuit breaker
         # deliberately never sent, not a fetch failure.
         FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value,
+        # 2026-08-19 (crawl-cancel): a URL deliberately never sent because
+        # the operator cancelled the job — a scheduling decision, not a
+        # fetch failure. Must not inflate fetch_failure_dominant, and must
+        # not trip failed_partial on a job the operator stopped on purpose.
+        FetchReasonCode.NOT_FETCHED_CANCELLED.value,
     }
 )
 _uncategorized_fetch_reason_codes = (
@@ -676,6 +681,15 @@ async def run_crawl_job(
     SPEC-TI-003-FOLLOWUP-001 AC-1: ``conn`` carries the RLS GUC from the
     caller's ``tenant_scoped_connection(org_id)`` block. Every knowledge.*
     statement below runs on this same connection.
+
+    2026-08-19 (crawl-cancel): ``POST .../crawl/sync/{job_id}/cancel`` sets
+    ``knowledge.crawl_jobs.cancel_requested``. ``crawl_site`` (and its
+    ``_chunked_bulk_fetch`` chunk loop) polls that flag between chunks via
+    the ``cancel_check`` closure below — this function is the only place
+    with the DB connection needed to read it, so it builds the closure and
+    hands it down rather than giving crawl4ai_client direct DB access.
+    Pages already fetched before cancellation are kept and ingested
+    normally; the terminal status becomes ``cancelled``, not a failure.
     """
     await _update_job(conn, job_id, status="running")
 
@@ -686,6 +700,9 @@ async def run_crawl_job(
     # populates crawl_jobs.error_summary (separate from `error`, which the
     # cookie-path AuthWallDetected handler still owns).
     auth_wall_pages: list[str] = []
+
+    async def cancel_check() -> bool:
+        return await _crawl_job_cancel_requested(conn, job_id)
 
     try:
         # 2026-08-17 (intermedia.com + support.ascendcloud.com incident): if
@@ -721,6 +738,17 @@ async def run_crawl_job(
             login_indicator_selector=login_indicator_selector,
             cookies=cookies,
             rate_limit=effective_rate_limit,
+            cancel_check=cancel_check,
+        )
+
+        # 2026-08-19 (crawl-cancel): detected purely from the reason code
+        # crawl_site attaches to every URL it stopped on for a cancel — no
+        # extra DB round-trip, and no race against a cancel that arrives
+        # after this crawl already finished on its own (crawl_site's return
+        # tuple stays 2-wide so every existing caller/test is unaffected).
+        job_cancelled = any(
+            outcome.get("reason_code") == FetchReasonCode.NOT_FETCHED_CANCELLED.value
+            for outcome in fetch_outcomes
         )
 
         # Validated-seed pass. A client-rendered homepage/hub can defeat the
@@ -740,7 +768,8 @@ async def run_crawl_job(
         # guaranteed to be ingested whenever it is fetchable.
         seed_canon = _canonicalise_url(discovery_seed_url) if discovery_seed_url else None
         if (
-            seed_canon is not None
+            not job_cancelled
+            and seed_canon is not None
             and seed_canon != _canonicalise_url(start_url)
             and seed_canon not in {_canonicalise_url(r.url) for r in results}
         ):
@@ -761,6 +790,7 @@ async def run_crawl_job(
                 login_indicator_selector=login_indicator_selector,
                 cookies=cookies,
                 rate_limit=effective_rate_limit,
+                cancel_check=cancel_check,
             )
             seen = {_canonicalise_url(r.url) for r in results}
             for seed_result in seed_results:
@@ -957,7 +987,16 @@ async def run_crawl_job(
         # takes priority. The ingest-failure guard sits right after the
         # fetch-failure guard: both are "Klai reached the site but the job
         # still produced nothing", just at a different pipeline stage.
-        if dirty_status:
+        if job_cancelled:
+            # 2026-08-19 (crawl-cancel): an operator cancel outranks every
+            # other terminal-status guard below. The user asked for this to
+            # stop — that is not a dirty-content trip, not a fetch-failure
+            # trip, not an ingest failure; it is intentional, and pages
+            # fetched before the cancel was observed are still ingested
+            # above (pages_done keeps whatever it already counted).
+            terminal_status = "cancelled"
+            await _update_job(conn, job_id, status=terminal_status)
+        elif dirty_status:
             terminal_status = dirty_status
             summary_payload = dirty_summary or {}
             # Preserve the existing wall-tracking diagnostics alongside the
@@ -1619,4 +1658,22 @@ async def _update_job(
         error,
         int(time.time()),
         job_id,
+    )
+
+
+async def _crawl_job_cancel_requested(conn: asyncpg.Connection, job_id: str) -> bool:
+    """Poll ``knowledge.crawl_jobs.cancel_requested`` for cooperative cancel.
+
+    Called from ``run_crawl_job``'s ``cancel_check`` closure, in turn called
+    by ``crawl4ai_client._chunked_bulk_fetch`` between chunks (never per
+    URL — see that function's docstring). A fresh read every call rather
+    than a cached flag: chunks are seconds apart, so the extra query is
+    cheap, and caching would mean a job started before a stale local
+    process picked up a cancel could never see it flip.
+    """
+    return bool(
+        await conn.fetchval(
+            "SELECT cancel_requested FROM knowledge.crawl_jobs WHERE id=$1",
+            job_id,
+        )
     )

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -13,6 +13,7 @@ import fnmatch
 import json
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from html import unescape
 from html.parser import HTMLParser
@@ -2011,6 +2012,7 @@ async def crawl_site(
     login_indicator_selector: str | None = None,
     cookies: list[dict[str, Any]] | None = None,
     rate_limit: float | None = None,
+    cancel_check: Callable[[], Awaitable[bool]] | None = None,
 ) -> tuple[list[CrawlResult], list[FetchOutcome]]:
     """Crawl a site with a Klai-owned deterministic frontier.
 
@@ -2023,6 +2025,17 @@ async def crawl_site(
     mechanism, and ``build_crawl_config``'s docstring for why crawl4ai's own
     ``CrawlerRunConfig`` pacing knobs (``semaphore_count`` / ``mean_delay``)
     cannot do this: the REST server ignores them.
+
+    ``cancel_check`` (2026-08-19, crawl-cancel, optional): awaited between
+    ``_chunked_bulk_fetch`` chunks — never per URL — so an operator-requested
+    cancel takes effect within one chunk instead of never (the caller,
+    ``adapters.crawler.run_crawl_job``, has the DB connection needed to poll
+    ``knowledge.crawl_jobs.cancel_requested``; this function deliberately does
+    not get direct DB access). When it stops the crawl, every URL left in
+    that chunk's remainder gets ``FetchReasonCode.NOT_FETCHED_CANCELLED`` in
+    the returned ``outcomes`` — the caller detects cancellation by checking
+    for that reason code rather than a third return value, so every existing
+    caller of this function keeps working unchanged.
 
     Returns ``(crawl_results, outcomes)``:
     - ``crawl_results``: same-domain pages with non-empty markdown.
@@ -2113,6 +2126,7 @@ async def crawl_site(
             crawler_config=crawler_config,
             cookies=cookies,
             rate_limit=current_rate_limit,
+            cancel_check=cancel_check,
         )
         fetched_count += len(batch)
 
@@ -2133,7 +2147,7 @@ async def crawl_site(
         # a real per-URL result in fetch.raw_results (or was intentionally
         # skipped above) and must not be re-fetched or reclassified.
         retry_urls = [u for u, exc in fetch.failed.items() if _is_recoverable_bulk_failure(exc)]
-        if retry_urls:
+        if retry_urls and not fetch.cancelled:
             # Escalation step 1: retry ONLY the still-failing subset with
             # crawl4ai's stealth mode + a randomised UA. Measured on
             # intermedia.com 2026-08-15: the plain bulk request 500s
@@ -2150,7 +2164,10 @@ async def crawl_site(
                 cookies=cookies,
                 stealth=True,
                 rate_limit=current_rate_limit,
+                cancel_check=cancel_check,
             )
+            if stealth_fetch.cancelled:
+                fetch.cancelled = True
             fetch.raw_results.extend(stealth_fetch.raw_results)
             for retried_url in retry_urls:
                 fetch.failed.pop(retried_url, None)
@@ -2175,7 +2192,15 @@ async def crawl_site(
         # finally given up on too — see that constant's docstring.
         carried_over_urls: list[str] = []
         stop_crawl_after_this_batch = False
-        if not_attempted_urls:
+        if fetch.cancelled:
+            # 2026-08-19 (crawl-cancel): an operator cancel always wins —
+            # no slowdown-and-retry, no further chunks, no stealth/sequential
+            # recovery for anything still outstanding. not_attempted_urls
+            # already carries NOT_FETCHED_CANCELLED (set inside
+            # _chunked_bulk_fetch) and is finalised below exactly like any
+            # other early stop.
+            stop_crawl_after_this_batch = True
+        elif not_attempted_urls:
             if stop_trigger_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value:
                 stop_crawl_after_this_batch = True
             elif consecutive_rate_limit_slowdowns < _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS:
@@ -2212,7 +2237,7 @@ async def crawl_site(
         recoverable_failed = {
             u: exc for u, exc in fetch.failed.items() if _is_recoverable_bulk_failure(exc)
         }
-        if recoverable_failed:
+        if recoverable_failed and not fetch.cancelled:
             # crawl4ai's bulk endpoint still failed this subset after the
             # stealth retry — either an opaque 5xx or a read-timeout
             # (evidence + budget: see _MAX_SEQUENTIAL_RECOVERY,
@@ -2325,6 +2350,7 @@ async def crawl_site(
                 cookies=cookies,
                 base_domain=base_domain,
                 rate_limit=current_rate_limit,
+                cancel_check=cancel_check,
             )
         for outcome in batch_outcomes:
             ledger.mark_outcome(outcome)
@@ -2339,10 +2365,11 @@ async def crawl_site(
                 ledger.add_links_from_result(result, source_depth=source_depth)
 
         if stop_crawl_after_this_batch:
-            # BLOCKED_ANTI_BOT, or a RATE_LIMITED signal that survived
-            # _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS halvings — further
-            # batches would either not help (a block) or keep paying a
-            # cooldown for no progress (an unrecoverable rate limit).
+            # BLOCKED_ANTI_BOT, a RATE_LIMITED signal that survived
+            # _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS halvings, or an operator
+            # cancel (fetch.cancelled) — further batches would either not
+            # help (a block), keep paying a cooldown for no progress (an
+            # unrecoverable rate limit), or simply not be wanted (cancel).
             # Remaining queued URLs get their honest reason via
             # ledger.mark_unfetched below, same as any other early stop.
             break
@@ -2976,6 +3003,7 @@ async def _recover_thin_bulk_results(
     cookies: list[dict[str, Any]] | None,
     base_domain: str,
     rate_limit: float | None = None,
+    cancel_check: Callable[[], Awaitable[bool]] | None = None,
 ) -> list[CrawlResult]:
     """Re-crawl thin-but-rich-HTML bulk pages with the relaxed config.
 
@@ -3013,6 +3041,7 @@ async def _recover_thin_bulk_results(
         crawler_config=_relax_seed_crawl_config(crawler_config),
         cookies=cookies,
         rate_limit=rate_limit,
+        cancel_check=cancel_check,
     )
     # Only the subset that actually transported can be compared against the
     # strict result — a URL whose relaxed chunk failed or was never
@@ -3487,7 +3516,17 @@ class ChunkedFetchResult:
             RATE_LIMIT_STOP by default (existing behaviour, unchanged),
             or NOT_FETCHED_CIRCUIT_BREAKER_STOP when
             ``circuit_breaker_triggered`` is True, so "how many times did
-            the breaker actually intervene" has an honest answer.
+            the breaker actually intervene" has an honest answer. Set to
+            NOT_FETCHED_CANCELLED when ``cancelled`` is True (see below).
+        cancelled: True when ``cancel_check`` (2026-08-19, crawl-cancel)
+            returned True BEFORE a chunk was sent, so chunking stopped for
+            an operator-requested cancellation rather than any site-side
+            signal. Kept separate from ``circuit_breaker_triggered`` and
+            ``stop_trigger_reason_code`` (which stays None here) because
+            the caller's response is different: no rate-limit slowdown
+            retry, no give-up-and-mark-BLOCKED_ANTI_BOT — just stop, and
+            the crawl_job's terminal status becomes ``cancelled``, never a
+            failure.
     """
 
     raw_results: list[dict[str, Any]] = field(default_factory=list)
@@ -3497,6 +3536,7 @@ class ChunkedFetchResult:
     stop_trigger_reason_code: str | None = None
     circuit_breaker_triggered: bool = False
     not_attempted_reason_code: str = FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+    cancelled: bool = False
 
 
 async def _chunked_bulk_fetch(
@@ -3506,6 +3546,7 @@ async def _chunked_bulk_fetch(
     cookies: list[dict[str, Any]] | None,
     stealth: bool = False,
     rate_limit: float | None = None,
+    cancel_check: Callable[[], Awaitable[bool]] | None = None,
 ) -> ChunkedFetchResult:
     """Submit ``urls`` to crawl4ai's bulk ``/crawl`` endpoint in chunks.
 
@@ -3562,6 +3603,20 @@ async def _chunked_bulk_fetch(
     chunk (never per URL), same as the anti-bot ratio tally above, so it
     can intervene within tens of seconds instead of the crawl's full page
     budget.
+
+    2026-08-19 (crawl-cancel): a FOURTH stop trigger, orthogonal to the
+    three above — operator-requested cancellation via ``POST
+    /ingest/v1/crawl/sync/{job_id}/cancel``. ``cancel_check`` (when given)
+    is awaited at the TOP of every loop iteration, BEFORE the pacing sleep
+    and before this chunk's request is built, so a cancellation is honoured
+    without ever sending one more request or waiting out one more pacing
+    gap. Checked once per chunk — same granularity as the breaker and the
+    anti-bot ratio gate, never per URL — which bounds reaction time to a
+    single chunk's own duration (seconds) instead of the crawl's full page
+    budget (previously: never, because nothing in this loop checked
+    cancellation at all — see ``knowledge.crawl_jobs.cancel_requested``
+    and ``adapters.crawler.run_crawl_job`` for where the flag is written
+    and polled).
     """
     result = ChunkedFetchResult()
     if not urls:
@@ -3572,6 +3627,18 @@ async def _chunked_bulk_fetch(
     antibot_signal_count = 0
     breaker_state = HostCircuitBreakerState()
     for chunk_start in range(0, len(urls), chunk_size):
+        if cancel_check is not None and await cancel_check():
+            remaining_urls = urls[chunk_start:]
+            result.stopped_early = True
+            result.not_attempted = remaining_urls
+            result.cancelled = True
+            result.not_attempted_reason_code = FetchReasonCode.NOT_FETCHED_CANCELLED.value
+            logger.info(
+                "crawl_bulk_stopped_cancelled",
+                sent_urls=chunk_start,
+                not_attempted_urls=len(remaining_urls),
+            )
+            break
         if rate_limit is not None and previous_chunk_start is not None:
             gap_seconds = chunk_size / rate_limit
             elapsed_since_previous_start = _pacing_monotonic() - previous_chunk_start

--- a/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
+++ b/klai-knowledge-ingest/knowledge_ingest/reason_codes.py
@@ -90,6 +90,16 @@ class FetchReasonCode(StrEnum):
     # NOT_FETCHED_RATE_LIMIT_STOP so "how many times did the breaker
     # actually intervene" has an honest, uninflated answer.
     NOT_FETCHED_CIRCUIT_BREAKER_STOP = "not_fetched_circuit_breaker_stop"
+    # 2026-08-19 (crawl-cancel): a URL abandoned because the operator
+    # requested cancellation (``POST .../crawl/sync/{job_id}/cancel``) —
+    # ``_chunked_bulk_fetch`` checks ``knowledge.crawl_jobs.cancel_requested``
+    # between chunks and stops sending further chunks the moment it flips
+    # true. Deliberately its own code, not NOT_FETCHED_RATE_LIMIT_STOP or
+    # NOT_FETCHED_CIRCUIT_BREAKER_STOP: those both mean "the site told us to
+    # stop"; this means "the operator told us to stop" — a different
+    # operator-facing story and a different terminal status
+    # (``crawl_jobs.status = 'cancelled'``, never a failure).
+    NOT_FETCHED_CANCELLED = "not_fetched_cancelled"
 
 
 class PersistSkipReason(StrEnum):

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py
@@ -391,6 +391,21 @@ async def crawl_sync_cancel(job_id: str) -> None:
     user-visible state (sync_run.status='failed') diverges from the data
     state (artifacts continue to accumulate after the failure).
 
+    2026-08-19 (crawl-cancel): this endpoint previously only called
+    Procrastinate's own ``cancel_job_by_id_async(abort=True)``, which sets
+    ``abort_requested`` on ``procrastinate_jobs`` — a signal the
+    ``run_crawl`` task never actually checked, so cancelling an in-flight
+    crawl was a silent no-op (verified in production: 204 returned, the
+    crawl kept fetching pages for minutes afterward). The fix is
+    cooperative cancellation via ``knowledge.crawl_jobs.cancel_requested``,
+    set below and polled by ``crawl_site``'s bulk-fetch loop between
+    chunks (``adapters.crawler.run_crawl_job`` builds the poll closure —
+    see its docstring). The Procrastinate-level abort call is kept
+    alongside it, not replaced: it still serves a job that has not started
+    running yet (status ``'todo'``), where it prevents the worker from
+    ever picking the job up at all — cheaper than relying on the new flag,
+    which only takes effect once ``run_crawl_job`` is already executing.
+
     Idempotent:
 
     * If the procrastinate task is already finished (succeeded / failed /
@@ -432,6 +447,20 @@ async def crawl_sync_cancel(job_id: str) -> None:
             crawl_status=crawl_row["status"],
         )
         return
+
+    # The task is still live (todo/doing) — mark it for cooperative
+    # cancellation. ``run_crawl_job`` polls this between bulk-fetch chunks
+    # and stops within one chunk once it flips true. Guarded to runnable
+    # statuses only so this never resurrects an already-terminal row (a
+    # narrow race against the running task finishing between the proc_row
+    # query above and this UPDATE is harmless: the flag would simply go
+    # unread).
+    await pool.execute(
+        "UPDATE knowledge.crawl_jobs SET cancel_requested=true, updated_at=$2 "
+        "WHERE id=$1 AND status IN ('pending', 'running')",
+        job_id,
+        int(time.time()),
+    )
 
     # Lazy import to keep procrastinate optional in test environments
     # where ENRICHMENT_ENABLED=false.

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_partial_retry.py
@@ -130,6 +130,7 @@ async def test_stealth_retry_only_resends_the_failed_subset(
         cookies: list[dict[str, Any]] | None,
         stealth: bool = False,
         rate_limit: float | None = None,
+        cancel_check: Any = None,
     ) -> ChunkedFetchResult:
         seen_url_sets.append(frozenset(urls))
         if not stealth:
@@ -196,6 +197,7 @@ async def test_first_attempts_successful_result_survives_into_final_results(
         cookies: list[dict[str, Any]] | None,
         stealth: bool = False,
         rate_limit: float | None = None,
+        cancel_check: Any = None,
     ) -> ChunkedFetchResult:
         if not stealth:
             return ChunkedFetchResult(
@@ -293,6 +295,7 @@ async def test_not_attempted_urls_never_enter_retry_or_recovery(
         cookies: list[dict[str, Any]] | None,
         stealth: bool = False,
         rate_limit: float | None = None,
+        cancel_check: Any = None,
     ) -> ChunkedFetchResult:
         calls.append({"urls": list(urls), "stealth": stealth})
         # Chunk 1 blocked, chunk 2 never attempted — no `failed` entry.

--- a/klai-knowledge-ingest/tests/test_crawl_cancel_chunked_fetch.py
+++ b/klai-knowledge-ingest/tests/test_crawl_cancel_chunked_fetch.py
@@ -1,0 +1,243 @@
+"""crawl-cancel — ``_chunked_bulk_fetch`` cooperative cancellation.
+
+Production incident (2026-08-19): ``POST .../crawl/sync/{job_id}/cancel``
+returned 204 on a running crawl, but the crawl kept fetching pages for
+minutes afterward (32 requests observed in the 2 minutes after cancel).
+The endpoint only set Procrastinate's ``abort_requested`` column — nothing
+in the crawl loop ever checked it.
+
+The fix: ``_chunked_bulk_fetch`` accepts an optional ``cancel_check``
+awaitable, checked once per chunk (same granularity as the host circuit
+breaker already wired into this loop — see
+``test_chunked_bulk_fetch_circuit_breaker_stop.py``), at the very top of
+the loop, BEFORE the pacing sleep and before the chunk's HTTP request is
+built. These tests lock in: no wasted request once cancelled, once-per-
+chunk (not per-URL) checking, and that cancellation and the circuit
+breaker do not interfere with each other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+# _burst_size_for(0.5) == max(1, min(100, int(0.5 * 10 + 0.5))) == 5 — five
+# URLs per chunk, so 20 URLs produce exactly four chunks.
+_FIVE_URLS_PER_CHUNK_RATE_LIMIT = 0.5
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _server_error_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 503,
+        "error_message": "Service Unavailable",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _disable_real_pacing_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same helper as test_chunked_bulk_fetch_circuit_breaker_stop.py — the
+    real inter-chunk pacing gap (chunk_size / rate_limit seconds) would
+    otherwise make these tests take real wall-clock seconds per chunk."""
+    monkeypatch.setattr(crawl4ai_client, "_pacing_monotonic", lambda: 0.0)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(crawl4ai_client, "_pacing_sleep", _no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_cancel_requested_before_first_chunk_sends_zero_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cancel_check() == True from the very first loop iteration: not one
+    HTTP request goes out, and every URL is reported not_fetched_cancelled."""
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_ok_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(5)]
+    cancel_check = AsyncMock(return_value=True)
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        cancel_check=cancel_check,
+    )
+
+    assert calls == [], "cancelled before the first chunk — no request may ever be sent"
+    assert fetch.cancelled is True
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted == urls
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CANCELLED.value
+    assert fetch.raw_results == []
+    assert fetch.failed == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_checked_once_per_chunk_not_per_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """20 URLs / 5 per chunk == 4 chunks. cancel_check flips true on the
+    3rd check (i.e. before chunk 3 is sent) — chunks 1 and 2 must have
+    already gone out, chunks 3 and 4 must never be attempted, and
+    cancel_check must be called exactly 3 times (once per chunk boundary
+    reached), never once per URL (which would be 20 calls)."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_ok_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(20)]
+    cancel_check = AsyncMock(side_effect=[False, False, True])
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_FIVE_URLS_PER_CHUNK_RATE_LIMIT,
+        cancel_check=cancel_check,
+    )
+
+    assert cancel_check.await_count == 3, (
+        f"expected exactly one cancel_check() per chunk boundary reached (3), "
+        f"got {cancel_check.await_count} — a per-URL check would be 20"
+    )
+    assert [len(c) for c in calls] == [5, 5], "only the first two chunks were sent"
+    assert fetch.cancelled is True
+    assert fetch.stopped_early is True
+    assert fetch.not_attempted == urls[10:]
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CANCELLED.value
+    # The first two chunks' real results are kept — cancellation does not
+    # discard work already done.
+    assert len(fetch.raw_results) == 10
+
+
+@pytest.mark.asyncio
+async def test_no_cancel_check_preserves_existing_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cancel_check omitted (default None) — the loop never evaluates
+    cancellation at all, matching pre-fix behaviour exactly."""
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {"results": [_ok_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(5)]
+    fetch = await _chunked_bulk_fetch(urls=urls, crawler_config={}, cookies=None)
+
+    assert fetch.cancelled is False
+    assert fetch.stopped_early is False
+    assert fetch.not_attempted == []
+    assert len(fetch.raw_results) == 5
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_circuit_breaker_do_not_interfere_cancel_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site that is ALSO failing every request (would eventually trip the
+    breaker) gets cancelled first — the breaker never gets the chance to
+    fire, and the outcome is reported as a cancel, not a breaker stop."""
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {"results": [_server_error_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(20)]
+    # Cancel fires on the very first check, before the breaker has seen a
+    # single observation.
+    cancel_check = AsyncMock(return_value=True)
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=_FIVE_URLS_PER_CHUNK_RATE_LIMIT,
+        cancel_check=cancel_check,
+    )
+
+    assert fetch.cancelled is True
+    assert fetch.circuit_breaker_triggered is False
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_still_fires_when_cancel_check_present_but_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: passing a cancel_check that always returns False must not
+    change the pre-existing circuit-breaker behaviour at all — the breaker
+    keeps working exactly as it did before this fix existed."""
+    _disable_real_pacing_sleep(monkeypatch)
+    calls: list[list[str]] = []
+
+    async def _fake_crawl_sync(
+        _client: httpx.AsyncClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        calls.append(list(payload["urls"]))
+        return {"results": [_server_error_page(u) for u in payload["urls"]]}
+
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
+
+    urls = [f"https://example.com/{i}" for i in range(50)]
+    cancel_check = AsyncMock(return_value=False)
+
+    fetch = await _chunked_bulk_fetch(
+        urls=urls,
+        crawler_config={},
+        cookies=None,
+        rate_limit=0.05,  # one URL per chunk, matches the breaker test file
+        cancel_check=cancel_check,
+    )
+
+    assert fetch.cancelled is False
+    assert fetch.circuit_breaker_triggered is True
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
+    assert len(calls) <= 5, (
+        f"expected the breaker to stop after a handful of chunks, got {len(calls)}"
+    )

--- a/klai-knowledge-ingest/tests/test_crawl_cancel_terminal_status.py
+++ b/klai-knowledge-ingest/tests/test_crawl_cancel_terminal_status.py
@@ -1,0 +1,237 @@
+"""crawl-cancel — ``run_crawl_job`` terminal status when a crawl is cancelled.
+
+``crawl_site`` reports a mid-crawl cancellation to its caller purely via
+``FetchReasonCode.NOT_FETCHED_CANCELLED`` entries in the returned
+``fetch_outcomes`` — no third return value, so every existing caller/test
+of ``crawl_site`` keeps working unchanged. ``run_crawl_job`` detects that
+reason code and must:
+
+- still ingest whatever pages were fetched before the cancel (no data loss),
+- end with ``crawl_jobs.status = 'cancelled'`` — never ``'failed'`` or
+  ``'failed_partial'`` — a user-requested stop is not a failure,
+- skip the discovery-seed retry pass entirely once cancelled (no point
+  starting a second crawl for a job that was just told to stop).
+
+Mirrors the mocking pattern in test_crawl_job_ingest_failure_status.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import link_graph
+from knowledge_ingest.adapters.crawler import run_crawl_job
+from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+
+def _make_mock_conn():
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.executemany = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+    conn.fetchrow = AsyncMock(return_value=None)
+    return conn
+
+
+def _make_crawl_result(url: str = "https://example.com/a") -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        fit_markdown="Some markdown content for testing",
+        raw_markdown="Some markdown content for testing",
+        html="<html><body><p>Test content</p></body></html>",
+        word_count=5,
+        success=True,
+        links={"internal": []},
+        error_message="",
+        metadata={},
+        response_headers={"content-type": "text/html"},
+    )
+
+
+def _last_status_call(mock_conn: MagicMock) -> str | None:
+    """Same helper as test_crawl_job_ingest_failure_status.py: the ``status``
+    argument of the LAST ``crawl_jobs`` status UPDATE issued on ``mock_conn``."""
+    status_calls = [
+        call for call in mock_conn.execute.call_args_list if "SET status=$1" in call.args[0]
+    ]
+    if not status_calls:
+        return None
+    return status_calls[-1].args[1]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mid_crawl_reports_status_cancelled_not_failed() -> None:
+    """One page already fetched, the rest cancelled — status must be
+    'cancelled', not 'completed', 'failed', or 'failed_partial'."""
+    mock_conn = _make_mock_conn()
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_result = _make_crawl_result()
+
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new_callable=AsyncMock) as mock_crawl,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new_callable=AsyncMock,
+            side_effect=_fake_ingest,
+        ) as mock_ingest,
+    ):
+        mock_crawl.return_value = (
+            [mock_result],
+            [
+                {
+                    "url": mock_result.url,
+                    "reason_code": FetchReasonCode.SUCCESS.value,
+                    "status_code": 200,
+                    "content_length": len(mock_result.html or ""),
+                },
+                {
+                    "url": "https://example.com/b",
+                    "reason_code": FetchReasonCode.NOT_FETCHED_CANCELLED.value,
+                    "status_code": None,
+                    "content_length": 0,
+                },
+                {
+                    "url": "https://example.com/c",
+                    "reason_code": FetchReasonCode.NOT_FETCHED_CANCELLED.value,
+                    "status_code": None,
+                    "content_length": 0,
+                },
+            ],
+        )
+        mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+        mock_pg.list_stale_connector_artifact_paths = AsyncMock(return_value=[])
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            max_depth=1,
+            rate_limit=100.0,
+        )
+
+    status = _last_status_call(mock_conn)
+    assert status == "cancelled", f"expected 'cancelled', got {status!r}"
+    # The page fetched before cancellation must still be ingested — no data
+    # loss on a cooperative stop.
+    mock_ingest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_skips_discovery_seed_retry() -> None:
+    """A cancelled primary crawl must not trigger the discovery-seed retry
+    pass — crawl_site is called exactly once, not twice."""
+    mock_conn = _make_mock_conn()
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new_callable=AsyncMock) as mock_crawl,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+    ):
+        # Zero pages fetched, discovery_seed_url never reached — normally
+        # this alone would trigger the seed-retry crawl_site call, but the
+        # job was cancelled before anything was fetched at all.
+        mock_crawl.return_value = (
+            [],
+            [
+                {
+                    "url": "https://example.com/a",
+                    "reason_code": FetchReasonCode.NOT_FETCHED_CANCELLED.value,
+                    "status_code": None,
+                    "content_length": 0,
+                },
+            ],
+        )
+        mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+        mock_pg.list_stale_connector_artifact_paths = AsyncMock(return_value=[])
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            discovery_seed_url="https://example.com/known-good",
+            max_depth=1,
+            rate_limit=100.0,
+        )
+
+    assert mock_crawl.await_count == 1, (
+        f"expected crawl_site to be called once (no seed retry after cancel), "
+        f"got {mock_crawl.await_count}"
+    )
+    status = _last_status_call(mock_conn)
+    assert status == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_no_cancellation_reason_code_still_reports_completed() -> None:
+    """Regression / counterpart: a normal, non-cancelled crawl is unaffected
+    by the new job_cancelled detection — matches the existing happy-path
+    test in test_crawl_job_ingest_failure_status.py."""
+    mock_conn = _make_mock_conn()
+    from tests.conftest import make_pg_store_mock
+
+    mock_pg = make_pg_store_mock()
+    mock_result = _make_crawl_result()
+
+    async def _fake_ingest(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return None
+
+    with (
+        patch("knowledge_ingest.adapters.crawler.crawl_site", new_callable=AsyncMock) as mock_crawl,
+        patch("knowledge_ingest.adapters.crawler.pg_store", mock_pg),
+        patch.object(link_graph, "get_outbound_urls", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_anchor_texts", new_callable=AsyncMock, return_value=[]),
+        patch.object(link_graph, "get_incoming_count", new_callable=AsyncMock, return_value=0),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new_callable=AsyncMock,
+            side_effect=_fake_ingest,
+        ),
+    ):
+        mock_crawl.return_value = (
+            [mock_result],
+            [
+                {
+                    "url": mock_result.url,
+                    "reason_code": FetchReasonCode.SUCCESS.value,
+                    "status_code": 200,
+                    "content_length": len(mock_result.html or ""),
+                }
+            ],
+        )
+        mock_pg.get_crawled_page_hashes = AsyncMock(return_value={})
+        mock_pg.list_stale_connector_artifact_paths = AsyncMock(return_value=[])
+
+        await run_crawl_job(
+            mock_conn,
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="docs",
+            start_url="https://example.com/a",
+            max_depth=1,
+            rate_limit=100.0,
+        )
+
+    status = _last_status_call(mock_conn)
+    assert status == "completed"

--- a/klai-knowledge-ingest/tests/test_crawl_sync_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_crawl_sync_endpoint.py
@@ -673,6 +673,74 @@ class TestCrawlSyncStatusEndpoint:
         assert update_calls == []
 
 
+class TestCrawlSyncCancelEndpoint:
+    """POST /ingest/v1/crawl/sync/{job_id}/cancel — crawl-cancel (2026-08-19).
+
+    Production incident: this endpoint returned 204 on a running crawl but
+    the crawl kept fetching pages for minutes afterward — it only signalled
+    Procrastinate's own (unread) ``abort_requested`` column. The fix sets
+    ``knowledge.crawl_jobs.cancel_requested``, which ``run_crawl_job`` polls
+    cooperatively between bulk-fetch chunks. These tests lock in the
+    endpoint's DB-write contract, not the crawl loop itself (see
+    test_crawl_cancel_chunked_fetch.py / test_crawl_cancel_terminal_status.py
+    for that).
+    """
+
+    def _cancel_requested_updates(self, pool: MagicMock) -> list:
+        return [
+            c for c in pool.execute.await_args_list if c.args and "cancel_requested" in c.args[0]
+        ]
+
+    def test_cancel_running_job_sets_cancel_requested_flag(self) -> None:
+        job_id = str(uuid.uuid4())
+        pool = _make_pool(
+            job_row={"status": "running"},
+            proc_row={"id": 999, "status": "doing"},
+        )
+        with _client_with_patches(pool) as (client, _defer):
+            resp = client.post(f"/ingest/v1/crawl/sync/{job_id}/cancel")
+        assert resp.status_code == 204
+
+        updates = self._cancel_requested_updates(pool)
+        assert updates, "expected an UPDATE ... SET cancel_requested=true call"
+        assert updates[0].args[1] == job_id
+
+    def test_cancel_pending_job_sets_cancel_requested_flag(self) -> None:
+        """A job that has not started running yet is also marked — the
+        endpoint must not assume 'running' is the only live state."""
+        job_id = str(uuid.uuid4())
+        pool = _make_pool(
+            job_row={"status": "pending"},
+            proc_row={"id": 1000, "status": "todo"},
+        )
+        with _client_with_patches(pool) as (client, _defer):
+            resp = client.post(f"/ingest/v1/crawl/sync/{job_id}/cancel")
+        assert resp.status_code == 204
+        assert self._cancel_requested_updates(pool)
+
+    def test_cancel_unknown_job_returns_404(self) -> None:
+        pool = _make_pool(job_row=None)
+        job_id = str(uuid.uuid4())
+        with _client_with_patches(pool) as (client, _defer):
+            resp = client.post(f"/ingest/v1/crawl/sync/{job_id}/cancel")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "job_not_found"
+        assert self._cancel_requested_updates(pool) == []
+
+    def test_cancel_already_finished_job_is_noop(self) -> None:
+        """No live procrastinate row (already succeeded/failed/aborted) —
+        cancel is idempotent and must not touch crawl_jobs at all."""
+        job_id = str(uuid.uuid4())
+        pool = _make_pool(
+            job_row={"status": "completed"},
+            proc_row=None,
+        )
+        with _client_with_patches(pool) as (client, _defer):
+            resp = client.post(f"/ingest/v1/crawl/sync/{job_id}/cancel")
+        assert resp.status_code == 204
+        assert self._cancel_requested_updates(pool) == []
+
+
 class TestDecryptFromBlobs:
     """End-to-end guarantee for the shared lib's blob decrypt method."""
 

--- a/klai-knowledge-ingest/tests/test_recover_thin_bulk_results_rate_limit.py
+++ b/klai-knowledge-ingest/tests/test_recover_thin_bulk_results_rate_limit.py
@@ -31,6 +31,7 @@ async def test_recover_thin_bulk_results_forwards_rate_limit(
         cookies: list[dict[str, Any]] | None,
         stealth: bool = False,
         rate_limit: float | None = None,
+        cancel_check: Any = None,
     ) -> crawl4ai_client.ChunkedFetchResult:
         seen_rate_limits.append(rate_limit)
         return crawl4ai_client.ChunkedFetchResult(


### PR DESCRIPTION
## Wat er misging

Vanochtend liep een crawl die op elk verzoek een fout kreeg. De annuleer-endpoint gaf keurig 204:

```
POST /ingest/v1/crawl/sync/{job_id}/cancel  →  204
```

Twintig seconden later stond de taak nog op `running`, en gingen er in de twee minuten daarna nog 32 verzoeken naar de doelsite. De enige manier om het te stoppen was `docker restart` op de container — wat elke andere lopende taak in diezelfde container ook omlegt.

De endpoint zette alleen `abort_requested` op de wachtrij-taak. De draaiende taak keek daar nergens naar. Voor een taak die nog niet was opgepakt werkte het wel; zodra hij liep, was annuleren een bevestigde lege huls.

## Wat er nu gebeurt

De lopende crawl kijkt zelf tussen blokken of er geannuleerd is, op dezelfde plek en met dezelfde mechaniek als de stroomonderbreker uit #1075 — geen tweede controlepad. Reactietijd is daarmee hooguit tientallen seconden in plaats van nooit. De controle staat vóór de pauze tussen blokken, zodat annuleren geen extra verzoek naar de site meer kost.

Stoppen is netjes: wat al opgehaald is blijft behouden en wordt verwerkt. De rest krijgt een eigen redencode. De eindstatus is "geannuleerd", niet "mislukt" — wie zelf op stop drukt hoort geen foutmelding te zien.

## Bevindingen onderweg

De werkers draaien in hetzelfde proces als de webserver (de lifespan start ze als asyncio-taak; er is geen aparte worker-container). Een vlag in het geheugen zou dus technisch volstaan, maar de kolom in de database is eerlijker over wat er gebeurt en overleeft een herstart.

## Bewijs

- 1476 tests geslaagd, 4 overgeslagen, 0 gefaald (12 nieuw)
- `ruff check` en `ruff format --check` schoon
- `alembic heads` toont precies één hoofd
- De stroomonderbreker blijft naast het annuleren werken; beide kunnen de lus stoppen zonder elkaar in de weg te zitten

🤖 Generated with [Claude Code](https://claude.com/claude-code)