### PR TITLE
feat(crawler): slow down on a high failure rate, not just on a readable 429

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -299,6 +299,28 @@ class Settings(BaseSettings):
         default=3,
         validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_REFUSAL_COUNT"),
     )
+    # 2026-08-19 (onderdeel 3 — "slow down before you give up"): a failure
+    # ratio ABOVE crawl_circuit_breaker_failure_ratio (0.5) is dead-site
+    # territory and stays an immediate abort, unchanged. But a ratio between
+    # this threshold and that one used to do NOTHING — a crawl with, say, a
+    # 30% failure rate over a dozen attempts is not "fine" (the existing
+    # RATE_LIMITED-only slowdown never fires because nothing classified as a
+    # readable rate-limit signal) and is not "dead" either. It sat in a gap
+    # where the crawler kept hammering at full speed. crawl_circuit_breaker_
+    # slowdown_ratio (0.25) closes that gap: crossing it (still gated by the
+    # SAME crawl_circuit_breaker_min_attempts floor as the abort ratio, no
+    # separate knob invented for that) makes host_circuit_breaker.evaluate_
+    # chunk return BreakerVerdict.SLOWDOWN, which _chunked_bulk_fetch reports
+    # to crawl_site as a RATE_LIMITED-flavoured stop — reusing the EXISTING
+    # halve-rate/cooldown/give-up-after-N-halvings ladder
+    # (crawl_rate_limit_slowdown_cooldown_seconds, MIN_DOMAIN_RATE_LIMIT floor,
+    # _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS in crawl4ai_client.py) instead of
+    # a second, parallel one. MUST stay below crawl_circuit_breaker_failure_
+    # ratio — see evaluate_chunk's docstring.
+    crawl_circuit_breaker_slowdown_ratio: float = Field(
+        default=0.25,
+        validation_alias=AliasChoices("KLAI_CRAWL_CIRCUIT_BREAKER_SLOWDOWN_RATIO"),
+    )
     # LLM enrichment (contextual prefix + HyPE questions via LiteLLM proxy)
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -2190,6 +2190,17 @@ async def crawl_site(
         # behaviour, immediately. A site that keeps rate-limiting through
         # ``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS`` halvings in a row is
         # finally given up on too — see that constant's docstring.
+        #
+        # 2026-08-19 (onderdeel 3): ``stop_trigger_reason_code`` here is also
+        # RATE_LIMITED when the host circuit breaker's own ratio ladder
+        # (``host_circuit_breaker.BreakerVerdict.SLOWDOWN``) is what stopped
+        # ``_chunked_bulk_fetch`` — a failure rate for an UNREADABLE reason
+        # (crawl4ai wrapping a 429 in an opaque 500 is the incident that
+        # motivated this) gets the exact same slow-down-then-give-up ladder
+        # as a genuine, readable RATE_LIMITED signal. This branch has no
+        # breaker-specific logic — it cannot tell the two apart, and does
+        # not need to (``fetch.circuit_breaker_slowdown_triggered`` carries
+        # that distinction for logging/observability only).
         carried_over_urls: list[str] = []
         stop_crawl_after_this_batch = False
         if fetch.cancelled:
@@ -3507,17 +3518,31 @@ class ChunkedFetchResult:
             will not help", the same give-up semantics as a confirmed
             block.
         circuit_breaker_triggered: True when
-            ``knowledge_ingest.host_circuit_breaker`` (onderdeel 2, the
-            general-purpose "everything is failing" backstop — see that
-            module's docstring) is why chunking stopped, as opposed to the
-            RATE_LIMITED/BLOCKED_ANTI_BOT triggers above.
+            ``knowledge_ingest.host_circuit_breaker`` returned an ABORT
+            verdict (persistent failure or repeated refusal — onderdeel 2,
+            the general-purpose "everything is failing" backstop) and is why
+            chunking stopped, as opposed to the RATE_LIMITED/BLOCKED_ANTI_BOT
+            triggers above. Give-up semantics — unchanged by onderdeel 3
+            below.
+        circuit_breaker_slowdown_triggered: True when the breaker instead
+            returned BreakerVerdict.SLOWDOWN (onderdeel 3, 2026-08-19 — a
+            failure ratio between ``crawl_circuit_breaker_slowdown_ratio``
+            and ``crawl_circuit_breaker_failure_ratio``, see config.py).
+            Deliberately a SEPARATE flag from ``circuit_breaker_triggered``
+            — this one gets RATE_LIMITED-flavoured retry-at-a-lower-rate
+            treatment in ``crawl_site``, not give-up treatment, so a caller
+            must not conflate the two when counting "how many times did the
+            breaker give up" vs. "how many times did the breaker just ask
+            for less speed".
         not_attempted_reason_code: the FetchReasonCode value ``crawl_site``
             should use for every URL in ``not_attempted`` — NOT_FETCHED_
-            RATE_LIMIT_STOP by default (existing behaviour, unchanged),
-            or NOT_FETCHED_CIRCUIT_BREAKER_STOP when
-            ``circuit_breaker_triggered`` is True, so "how many times did
-            the breaker actually intervene" has an honest answer. Set to
-            NOT_FETCHED_CANCELLED when ``cancelled`` is True (see below).
+            RATE_LIMIT_STOP by default (existing behaviour, unchanged; also
+            what a SLOWDOWN verdict leaves this as, since those URLs are
+            expected to be retried, not abandoned), or NOT_FETCHED_CIRCUIT_
+            BREAKER_STOP when ``circuit_breaker_triggered`` (an ABORT
+            verdict) is True, so "how many times did the breaker actually
+            give up" has an honest answer. Set to NOT_FETCHED_CANCELLED when
+            ``cancelled`` is True (see below).
         cancelled: True when ``cancel_check`` (2026-08-19, crawl-cancel)
             returned True BEFORE a chunk was sent, so chunking stopped for
             an operator-requested cancellation rather than any site-side
@@ -3535,6 +3560,7 @@ class ChunkedFetchResult:
     stopped_early: bool = False
     stop_trigger_reason_code: str | None = None
     circuit_breaker_triggered: bool = False
+    circuit_breaker_slowdown_triggered: bool = False
     not_attempted_reason_code: str = FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
     cancelled: bool = False
 
@@ -3603,6 +3629,21 @@ async def _chunked_bulk_fetch(
     chunk (never per URL), same as the anti-bot ratio tally above, so it
     can intervene within tens of seconds instead of the crawl's full page
     budget.
+
+    2026-08-19 (onderdeel 3 — "slow down before you give up"): the breaker's
+    ratio trigger is a two-step ladder, not abort-or-nothing (see
+    ``host_circuit_breaker.evaluate_chunk``'s docstring). A
+    ``BreakerVerdict.SLOWDOWN`` verdict is treated exactly like a genuine
+    RATE_LIMITED page signal below — ``stop_trigger_reason_code`` is set to
+    RATE_LIMITED, not BLOCKED_ANTI_BOT, so ``crawl_site`` retries the
+    abandoned URLs at a halved rate (Deel B) instead of giving up on them.
+    Only ``BreakerVerdict.ABORT_PERSISTENT_FAILURE``/``ABORT_REFUSAL`` keep
+    the give-up treatment. This reuses ``crawl_site``'s existing halving/
+    cooldown/``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS`` give-up ladder
+    unchanged — no second slowdown mechanism exists, so a chunk that is
+    simultaneously flagged by the real RATE_LIMITED page-signal AND this
+    breaker verdict still produces exactly ONE ``stop_trigger_reason_code``
+    and is halved at most once per ``crawl_site`` batch.
 
     2026-08-19 (crawl-cancel): a FOURTH stop trigger, orthogonal to the
     three above — operator-requested cancellation via ``POST
@@ -3722,8 +3763,17 @@ async def _chunked_bulk_fetch(
             min_attempts_for_ratio=settings.crawl_circuit_breaker_min_attempts,
             failure_ratio_threshold=settings.crawl_circuit_breaker_failure_ratio,
             refusal_threshold=settings.crawl_circuit_breaker_refusal_count,
+            slowdown_ratio_threshold=settings.crawl_circuit_breaker_slowdown_ratio,
         )
-        breaker_tripped = breaker_verdict != BreakerVerdict.CONTINUE
+        # onderdeel 3: ABORT_* keeps the pre-existing give-up semantics;
+        # SLOWDOWN is a new, separate trip that gets RATE_LIMITED-flavoured
+        # retry treatment below instead — see this function's docstring.
+        breaker_abort_tripped = breaker_verdict in (
+            BreakerVerdict.ABORT_PERSISTENT_FAILURE,
+            BreakerVerdict.ABORT_REFUSAL,
+        )
+        breaker_slowdown_tripped = breaker_verdict == BreakerVerdict.SLOWDOWN
+        breaker_tripped = breaker_abort_tripped or breaker_slowdown_tripped
         stop_triggered = (
             bool(chunk_reason_codes & _STOP_CHUNKING_REASON_CODES)
             or (
@@ -3748,21 +3798,25 @@ async def _chunked_bulk_fetch(
                 # never crossed ``crawl_antibot_stop_ratio`` while RATE_LIMITED
                 # is what actually triggered ``stop_triggered`` above; using
                 # the unfiltered set would misreport that stop as a block.
-                # 2026-08-19: the host circuit breaker's verdict (either
-                # persistent-failure or refusal) gets the SAME give-up
+                # 2026-08-19: the host circuit breaker's ABORT verdict
+                # (persistent-failure or refusal) gets the SAME give-up
                 # treatment as BLOCKED_ANTI_BOT — neither is fixed by
-                # slowing down.
+                # slowing down. Its SLOWDOWN verdict (onderdeel 3) is
+                # deliberately NOT in this condition — it falls through to
+                # RATE_LIMITED below, same as a genuine 429.
                 result.stop_trigger_reason_code = (
                     FetchReasonCode.BLOCKED_ANTI_BOT.value
-                    if breaker_tripped
+                    if breaker_abort_tripped
                     or FetchReasonCode.BLOCKED_ANTI_BOT.value in triggering_reason_codes
                     else FetchReasonCode.RATE_LIMITED.value
                 )
-                if breaker_tripped:
+                if breaker_abort_tripped:
                     result.circuit_breaker_triggered = True
                     result.not_attempted_reason_code = (
                         FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
                     )
+                elif breaker_slowdown_tripped:
+                    result.circuit_breaker_slowdown_triggered = True
                 logger.warning(
                     "crawl_bulk_stopped_after_rate_limit_signal",
                     sent_urls=chunk_start + len(chunk_urls),

--- a/klai-knowledge-ingest/knowledge_ingest/host_circuit_breaker.py
+++ b/klai-knowledge-ingest/knowledge_ingest/host_circuit_breaker.py
@@ -23,16 +23,35 @@ minutes):
   not twenty) — see ``ChunkObservation``. A single success anywhere resets
   the counter to zero.
 - Ratio: once at least ``min_attempts_for_ratio`` URLs have been attempted
-  (crawl-wide, within ONE ``_chunked_bulk_fetch`` call), abort once MORE
-  than ``failure_ratio_threshold`` of them failed. Unlike the consecutive
-  trigger, this one counts real per-URL attempts/failures, not
-  chunk-as-one-observation.
+  (crawl-wide, within ONE ``_chunked_bulk_fetch`` call), this is now a
+  TWO-STEP LADDER instead of a single abort-or-nothing gate (2026-08-19,
+  onderdeel 3 — the "20 minutes, zero pages" incident's actual trigger was
+  crawl4ai wrapping a 429 in an opaque 500, so the failure REASON was
+  unreadable but the failure RATE was known — 100%. The rate should have
+  driven a response even though the reason didn't):
+
+  - once the ratio exceeds ``slowdown_ratio_threshold``, verdict is
+    SLOWDOWN — not an abort. The caller (``crawl4ai_client._chunked_bulk_
+    fetch``) reuses the EXISTING RATE_LIMITED-flavoured stop-and-retry
+    path (``crawl_site``'s Deel B halving/cooldown/give-up-after-N-
+    halvings ladder) for this verdict too, so a persistently high ratio
+    that never recovers still gives up eventually — via the SAME
+    ``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS`` cap, not a second one.
+  - once the ratio exceeds ``failure_ratio_threshold`` (unchanged, the
+    original single gate), verdict is ABORT_PERSISTENT_FAILURE — give up
+    immediately, same as before. This threshold MUST stay above
+    ``slowdown_ratio_threshold`` (checked first) so a genuinely dead site
+    is never mistaken for merely a "go slower" case.
+
+  Unlike the consecutive trigger, this one counts real per-URL
+  attempts/failures, not chunk-as-one-observation.
 - Refusal: ``refusal_threshold`` observed REFUSED outcomes (see
   ``knowledge_ingest.reason_codes.FetchReasonCode.REFUSED``) abort
   immediately. The site is explicitly refusing automated access — slowing
   down does not fix that, unlike real rate-limiting — so this counter is
-  never reset by an interleaved success and is checked independently of
-  the other two.
+  never reset by an interleaved success, is checked independently of (and
+  before) the other two, and NEVER downgrades to SLOWDOWN regardless of
+  the concurrent failure ratio.
 
 Pure function, no I/O, no wall clock — every caller-observable value is a
 parameter, matching ``domain_rate_limit_control.compute_domain_rate_limit_
@@ -49,9 +68,16 @@ from enum import StrEnum
 
 
 class BreakerVerdict(StrEnum):
-    """The three outcomes ``evaluate_chunk`` can return."""
+    """The four outcomes ``evaluate_chunk`` can return.
+
+    SLOWDOWN sits between CONTINUE and the two ABORT verdicts: the failure
+    ratio is elevated enough to warrant pacing down, but not (yet) high
+    enough to justify giving up. See the module docstring's "Ratio" bullet
+    for the full ladder and how the caller is expected to treat each verdict.
+    """
 
     CONTINUE = "continue"
+    SLOWDOWN = "slowdown"
     ABORT_PERSISTENT_FAILURE = "abort_persistent_failure"
     ABORT_REFUSAL = "abort_refusal"
 
@@ -98,13 +124,24 @@ def evaluate_chunk(
     min_attempts_for_ratio: int,
     failure_ratio_threshold: float,
     refusal_threshold: int,
+    slowdown_ratio_threshold: float,
 ) -> tuple[HostCircuitBreakerState, BreakerVerdict]:
-    """Fold ``observation`` into ``state`` and decide continue vs. abort.
+    """Fold ``observation`` into ``state`` and decide continue/slowdown/abort.
 
     Refusal is checked first — it is never undone by a success in the same
-    or an earlier chunk, unlike the consecutive-failure streak. Either the
-    consecutive-failure trigger or the ratio trigger is independently
-    sufficient to abort once refusal does not already apply.
+    or an earlier chunk, unlike the consecutive-failure streak, and it NEVER
+    downgrades to SLOWDOWN: a refusal is not a pacing problem. Consecutive
+    failures abort next — an intermittently-failing site never reaches
+    ``min_attempts_for_ratio`` worth of runway before this trips, so it is
+    checked before the ratio ladder, not after.
+
+    The ratio ladder itself checks the higher (abort) threshold before the
+    lower (slowdown) one, so a ratio that already exceeds
+    ``failure_ratio_threshold`` the very first time ``min_attempts_for_ratio``
+    is reached goes straight to ABORT_PERSISTENT_FAILURE — it is never
+    reported as SLOWDOWN first. Callers MUST pass
+    ``slowdown_ratio_threshold < failure_ratio_threshold``; this function
+    does not itself validate the ordering.
     """
     new_state = HostCircuitBreakerState(
         consecutive_failures=(0 if observation.any_success else state.consecutive_failures + 1),
@@ -119,10 +156,11 @@ def evaluate_chunk(
     if new_state.consecutive_failures >= consecutive_failure_threshold:
         return new_state, BreakerVerdict.ABORT_PERSISTENT_FAILURE
 
-    if (
-        new_state.attempted >= min_attempts_for_ratio
-        and new_state.failed / new_state.attempted > failure_ratio_threshold
-    ):
-        return new_state, BreakerVerdict.ABORT_PERSISTENT_FAILURE
+    if new_state.attempted >= min_attempts_for_ratio:
+        failure_ratio = new_state.failed / new_state.attempted
+        if failure_ratio > failure_ratio_threshold:
+            return new_state, BreakerVerdict.ABORT_PERSISTENT_FAILURE
+        if failure_ratio > slowdown_ratio_threshold:
+            return new_state, BreakerVerdict.SLOWDOWN
 
     return new_state, BreakerVerdict.CONTINUE

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
@@ -122,6 +122,7 @@ async def test_five_consecutive_plain_5xx_chunks_stop_the_crawl(
     assert len(calls) == 5
     assert fetch.stopped_early is True
     assert fetch.circuit_breaker_triggered is True
+    assert fetch.circuit_breaker_slowdown_triggered is False
     assert fetch.not_attempted == urls[5:]
     assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
     # Give-up semantics, same as a confirmed block — crawl_site must not
@@ -163,15 +164,25 @@ async def test_a_success_between_5xx_failures_prevents_the_stop(
 
 
 @pytest.mark.asyncio
-async def test_majority_failure_ratio_stops_the_crawl(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_fifty_percent_failure_ratio_triggers_slowdown_not_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Alternating fail/success so the consecutive-streak keeps resetting
-    (never reaches 5), but the crawl-wide ratio crosses 50% once at least
-    10 URLs have been attempted — this isolates the ratio trigger from the
-    consecutive-failure trigger."""
+    (never reaches 5); the crawl-wide ratio reaches exactly 50% the moment
+    10 URLs have been attempted. 50% is NOT above failure_ratio_threshold
+    (0.5, 'meer dan de helft'), so this must not abort — but it IS above
+    the onderdeel-3 slowdown_ratio_threshold (0.25), so it must trip
+    SLOWDOWN, reported to crawl_site as a RATE_LIMITED-flavoured stop so
+    the retry-at-a-lower-rate ladder applies instead of giving up.
+
+    Renamed from the pre-onderdeel-3 test of the same scenario, which
+    asserted an immediate ABORT at 11 calls — the new lower rung in the
+    ladder now intervenes one call earlier, at the 10th, before the ratio
+    ever reaches the 11th attempt's 0.545."""
     _disable_real_pacing_sleep(monkeypatch)
     calls: list[list[str]] = []
-    # 11 urls: F,S,F,S,F,S,F,S,F,S,F — after url #11 (the 11th attempt),
-    # 6 of 11 have failed (0.545 > 0.5) with attempted=11 >= 10.
+    # 11 urls: F,S,F,S,F,S,F,S,F,S,F — attempted=10 (after the 10th call,
+    # a success) already has 5 of 10 failed (ratio exactly 0.5).
     pattern = [_server_error_page if i % 2 == 0 else _ok_page for i in range(11)]
 
     async def _fake_crawl_sync(_client: Any, payload: dict[str, Any]) -> dict[str, Any]:
@@ -189,10 +200,18 @@ async def test_majority_failure_ratio_stops_the_crawl(monkeypatch: pytest.Monkey
         rate_limit=_ONE_URL_PER_CHUNK_RATE_LIMIT,
     )
 
-    assert len(calls) == 11
+    assert len(calls) == 10
     assert fetch.stopped_early is True
-    assert fetch.circuit_breaker_triggered is True
-    assert fetch.not_attempted == urls[11:]
+    # SLOWDOWN is NOT the give-up verdict — circuit_breaker_triggered stays
+    # False (it exclusively means "the breaker gave up"); the new, separate
+    # flag records the slowdown intervention instead.
+    assert fetch.circuit_breaker_triggered is False
+    assert fetch.circuit_breaker_slowdown_triggered is True
+    assert fetch.not_attempted == urls[10:]
+    # RATE_LIMITED, not BLOCKED_ANTI_BOT — crawl_site must retry these at a
+    # lower rate, not give up on them.
+    assert fetch.stop_trigger_reason_code == FetchReasonCode.RATE_LIMITED.value
+    assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
 
 
 @pytest.mark.asyncio
@@ -221,8 +240,12 @@ async def test_three_refusals_stop_the_crawl_immediately(monkeypatch: pytest.Mon
     assert len(calls) == 5
     assert fetch.stopped_early is True
     assert fetch.circuit_breaker_triggered is True
+    assert fetch.circuit_breaker_slowdown_triggered is False
     assert fetch.not_attempted == urls[5:]
     assert fetch.not_attempted_reason_code == FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value
+    # A refusal never slows down, it gives up — same give-up reason code as
+    # a confirmed block, never RATE_LIMITED.
+    assert fetch.stop_trigger_reason_code == FetchReasonCode.BLOCKED_ANTI_BOT.value
 
     # The three real REFUSED observations survive in raw_results, distinct
     # from the abandoned URLs — "how many times did this domain actually

--- a/klai-knowledge-ingest/tests/test_crawl_slowdown_on_failure_rate.py
+++ b/klai-knowledge-ingest/tests/test_crawl_slowdown_on_failure_rate.py
@@ -1,0 +1,260 @@
+"""Onderdeel 3 (2026-08-19, "close the gap between nothing and giving up")
+— crawl_site-level integration tests for the host circuit breaker's new
+SLOWDOWN verdict (knowledge_ingest.host_circuit_breaker.BreakerVerdict.
+SLOWDOWN).
+
+Before this fix: a crawl with a ~30% failure rate for a reason
+``_chunked_bulk_fetch`` cannot read as RATE_LIMITED (crawl4ai wrapping a
+429 in an opaque 500 is the incident that motivated this — see
+host_circuit_breaker.py's module docstring) never slowed down (no
+readable RATE_LIMITED signal) and never gave up (below the 50% abort
+ratio) — it kept hammering the site at full speed for the rest of the
+crawl's page budget.
+
+These tests exercise the wiring end-to-end at the ``crawl_site`` level,
+the same way ``tests/test_crawl_rate_limit_slowdown.py`` locks in the
+pre-existing (real-429) Deel B retry/give-up ladder — by mocking
+``_chunked_bulk_fetch`` directly and controlling exactly which
+``ChunkedFetchResult`` flags it returns, so these tests do not depend on
+choreographing crawl4ai's bulk-fetch/chunking internals to reproduce a
+specific failure ratio.
+
+Pure-function coverage of the ratio ladder itself (SLOWDOWN vs CONTINUE
+vs the two ABORT verdicts) lives in tests/test_host_circuit_breaker.py.
+Wiring from a real failure pattern into a single ``_chunked_bulk_fetch``
+call's ``ChunkedFetchResult`` flags lives in
+tests/test_chunked_bulk_fetch_circuit_breaker_stop.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
+from knowledge_ingest.crawl4ai_client import ChunkedFetchResult, CrawlResult
+from knowledge_ingest.reason_codes import FetchReasonCode
+
+
+def _rate_limited_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": False,
+        "status_code": 429,
+        "error_message": "Too Many Requests",
+        "html": "",
+        "markdown": "",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _ok_page(url: str) -> dict[str, Any]:
+    return {
+        "url": url,
+        "success": True,
+        "status_code": 200,
+        "html": "<html><body>Real content, several words here.</body></html>",
+        "markdown": "Real content, several words here.",
+        "links": {"internal": []},
+        "media": {},
+    }
+
+
+def _patch_seed_with_links(monkeypatch: pytest.MonkeyPatch, links: list[str]) -> None:
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="Seed",
+            raw_markdown="Seed",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+            links={"internal": [{"href": h, "text": ""} for h in links]},
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+
+    async def _no_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+
+
+def _patch_no_real_slowdown_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    recorded: list[float] = []
+
+    async def _instant(seconds: float) -> None:
+        recorded.append(seconds)
+
+    monkeypatch.setattr(crawl4ai_client, "_slowdown_sleep", _instant)
+    return recorded
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_slowdown_retries_skipped_urls_at_a_lower_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A breaker SLOWDOWN verdict (an unreadable-cause high failure ratio,
+    e.g. crawl4ai wrapping a 429 in an opaque 500) must retry the abandoned
+    URLs on a later batch at a halved rate — the same treatment a genuine,
+    readable RATE_LIMITED signal already gets (Deel B) — not give up."""
+    _patch_seed_with_links(
+        monkeypatch,
+        [
+            "https://example.com/a",
+            "https://example.com/b",
+            "https://example.com/c",
+        ],
+    )
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        if len(calls) == 1:
+            # First batch: the circuit breaker's ratio ladder tripped
+            # SLOWDOWN on an opaque-cause failure — no genuine 429 was ever
+            # observed, only a high failure rate.
+            return ChunkedFetchResult(
+                raw_results=[_rate_limited_page(urls[0])],
+                not_attempted=urls[1:],
+                stopped_early=True,
+                stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+                circuit_breaker_slowdown_triggered=True,
+            )
+        return ChunkedFetchResult(raw_results=[_ok_page(u) for u in urls])
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+        rate_limit=2.0,
+    )
+
+    assert len(calls) == 2, "the abandoned URLs must be retried in a later batch, not given up on"
+    assert calls[1]["urls"] == ["https://example.com/b", "https://example.com/c"]
+    # Same floor/halving mechanism as the real-429 path — see
+    # _lower_rate_limit_for_slowdown.
+    assert calls[1]["rate_limit"] < calls[0]["rate_limit"]
+    assert calls[1]["rate_limit"] == pytest.approx(1.0)
+    assert slowdown_sleeps == [settings.crawl_rate_limit_slowdown_cooldown_seconds]
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    assert by_url["https://example.com/b"] == FetchReasonCode.SUCCESS.value
+    assert by_url["https://example.com/c"] == FetchReasonCode.SUCCESS.value
+    assert {r.url for r in results} >= {
+        "https://example.com/b",
+        "https://example.com/c",
+    }
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_slowdown_gives_up_after_max_consecutive_halvings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A site whose failure ratio stays high through every slowdown attempt
+    must eventually be abandoned too — slowing down forever is not a fix,
+    the same conclusion the real-429 path already reaches via
+    _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS. This is the SAME cap, reused —
+    no second, breaker-specific give-up counter exists."""
+    urls = [f"https://example.com/{c}" for c in "abcde"]
+    _patch_seed_with_links(monkeypatch, urls)
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        return ChunkedFetchResult(
+            raw_results=[_rate_limited_page(urls[0])],
+            not_attempted=urls[1:],
+            stopped_early=True,
+            stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+            circuit_breaker_slowdown_triggered=True,
+        )
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    _results, outcomes = await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=20,
+        rate_limit=2.0,
+    )
+
+    # 1 (initial) + _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS retries, then give up
+    # — identical shape to the real-429 exhaustion test.
+    assert len(calls) == crawl4ai_client._MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS + 1
+    rate_limits = [c["rate_limit"] for c in calls]
+    assert rate_limits == sorted(rate_limits, reverse=True), "rate must monotonically decrease"
+    assert rate_limits[-1] < rate_limits[0]
+    assert len(slowdown_sleeps) == crawl4ai_client._MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS
+
+    by_url = {o["url"]: o["reason_code"] for o in outcomes}
+    # The final abandoned URL is honestly marked as a rate-limit-flavoured
+    # scheduling stop — NOT_FETCHED_CIRCUIT_BREAKER_STOP is reserved for the
+    # give-up (ABORT) verdicts, not for an exhausted SLOWDOWN ladder.
+    assert by_url[urls[-1]] == FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value
+
+
+@pytest.mark.asyncio
+async def test_a_batch_flagged_by_both_real_rate_limit_and_breaker_slowdown_halves_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single ``_chunked_bulk_fetch`` call can only ever produce ONE
+    ``ChunkedFetchResult`` (the chunking loop breaks at most once — see
+    that function's docstring), so a batch where BOTH the pre-existing
+    genuine-RATE_LIMITED signal AND the new breaker SLOWDOWN verdict would
+    apply must still result in exactly ONE halving in crawl_site, not two.
+    This is the mechanical reason double-slowdown cannot happen: there is
+    only one stop_trigger_reason_code / not_attempted per call for
+    crawl_site to react to, regardless of how many trigger sources
+    contributed to that single stop."""
+    _patch_seed_with_links(
+        monkeypatch,
+        ["https://example.com/a", "https://example.com/b", "https://example.com/c"],
+    )
+    slowdown_sleeps = _patch_no_real_slowdown_sleep(monkeypatch)
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_chunked_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        calls.append({"urls": list(urls), "rate_limit": rate_limit})
+        if len(calls) == 1:
+            # Simulates a chunk that is simultaneously a genuine 429 AND
+            # crossed the breaker's slowdown ratio in the same evaluation —
+            # ChunkedFetchResult only ever carries ONE stop signal.
+            return ChunkedFetchResult(
+                raw_results=[_rate_limited_page(urls[0])],
+                not_attempted=urls[1:],
+                stopped_early=True,
+                stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+                circuit_breaker_slowdown_triggered=True,
+            )
+        return ChunkedFetchResult(raw_results=[_ok_page(u) for u in urls])
+
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_chunked_bulk_fetch)
+
+    await crawl4ai_client.crawl_site(
+        start_url="https://example.com",
+        max_pages=10,
+        rate_limit=2.0,
+    )
+
+    assert len(calls) == 2
+    # Halved exactly ONCE: 2.0 -> 1.0, not 2.0 -> 0.5 (which would be two
+    # halvings collapsed into a single batch transition).
+    assert calls[0]["rate_limit"] == 2.0
+    assert calls[1]["rate_limit"] == pytest.approx(1.0)
+    # Exactly one cooldown sleep for the one halving that happened.
+    assert slowdown_sleeps == [settings.crawl_rate_limit_slowdown_cooldown_seconds]

--- a/klai-knowledge-ingest/tests/test_host_circuit_breaker.py
+++ b/klai-knowledge-ingest/tests/test_host_circuit_breaker.py
@@ -4,7 +4,9 @@ Onderdeel 2 of the 2026-08-19 intermedia.com "20 minutes, zero pages"
 fix — see the module docstring in host_circuit_breaker.py for the full
 rationale. Defaults used throughout mirror settings.py's:
 consecutive_failure_threshold=5, min_attempts_for_ratio=10,
-failure_ratio_threshold=0.5, refusal_threshold=3.
+failure_ratio_threshold=0.5, refusal_threshold=3,
+slowdown_ratio_threshold=0.25 (onderdeel 3, 2026-08-19 — the SLOWDOWN
+verdict added between CONTINUE and the two ABORT verdicts).
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ _DEFAULT_KWARGS = {
     "min_attempts_for_ratio": 10,
     "failure_ratio_threshold": 0.5,
     "refusal_threshold": 3,
+    "slowdown_ratio_threshold": 0.25,
 }
 
 
@@ -105,12 +108,18 @@ class TestFailureRatio:
         assert state.failed == 7
         assert verdict == BreakerVerdict.ABORT_PERSISTENT_FAILURE
 
-    def test_exactly_half_failed_does_not_abort(self) -> None:
-        """'meer dan de helft' (MORE than half) — exactly 50% must not trip."""
+    def test_exactly_half_failed_slows_down_but_does_not_abort(self) -> None:
+        """'meer dan de helft' (MORE than half) — exactly 50% must not ABORT.
+
+        Onderdeel 3 (2026-08-19): it now DOES cross the lower
+        slowdown_ratio_threshold (0.25), so the verdict is SLOWDOWN, not a
+        silent CONTINUE — the old assertion (CONTINUE) is no longer correct
+        once the ladder has a middle rung.
+        """
         observations = [_failure() for _ in range(5)] + [_success() for _ in range(5)]
         state, verdict = _run(observations)
         assert state.attempted == 10
-        assert verdict == BreakerVerdict.CONTINUE
+        assert verdict == BreakerVerdict.SLOWDOWN
 
 
 class TestRefusal:
@@ -153,6 +162,79 @@ class TestRefusal:
             ChunkObservation(attempted=1, failed=1, any_success=False, refused=1) for _ in range(5)
         ]
         _state, verdict = _run(observations)
+        assert verdict == BreakerVerdict.ABORT_REFUSAL
+
+
+class TestSlowdown:
+    """Onderdeel 3 (2026-08-19) — the gap between 'nothing reacts' and
+    'give up entirely': a failure ratio above slowdown_ratio_threshold
+    (0.25) but at or below failure_ratio_threshold (0.5) must SLOW DOWN,
+    not silently continue at full speed and not abort outright."""
+
+    def test_thirty_percent_ratio_over_twelve_attempts_slows_down_not_aborts(self) -> None:
+        """The exact gap this closes: a crawl where ~30% of attempts fail
+        (4/12 = 0.333) neither trips the old single ratio gate (not above
+        0.5) nor the consecutive-failure trigger (never 5 failures running,
+        by construction below), yet was previously hammered at full speed
+        for the rest of the crawl."""
+        observations = [_failure() for _ in range(4)] + [_success() for _ in range(8)]
+        state, verdict = _run(observations)
+        assert state.attempted == 12
+        assert state.failed == 4
+        assert verdict == BreakerVerdict.SLOWDOWN
+
+    def test_low_failure_ratio_does_not_slow_down(self) -> None:
+        """10% failed — comfortably under slowdown_ratio_threshold — must
+        just continue."""
+        observations = [_failure()] + [_success() for _ in range(9)]
+        state, verdict = _run(observations)
+        assert state.attempted == 10
+        assert state.failed == 1
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_too_few_observations_never_slows_down_regardless_of_ratio(self) -> None:
+        """3/8 = 0.375 (comfortably inside the slowdown band) but only 8
+        attempts — below min_attempts_for_ratio (10) — so the ladder must
+        not react at all yet, same protection the abort ratio already had."""
+        observations = [_failure() for _ in range(3)] + [_success() for _ in range(5)]
+        state, verdict = _run(observations)
+        assert state.attempted == 8
+        assert state.failed == 3
+        assert verdict == BreakerVerdict.CONTINUE
+
+    def test_ratio_already_above_abort_threshold_goes_straight_to_abort_not_slowdown(self) -> None:
+        """When min_attempts_for_ratio is first reached with the ratio
+        ALREADY above failure_ratio_threshold, the verdict must be
+        ABORT_PERSISTENT_FAILURE directly — SLOWDOWN must never mask a
+        ratio that is already in dead-site territory."""
+        observations = [
+            _failure(),
+            _success(),
+            _failure(),
+            _success(),
+            _failure(),
+            _success(),
+            _failure(),
+            _success(),
+            _failure(),
+            _failure(),
+        ]
+        state, verdict = _run(observations)
+        assert state.attempted == 10
+        assert state.failed == 6
+        assert verdict == BreakerVerdict.ABORT_PERSISTENT_FAILURE
+
+    def test_refusal_aborts_even_when_ratio_is_only_in_the_slowdown_band(self) -> None:
+        """A refusal never downgrades to SLOWDOWN just because the
+        concurrent failure ratio happens to sit in the 25-50% band —
+        refusal is independent of, and takes priority over, the ratio
+        ladder entirely."""
+        observations = [
+            ChunkObservation(attempted=1, failed=1, any_success=False, refused=1) for _ in range(3)
+        ] + [_success() for _ in range(7)]
+        state, verdict = _run(observations)
+        assert state.attempted == 10
+        assert state.failed == 3
         assert verdict == BreakerVerdict.ABORT_REFUSAL
 
 


### PR DESCRIPTION
## Het gat dat dit dicht

Er waren twee losse mechanismen met een gat ertussen:

- **vertragen** — alleen bij een *herkende* 429
- **afbreken** — bij meer dan de helft mislukt

Een crawl waarin dertig procent faalt zonder herkenbare 429 viel daar precies tussendoor: vertraagde niet, brak niet af, en denderde op volle snelheid door terwijl een derde van de site niets teruggaf.

Dat is geen theoretisch geval. Vanochtend verpakte crawl4ai een 429 van intermedia.com in een ondoorzichtige 500 (`{"error":"Internal server error","correlation_id":"..."}`, geverifieerd tegen opgeslagen productiedata). We begrepen de reden dus niet en vertraagden niet. Het foutpercentage wisten we wél — honderd procent.

## Wat er nu gebeurt

Het vertragen wordt net zo reden-onafhankelijk als het afbreken al was. De stroomonderbreker telde het foutpercentage al; die geeft nu naast "doorgaan" en "afbreken" ook "vertragen" terug.

```
het gaat goed          → tempo mag omhoog
foutpercentage > 25%   → halveren, ongeacht de reden
blijft hoog na 3×      → afbreken
weigering              → meteen afbreken (langzamer lost een blokkade niet op)
```

Er komt géén tweede vertraagmechanisme naast het bestaande. Het nieuwe oordeel voedt de bestaande halveer-, afkoel- en opgeef-ladder in `crawl_site`, zodat er één plek blijft die het tempo verlaagt.

## Dubbele vertraging

Uitgesloten, en niet op hoop: één aanroep van de blokkenlus levert per definitie hooguit één stopsignaal op, dus er wordt hoogstens één keer per batch gehalveerd — of dat nu door een echte 429 kwam, door de verhouding, of door allebei tegelijk. Er is een test die beide signalen in hetzelfde blok zet en vastlegt dat het tempo van 2,0 naar 1,0 gaat en niet naar 0,5.

## Gedragsverandering om te weten

`test_majority_failure_ratio_stops_the_crawl` is hernoemd naar `test_fifty_percent_failure_ratio_triggers_slowdown_not_abort`. Vijftig procent mislukking leidt nu eerst tot vertragen in plaats van meteen afbreken — je gaat niet van volle snelheid naar stoppen zonder de tussenstap te proberen. De afbreekregels zelf zijn ongewijzigd en vangen nog steeds af wat na het vertragen niet herstelt.

## Bewijs

- 1484 tests geslaagd, 4 overgeslagen, 0 gefaald
- \`ruff check\` en \`ruff format --check\` schoon
- \`alembic heads\` toont precies één hoofd

🤖 Generated with [Claude Code](https://claude.com/claude-code)