### PR TITLE
fix(rag): select sources by comparison instead of string match

### DIFF
--- a/deploy/litellm/eval_suites/chat.yaml
+++ b/deploy/litellm/eval_suites/chat.yaml
@@ -1,7 +1,7 @@
 suite: chat
 description: |
   Conversational queries against Voys's support KB. Style mirrors how a Voys CS-medewerker
-  would phrase a question to klai's chat. 42 queries with a curated mix:
+  would phrase a question to klai's chat. 41 queries with a curated mix:
     - 9 easy-lookup (regression canaries; expected_chunks populated)
     - 9 vague-pronoun (query-rewrite targets)
     - 6 multi-doc synthesis (parent-child targets)
@@ -9,7 +9,7 @@ description: |
     - 2 edge cases (mixed-language + malformed)
     - 7 brand-bridging queries
     - 3 pasted-correspondence queries
-    - 2 source-selection queries
+    - 1 source-selection query
   All queries target tenant Voys (org_zitadel_id 368884765035593759).
 queries:
   # --- Easy-lookup canaries (9) — should always score ~1.0 ---
@@ -357,7 +357,7 @@ queries:
     expected_topics: [zoom, integratie]
     mix: brand_bridging
 
-  # --- Source-selection canaries (2) — SPEC-RAG-SOURCE-SELECTION-001 ---
+  # --- Source-selection canary — SPEC-RAG-SOURCE-SELECTION-001 ---
   - id: chat-source-selection-brand-token-404
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
@@ -365,15 +365,6 @@ queries:
     reference_answer: "Leg uit dat SIP 404 Not Found betekent dat de gebelde gebruiker, het toestel of de extensie niet gevonden of niet toegewezen is. Het woord Voys mag de evidence-selectie niet beperken tot help.voys.nl als een beter scorende bron de responscode verklaart."
     expected_topics: [voys, sip, 404, trunk, responscode]
     expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
-    mix: source_selection
-
-  - id: chat-source-selection-single-strong-hit
-    org_zitadel_id: "368884765035593759"
-    user_zitadel_id: null
-    query: "Ondersteunt Voys de fictieve QuasarDesk PBX-koppeling?"
-    reference_answer: "De kennisbank bevat geen betrouwbare informatie over een QuasarDesk PBX-koppeling. Een enkel sterk lijkend algemeen integratiedocument is onvoldoende bevestiging; het antwoord moet de onzekerheid benoemen en om verificatie of meer context vragen."
-    expected_topics: [onbekend, integratie, pbx]
-    expected_chunks: []
     mix: source_selection
 
   # --- Pasted-correspondence canaries (3) — SPEC-RAG-CORRESPONDENCE-DISTILL-001 ---

--- a/deploy/litellm/eval_suites/chat.yaml
+++ b/deploy/litellm/eval_suites/chat.yaml
@@ -1,12 +1,15 @@
 suite: chat
 description: |
   Conversational queries against Voys's support KB. Style mirrors how a Voys CS-medewerker
-  would phrase a question to klai's chat. 30 queries with a curated mix:
+  would phrase a question to klai's chat. 42 queries with a curated mix:
     - 9 easy-lookup (regression canaries; expected_chunks populated)
     - 9 vague-pronoun (query-rewrite targets)
     - 6 multi-doc synthesis (parent-child targets)
     - 4 long-tail (recall test)
     - 2 edge cases (mixed-language + malformed)
+    - 7 brand-bridging queries
+    - 3 pasted-correspondence queries
+    - 2 source-selection queries
   All queries target tenant Voys (org_zitadel_id 368884765035593759).
 queries:
   # --- Easy-lookup canaries (9) — should always score ~1.0 ---
@@ -353,6 +356,25 @@ queries:
     reference_answer: "Als de KB geen specifieke Zoom-koppeling met Voys bevat, moet het antwoord geen integratie verzinnen en vragen om nadere context of verwijzen naar bekende integratieopties."
     expected_topics: [zoom, integratie]
     mix: brand_bridging
+
+  # --- Source-selection canaries (2) — SPEC-RAG-SOURCE-SELECTION-001 ---
+  - id: chat-source-selection-brand-token-404
+    org_zitadel_id: "368884765035593759"
+    user_zitadel_id: null
+    query: "Voys trunk: wat betekent een SIP 404 Not Found?"
+    reference_answer: "Leg uit dat SIP 404 Not Found betekent dat de gebelde gebruiker, het toestel of de extensie niet gevonden of niet toegewezen is. Het woord Voys mag de evidence-selectie niet beperken tot help.voys.nl als een beter scorende bron de responscode verklaart."
+    expected_topics: [voys, sip, 404, trunk, responscode]
+    expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
+    mix: source_selection
+
+  - id: chat-source-selection-single-strong-hit
+    org_zitadel_id: "368884765035593759"
+    user_zitadel_id: null
+    query: "Ondersteunt Voys de fictieve QuasarDesk PBX-koppeling?"
+    reference_answer: "De kennisbank bevat geen betrouwbare informatie over een QuasarDesk PBX-koppeling. Een enkel sterk lijkend algemeen integratiedocument is onvoldoende bevestiging; het antwoord moet de onzekerheid benoemen en om verificatie of meer context vragen."
+    expected_topics: [onbekend, integratie, pbx]
+    expected_chunks: []
+    mix: source_selection
 
   # --- Pasted-correspondence canaries (3) — SPEC-RAG-CORRESPONDENCE-DISTILL-001 ---
   # Reproduces the 2026-08-17 Voys production incident (conversation ID

--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -583,7 +583,7 @@ class KlaiKnowledgeHook(CustomLogger):
         # conversation contains correspondence.
         if pasted_correspondence:
             _prepend_system_prefix(messages, _PASTED_CORRESPONDENCE_SCOPE)
-            logger.info(
+            logger.warning(
                 "pasted_correspondence_detected org_id=%s user_id=%s",
                 org_id,
                 librechat_user_id,
@@ -788,11 +788,9 @@ class KlaiKnowledgeHook(CustomLogger):
         # see literal customer text.
         telemetry_level = feature.get("telemetry_level", "shadow")
         try:
-            # Guard-fire is warning-level on purpose: the info-level
-            # query_rewrite telemetry below does not reach VictoriaLogs in
-            # production, and an invisible guard cannot be monitored for
-            # hijacks or false positives. Dropped tokens are literal customer
-            # text → full-telemetry orgs only.
+            # Guard-fire is warning-level on purpose: decision telemetry must
+            # reach VictoriaLogs in production. Dropped tokens are literal
+            # customer text → full-telemetry orgs only.
             if rewrite_meta.get("skipped") == "destructive_rewrite":
                 dropped = rewrite_meta.get("dropped_salient_tokens", [])
                 logger.warning(
@@ -809,7 +807,7 @@ class KlaiKnowledgeHook(CustomLogger):
             # REQ-OBS-03: ``skipped`` IS the skip reason (empty when the
             # rewrite ran); ``prompt_variant`` distinguishes plain/classify.
             if telemetry_level == "full":
-                logger.info(
+                logger.warning(
                     "query_rewrite org_id=%s user_id=%s raw_query=%r rewritten_query=%r "
                     "rewrite_ms=%d was_changed=%s skipped=%s prompt_variant=%s "
                     "pasted_correspondence_detected=%s",
@@ -824,7 +822,7 @@ class KlaiKnowledgeHook(CustomLogger):
                     rewrite_meta.get("pasted_correspondence_detected", False),
                 )
             else:
-                logger.info(
+                logger.warning(
                     "query_rewrite_metadata org_id=%s user_id=%s "
                     "rewrite_ms=%d was_changed=%s skipped=%s prompt_variant=%s "
                     "pasted_correspondence_detected=%s",
@@ -889,7 +887,7 @@ class KlaiKnowledgeHook(CustomLogger):
         # distilled query as a search leg (production replay, 2026-08-18).
         if latest_turn_correspondence:
             all_sub_questions: list[str] = []
-            logger.info(
+            logger.warning(
                 "sub_question_split_skipped_pasted_correspondence org_id=%s user_id=%s",
                 org_id,
                 user_id,
@@ -1576,7 +1574,7 @@ class KlaiKnowledgeHook(CustomLogger):
         ):
             stats = _compose_non_streaming_kb_response(response, kb_meta)
             _log_kb_citation_render(logger, kb_meta, stats, stream=False)
-            logger.info(
+            logger.warning(
                 "KB injection: org=%s user=%s chunks=%d retrieval_ms=%d",
                 kb_meta["org_id"],
                 kb_meta["user_id"],

--- a/deploy/litellm/tests/test_telemetry_level_forwarding.py
+++ b/deploy/litellm/tests/test_telemetry_level_forwarding.py
@@ -15,9 +15,11 @@ as the rest of the hook tests.
 
 # noqa: I001
 import importlib.util
+import logging
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -178,7 +180,7 @@ async def test_query_rewrite_log_redacts_in_shadow_mode(monkeypatch, caplog):
         mc.__aexit__ = AsyncMock(return_value=None)
         cls.return_value = mc
 
-        with caplog.at_level("INFO"):
+        with caplog.at_level(logging.WARNING, logger="klai_knowledge"):
             await hook.async_pre_call_hook(
                 _make_user_api_key(), cache, data, "completion"
             )
@@ -215,7 +217,7 @@ async def test_query_rewrite_log_keeps_text_in_full_mode(monkeypatch, caplog):
         mc.__aexit__ = AsyncMock(return_value=None)
         cls.return_value = mc
 
-        with caplog.at_level("INFO"):
+        with caplog.at_level(logging.WARNING, logger="klai_knowledge"):
             await hook.async_pre_call_hook(
                 _make_user_api_key(), cache, data, "completion"
             )
@@ -227,3 +229,117 @@ async def test_query_rewrite_log_keeps_text_in_full_mode(monkeypatch, caplog):
     assert "query_rewrite" in rendered
     # Verify it's NOT the metadata-only variant (that's the redacted form).
     assert "query_rewrite_metadata" not in rendered
+    rewrite_record = next(
+        record
+        for record in caplog.records
+        if "query_rewrite org_id=" in record.getMessage()
+    )
+    assert rewrite_record.levelno == logging.WARNING
+
+
+@pytest.mark.asyncio
+async def test_shadow_decision_events_reach_warning_log_level(monkeypatch, caplog):
+    """SPEC-RAG-SOURCE-SELECTION-001 REQ-1: decision events emitted on the
+    pasted-correspondence path must survive the production WARNING filter.
+
+    Shadow telemetry intentionally exercises the metadata-only rewrite event
+    so the observability change cannot widen raw query logging.
+    """
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    cache = _make_cache(feature_enabled=True, feature={"telemetry_level": "shadow"})
+    pasted_query = (
+        "Van: Klant <klant@example.nl>\n"
+        "Aan: Support <support@example.nl>\n"
+        "Onderwerp: storing\n\n"
+        "Waarom geeft de trunk een 404 Not Found?"
+    )
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": pasted_query}],
+    }
+    mock_resp = _make_resp({"chunks": [], "retrieval_bypassed": False})
+
+    with patch("klai_knowledge.httpx.AsyncClient") as cls:
+        mc = AsyncMock()
+        mc.post = AsyncMock(return_value=mock_resp)
+        mc.get = AsyncMock(return_value=_make_resp({"enabled": True}))
+        mc.__aenter__ = AsyncMock(return_value=mc)
+        mc.__aexit__ = AsyncMock(return_value=None)
+        cls.return_value = mc
+
+        caplog.set_level(logging.WARNING, logger="klai_knowledge")
+        await hook.async_pre_call_hook(
+            _make_user_api_key(), cache, data, "completion"
+        )
+
+    warning_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "klai_knowledge" and record.levelno >= logging.WARNING
+    ]
+    rendered = " ".join(warning_messages)
+    assert "pasted_correspondence_detected org_id=" in rendered
+    assert "query_rewrite_metadata org_id=" in rendered
+    assert "sub_question_split_skipped_pasted_correspondence org_id=" in rendered
+    assert "klant@example.nl" not in rendered
+    assert "support@example.nl" not in rendered
+    assert "Waarom geeft de trunk een 404 Not Found?" not in rendered
+    assert pasted_query not in rendered
+
+
+@pytest.mark.asyncio
+async def test_kb_injection_summary_reaches_warning_log_level(monkeypatch, caplog):
+    """SPEC-RAG-SOURCE-SELECTION-001 REQ-1: the post-call KB injection
+    summary must survive the production WARNING filter.
+    """
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content="Gebruik de handleiding.")
+            )
+        ]
+    )
+    data = {
+        "metadata": {
+            "_klai_kb_meta": {
+                "org_id": "org123",
+                "user_id": "user123",
+                "chunks_injected": 1,
+                "retrieval_ms": 12,
+                "gate_bypassed": False,
+                "allowed_source_urls": ["https://docs.getklai.com/handleiding"],
+                "allowed_image_urls": [],
+                "trusted_sources": [
+                    {
+                        "label": "1",
+                        "title": "Handleiding",
+                        "url": "https://docs.getklai.com/handleiding",
+                    }
+                ],
+                "citation_chunks": [
+                    {
+                        "title": "Handleiding",
+                        "source_url": "https://docs.getklai.com/handleiding",
+                        "text": "Gebruik de handleiding.",
+                    }
+                ],
+            }
+        }
+    }
+
+    caplog.set_level(logging.WARNING, logger="klai_knowledge")
+    await hook.async_post_call_success_hook(data, None, response)
+
+    summary_record = next(
+        (
+            record
+            for record in caplog.records
+            if record.getMessage().startswith("KB injection: org=")
+        ),
+        None,
+    )
+    assert summary_record is not None
+    assert summary_record.levelno == logging.WARNING

--- a/docs/architecture/knowledge-rag-improvement-plan.md
+++ b/docs/architecture/knowledge-rag-improvement-plan.md
@@ -120,7 +120,7 @@ Key files: `routes/ingest.py`, `pg_store.py`, `qdrant_store.py`, `enrichment.py`
 
 LibreChat / Partner API / widget → LiteLLM `KlaiKnowledgeHook` (`deploy/litellm/klai_knowledge.py` + `klai_kb_*` modules): trivial check → feature/scope lookup (30s/300s two-level cache) → taxonomy trees+coverage (Redis) → combined rewrite+classify in one `QUERY_REWRITE_MODEL` call → `retrieval-api /retrieve` (`api/retrieve.py::retrieve`):
 
-identity verify → coreference (skipped when caller pre-resolved) → dense+sparse embed → **gate (shadow)** → **router** (source labels; keyword/centroid layers, LLM layer dead) → Qdrant native RRF (`FusionQuery`, prefetch `max(candidates×4, 20)`; 2–5 legs + parallel Graphiti leg) → link expansion + authority boost → Infinity rerank (top 20) → quality boost (≥3 votes, ±10%) → source-aware select → parent expansion → **evidence-tier shadow scoring** → EvidencePack.
+identity verify → coreference (skipped when caller pre-resolved) → dense+sparse embed → **gate (shadow)** → **router** (semantic source-label centroids; optional LLM fallback disabled by default) → Qdrant native RRF (`FusionQuery`, prefetch `max(candidates×4, 20)`; 2–5 legs + parallel Graphiti leg) → link expansion + authority boost → Infinity rerank (top 20) → quality floor → source-aware select (bounded router preference + diversity) → quality boost (≥3 votes, ±10%) → parent expansion → **evidence-tier shadow scoring** → EvidencePack.
 
 ### Citation path **[doc]**
 

--- a/docs/architecture/knowledge-retrieval-flow.md
+++ b/docs/architecture/knowledge-retrieval-flow.md
@@ -81,11 +81,11 @@ User types a message (LibreChat | Partner API consumer | chat widget on external
         │         │    SPEC-RAG-CONTEXTUAL-001 — Anthropic-pattern contextual retrieval)
         │         ├── Apply taxonomy_node_ids filter (when classifier returned IDs
         │         │   AND in-scope KB has coverage)
-        │         ├── Source-aware selection (mentioned / diversify mode, SPEC-KB-021)
         │         ├── Reranking (cross-encoder scores each chunk against the query)
+        │         ├── Source-aware selection (semantic preference + diversity, SPEC-KB-021)
+        │         ├── Quality score boost (feedback signals from Qdrant payload)
         │         ├── Parent expansion — expand each top-K child to its parent chunk
         │         │   text via parent_chunk_id (SPEC-RAG-PARENT-CHILD-001)
-        │         ├── Quality score boost (feedback signals from Qdrant payload)
         │         └── Return top-K chunks (parent text where expansion succeeded)
         │
         ├──▶ Write retrieval log to Redis (fire-and-forget, for feedback correlation)
@@ -642,47 +642,48 @@ for the full picture.
 ### Step 5c: Source-aware selection (SPEC-KB-021)
 
 **Simple:** When an org has multiple knowledge bases, Klai ensures that the top-K results
-are not monopolized by a single source. This step enforces source diversity while respecting
-the user's query intent — if they explicitly mention a source by name, that source gets
-priority.
+are not monopolized by a single source. This step enforces source diversity while allowing
+the semantic source router to apply a small, bounded preference to relevant sources.
 
-**Technical:** After quality boost, `source_aware_select()` applies two filters in sequence:
+**Technical:** After reranking and the quality floor, `source_aware_select()` applies two
+ranking steps in sequence:
 
-**1. Mention and gate detection:**
-- If the `query_resolved` contains a substring match (lowercase) of any `kb_slug` longer
-  than 3 characters, that source is "mentioned" and gets priority.
-- Alternatively, if the router (see below) has selected specific sources, those are
-  "selected" and get priority.
+**1. Bounded semantic preference:**
+- Source labels selected by the router receive a configurable additive score boost
+  (`SOURCE_PREFERENCE_BOOST`, default `0.05`). There is no query substring, keyword-map,
+  or stop-word matching in this path.
+- When the request pins `kb_slugs`, both the source label and the KB slug must match before
+  a chunk receives the boost. This prevents a personal chunk with a generic label from
+  inheriting an organization-KB preference in `scope=both` requests.
+- The original score-only pack is retained in decision metadata as the counterfactual;
+  suppression count and maximum score inversion quantify the preference's effect.
 
 **2. Diversity enforcement:**
-- If a source is mentioned or selected: allocate all remaining slots to chunks from that
-  source(s), sorted by reranker score descending.
-- Otherwise ("diversify" mode): greedily select chunks sorted by reranker score, with a
-  hard limit of `max_per_source` (default: 2) chunks per `source_label`. When a source hits
-  its quota, skip to the next highest-scoring chunk from a different source. If fewer than
-  `top_k` results remain after quota enforcement, fill remaining slots with the
-  highest-scoring chunks regardless of source (fallback fill).
+- Greedily select chunks by boosted score with a hard limit of `max_per_source` (default:
+  2) chunks per `source_label`. When a source hits its quota, skip to the next
+  highest-scoring chunk from a different source.
+- If fewer than `top_k` results remain after quota enforcement, fill remaining slots with
+  the highest-scoring chunks regardless of source. The same cap applies whether or not the
+  router supplied a preference.
 
 The `source_label` field (computed during ingestion, see
 [knowledge-ingest-flow.md — Source-label and source-aware enrichment](knowledge-ingest-flow.md#step-d5--source-label-and-source-aware-enrichment-spec-kb-021))
 is read from each chunk's Qdrant payload.
 
 **Router as a pre-search signal (SPEC-KB-021):**
-Before executing `hybrid_search`, if the user has not specified `kb_slugs` (i.e., they
-are not filtering manually) and the org has ≥ 4 knowledge bases, a three-layer router
-is invoked:
+Before executing `hybrid_search`, organization-scoped requests with enough distinct source
+labels invoke a two-layer router. The source catalog and centroid reads are filtered by
+`org_id` and, when supplied, the pinned `kb_slugs`:
 
 | Layer | Method | Input |
 |-------|--------|-------|
-| Layer 1 | Keyword gate | Pre-computed `{brand_term → kb_slug}` map from KB name + description |
-| Layer 2 | Semantic margin | Cosine similarity between `query_vector` and pre-computed centroids per source |
-| Layer 3 | LLM fallback | (Optional) Route via `klai-fast` with 500ms timeout if Layer 1+2 are inconclusive |
+| Layer 1 | Semantic margin | Cosine similarity between `query_vector` and pre-computed centroids per source |
+| Layer 2 | LLM fallback | Optional, disabled by default; 500ms timeout when semantic routing abstains |
 
 The router's decision is **not** applied as a hard filter to the Qdrant query. Instead,
-it signals which sources *might* be relevant, and is passed to `source_aware_select` as
-the `router_selected` parameter. The search still retrieves candidates from all sources;
-the router influence is applied in the diversity step, not the search step. This allows
-semantic relevance to trump router signal when appropriate.
+it signals which sources *might* be relevant, and the selected labels are passed to
+`source_aware_select` as a bounded preference. The search still retrieves candidates from
+all in-scope sources; router influence is applied after reranking, not as a search filter.
 
 Router centroids are pre-computed as the mean vector of the top-10 chunk embeddings per
 source. They are cached in memory with a TTL (default: 10 minutes) and refreshed on-demand
@@ -690,12 +691,13 @@ when the org's KB catalog changes (new KB added, description updated).
 
 **Decision record logging (SPEC-KB-021):**
 Every retrieval request logs the following to `RetrieveMetadata` for observability:
-- `source_aware_mode`: "mentioned" | "diversify" (which diversity strategy was used)
-- `router_layer_used`: "keyword" | "semantic" | "llm" | "skipped" (which layer fired, if any)
-- `router_decision`: list of selected `kb_slug` values, or None if no router selection
-- `router_margin`: cosine margin value from Layer 2, or None if Layer 2 didn't run
-- `quota_applied`: bool (whether source quota affected the final result)
-- `quota_per_source_counts`: dict mapping `kb_slug` to count of chunks in final result
+- `source_select.source_select_mode`: "router" | "diversify" | "disabled" | "empty"
+- `source_select.preference_applied`, `preferred_labels`, `boost`,
+  `pack_without_preference`, `suppressed_count`, and `max_score_inversion`
+- `router.router_layer_used`: "semantic" | "llm" | "none" | "skipped"
+- `router.router_decision`: list of selected `source_label` values, or None
+- `router.router_margin`: cosine margin value from Layer 1, or None if it did not run
+- `source_select.source_counts`: dict mapping `source_label` to final chunk count
 
 These fields enable post-retrieval analysis: which sources does the router recommend vs.
 which the diversity algorithm selects vs. which actually end up in the top-K.
@@ -1098,14 +1100,14 @@ snapshot: [docs/architecture/retrieval-improvements-roadmap.md](retrieval-improv
 | Coreference | `klai-retrieval-api/retrieval_api/services/coreference.py` | Pronoun resolution via `klai-fast` |
 | Embeddings | `klai-retrieval-api/retrieval_api/services/tei.py` | Dense + sparse embedding via BGE-M3 |
 | Qdrant search | `klai-retrieval-api/retrieval_api/services/search.py` | Hybrid three-leg RRF search |
-| Source-aware select | `klai-retrieval-api/retrieval_api/services/diversity.py` | `source_aware_select()` — `mentioned` / `diversify` mode + `STOP_WORDS`. Called from `retrieve.py` step 5c. |
+| Source-aware select | `klai-retrieval-api/retrieval_api/services/diversity.py` | `source_aware_select()` — bounded semantic source preference followed by per-label diversity. Called from `retrieve.py` step 5c. |
 | Evidence tier | `klai-retrieval-api/retrieval_api/services/evidence_tier.py` | `apply()` + `_order_for_llm()` U-shape; content_type / temporal / pagerank weights. Shadow-mode default. |
 | Parent text swap | `klai-retrieval-api/retrieval_api/services/parent_lookup.py` | SPEC-RAG-PARENT-CHILD-001 — batch-fetches `knowledge.parent_chunks` rows for chunks with `parent_chunk_id`. |
 | Quality boost | `klai-retrieval-api/retrieval_api/quality_boost.py` | SPEC-KB-015 — `feedback_count >= 3` cold-start gate, ±10% boost. |
 | Identity verify (portal) | `klai-portal/backend/app/services/identity_verifier.py` | `verify_identity_claim()` — JWT / membership / `partner:<key_id>` branches. |
 | Identity asserter (lib) | `klai-libs/identity-assert/klai_identity_assert/` | Consumer-side cache + retry around `/internal/identity/verify`. |
 | F2 audit ref | `.moai/audits/retrieval-coupling-2026-05-06/findings/F2-...md` | Why partner-key verification lives portal-side (not in retrieval-api). |
-| Router (signal) | `klai-retrieval-api/retrieval_api/services/router.py` | Keyword + semantic-centroid signal for source-aware select (SPEC-KB-021) |
+| Router (signal) | `klai-retrieval-api/retrieval_api/services/router.py` | Semantic-centroid signal with optional LLM fallback for source-aware select (SPEC-KB-021) |
 | Graph search | `klai-retrieval-api/retrieval_api/services/graph_search.py` | FalkorDB/Graphiti parallel traversal, RRF-merged with Qdrant results |
 | Reranker | `klai-retrieval-api/retrieval_api/services/reranker.py` | Cross-encoder reranking via BGE-reranker-v2-m3 on gpu-01 (Infinity) |
 | Retrieval gate | `klai-retrieval-api/retrieval_api/services/gate.py` | Cosine margin bypass check |

--- a/docs/architecture/knowledge-retrieval-flow.md
+++ b/docs/architecture/knowledge-retrieval-flow.md
@@ -82,6 +82,7 @@ User types a message (LibreChat | Partner API consumer | chat widget on external
         │         ├── Apply taxonomy_node_ids filter (when classifier returned IDs
         │         │   AND in-scope KB has coverage)
         │         ├── Reranking (cross-encoder scores each chunk against the query)
+        │         ├── Quality floor (remove explicitly degraded chunks)
         │         ├── Source-aware selection (semantic preference + diversity, SPEC-KB-021)
         │         ├── Quality score boost (feedback signals from Qdrant payload)
         │         ├── Parent expansion — expand each top-K child to its parent chunk
@@ -532,8 +533,9 @@ Scope `"org"` or `"both"`:
 
 KB slug filter (when active):
 - `kb_slug IN [requested slugs]`
-- Exception: when scope is `"both"`, personal chunks (`user_id == request.user_id`)
-  bypass the slug filter and are always included
+- Exception: when scope is `"both"`, the requester's canonical personal KB slug is
+  allowed alongside the selected organization KB slugs. Other user-stamped chunks in
+  unselected KBs do not bypass the filter.
 
 **Parallel graph search:**
 FalkorDB/Graphiti runs a graph traversal in parallel with the Qdrant search, resolving
@@ -603,43 +605,21 @@ Timeout: 30 seconds. On failure, the top-K Qdrant results are returned unranked.
 
 ---
 
-### Step 5b: Quality score boost (SPEC-KB-015)
+### Step 5a: Quality floor (SPEC-INGEST-LOGIN-WALL-DETECT-001)
 
-**Simple:** Chunks that users have previously rated helpful get a small ranking boost.
-Chunks rated unhelpful get a small penalty. This makes the knowledge base self-improving
-over time — popular, useful answers rise; outdated or irrelevant ones sink.
+**Simple:** Chunks explicitly degraded as login-walled or unusable are removed before
+they can consume a source-diversity slot.
 
-**Technical:** After reranking, `quality_boost()` reads two payload fields from each Qdrant
-result:
-
-- `quality_score` — running average of thumbs up/down signals, initialized at `0.5` (neutral)
-- `feedback_count` — total number of feedback events on this chunk
-
-```python
-boosted_score = rrf_score * (1 + 0.2 * (quality_score - 0.5))
-```
-
-The boost is only applied when `feedback_count >= 3` (cold-start guard). Below this
-threshold, chunks rank purely on retrieval score. The threshold is 3 rather than the
-statistically ideal 5–10 because Klai's per-org user pool is small; see SPEC-KB-015
-§Design notes for full rationale.
-
-At maximum signal (quality_score = 1.0 or 0.0), the adjustment is ±10% of the RRF score
-— intentionally conservative to avoid letting feedback dominate over semantic relevance.
-
-Results are re-sorted by the boosted score.
-
-**Feedback loop:** After the retrieval-api responds, the LiteLLM hook fires a retrieval
-log to `portal-api /internal/v1/retrieval-log` (fire-and-forget). This log is stored in
-Redis (1-hour TTL). When the user later clicks 👍 or 👎 on the AI response, LibreChat
-forwards the feedback to `portal-api /internal/v1/kb-feedback`, which correlates it with
-the retrieval log and updates the Qdrant payload. See
-[knowledge-ingest-flow.md — Self-learning feedback loop](knowledge-ingest-flow.md#self-learning-feedback-loop-spec-kb-015)
-for the full picture.
+**Technical:** After reranking, `filter_quality_floor()` removes chunks whose numeric
+`quality_score` is below `KLAI_RETRIEVAL_QUALITY_FLOOR` (default `0.05`). Missing or
+non-numeric values use the neutral default `0.5`. One or two feedback votes remain in the
+cold-start window and are also treated as neutral; a single thumbs-down must not become a
+hard exclusion. The filter preserves candidate order and records the removed count in
+`quality_floor_filtered`.
 
 ---
 
-### Step 5c: Source-aware selection (SPEC-KB-021)
+### Step 5b: Source-aware selection (SPEC-KB-021)
 
 **Simple:** When an org has multiple knowledge bases, Klai ensures that the top-K results
 are not monopolized by a single source. This step enforces source diversity while allowing
@@ -702,7 +682,41 @@ Every retrieval request logs the following to `RetrieveMetadata` for observabili
 These fields enable post-retrieval analysis: which sources does the router recommend vs.
 which the diversity algorithm selects vs. which actually end up in the top-K.
 
-The final `top_k` chunks (default: 5) are returned to the LiteLLM hook.
+The selected chunks then receive the feedback-based quality boost.
+
+---
+
+### Step 5c: Quality score boost (SPEC-KB-015)
+
+**Simple:** Chunks that users have previously rated helpful get a small ranking boost.
+Chunks rated unhelpful get a small penalty. This makes the knowledge base self-improving
+over time — popular, useful answers rise; outdated or irrelevant ones sink.
+
+**Technical:** After source-aware selection, `quality_boost()` reads two payload fields
+from each selected chunk:
+
+- `quality_score` — running average of thumbs up/down signals, initialized at `0.5` (neutral)
+- `feedback_count` — total number of feedback events on this chunk
+
+```python
+boosted_score = base_rank_score * (1 + 0.2 * (quality_score - 0.5))
+```
+
+The boost is only applied when `feedback_count >= 3` (cold-start guard). Below this
+threshold, chunks rank purely on retrieval score. At maximum signal (`quality_score` 1.0
+or 0.0), the adjustment is ±10% of the ranking score. Results are re-sorted when the
+active ranking contract applies a boost; shadow serving retains its legacy score ordering.
+
+**Feedback loop:** After the retrieval-api responds, the LiteLLM hook fires a retrieval
+log to `portal-api /internal/v1/retrieval-log` (fire-and-forget). This log is stored in
+Redis (1-hour TTL). When the user later clicks 👍 or 👎 on the AI response, LibreChat
+forwards the feedback to `portal-api /internal/v1/kb-feedback`, which correlates it with
+the retrieval log and updates the Qdrant payload. See
+[knowledge-ingest-flow.md — Self-learning feedback loop](knowledge-ingest-flow.md#self-learning-feedback-loop-spec-kb-015)
+for the full picture.
+
+The final `top_k` chunks (default: 5) continue to parent expansion and are then returned
+to the LiteLLM hook.
 
 ---
 

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -778,7 +778,7 @@ Legend: ✅ confirmed compatible | ⚠️ attention point | ❌ correction neede
 | 📋 Planned | Guardrail Rules | PII block/redact + keyword block/redact via klai-pii microservice (SPEC-CHAT-GUARDRAILS-001). |
 | ✅ Done | Two-phase web crawler | BFS discovery + extraction split (SPEC-CRAWL-002). Cookie auth, canary + login-indicator guard, SimHash-LSH dedup for >200 pages (SPEC-CRAWL-003), Layer A/B/C quality status. |
 | ✅ Done | Google Drive OAuth connector | SPEC-KB-025a. First OAuth-based connector. |
-| ✅ Done | Source-aware retrieval | `source_aware_select` replaces router+quota (SPEC-KB-021). Router-as-signal (keyword + semantic centroid). `source_label` Qdrant payload field enables Facet API. |
+| ✅ Done | Source-aware retrieval | `source_aware_select` applies a bounded semantic-router preference plus per-source diversity (SPEC-KB-021). `source_label` Qdrant payload field enables Facet API. |
 | ✅ Done | KB editor reliability | Full-UUID page URLs, BlockNote JSON persistence, client-owned SHA + promise queue, 409 auto-retry (SPEC-DOCS-001). |
 | ✅ Done | Dev environment | Parallel stack on `dev.getklai.com` with isolated LibreChat + LiteLLM. |
 | ✅ Done | Graph retrieval re-enabled | `GRAPHITI_ENABLED=true` on both `knowledge-ingest` and `retrieval-api` now that LLM + reranker dependencies run on gpu-01. Graph search leg rejoins Qdrant 3-leg RRF fusion. |

--- a/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
+++ b/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
@@ -246,7 +246,9 @@ rows. A unit test asserting the log level is required but is not sufficient evid
 
 **WHEN** a set of preferred source labels is available, **THE selection SHALL** apply a
 bounded additive boost `β` to the ranking score of chunks belonging to those labels, and
-**SHALL NOT** allocate slots by source.
+**SHALL NOT** allocate extra or guaranteed slots based on preferred status. The existing
+per-source diversity cap remains unchanged and applies equally to preferred and
+non-preferred labels.
 
 The boosted value is derived from the same field `ranking_score()` already uses
 (`final_rank_score` when the ranking contract is active, `reranker_score` otherwise) so
@@ -258,15 +260,19 @@ eval run is what validates or replaces it.
 
 #### REQ-3 — rank inversion is bounded by construction (ubiquitous)
 
-**THE selection SHALL** guarantee that no chunk is ranked below another whose unboosted
-ranking score is more than `β` higher.
+**THE source-preference step SHALL** guarantee that it does not rank or displace a chunk
+below another whose unboosted ranking score is more than `β` lower.
 
 This is a property of REQ-2's bounded additive form, not additional runtime logic: an
 additive boost capped at `β` cannot move a chunk past one scoring more than `β` above it.
 The requirement exists so it is **tested as an invariant** rather than assumed, and so any
 future source-preference mechanism inherits the bound.
 
-A property test SHALL assert this over randomised score/label distributions.
+A property test SHALL assert this over randomised score/label distributions. It SHALL
+also compare the served pack with `β=0` against `β>0` while the production diversity cap
+is enabled, so any displacement caused by preference remains bounded. Diversity may
+independently select a lower-scoring label in both packs; that pre-existing, symmetric
+cap behaviour is not a preference-caused inversion.
 
 #### REQ-4 — the counterfactual is logged (ubiquitous)
 
@@ -299,8 +305,10 @@ Concretely, delete:
 - the Layer-1 branch in `route_to_sources` (`router.py:257-264`)
 - `diversity.py:27-63` `STOP_WORDS`
 
-`STOP_WORDS` has exactly two consumers (`diversity.py:86` and `router.py:111`), both
-removed here — verified 2026-08-19 by repository-wide grep. Confirm again before deleting.
+The retrieval source-selection `STOP_WORDS` constant has exactly two consumers
+(`diversity.py:86` and `router.py:111`), both removed here — verified 2026-08-19 by
+repository-wide grep. Unrelated stop-word lists outside retrieval source selection are
+not part of this requirement.
 
 `RoutingDecision.layer_used` loses the `"keyword"` value. Update its docstring and every
 consumer, including the `router_layer_used` telemetry field and its tests.
@@ -377,9 +385,9 @@ enforcement in the same PR is out of scope.
 |-------|------|-------------------|
 | AC-1 | After Phase 0 deploy, LogsQL for each event name in REQ-1 over a 1h window with real chat traffic | ≥1 row per event name; raw query text absent for orgs whose `telemetry_level` is not `full` |
 | AC-2 | Unit: `source_aware_select` with two labels, chunk A (label X) at 0.66 and chunk B (label Y) at 0.28, preference on Y | A still ranks above B; B is not promoted past A |
-| AC-3 | Property test over randomised (score, label) sets with preference on a random label | No chunk ranks below another whose unboosted score is more than `β` higher — REQ-3 invariant holds for all generated cases |
+| AC-3 | Property test over randomised (score, label) sets with preference on a random label, including the production diversity cap | No preference-caused reorder or `β=0` → `β>0` pack displacement exceeds `β`; the independent diversity-cap outcome may differ from pure score order in both packs |
 | AC-4 | Replay of the incident shape: query containing the tenant brand token, chunks split across `help.voys.nl` and another label | `suppressed_count == 0`; chunks at 0.658/0.616 present in the served pack |
-| AC-5 | Repository grep after Phase 2 | Zero occurrences of `_detect_mentioned_sources`, `layer1_keyword`, `_build_keyword_map`, `STOP_WORDS`; drift-guard test present and failing on a deliberately reintroduced substring match |
+| AC-5 | Retrieval source-selection grep after Phase 2 | Zero occurrences of `_detect_mentioned_sources`, `layer1_keyword`, `_build_keyword_map`, or `STOP_WORDS` in `retrieval_api/services/{diversity,router}.py`; drift-guard test present and failing on a deliberately reintroduced substring match |
 | AC-6 | Unit: `route_to_sources` on a catalogue whose labels are all semantically similar (Voys-shaped) | Returns `selected_source_labels=None`, `layer_used="none"` — abstains rather than committing |
 | AC-7 | Unit: `fetch_source_catalog` with `kb_slugs=["sip"]` | Facet filter carries both `org_id` and `kb_slug`; cache key differs from the unscoped call |
 | AC-8 | Full `chat.yaml` suite before vs. after Phase 2 | Aggregate `context_recall` MUST NOT decrease; aggregate `context_precision` MUST NOT decrease by more than 0.02. Per-canary deltas reported in the PR body regardless of outcome |

--- a/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
+++ b/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-RAG-SOURCE-SELECTION-001
-version: "0.1.0"
+version: "0.1.1"
 status: draft
 created: 2026-08-19
 updated: 2026-08-19
@@ -20,6 +20,7 @@ roadmap: docs/architecture/retrieval-improvements-roadmap.md
 
 | Version | Date       | Author       | Change        |
 |---------|------------|--------------|---------------|
+| 0.1.1   | 2026-08-19 | Codex | Review clarification: the chat suite keeps only the retrieval-testable brand-token canary; the single-strong-hit confidence contract is proved through the retrieval decision record. A one-chunk served pack deliberately remains `medium` in shadow and must be analysed separately before enforcement. |
 | 0.1.0   | 2026-08-19 | Mark Vletter | Initial draft. Written after a production trace of the 2026-08-19 Voys trunk conversation (`request_id=d83d2c14-c2bb-4557-91a1-5831fa9a5a78`) showed the shipped correspondence distillation working correctly while the answer was still wrong, because source selection narrowed the evidence pack on the tenant's own brand name. Four phases, ordered by impact and by dependency. Implementation is delegated (Codex/Sol); this document is the complete, self-contained brief. |
 
 ---
@@ -198,8 +199,10 @@ afterthought.
 
 **Eval**
 
-- New canaries in `klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml`
-  covering the brand-token false positive and the single-strong-hit band case.
+- A retrieval-testable brand-token canary in
+  `klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml`.
+- The single-strong-hit band case is asserted on `retrieval_decision_record`; an empty
+  `expected_chunks` list is not a RAGAS canary and therefore must not be presented as one.
 
 ### Out of scope
 
@@ -349,6 +352,9 @@ A single chunk at or above the threshold with no second supporting chunk yields 
 `medium`.
 
 `low` and `unknown` semantics are unchanged. `medium` remains the residual bucket.
+This includes a served pack containing exactly one strong chunk: it deliberately remains
+`medium` in shadow. The later enforcement decision must report one-chunk packs separately,
+rather than silently treating the shadow contract as already approved for serving.
 
 #### REQ-9 — shadow before enforcement (ubiquitous)
 
@@ -403,6 +409,7 @@ enforcement in the same PR is out of scope.
 | `β = 0.05` is wrong for the actual reranker score distribution | high | low | Explicitly declared an untested starting point. Env-tunable, validated by AC-8, and bounded by REQ-3 so a wrong value cannot reproduce the original failure class — only weaken or strengthen a tiebreak |
 | Cold centroid cache adds latency on the pinned-KB path, which previously skipped the router entirely | medium | medium | 10-chunk sample per label, ≤50 labels, 600 s TTL. NFR sets a 100 ms p95 ceiling. If exceeded, warm the cache on catalogue build rather than relax the ceiling |
 | Cache key omits `kb_slugs` and serves a catalogue from the wrong scope | medium | high | Called out explicitly in REQ-6. AC-7 tests it. Tenant-isolation-adjacent: a wrong cache key across orgs would be a cross-tenant leak, so `/klai:tenant-review` is mandatory on this PR |
+| Router catalogues and centroids are organisation-scoped, not user-visibility-scoped | low | medium | Serving-time Qdrant filters remain authoritative, so inaccessible chunks cannot enter the response. A broader per-user router geometry redesign is intentionally deferred; it needs an explicit cache-cardinality and private-KB routing contract rather than a partial change in this SPEC |
 | Corroboration requirement raises the Strict abstain rate and users see more refusals | medium | high | Exactly why REQ-9 mandates shadow-first. Enforcement is a separate decision with AC-11 data behind it |
 | Phase 2 lands before Phase 1 and a routing regression reproduces the demotion bug | low | high | Phase ordering is a hard requirement, not a preference: Phase 1's bound is what makes Phase 2 safe to get wrong. Enforce via PR sequencing |
 

--- a/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
+++ b/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
@@ -1,0 +1,456 @@
+---
+id: SPEC-RAG-SOURCE-SELECTION-001
+version: "0.1.0"
+status: draft
+created: 2026-08-19
+updated: 2026-08-19
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-KB-021 (introduced source_label, source_aware_select, and the three-layer router this SPEC rewrites)
+  - SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 (owns _compute_confidence_band; REQ-4 changes its input semantics)
+  - SPEC-RAG-CORRESPONDENCE-DISTILL-001 (the distillation whose output was neutralised by the defect this SPEC fixes)
+  - SPEC-RAG-ANSWER-EPISTEMICS-001 (sibling SPEC; independent, shares the Phase 0 observability precondition)
+  - SPEC-RAG-EVAL-001 (acceptance criteria use its eval harness)
+  - SPEC-PRIVACY-QUERY-SHADOW-001 (REQ-1 must not widen what query text is logged)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# HISTORY
+
+| Version | Date       | Author       | Change        |
+|---------|------------|--------------|---------------|
+| 0.1.0   | 2026-08-19 | Mark Vletter | Initial draft. Written after a production trace of the 2026-08-19 Voys trunk conversation (`request_id=d83d2c14-c2bb-4557-91a1-5831fa9a5a78`) showed the shipped correspondence distillation working correctly while the answer was still wrong, because source selection narrowed the evidence pack on the tenant's own brand name. Four phases, ordered by impact and by dependency. Implementation is delegated (Codex/Sol); this document is the complete, self-contained brief. |
+
+---
+
+# SPEC-RAG-SOURCE-SELECTION-001: Source selection by comparison, not by string match
+
+## Summary
+
+Retrieval-api decides which knowledge sources get preference by **substring-matching
+source-label tokens against the raw query text**. For a tenant whose brand name appears
+in its own source domain, this fires on essentially every query and hands one source the
+entire evidence pack — demoting materially better-scoring chunks from other sources.
+
+The same defective heuristic exists in two independent places, and in one of them it
+short-circuits the semantically correct mechanism that already exists next to it.
+
+This SPEC replaces matching with comparison, bounds the damage any source preference can
+do, and makes the whole decision observable. It changes behaviour for **all** tenants —
+that is intended, not a side effect.
+
+## Motivation
+
+### The production trace
+
+2026-08-19 07:06 CEST, Voys production (org `368884765035593759`), one minute after the
+SPEC-RAG-CORRESPONDENCE-DISTILL-001 v0.7.0 deploy (litellm container restart
+`05:04:58Z`). A support agent pasted a customer email about a VoIP trunk failing with SIP
+`404 Not Found` / `Q.850;cause=1` and asked for a diagnosis.
+
+The distillation worked. The FalkorDB graph-search query recorded for
+`request_id=d83d2c14-c2bb-4557-91a1-5831fa9a5a78` shows the effective search terms:
+
+```
+Voys | trunk | 404 | Found | uitgaand | bellen | 407 | Proxy |
+Authentication | 183 | Session | Progress | Q | 850 | cause | 1 | VGUA
+```
+
+That is a keyword-style distillate, not the raw 5760-character email. The sub-question
+fan-out was correctly skipped. Everything SPEC-RAG-CORRESPONDENCE-DISTILL-001 promised
+held.
+
+The answer was still wrong, and `01_sip_response_codes.md` — the article that states
+plainly *"404 | Not Found | Gebruiker/toestel bestaat niet, of extensie niet gevonden"* —
+did not reach the model. The `retrieval_decision_record` for the same request shows why:
+
+| Field | Value |
+|---|---|
+| `source_select.source_select_mode` | `mentioned` |
+| `source_select.mentioned_sources` | `["help.voys.nl"]` |
+| `source_select.source_counts` | `{help.voys.nl: 12, notion: 6, support: 2}` |
+| `reranker_scores_top5` | `[0.8661, 0.6584, 0.6156, 0.2806, 0.2689]` |
+| `evidence_pack.sources` | FreePBX 0.8661 · Android Probleemoplosser 0.2806 · VoIP-trunk configuratie 0.2082 |
+| `retrieval_confidence_band` | `high` |
+| `router.router_layer_used` | `skipped` |
+
+The chunks scoring **0.6584 and 0.6156 never reached the evidence pack**, while chunks
+scoring **0.2806 and 0.2082 did**. Nothing about relevance caused that. Source label did.
+
+### Root cause 1 — the match has no normalisation
+
+`retrieval_api/services/diversity.py:66` `_detect_mentioned_sources` splits each
+`source_label` on `[-./:]`, drops tokens of ≤3 characters and a hand-curated `STOP_WORDS`
+list, then does a **substring check against the query**. For `help.voys.nl`: `help` is in
+`STOP_WORDS`, `nl` is too short, leaving exactly one token — **`voys`**.
+
+That is the tenant's own brand name. It is present in nearly every query this tenant
+sends, and in nearly every document this tenant owns. A signal that is uniformly present
+cannot discriminate, yet it is being used to make a discriminating decision.
+
+On a match, `source_aware_select` (`diversity.py:125-134`) gives the matched source
+**all** `top_n` slots; other sources only fill the remainder. That is a hard filter
+wearing the costume of a soft preference.
+
+The same class of false positive exists for every label: `notion` fires on any query
+mentioning Notion for unrelated reasons, `meetings` on any query about meetings. A
+hand-maintained stop-word list cannot fix this, because the offending token is
+tenant-specific (`voys`, `mitel`, …) and the list is global.
+
+### Root cause 2 — the good mechanism is short-circuited by the bad one
+
+`retrieval_api/services/router.py` implements a three-layer router. Layer 2
+(`layer2_semantic`, `router.py:139-172`) compares the query vector against per-source
+centroids and commits only when the top-1/top-2 cosine margin exceeds a threshold.
+
+**Layer 1 (`router.py:119-127` `layer1_keyword`, fed by `_build_keyword_map`,
+`router.py:89-117`) is the same substring heuristic, importing the same `STOP_WORDS`
+from `diversity.py` (`router.py:9`).** `route_to_sources` returns immediately on a Layer-1 match
+(`router.py:257-264`), so the semantic layer is never reached for exactly those queries
+where the keyword signal is a false positive.
+
+Why comparison is structurally immune where matching is not: ambient tenant vocabulary
+("Voys") is present in **every** source's content, so it lifts every centroid's
+similarity equally and **cancels in the top1−top2 margin**. Substring matching has no
+such normalisation — it is a direct hit on the one label that happens to contain the
+brand. A margin-based comparison also *abstains* when all sources look alike, which is
+the correct behaviour for a tenant whose sources are all about one company. The keyword
+layer always commits.
+
+### Root cause 3 — the router does not run on the path that matters
+
+`retrieval_api/api/retrieve.py:557-561` gates the router on `req.kb_slugs is None`. When
+the caller pins KBs (as the litellm hook does — the footer for this conversation read
+"Kennisbanken in scope: org, sip, support"), the router is skipped entirely, while
+`source_aware_select`'s keyword narrowing still runs unconditionally. The stronger
+mechanism is conditional; the weaker one is not.
+
+### Root cause 4 — the confidence band is the max, so one strong wrong hit reads as "high"
+
+`retrieval_api/api/ranking.py:20-44` `_compute_confidence_band` buckets on the **maximum**
+post-rerank score (`confidence_band_high_threshold: 0.60`, `config.py:92`). In this
+request, FreePBX at 0.8661 alone produced `confidence_band: high` while six of the seven
+served items scored ≤0.28.
+
+`high` is what suppresses the deterministic low-confidence abstain of
+SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-2 and licenses assertive phrasing. A single
+uncorroborated hit should not be able to do that.
+
+### Root cause 0 — none of this was visible
+
+Every decision-relevant event in the litellm hook (`query_rewrite`,
+`query_rewrite_metadata`, `pasted_correspondence_detected`,
+`sub_question_split_skipped_pasted_correspondence`, `KB injection`) is emitted at
+`logger.info` and does not reach VictoriaLogs in production. The code already knows this
+(`deploy/litellm/klai_knowledge.py:791-795`) and works around it for one event only.
+Establishing the facts above required reconstructing the distilled query from an
+**unrelated service's FalkorDB error stack trace**.
+
+Consequently SPEC-RAG-CORRESPONDENCE-DISTILL-001 AC-8 ("rewrite-call latency p95 over
+first 24h post-deploy") has never been measurable, and no acceptance criterion in this
+SPEC could be verified in production either. Observability is therefore Phase 0, not an
+afterthought.
+
+### Why this is a documented failure class
+
+- Hard metadata filters destroy recall irrecoverably: once the gold document is excluded,
+  no reranker or better embedding can recover it, while every downstream metric still
+  looks reasonable ([OptyxStack](https://optyxstack.com/rag-reliability/metadata-filters-in-rag-why-good-documents-disappear-before-retrieval-starts)).
+- The prevailing decision rule: hard-filter only when correctness is binary (ACL,
+  jurisdiction, published-vs-draft); prefer a soft ranking signal when relevance is
+  graded (locale, recency, source preference). Source preference is graded.
+- Routing strategies trade off predictably: rule-based is fast and brittle,
+  semantic/embedding-based is fast and robust, LLM/logical is most accurate and most
+  expensive ([Milvus](https://milvus.io/blog/build-smarter-rag-routing-hybrid-retrieval.md),
+  [BetterLink](https://eastondev.com/blog/en/posts/ai/20260513-rag-query-routing/)).
+  What is deployed today is rule-based in its most brittle possible form: a substring
+  test on a single token.
+- The recommended instrumentation is *filter suppression rate* — how often an
+  answer-bearing document exists in the full corpus but not in the filtered subset —
+  plus empty-filtered-candidate rate and fallback rate. None of these are measured today.
+
+## Scope
+
+### In scope
+
+**Phase 0 — observability (`deploy/litellm/klai_knowledge.py`)**
+
+- Promote a named, closed set of decision events from `info` to `warning`, matching the
+  precedent already established in this file for `query_rewrite_destructive_blocked`
+  (`klai_knowledge.py:791-798`) and in `klai_kb_citation_render.py:756`.
+
+**Phase 1 — bounded preference (`klai-retrieval-api/retrieval_api/services/diversity.py`)**
+
+- Replace slot allocation in `source_aware_select`'s `mentioned` branch with a bounded
+  additive score boost.
+- New telemetry fields on the `retrieval_decision_record` `source_select` block.
+
+**Phase 2 — comparison-based selection (`diversity.py`, `router.py`, `api/retrieve.py`)**
+
+- Delete `_detect_mentioned_sources`, `layer1_keyword`, `_build_keyword_map`, and
+  `STOP_WORDS`.
+- Run the router on the pinned-KB path, scoped to the pinned KBs.
+
+**Phase 3 — corroborated confidence (`klai-retrieval-api/retrieval_api/api/ranking.py`)**
+
+- Band derived from the served pack rather than its maximum, shipped in shadow first.
+
+**Eval**
+
+- New canaries in `klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml`
+  covering the brand-token false positive and the single-strong-hit band case.
+
+### Out of scope
+
+- Changing `compute_source_label()` (`klai-knowledge-ingest/knowledge_ingest/source_label.py:12`).
+  The domain-derived label is an identity used by citation titles
+  (`klai_kb_citation_render.py:284`, `:454`), the router's Facet catalogue
+  (`router.py::fetch_source_catalog`), and traceability
+  (`klai_kb_traceability.py:50`). The defect is in what the routing does with the label,
+  not in the label. Stripping the domain would break three consumers and fix nothing.
+- Enabling the Layer-3 LLM router fallback (`router_llm_fallback`, default `False`).
+  Unchanged by this SPEC.
+- Re-indexing, re-embedding, or any change to chunking or the reranker.
+- Anything in the answer layer — that is SPEC-RAG-ANSWER-EPISTEMICS-001.
+- Per-org IDF-based stop-word computation. Considered and deliberately rejected for this
+  SPEC: once Phase 2 removes all lexical matching, there is no stop-word list left to
+  compute. Revisit only if REQ-6's abstention rate proves unacceptable and a lexical
+  signal must be reintroduced.
+
+## Functional Requirements (EARS)
+
+### Phase 0 — observability (precondition for verifying every later phase)
+
+#### REQ-1 — decision events must reach VictoriaLogs (ubiquitous)
+
+**THE litellm hook SHALL** emit the following events at a level that reaches production
+log aggregation: `query_rewrite` / `query_rewrite_metadata`,
+`pasted_correspondence_detected`, `sub_question_split_skipped_pasted_correspondence`, and
+the `KB injection` summary.
+
+Implementation constraint: promote these specific call sites to `logger.warning`, in line
+with the two existing precedents in this codebase. **Do NOT** raise a global log level —
+that floods the stream with third-party litellm output and is not the established pattern.
+
+**THE promotion SHALL NOT** widen what query text is logged. The
+`telemetry_level` branch (`klai_knowledge.py:810-838`) governing raw vs. redacted query
+text is unchanged, per SPEC-PRIVACY-QUERY-SHADOW-001 REQ-6.
+
+Verification is external: after deploy, a LogsQL query for each event name must return
+rows. A unit test asserting the log level is required but is not sufficient evidence.
+
+### Phase 1 — bounded preference (kills the failure class independently of routing)
+
+#### REQ-2 — source preference is an additive bounded boost (event-driven)
+
+**WHEN** a set of preferred source labels is available, **THE selection SHALL** apply a
+bounded additive boost `β` to the ranking score of chunks belonging to those labels, and
+**SHALL NOT** allocate slots by source.
+
+The boosted value is derived from the same field `ranking_score()` already uses
+(`final_rank_score` when the ranking contract is active, `reranker_score` otherwise) so
+that shadow and contract modes stay consistent.
+
+`β` is configurable as `source_preference_boost` (env `SOURCE_PREFERENCE_BOOST`), default
+**0.05**. This default is an untested starting point chosen to be a mild tiebreak; REQ-7's
+eval run is what validates or replaces it.
+
+#### REQ-3 — rank inversion is bounded by construction (ubiquitous)
+
+**THE selection SHALL** guarantee that no chunk is ranked below another whose unboosted
+ranking score is more than `β` higher.
+
+This is a property of REQ-2's bounded additive form, not additional runtime logic: an
+additive boost capped at `β` cannot move a chunk past one scoring more than `β` above it.
+The requirement exists so it is **tested as an invariant** rather than assumed, and so any
+future source-preference mechanism inherits the bound.
+
+A property test SHALL assert this over randomised score/label distributions.
+
+#### REQ-4 — the counterfactual is logged (ubiquitous)
+
+**THE `retrieval_decision_record` `source_select` block SHALL** additionally carry:
+
+- `preference_applied: bool`
+- `preferred_labels: list[str]`
+- `boost: float`
+- `pack_without_preference: list[str]` — chunk ids that would have been served with `β=0`
+- `suppressed_count: int` — chunks displaced from the served pack purely by preference
+- `max_score_inversion: float` — largest observed (unboosted) score gap across a
+  preference-caused reordering
+
+`suppressed_count` is the filter-suppression-rate signal named in the Motivation. It is
+the primary post-deploy monitoring field for this SPEC.
+
+### Phase 2 — comparison replaces matching
+
+#### REQ-5 — all lexical source matching is removed (ubiquitous)
+
+**THE codebase SHALL NOT** contain a source-selection path that decides preference by
+substring-matching source-label tokens against query text.
+
+Concretely, delete:
+
+- `diversity.py:66-91` `_detect_mentioned_sources` and its call in `source_aware_select`
+- `router.py:89-117` `_build_keyword_map`
+- `router.py:119-127` `layer1_keyword`
+- `router.py:9` the `STOP_WORDS` import
+- the Layer-1 branch in `route_to_sources` (`router.py:257-264`)
+- `diversity.py:27-63` `STOP_WORDS`
+
+`STOP_WORDS` has exactly two consumers (`diversity.py:86` and `router.py:111`), both
+removed here — verified 2026-08-19 by repository-wide grep. Confirm again before deleting.
+
+`RoutingDecision.layer_used` loses the `"keyword"` value. Update its docstring and every
+consumer, including the `router_layer_used` telemetry field and its tests.
+
+A source-scan guard test SHALL fail CI if `source_label` is ever again compared against
+query text with `in`, mirroring the drift-guard pattern already used by
+`test_direct_mistral_throttle_drift.py` and `test_truncated_render_label_guard.py`.
+
+#### REQ-6 — the router runs on the pinned-KB path (event-driven)
+
+**WHEN** `req.kb_slugs` is not `None`, **THE router SHALL** still run, with its source
+catalogue restricted to labels occurring within those KBs.
+
+`fetch_source_catalog` gains a `kb_slugs` parameter and adds a `kb_slug` condition to its
+Qdrant facet filter. `kb_slug` is a keyword-indexed payload field
+(`klai-knowledge-ingest/knowledge_ingest/qdrant_store.py:126`) — verified 2026-08-19;
+re-confirm before implementing. The per-org catalogue cache key SHALL include the
+`kb_slugs` set, or the cache will serve a catalogue from the wrong scope.
+
+**WHEN** `layer2_semantic` returns `None` (margin below `router_margin_dual`), **THE
+selection SHALL** apply no source preference at all. Abstention is the correct outcome for
+a tenant whose sources are semantically similar, and must not fall back to any lexical
+heuristic.
+
+#### REQ-7 — behaviour change is measured, not assumed (ubiquitous)
+
+**THE change SHALL** be evaluated on the full `chat.yaml` suite before and after, with
+per-canary deltas reported. A tenant-wide behaviour change is explicitly accepted by the
+product owner (2026-08-19); an *unmeasured* one is not.
+
+### Phase 3 — corroborated confidence
+
+#### REQ-8 — `high` requires corroboration (state-driven)
+
+**WHILE** the reranker is enabled and the served pack is non-empty, **THE confidence band
+SHALL** be `high` only when at least two served chunks score ≥ `confidence_band_high_threshold`.
+A single chunk at or above the threshold with no second supporting chunk yields at most
+`medium`.
+
+`low` and `unknown` semantics are unchanged. `medium` remains the residual bucket.
+
+#### REQ-9 — shadow before enforcement (ubiquitous)
+
+**THE new band SHALL** first ship computed-but-not-acted-upon, emitting both
+`confidence_band` (old, authoritative) and `confidence_band_corroborated` (new, shadow) on
+the decision record — the same shadow pattern already used by `gate_shadow_mode`,
+`evidence_shadow_mode`, and `citation_rescue_mode`.
+
+Enforcement is a separate, later change, gated on a shadow-period comparison of how often
+the two disagree and what that would have done to the Strict abstain rate. Flipping
+enforcement in the same PR is out of scope.
+
+## Non-Functional Requirements
+
+- **Latency**: Phase 2 adds the router to the pinned-KB path. Layer 2 is 5–20 ms with a
+  warm centroid cache (`router_centroid_ttl_seconds: 600`); a cold cache scrolls up to 10
+  chunks per label for at most 50 labels. Retrieval p95 MUST NOT regress by more than 100 ms.
+  If cold-start cost exceeds that, the centroid cache must be warmed rather than the
+  requirement relaxed.
+- **Tenant isolation**: centroid computation already filters on `org_id`
+  (`router.py::_default_compute_centroids`, per audit-tenant-isolation-2026-05-05 finding
+  B-1). Any new Qdrant filter added under REQ-6 MUST keep that condition. This is a
+  tenant-isolation-relevant change — `/klai:tenant-review` applies.
+- **Fail-open**: every new path degrades to "no source preference" on failure. A router
+  error, a facet failure, or an empty catalogue MUST mean full recall, never a narrowed
+  pack. `fetch_source_catalog` already returns `[]` on exception; preserve that.
+- **Backwards compatibility**: `source_aware_select`'s signature may change; it has one
+  production caller (`api/retrieve.py:762`, `:801`). No external contract changes.
+- **Multi-tenant**: applies uniformly. Voys is the reproduction case, not the target.
+
+## Acceptance Criteria
+
+| AC ID | Test | Expected outcome |
+|-------|------|-------------------|
+| AC-1 | After Phase 0 deploy, LogsQL for each event name in REQ-1 over a 1h window with real chat traffic | ≥1 row per event name; raw query text absent for orgs whose `telemetry_level` is not `full` |
+| AC-2 | Unit: `source_aware_select` with two labels, chunk A (label X) at 0.66 and chunk B (label Y) at 0.28, preference on Y | A still ranks above B; B is not promoted past A |
+| AC-3 | Property test over randomised (score, label) sets with preference on a random label | No chunk ranks below another whose unboosted score is more than `β` higher — REQ-3 invariant holds for all generated cases |
+| AC-4 | Replay of the incident shape: query containing the tenant brand token, chunks split across `help.voys.nl` and another label | `suppressed_count == 0`; chunks at 0.658/0.616 present in the served pack |
+| AC-5 | Repository grep after Phase 2 | Zero occurrences of `_detect_mentioned_sources`, `layer1_keyword`, `_build_keyword_map`, `STOP_WORDS`; drift-guard test present and failing on a deliberately reintroduced substring match |
+| AC-6 | Unit: `route_to_sources` on a catalogue whose labels are all semantically similar (Voys-shaped) | Returns `selected_source_labels=None`, `layer_used="none"` — abstains rather than committing |
+| AC-7 | Unit: `fetch_source_catalog` with `kb_slugs=["sip"]` | Facet filter carries both `org_id` and `kb_slug`; cache key differs from the unscoped call |
+| AC-8 | Full `chat.yaml` suite before vs. after Phase 2 | Aggregate `context_recall` MUST NOT decrease; aggregate `context_precision` MUST NOT decrease by more than 0.02. Per-canary deltas reported in the PR body regardless of outcome |
+| AC-9 | Unit: `_compute_confidence_band` with scores `[0.87, 0.28, 0.21]` | `confidence_band_corroborated == "medium"`; `confidence_band` (old) still `high` in shadow |
+| AC-10 | Unit: same function with `[0.87, 0.72, 0.21]` | `confidence_band_corroborated == "high"` |
+| AC-11 | Post-deploy, 48h of `retrieval_decision_record` | `suppressed_count` distribution reported; disagreement rate between the two bands reported. Both are inputs to the enforcement decision deferred by REQ-9 |
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Router abstains far more often than the keyword layer committed, so source preference effectively disappears for most tenants | high | low | This is the intended direction (recall over precision) and the failure mode is full recall, not a wrong pack. AC-8 quantifies it. If precision loss exceeds the bar, the correct response is to tune `router_margin_dual`, not to reinstate lexical matching |
+| `β = 0.05` is wrong for the actual reranker score distribution | high | low | Explicitly declared an untested starting point. Env-tunable, validated by AC-8, and bounded by REQ-3 so a wrong value cannot reproduce the original failure class — only weaken or strengthen a tiebreak |
+| Cold centroid cache adds latency on the pinned-KB path, which previously skipped the router entirely | medium | medium | 10-chunk sample per label, ≤50 labels, 600 s TTL. NFR sets a 100 ms p95 ceiling. If exceeded, warm the cache on catalogue build rather than relax the ceiling |
+| Cache key omits `kb_slugs` and serves a catalogue from the wrong scope | medium | high | Called out explicitly in REQ-6. AC-7 tests it. Tenant-isolation-adjacent: a wrong cache key across orgs would be a cross-tenant leak, so `/klai:tenant-review` is mandatory on this PR |
+| Corroboration requirement raises the Strict abstain rate and users see more refusals | medium | high | Exactly why REQ-9 mandates shadow-first. Enforcement is a separate decision with AC-11 data behind it |
+| Phase 2 lands before Phase 1 and a routing regression reproduces the demotion bug | low | high | Phase ordering is a hard requirement, not a preference: Phase 1's bound is what makes Phase 2 safe to get wrong. Enforce via PR sequencing |
+
+## Implementation handoff
+
+Implementation is delegated. Four PRs, in this order; do not combine.
+
+| PR | Phase | Files | Gate before merge |
+|----|-------|-------|-------------------|
+| 1 | 0 | `deploy/litellm/klai_knowledge.py` + tests | AC-1 (needs a deploy; state explicitly if not yet observed) |
+| 2 | 1 | `retrieval_api/services/diversity.py`, `api/retrieve.py`, config, tests | AC-2, AC-3, AC-4 |
+| 3 | 2 | `retrieval_api/services/diversity.py`, `services/router.py`, `api/retrieve.py`, tests, drift guard | AC-5, AC-6, AC-7, AC-8 + `/klai:tenant-review` |
+| 4 | 3 | `retrieval_api/api/ranking.py`, `api/retrieve.py`, tests | AC-9, AC-10 |
+
+Rules for the implementer:
+
+- Write the failing test first for every requirement. AC-4 and AC-9 must be RED against
+  current `main` before the fix, and that must be stated in the PR body with the actual
+  failure output — not asserted.
+- Run `mcp__codeindex__impact` on `source_aware_select`, `route_to_sources`,
+  `fetch_source_catalog`, and `_compute_confidence_band` before editing. These are shared
+  helpers on a cross-service contract; AGENTS.md requires it.
+- Do not "improve" adjacent code. `minimal-changes` applies. Deleting the functions named
+  in REQ-5 is in scope; refactoring what remains is not.
+- Remove what you replace in the same PR. No feature flag keeping the keyword path alive
+  beside the new one — `clean over clever, no parallel old+new`.
+- Report `git diff --stat` and the actual test command output in each PR body. "Tests
+  pass" without the command and its output scores zero.
+
+## Sources
+
+Production evidence (2026-08-19, VictoriaLogs, org `368884765035593759`):
+
+- `request_id=d83d2c14-c2bb-4557-91a1-5831fa9a5a78` — post-deploy run, `retrieval_decision_record`
+  and `kb_citations_rendered_structured`.
+- `request_id=58d22917-bae2-4956-b4c4-08566d2a1795` — pre-deploy run 15 minutes earlier,
+  byte-identical retrieval scores, which is what established that the distillation change
+  was not the variable.
+- litellm container restart at `2026-08-19T05:04:58Z` — the deploy boundary between the two.
+
+Source references:
+
+- `klai-retrieval-api/retrieval_api/services/diversity.py:27-63,66-91,94-156`
+- `klai-retrieval-api/retrieval_api/services/router.py:9,89-117,119-127,139-172,236-264`
+- `klai-retrieval-api/retrieval_api/api/retrieve.py:555-583,762,801`
+- `klai-retrieval-api/retrieval_api/api/ranking.py:20-44`
+- `klai-retrieval-api/retrieval_api/config.py:92-93,107-112`
+- `klai-knowledge-ingest/knowledge_ingest/source_label.py:12-38`
+- `klai-knowledge-ingest/knowledge_ingest/qdrant_store.py:126`
+- `deploy/litellm/klai_knowledge.py:774,790-838,890-896`
+- `deploy/litellm/klai_kb_citation_render.py:756`
+
+External research:
+
+- [Metadata Filters in RAG: Why Good Documents Disappear Before Retrieval Starts — OptyxStack](https://optyxstack.com/rag-reliability/metadata-filters-in-rag-why-good-documents-disappear-before-retrieval-starts)
+- [Build Smarter RAG with Routing and Hybrid Retrieval — Milvus](https://milvus.io/blog/build-smarter-rag-routing-hybrid-retrieval.md)
+- [RAG Query Routing in Practice — BetterLink](https://eastondev.com/blog/en/posts/ai/20260513-rag-query-routing/)
+- [Hybrid Search and Re-Ranking in Production RAG — Towards Data Science](https://towardsdatascience.com/hybrid-search-and-re-ranking-in-production-rag/)
+- [Rerankers and Two-Stage Retrieval — Pinecone](https://www.pinecone.io/learn/series/rag/rerankers/)

--- a/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
@@ -1,7 +1,7 @@
 suite: chat
 description: |
   Conversational queries against Voys's support KB. Style mirrors how a Voys CS-medewerker
-  would phrase a question to klai's chat. 42 queries with a curated mix:
+  would phrase a question to klai's chat. 41 queries with a curated mix:
     - 9 easy-lookup (regression canaries; expected_chunks populated)
     - 9 vague-pronoun (query-rewrite targets)
     - 6 multi-doc synthesis (parent-child targets)
@@ -9,7 +9,7 @@ description: |
     - 2 edge cases (mixed-language + malformed)
     - 7 brand-bridging queries
     - 3 pasted-correspondence queries
-    - 2 source-selection queries
+    - 1 source-selection query
   All queries target tenant Voys (org_zitadel_id 368884765035593759).
 queries:
   # --- Easy-lookup canaries (9) — should always score ~1.0 ---
@@ -357,7 +357,7 @@ queries:
     expected_topics: [zoom, integratie]
     mix: brand_bridging
 
-  # --- Source-selection canaries (2) — SPEC-RAG-SOURCE-SELECTION-001 ---
+  # --- Source-selection canary — SPEC-RAG-SOURCE-SELECTION-001 ---
   - id: chat-source-selection-brand-token-404
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
@@ -365,15 +365,6 @@ queries:
     reference_answer: "Leg uit dat SIP 404 Not Found betekent dat de gebelde gebruiker, het toestel of de extensie niet gevonden of niet toegewezen is. Het woord Voys mag de evidence-selectie niet beperken tot help.voys.nl als een beter scorende bron de responscode verklaart."
     expected_topics: [voys, sip, 404, trunk, responscode]
     expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
-    mix: source_selection
-
-  - id: chat-source-selection-single-strong-hit
-    org_zitadel_id: "368884765035593759"
-    user_zitadel_id: null
-    query: "Ondersteunt Voys de fictieve QuasarDesk PBX-koppeling?"
-    reference_answer: "De kennisbank bevat geen betrouwbare informatie over een QuasarDesk PBX-koppeling. Een enkel sterk lijkend algemeen integratiedocument is onvoldoende bevestiging; het antwoord moet de onzekerheid benoemen en om verificatie of meer context vragen."
-    expected_topics: [onbekend, integratie, pbx]
-    expected_chunks: []
     mix: source_selection
 
   # --- Pasted-correspondence canaries (3) — SPEC-RAG-CORRESPONDENCE-DISTILL-001 ---

--- a/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
@@ -1,12 +1,15 @@
 suite: chat
 description: |
   Conversational queries against Voys's support KB. Style mirrors how a Voys CS-medewerker
-  would phrase a question to klai's chat. 30 queries with a curated mix:
+  would phrase a question to klai's chat. 42 queries with a curated mix:
     - 9 easy-lookup (regression canaries; expected_chunks populated)
     - 9 vague-pronoun (query-rewrite targets)
     - 6 multi-doc synthesis (parent-child targets)
     - 4 long-tail (recall test)
     - 2 edge cases (mixed-language + malformed)
+    - 7 brand-bridging queries
+    - 3 pasted-correspondence queries
+    - 2 source-selection queries
   All queries target tenant Voys (org_zitadel_id 368884765035593759).
 queries:
   # --- Easy-lookup canaries (9) — should always score ~1.0 ---
@@ -353,6 +356,25 @@ queries:
     reference_answer: "Als de KB geen specifieke Zoom-koppeling met Voys bevat, moet het antwoord geen integratie verzinnen en vragen om nadere context of verwijzen naar bekende integratieopties."
     expected_topics: [zoom, integratie]
     mix: brand_bridging
+
+  # --- Source-selection canaries (2) — SPEC-RAG-SOURCE-SELECTION-001 ---
+  - id: chat-source-selection-brand-token-404
+    org_zitadel_id: "368884765035593759"
+    user_zitadel_id: null
+    query: "Voys trunk: wat betekent een SIP 404 Not Found?"
+    reference_answer: "Leg uit dat SIP 404 Not Found betekent dat de gebelde gebruiker, het toestel of de extensie niet gevonden of niet toegewezen is. Het woord Voys mag de evidence-selectie niet beperken tot help.voys.nl als een beter scorende bron de responscode verklaart."
+    expected_topics: [voys, sip, 404, trunk, responscode]
+    expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
+    mix: source_selection
+
+  - id: chat-source-selection-single-strong-hit
+    org_zitadel_id: "368884765035593759"
+    user_zitadel_id: null
+    query: "Ondersteunt Voys de fictieve QuasarDesk PBX-koppeling?"
+    reference_answer: "De kennisbank bevat geen betrouwbare informatie over een QuasarDesk PBX-koppeling. Een enkel sterk lijkend algemeen integratiedocument is onvoldoende bevestiging; het antwoord moet de onzekerheid benoemen en om verificatie of meer context vragen."
+    expected_topics: [onbekend, integratie, pbx]
+    expected_chunks: []
+    mix: source_selection
 
   # --- Pasted-correspondence canaries (3) — SPEC-RAG-CORRESPONDENCE-DISTILL-001 ---
   # Reproduces the 2026-08-17 Voys production incident (conversation ID

--- a/klai-knowledge-ingest/tests/eval/test_seed_suites.py
+++ b/klai-knowledge-ingest/tests/eval/test_seed_suites.py
@@ -14,8 +14,9 @@ SHIPPED_SUITES = ["chat", "knowledge_org"]
 # The curated mix per suite. The chat suite gained 7 brand-bridging canaries in
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 (REQ-7, commit b9c1d1229) and 3
 # pasted-correspondence canaries in SPEC-RAG-CORRESPONDENCE-DISTILL-001
-# (REQ-6); knowledge_org keeps the original Unit-4 mix. Each suite's expected
-# mix is therefore distinct.
+# (REQ-6), plus 2 source-selection canaries in SPEC-RAG-SOURCE-SELECTION-001.
+# knowledge_org keeps the original Unit-4 mix. Each suite's expected mix is
+# therefore distinct.
 EXPECTED_MIX_BY_SUITE = {
     "chat": {
         "easy_lookup": 9,
@@ -24,6 +25,7 @@ EXPECTED_MIX_BY_SUITE = {
         "long_tail": 4,
         "edge_case": 2,
         "brand_bridging": 7,
+        "source_selection": 2,
         "pasted_correspondence": 3,
     },
     "knowledge_org": {
@@ -36,7 +38,7 @@ EXPECTED_MIX_BY_SUITE = {
 }
 EXPECTED_QUERIES_BY_SUITE = {
     name: sum(mix.values()) for name, mix in EXPECTED_MIX_BY_SUITE.items()
-}  # chat: 40, knowledge_org: 30
+}  # chat: 42, knowledge_org: 30
 # Real Voys tenant org id used by every query in both shipped suites.
 VOYS_ORG_ID = "368884765035593759"
 
@@ -54,7 +56,7 @@ def test_shipped_suite_loads_without_validation_error(shipped_suite: Suite) -> N
 
 
 def test_shipped_suite_query_count(shipped_suite: Suite) -> None:
-    """Each shipped suite carries its curated query count (chat: 40, knowledge_org: 30)."""
+    """Each shipped suite carries its curated query count (chat: 42, knowledge_org: 30)."""
     assert len(shipped_suite.queries) == EXPECTED_QUERIES_BY_SUITE[shipped_suite.name]
 
 
@@ -74,8 +76,7 @@ def test_shipped_suite_query_ids_unique(shipped_suite: Suite) -> None:
 
 
 def test_shipped_suite_mix(shipped_suite: Suite) -> None:
-    """Each suite follows its curated mix (chat adds brand_bridging per REQ-7,
-    pasted_correspondence per SPEC-RAG-CORRESPONDENCE-DISTILL-001 REQ-6)."""
+    """Each suite follows its curated mix, including chat-specific canaries."""
     raw = (SUITES_DIR / f"{shipped_suite.name}.yaml").read_text(encoding="utf-8")
     actual_mix: Counter[str] = Counter()
     for line in raw.splitlines():
@@ -108,6 +109,22 @@ def test_easy_lookup_canaries_have_expected_chunks(shipped_suite: Suite) -> None
         assert q.expected_chunks, (
             f"Easy-lookup canary {cid!r} must declare expected_chunks (regression-detection signal)"
         )
+
+
+def test_chat_source_selection_canaries_cover_required_failure_shapes() -> None:
+    suite = load_suite(SUITES_DIR / "chat.yaml", require_reference_answer=True)
+    by_id = {query.id: query for query in suite.queries}
+
+    brand_token = by_id["chat-source-selection-brand-token-404"]
+    assert "Voys" in brand_token.query
+    assert brand_token.expected_chunks == [
+        "Gebruiker/toestel bestaat niet, of extensie niet gevonden"
+    ]
+
+    single_strong_hit = by_id["chat-source-selection-single-strong-hit"]
+    assert "QuasarDesk" in single_strong_hit.query
+    assert single_strong_hit.expected_chunks == []
+    assert "onvoldoende bevestiging" in single_strong_hit.reference_answer
 
 
 def test_invalid_yaml_raises_validation_error(tmp_path: Path) -> None:

--- a/klai-knowledge-ingest/tests/eval/test_seed_suites.py
+++ b/klai-knowledge-ingest/tests/eval/test_seed_suites.py
@@ -14,7 +14,8 @@ SHIPPED_SUITES = ["chat", "knowledge_org"]
 # The curated mix per suite. The chat suite gained 7 brand-bridging canaries in
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 (REQ-7, commit b9c1d1229) and 3
 # pasted-correspondence canaries in SPEC-RAG-CORRESPONDENCE-DISTILL-001
-# (REQ-6), plus 2 source-selection canaries in SPEC-RAG-SOURCE-SELECTION-001.
+# (REQ-6), plus 1 retrieval-testable source-selection canary in
+# SPEC-RAG-SOURCE-SELECTION-001.
 # knowledge_org keeps the original Unit-4 mix. Each suite's expected mix is
 # therefore distinct.
 EXPECTED_MIX_BY_SUITE = {
@@ -25,7 +26,7 @@ EXPECTED_MIX_BY_SUITE = {
         "long_tail": 4,
         "edge_case": 2,
         "brand_bridging": 7,
-        "source_selection": 2,
+        "source_selection": 1,
         "pasted_correspondence": 3,
     },
     "knowledge_org": {
@@ -38,7 +39,7 @@ EXPECTED_MIX_BY_SUITE = {
 }
 EXPECTED_QUERIES_BY_SUITE = {
     name: sum(mix.values()) for name, mix in EXPECTED_MIX_BY_SUITE.items()
-}  # chat: 42, knowledge_org: 30
+}  # chat: 41, knowledge_org: 30
 # Real Voys tenant org id used by every query in both shipped suites.
 VOYS_ORG_ID = "368884765035593759"
 
@@ -56,7 +57,7 @@ def test_shipped_suite_loads_without_validation_error(shipped_suite: Suite) -> N
 
 
 def test_shipped_suite_query_count(shipped_suite: Suite) -> None:
-    """Each shipped suite carries its curated query count (chat: 42, knowledge_org: 30)."""
+    """Each shipped suite carries its curated query count (chat: 41, knowledge_org: 30)."""
     assert len(shipped_suite.queries) == EXPECTED_QUERIES_BY_SUITE[shipped_suite.name]
 
 
@@ -111,7 +112,7 @@ def test_easy_lookup_canaries_have_expected_chunks(shipped_suite: Suite) -> None
         )
 
 
-def test_chat_source_selection_canaries_cover_required_failure_shapes() -> None:
+def test_chat_source_selection_canary_is_retrieval_testable() -> None:
     suite = load_suite(SUITES_DIR / "chat.yaml", require_reference_answer=True)
     by_id = {query.id: query for query in suite.queries}
 
@@ -121,10 +122,11 @@ def test_chat_source_selection_canaries_cover_required_failure_shapes() -> None:
         "Gebruiker/toestel bestaat niet, of extensie niet gevonden"
     ]
 
-    single_strong_hit = by_id["chat-source-selection-single-strong-hit"]
-    assert "QuasarDesk" in single_strong_hit.query
-    assert single_strong_hit.expected_chunks == []
-    assert "onvoldoende bevestiging" in single_strong_hit.reference_answer
+    source_selection = [
+        query for query in suite.queries if query.id.startswith("chat-source-selection-")
+    ]
+    assert source_selection == [brand_token]
+    assert all(query.expected_chunks for query in source_selection)
 
 
 def test_invalid_yaml_raises_validation_error(tmp_path: Path) -> None:

--- a/klai-retrieval-api/retrieval_api/api/ranking.py
+++ b/klai-retrieval-api/retrieval_api/api/ranking.py
@@ -23,6 +23,7 @@ def _compute_confidence_band(
     high_threshold: float,
     low_threshold: float,
     reranker_enabled: bool,
+    require_corroboration: bool = False,
 ) -> ConfidenceBand:
     """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: bucket the served result by
     the max post-rerank ranking score. Driven by the litellm-hook
@@ -39,7 +40,8 @@ def _compute_confidence_band(
     Returns:
         - ``unknown`` when reranker is disabled, every chunk's reranker_score
           is None (fallback path), or the served list is empty
-        - ``high`` when max ≥ high_threshold
+        - ``high`` when max ≥ high_threshold; when corroboration is required,
+          at least two scores must meet that threshold
         - ``low`` when max < low_threshold
         - ``medium`` otherwise
 
@@ -57,7 +59,9 @@ def _compute_confidence_band(
     if not valid_scores:
         return "unknown"
     max_score = max(valid_scores)
-    if max_score >= high_threshold:
+    if max_score >= high_threshold and (
+        not require_corroboration or sum(score >= high_threshold for score in valid_scores) >= 2
+    ):
         return "high"
     if max_score < low_threshold:
         return "low"

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -760,12 +760,19 @@ async def retrieve(
                 top_n=req.top_k,
                 max_per_source=settings.source_quota_max_per_source,
                 router_selected=router_selected,
+                source_preference_boost=settings.source_preference_boost,
             )
         else:
             source_meta = {
                 "source_select_mode": "disabled",
                 "source_counts": {},
                 "mentioned_sources": [],
+                "preference_applied": False,
+                "preferred_labels": [],
+                "boost": settings.source_preference_boost,
+                "pack_without_preference": [],
+                "suppressed_count": 0,
+                "max_score_inversion": 0.0,
             }
         decision_record["source_select"] = source_meta
 
@@ -799,6 +806,7 @@ async def retrieve(
                     top_n=req.top_k,
                     max_per_source=settings.source_quota_max_per_source,
                     router_selected=router_selected,
+                    source_preference_boost=settings.source_preference_boost,
                 )
             ranking_shadow_preview = quality_boost(ranking_shadow_preview, contract_active=True)
 

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -97,6 +97,7 @@ _SHADOW_PREVIEW_KEYS = (
     "source_url",
     "artifact_id",
     "source_label",
+    "kb_slug",
     "reranker_score",
     "score",
     "quality_score",

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -755,6 +755,7 @@ async def retrieve(
                 top_n=req.top_k,
                 max_per_source=settings.source_quota_max_per_source,
                 preferred_labels=router_selected,
+                preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
                 source_preference_boost=settings.source_preference_boost,
             )
         else:
@@ -799,6 +800,7 @@ async def retrieve(
                     top_n=req.top_k,
                     max_per_source=settings.source_quota_max_per_source,
                     preferred_labels=router_selected,
+                    preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
                     source_preference_boost=settings.source_preference_boost,
                 )
             ranking_shadow_preview = quality_boost(ranking_shadow_preview, contract_active=True)

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -952,7 +952,15 @@ async def retrieve(
             low_threshold=settings.confidence_band_low_threshold,
             reranker_enabled=settings.reranker_enabled,
         )
+        confidence_band_corroborated = _compute_confidence_band(
+            serving,
+            high_threshold=settings.confidence_band_high_threshold,
+            low_threshold=settings.confidence_band_low_threshold,
+            reranker_enabled=settings.reranker_enabled,
+            require_corroboration=True,
+        )
         decision_record["confidence_band"] = confidence_band
+        decision_record["confidence_band_corroborated"] = confidence_band_corroborated
         retrieval_confidence_band_total.labels(band=confidence_band, org_id=req.org_id).inc()
 
     evidence_query = (

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -754,9 +754,7 @@ async def retrieve(
         # A router preference is derived from the org source catalog, so it
         # must never boost a personal chunk merely because the labels match.
         excluded_preferred_kb_slugs = (
-            {personal_kb_slug(req.user_id)}
-            if req.scope == "both" and req.user_id
-            else None
+            {personal_kb_slug(req.user_id)} if req.scope == "both" and req.user_id else None
         )
         if settings.source_quota_enabled:
             reranked, source_meta = source_aware_select(

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -554,13 +554,8 @@ async def retrieve(
     # 3b. Query router — identifies relevant sources for post-rerank selection
     router_meta: dict = {"router_decision": None, "router_layer_used": "skipped"}
     router_selected: set[str] | None = None
-    if (
-        req.kb_slugs is None
-        and settings.router_enabled
-        and req.scope in ("org", "both")
-        and not bypassed
-    ):
-        source_label_catalog = await fetch_source_catalog(req.org_id)
+    if settings.router_enabled and req.scope in ("org", "both") and not bypassed:
+        source_label_catalog = await fetch_source_catalog(req.org_id, req.kb_slugs)
         if len(source_label_catalog) >= settings.router_min_source_label_count:
             routing = await route_to_sources(
                 query_resolved=query_resolved,
@@ -571,6 +566,7 @@ async def retrieve(
                 margin_dual=settings.router_margin_dual,
                 llm_fallback=settings.router_llm_fallback,
                 centroid_ttl_seconds=settings.router_centroid_ttl_seconds,
+                kb_slugs=req.kb_slugs,
             )
             if routing.selected_source_labels:
                 router_selected = set(routing.selected_source_labels)
@@ -756,17 +752,15 @@ async def retrieve(
         if settings.source_quota_enabled:
             reranked, source_meta = source_aware_select(
                 reranked,
-                query_resolved,
                 top_n=req.top_k,
                 max_per_source=settings.source_quota_max_per_source,
-                router_selected=router_selected,
+                preferred_labels=router_selected,
                 source_preference_boost=settings.source_preference_boost,
             )
         else:
             source_meta = {
                 "source_select_mode": "disabled",
                 "source_counts": {},
-                "mentioned_sources": [],
                 "preference_applied": False,
                 "preferred_labels": [],
                 "boost": settings.source_preference_boost,
@@ -802,10 +796,9 @@ async def retrieve(
             if settings.source_quota_enabled:
                 ranking_shadow_preview, _ = source_aware_select(
                     ranking_shadow_preview,
-                    query_resolved,
                     top_n=req.top_k,
                     max_per_source=settings.source_quota_max_per_source,
-                    router_selected=router_selected,
+                    preferred_labels=router_selected,
                     source_preference_boost=settings.source_preference_boost,
                 )
             ranking_shadow_preview = quality_boost(ranking_shadow_preview, contract_active=True)

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -750,6 +750,14 @@ async def retrieve(
 
         # 5b. Source-aware selection (SPEC-KB-021)
         # Replaces separate router + quota: uses reranker scores to decide.
+        # scope=both may retrieve the canonical personal KB alongside org KBs.
+        # A router preference is derived from the org source catalog, so it
+        # must never boost a personal chunk merely because the labels match.
+        excluded_preferred_kb_slugs = (
+            {personal_kb_slug(req.user_id)}
+            if req.scope == "both" and req.user_id
+            else None
+        )
         if settings.source_quota_enabled:
             reranked, source_meta = source_aware_select(
                 reranked,
@@ -757,6 +765,7 @@ async def retrieve(
                 max_per_source=settings.source_quota_max_per_source,
                 preferred_labels=router_selected,
                 preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
+                excluded_preferred_kb_slugs=excluded_preferred_kb_slugs,
                 source_preference_boost=settings.source_preference_boost,
             )
         else:
@@ -802,6 +811,7 @@ async def retrieve(
                     max_per_source=settings.source_quota_max_per_source,
                     preferred_labels=router_selected,
                     preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
+                    excluded_preferred_kb_slugs=excluded_preferred_kb_slugs,
                     source_preference_boost=settings.source_preference_boost,
                 )
             ranking_shadow_preview = quality_boost(ranking_shadow_preview, contract_active=True)

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     # Source-aware selection (SPEC-KB-021)
     source_quota_enabled: bool = True
     source_quota_max_per_source: int = 2
+    source_preference_boost: float = 0.05
 
     # SPEC-RAG-EVIDENCE-INTEGRITY-001 REQ-RANK-04 — ranking-contract rollout
     # flag. "shadow" (default) serves the pre-contract behavior byte-identical

--- a/klai-retrieval-api/retrieval_api/quality_floor.py
+++ b/klai-retrieval-api/retrieval_api/quality_floor.py
@@ -17,8 +17,7 @@ because its boost only kicks in after ``feedback_count >= 3`` — meaning a
 brand-new degraded chunk has zero negative pull on its retrieval ranking.
 
 This filter is the actual exclusion mechanism for ``quality_score=0.0``
-chunks. Sits in the pipeline between source-aware-select and quality_boost
-so that:
+chunks. Sits in the pipeline between rerank and source-aware-select so that:
   1. Source quotas pick from clean candidates (no walled chunk burning a
      diversity slot).
   2. quality_boost only sees passing chunks.

--- a/klai-retrieval-api/retrieval_api/services/diversity.py
+++ b/klai-retrieval-api/retrieval_api/services/diversity.py
@@ -27,6 +27,7 @@ def source_aware_select(
     max_per_source: int = 2,
     preferred_labels: set[str] | None = None,
     preferred_kb_slugs: set[str] | None = None,
+    excluded_preferred_kb_slugs: set[str] | None = None,
     source_preference_boost: float = 0.05,
 ) -> tuple[list[dict], dict]:
     """Select top-N chunks with source-aware diversity.
@@ -53,9 +54,12 @@ def source_aware_select(
 
     preferred = set(preferred_labels or ())
     preferred_slugs = set(preferred_kb_slugs or ())
+    excluded_preferred_slugs = set(excluded_preferred_kb_slugs or ())
 
     def is_preferred(chunk: dict) -> bool:
         if chunk.get("source_label") not in preferred:
+            return False
+        if chunk.get("kb_slug") in excluded_preferred_slugs:
             return False
         return not preferred_slugs or chunk.get("kb_slug") in preferred_slugs
 
@@ -141,11 +145,3 @@ def source_aware_select(
         "suppressed_count": suppressed_count,
         "max_score_inversion": max_score_inversion,
     }
-
-
-def _count_sources(chunks: list[dict]) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for c in chunks:
-        label = c.get("source_label") or _UNKNOWN
-        counts[label] = counts.get(label, 0) + 1
-    return counts

--- a/klai-retrieval-api/retrieval_api/services/diversity.py
+++ b/klai-retrieval-api/retrieval_api/services/diversity.py
@@ -5,14 +5,12 @@ diversity.  Replaces the separate router (pre-search) + quota (post-rerank)
 with one function that uses the actual reranker scores to decide.
 
 Logic:
-- If the query mentions a specific source → give that source all slots
-- If scores are spread across sources → diversify (max N per source)
-- Scores decide, not pre-computed centroids or label embeddings
+- Semantic router labels receive a bounded additive score boost
+- Scores remain authoritative outside that bounded tiebreak
+- Selected chunks are diversified with a per-source cap
 """
 
 from __future__ import annotations
-
-import re
 
 import structlog
 
@@ -22,81 +20,12 @@ logger = structlog.get_logger()
 
 _UNKNOWN = "_unknown"
 
-# Common words that appear in source labels but are too generic for matching.
-# Shared with router.py (imported there).
-STOP_WORDS: set[str] = {
-    "help",
-    "docs",
-    "wiki",
-    "info",
-    "data",
-    "page",
-    "site",
-    "team",
-    "voor",
-    "over",
-    "alle",
-    "deze",
-    "onze",
-    "meer",
-    "door",
-    "naar",
-    "with",
-    "from",
-    "that",
-    "this",
-    "your",
-    "about",
-    "what",
-    "will",
-    "documentatie",
-    "interne",
-    "externe",
-    "handleiding",
-    "informatie",
-    "helpcenter",
-    "helpdesk",
-    "support",
-    "klant",
-    "intern",
-    "kennis",
-}
-
-
-def _detect_mentioned_sources(
-    reranked: list[dict],
-    query_resolved: str,
-) -> set[str]:
-    """Detect which source_labels are explicitly mentioned in the query.
-
-    Splits each label on separators, filters stop words and short tokens,
-    checks substring match in query.  Returns all matching labels.
-    """
-    query_lower = query_resolved.lower()
-    mentioned: set[str] = set()
-
-    seen: set[str] = set()
-    for chunk in reranked:
-        label = chunk.get("source_label") or _UNKNOWN
-        if label in seen or label == _UNKNOWN or len(label) <= 3:
-            continue
-        seen.add(label)
-
-        tokens = [
-            t for t in re.split(r"[-./:]", label.lower()) if len(t) > 3 and t not in STOP_WORDS
-        ]
-        if any(token in query_lower for token in tokens):
-            mentioned.add(label)
-
-    return mentioned
-
 
 def source_aware_select(
     reranked: list[dict],
-    query_resolved: str,
     top_n: int = 5,
     max_per_source: int = 2,
-    router_selected: set[str] | None = None,
+    preferred_labels: set[str] | None = None,
     source_preference_boost: float = 0.05,
 ) -> tuple[list[dict], dict]:
     """Select top-N chunks with source-aware diversity.
@@ -113,7 +42,6 @@ def source_aware_select(
         return [], {
             "source_select_mode": "empty",
             "source_counts": {},
-            "mentioned_sources": [],
             "preference_applied": False,
             "preferred_labels": [],
             "boost": source_preference_boost,
@@ -122,14 +50,10 @@ def source_aware_select(
             "max_score_inversion": 0.0,
         }
 
-    # Step 1: detect preferred sources — from query keywords AND router decision
-    keyword_mentioned = _detect_mentioned_sources(reranked, query_resolved)
-    mentioned = set(keyword_mentioned)
-    if router_selected:
-        mentioned = mentioned | router_selected
+    preferred = set(preferred_labels or ())
 
     preference_applied = bool(
-        mentioned and any(chunk.get("source_label") in mentioned for chunk in reranked)
+        preferred and any(chunk.get("source_label") in preferred for chunk in reranked)
     )
 
     def base_score(chunk: dict) -> float:
@@ -137,7 +61,7 @@ def source_aware_select(
 
     def preference_score(chunk: dict) -> float:
         score = base_score(chunk)
-        if preference_applied and chunk.get("source_label") in mentioned:
+        if preference_applied and chunk.get("source_label") in preferred:
             return score + source_preference_boost
         return score
 
@@ -183,22 +107,18 @@ def source_aware_select(
 
     max_score_inversion = 0.0
     for index, earlier in enumerate(ranked):
-        if earlier.get("source_label") not in mentioned:
+        if earlier.get("source_label") not in preferred:
             continue
         earlier_score = base_score(earlier)
         for later in ranked[index + 1 :]:
-            if later.get("source_label") in mentioned:
+            if later.get("source_label") in preferred:
                 continue
             max_score_inversion = max(
                 max_score_inversion,
                 base_score(later) - earlier_score,
             )
 
-    mode = "diversify"
-    if preference_applied:
-        mode = "router" if router_selected and not keyword_mentioned else "mentioned"
-        if router_selected and keyword_mentioned:
-            mode = "keyword+router"
+    mode = "router" if preference_applied else "diversify"
 
     logger.debug(
         "source_aware_select",
@@ -209,9 +129,8 @@ def source_aware_select(
     return selected, {
         "source_select_mode": mode,
         "source_counts": dict(per_source),
-        "mentioned_sources": sorted(mentioned),
         "preference_applied": preference_applied,
-        "preferred_labels": sorted(mentioned),
+        "preferred_labels": sorted(preferred),
         "boost": source_preference_boost,
         "pack_without_preference": without_ids,
         "suppressed_count": suppressed_count,

--- a/klai-retrieval-api/retrieval_api/services/diversity.py
+++ b/klai-retrieval-api/retrieval_api/services/diversity.py
@@ -26,6 +26,7 @@ def source_aware_select(
     top_n: int = 5,
     max_per_source: int = 2,
     preferred_labels: set[str] | None = None,
+    preferred_kb_slugs: set[str] | None = None,
     source_preference_boost: float = 0.05,
 ) -> tuple[list[dict], dict]:
     """Select top-N chunks with source-aware diversity.
@@ -51,17 +52,21 @@ def source_aware_select(
         }
 
     preferred = set(preferred_labels or ())
+    preferred_slugs = set(preferred_kb_slugs or ())
 
-    preference_applied = bool(
-        preferred and any(chunk.get("source_label") in preferred for chunk in reranked)
-    )
+    def is_preferred(chunk: dict) -> bool:
+        if chunk.get("source_label") not in preferred:
+            return False
+        return not preferred_slugs or chunk.get("kb_slug") in preferred_slugs
+
+    preference_applied = bool(preferred and any(is_preferred(chunk) for chunk in reranked))
 
     def base_score(chunk: dict) -> float:
         return ranking_score(chunk, "reranker_score", "score")
 
     def preference_score(chunk: dict) -> float:
         score = base_score(chunk)
-        if preference_applied and chunk.get("source_label") in preferred:
+        if preference_applied and is_preferred(chunk):
             return score + source_preference_boost
         return score
 
@@ -107,11 +112,11 @@ def source_aware_select(
 
     max_score_inversion = 0.0
     for index, earlier in enumerate(ranked):
-        if earlier.get("source_label") not in preferred:
+        if not is_preferred(earlier):
             continue
         earlier_score = base_score(earlier)
         for later in ranked[index + 1 :]:
-            if later.get("source_label") in preferred:
+            if is_preferred(later):
                 continue
             max_score_inversion = max(
                 max_score_inversion,

--- a/klai-retrieval-api/retrieval_api/services/diversity.py
+++ b/klai-retrieval-api/retrieval_api/services/diversity.py
@@ -97,15 +97,14 @@ def source_aware_select(
     top_n: int = 5,
     max_per_source: int = 2,
     router_selected: set[str] | None = None,
+    source_preference_boost: float = 0.05,
 ) -> tuple[list[dict], dict]:
     """Select top-N chunks with source-aware diversity.
 
     Uses reranker scores + optional router signal for source selection.
 
-    Behaviour:
-    1. If query mentions specific source(s): those sources get all slots.
-       The reranker already scored them highest if they're relevant.
-    2. Otherwise: greedy select with per-source cap, fallback fill if needed.
+    Preferred sources receive a bounded additive ranking boost. Selection then
+    uses the same per-source diversity cap for every source.
 
     Returns:
         (selected_chunks, metadata_dict)
@@ -115,86 +114,108 @@ def source_aware_select(
             "source_select_mode": "empty",
             "source_counts": {},
             "mentioned_sources": [],
+            "preference_applied": False,
+            "preferred_labels": [],
+            "boost": source_preference_boost,
+            "pack_without_preference": [],
+            "suppressed_count": 0,
+            "max_score_inversion": 0.0,
         }
 
-    # Step 1: detect relevant sources — from query keywords AND router decision
-    mentioned = _detect_mentioned_sources(reranked, query_resolved)
+    # Step 1: detect preferred sources — from query keywords AND router decision
+    keyword_mentioned = _detect_mentioned_sources(reranked, query_resolved)
+    mentioned = set(keyword_mentioned)
     if router_selected:
         mentioned = mentioned | router_selected
 
-    if mentioned:
-        # Query is source-specific → give mentioned sources all slots.
-        # Still sorted by the retrieval pipeline's final ranking score.
-        from_mentioned = [c for c in reranked if c.get("source_label") in mentioned]
-        selected = from_mentioned[:top_n]
+    preference_applied = bool(
+        mentioned and any(chunk.get("source_label") in mentioned for chunk in reranked)
+    )
 
-        # If mentioned sources don't fill top_n, add others
-        if len(selected) < top_n:
-            others = [c for c in reranked if c.get("source_label") not in mentioned]
-            selected.extend(others[: top_n - len(selected)])
+    def base_score(chunk: dict) -> float:
+        return ranking_score(chunk, "reranker_score", "score")
 
-        counts = _count_sources(selected)
-        logger.debug(
-            "source_aware_select",
-            mode="mentioned",
-            mentioned=sorted(mentioned),
-            selected=len(selected),
-            source_counts=counts,
-        )
-        # Distinguish keyword-only, router-only, or both
-        keyword_mentioned = _detect_mentioned_sources(reranked, query_resolved)
-        mode = "mentioned"
-        if router_selected and keyword_mentioned:
-            mode = "keyword+router"
-        elif router_selected:
-            mode = "router"
+    def preference_score(chunk: dict) -> float:
+        score = base_score(chunk)
+        if preference_applied and chunk.get("source_label") in mentioned:
+            return score + source_preference_boost
+        return score
 
-        return selected, {
-            "source_select_mode": mode,
-            "source_counts": counts,
-            "mentioned_sources": sorted(mentioned),
-        }
+    base_ranked = sorted(reranked, key=base_score, reverse=True)
+    ranked = sorted(reranked, key=preference_score, reverse=True)
 
-    # Step 2: no specific source mentioned → diversify with per-source cap
-    per_source: dict[str, int] = {}
-    selected: list[dict] = []
-    leftover: list[dict] = []
+    def select_diverse(
+        ranked_chunks: list[dict],
+        score_fn,
+    ) -> tuple[list[dict], dict[str, int]]:
+        per_source: dict[str, int] = {}
+        selected: list[dict] = []
+        leftover: list[dict] = []
 
-    for chunk in reranked:
-        if len(selected) == top_n:
-            break
-        label = chunk.get("source_label") or _UNKNOWN
-        count = per_source.get(label, 0)
-        if count < max_per_source:
-            selected.append(chunk)
-            per_source[label] = count + 1
-        else:
-            leftover.append(chunk)
-
-    # Fallback: fill remaining slots from leftover in score order
-    if len(selected) < top_n:
-        for chunk in leftover:
+        for chunk in ranked_chunks:
             if len(selected) == top_n:
                 break
-            selected.append(chunk)
             label = chunk.get("source_label") or _UNKNOWN
-            per_source[label] = per_source.get(label, 0) + 1
+            count = per_source.get(label, 0)
+            if count < max_per_source:
+                selected.append(chunk)
+                per_source[label] = count + 1
+            else:
+                leftover.append(chunk)
 
-    # Legacy fallback key is the raw ``score`` — the pre-contract diversify
-    # sort. ``final_rank_score`` is only present when the ranking contract
-    # is active (REQ-RANK-01), so shadow mode keeps the old ordering.
-    selected.sort(key=lambda c: ranking_score(c, "score"), reverse=True)
+        if len(selected) < top_n:
+            for chunk in leftover:
+                if len(selected) == top_n:
+                    break
+                selected.append(chunk)
+                label = chunk.get("source_label") or _UNKNOWN
+                per_source[label] = per_source.get(label, 0) + 1
+
+        selected.sort(key=score_fn, reverse=True)
+        return selected, per_source
+
+    selected_without_preference, _ = select_diverse(base_ranked, base_score)
+    selected, per_source = select_diverse(ranked, preference_score)
+
+    without_ids = [str(chunk.get("chunk_id") or "") for chunk in selected_without_preference]
+    selected_ids = {str(chunk.get("chunk_id") or "") for chunk in selected}
+    suppressed_count = len(set(without_ids) - selected_ids)
+
+    max_score_inversion = 0.0
+    for index, earlier in enumerate(ranked):
+        if earlier.get("source_label") not in mentioned:
+            continue
+        earlier_score = base_score(earlier)
+        for later in ranked[index + 1 :]:
+            if later.get("source_label") in mentioned:
+                continue
+            max_score_inversion = max(
+                max_score_inversion,
+                base_score(later) - earlier_score,
+            )
+
+    mode = "diversify"
+    if preference_applied:
+        mode = "router" if router_selected and not keyword_mentioned else "mentioned"
+        if router_selected and keyword_mentioned:
+            mode = "keyword+router"
 
     logger.debug(
         "source_aware_select",
-        mode="diversify",
+        mode=mode,
         selected=len(selected),
         source_counts=per_source,
     )
     return selected, {
-        "source_select_mode": "diversify",
+        "source_select_mode": mode,
         "source_counts": dict(per_source),
-        "mentioned_sources": [],
+        "mentioned_sources": sorted(mentioned),
+        "preference_applied": preference_applied,
+        "preferred_labels": sorted(mentioned),
+        "boost": source_preference_boost,
+        "pack_without_preference": without_ids,
+        "suppressed_count": suppressed_count,
+        "max_score_inversion": max_score_inversion,
     }
 
 

--- a/klai-retrieval-api/retrieval_api/services/router.py
+++ b/klai-retrieval-api/retrieval_api/services/router.py
@@ -9,11 +9,28 @@ from retrieval_api.config import settings
 
 logger = structlog.get_logger()
 
+_ROUTER_CACHE_MAX_ENTRIES = 256
+
 
 # ---------------------------------------------------------------------------
 # Source catalog cache: {(org_id, kb_slug_scope): (catalog, timestamp)}
 # ---------------------------------------------------------------------------
 _catalog_cache: dict[tuple[str, tuple[str, ...] | None], tuple[list[KBEntry], float]] = {}
+
+
+def _prune_cache(cache: dict, *, ttl_seconds: int, now: float) -> None:
+    """Drop expired entries."""
+    for key in [key for key, (_, timestamp) in cache.items() if now - timestamp >= ttl_seconds]:
+        cache.pop(key, None)
+
+
+def _make_cache_room(cache: dict) -> None:
+    """Evict oldest entries before inserting a new tenant/scope key."""
+    overflow = len(cache) - _ROUTER_CACHE_MAX_ENTRIES + 1
+    if overflow > 0:
+        oldest = sorted(cache, key=lambda key: cache[key][1])[:overflow]
+        for key in oldest:
+            cache.pop(key, None)
 
 
 async def fetch_source_catalog(org_id: str, kb_slugs: list[str] | None = None) -> list[KBEntry]:
@@ -26,8 +43,10 @@ async def fetch_source_catalog(org_id: str, kb_slugs: list[str] | None = None) -
     """
     kb_scope = tuple(sorted(set(kb_slugs))) if kb_slugs else None
     cache_key = (org_id, kb_scope)
+    now = time.monotonic()
+    _prune_cache(_catalog_cache, ttl_seconds=settings.router_centroid_ttl_seconds, now=now)
     cached = _catalog_cache.get(cache_key)
-    if cached and (time.monotonic() - cached[1]) < settings.router_centroid_ttl_seconds:
+    if cached:
         return cached[0]
 
     from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
@@ -57,8 +76,9 @@ async def fetch_source_catalog(org_id: str, kb_slugs: list[str] | None = None) -
         # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
         # traceback that the previous `error=str(exc)` dropped (TRY401).
         logger.warning("router_facet_failed", org_id=org_id, exc_info=True)
-        entries = []
+        return []
 
+    _make_cache_room(_catalog_cache)
     _catalog_cache[cache_key] = (entries, time.monotonic())
     logger.info(
         "router_catalog_built",
@@ -231,8 +251,10 @@ async def route_to_sources(
     kb_scope = tuple(sorted(set(kb_slugs))) if kb_slugs else None
     catalog_scope = tuple(sorted(entry.source_label for entry in source_label_catalog))
     cache_key = (org_id, kb_scope, catalog_scope)
+    now = time.monotonic()
+    _prune_cache(_centroid_cache, ttl_seconds=centroid_ttl_seconds, now=now)
     cached = _centroid_cache.get(cache_key)
-    if cached and (time.monotonic() - cached[1]) < centroid_ttl_seconds:
+    if cached:
         centroids = cached[0]
         cache_hit = True
 
@@ -241,6 +263,7 @@ async def route_to_sources(
             centroids = await compute_centroid_fn(source_label_catalog, org_id)
         else:
             centroids = await _default_compute_centroids(source_label_catalog, org_id, kb_slugs)
+        _make_cache_room(_centroid_cache)
         _centroid_cache[cache_key] = (centroids, time.monotonic())
 
     if centroids:
@@ -291,3 +314,12 @@ def clear_centroid_cache(org_id: str | None = None) -> None:
             _centroid_cache.pop(cache_key, None)
     else:
         _centroid_cache.clear()
+
+
+def clear_catalog_cache(org_id: str | None = None) -> None:
+    """Clear source catalog cache. For testing and cache invalidation."""
+    if org_id:
+        for cache_key in [key for key in _catalog_cache if key[0] == org_id]:
+            _catalog_cache.pop(cache_key, None)
+    else:
+        _catalog_cache.clear()

--- a/klai-retrieval-api/retrieval_api/services/router.py
+++ b/klai-retrieval-api/retrieval_api/services/router.py
@@ -6,38 +6,39 @@ from dataclasses import dataclass
 import structlog
 
 from retrieval_api.config import settings
-from retrieval_api.services.diversity import STOP_WORDS
 
 logger = structlog.get_logger()
 
 
 # ---------------------------------------------------------------------------
-# Source catalog cache: {org_id: (catalog, timestamp)}
+# Source catalog cache: {(org_id, kb_slug_scope): (catalog, timestamp)}
 # ---------------------------------------------------------------------------
-_catalog_cache: dict[str, tuple[list[KBEntry], float]] = {}
+_catalog_cache: dict[tuple[str, tuple[str, ...] | None], tuple[list[KBEntry], float]] = {}
 
 
-async def fetch_source_catalog(org_id: str) -> list[KBEntry]:
+async def fetch_source_catalog(org_id: str, kb_slugs: list[str] | None = None) -> list[KBEntry]:
     """Fetch distinct source_labels for an org from Qdrant via the Facet API.
 
     Single call — returns unique source_label values with counts.
     Requires a keyword index on source_label (created by ensure_collection).
-    Cached per org for router_centroid_ttl_seconds.
+    When the request pins knowledge bases, the catalog contains only source
+    labels from those KBs. Cached per org and KB scope.
     """
-    cached = _catalog_cache.get(org_id)
+    kb_scope = tuple(sorted(set(kb_slugs))) if kb_slugs else None
+    cache_key = (org_id, kb_scope)
+    cached = _catalog_cache.get(cache_key)
     if cached and (time.monotonic() - cached[1]) < settings.router_centroid_ttl_seconds:
         return cached[0]
 
-    from qdrant_client.models import FieldCondition, Filter, MatchValue
+    from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
 
     from retrieval_api.services.search import _get_client
 
     client = _get_client()
-    facet_filter = Filter(
-        must=[
-            FieldCondition(key="org_id", match=MatchValue(value=org_id)),
-        ]
-    )
+    must = [FieldCondition(key="org_id", match=MatchValue(value=org_id))]
+    if kb_scope:
+        must.append(FieldCondition(key="kb_slug", match=MatchAny(any=list(kb_scope))))
+    facet_filter = Filter(must=must)
 
     try:
         result = await client.facet(
@@ -58,8 +59,13 @@ async def fetch_source_catalog(org_id: str) -> list[KBEntry]:
         logger.warning("router_facet_failed", org_id=org_id, exc_info=True)
         entries = []
 
-    _catalog_cache[org_id] = (entries, time.monotonic())
-    logger.info("router_catalog_built", org_id=org_id, source_labels=len(entries))
+    _catalog_cache[cache_key] = (entries, time.monotonic())
+    logger.info(
+        "router_catalog_built",
+        org_id=org_id,
+        kb_slugs=list(kb_scope) if kb_scope else None,
+        source_labels=len(entries),
+    )
     return entries
 
 
@@ -77,53 +83,16 @@ class RoutingDecision:
     """Result of the query router."""
 
     selected_source_labels: list[str] | None  # None = no filter (search all)
-    layer_used: str  # "keyword" | "semantic" | "llm" | "none"
+    layer_used: str  # "semantic" | "llm" | "none"
     margin: float | None = None
     cache_hit: bool = False
 
 
-# Centroid cache: {org_id: (centroids_dict, timestamp)}
-_centroid_cache: dict[str, tuple[dict[str, list[float]], float]] = {}
-
-
-def _build_keyword_map(catalog: list[KBEntry]) -> dict[str, set[str]]:
-    """Build {term -> set of source_labels} map from catalog entries.
-
-    Only uses source_label and name tokens — NOT description words, because
-    descriptions contain too many generic terms that cause false-positive routing.
-    Filters out stop words.
-    """
-    keyword_map: dict[str, set[str]] = {}
-    for entry in catalog:
-        tokens: set[str] = set()
-        # Split source_label on separators
-        for sep_char in "-./: ":
-            for part in entry.source_label.split(sep_char):
-                if len(part) > 3:
-                    tokens.add(part.lower())
-        # Also split name (but NOT description — too many generic words)
-        if entry.name:
-            for word in entry.name.lower().split():
-                if len(word) > 3:
-                    tokens.add(word)
-
-        for token in tokens:
-            if token in STOP_WORDS:
-                continue
-            if token not in keyword_map:
-                keyword_map[token] = set()
-            keyword_map[token].add(entry.source_label)
-    return keyword_map
-
-
-def layer1_keyword(query_resolved: str, keyword_map: dict[str, set[str]]) -> list[str] | None:
-    """Layer 1: exact keyword matching. Returns matched source_labels or None."""
-    query_lower = query_resolved.lower()
-    matched: set[str] = set()
-    for term, source_labels in keyword_map.items():
-        if term in query_lower:
-            matched.update(source_labels)
-    return sorted(matched) if matched else None
+# Centroid cache: {(org_id, kb_slug_scope, catalog_labels): (centroids_dict, timestamp)}
+_centroid_cache: dict[
+    tuple[str, tuple[str, ...] | None, tuple[str, ...]],
+    tuple[dict[str, list[float]], float],
+] = {}
 
 
 def _cosine_similarity(a: list[float], b: list[float]) -> float:
@@ -176,6 +145,7 @@ def layer2_semantic(
 async def _default_compute_centroids(
     catalog: list[KBEntry],
     org_id: str,
+    kb_slugs: list[str] | None = None,
 ) -> dict[str, list[float]]:
     """Compute centroids from actual chunk vectors per source_label in Qdrant.
 
@@ -187,12 +157,13 @@ async def _default_compute_centroids(
     # to prevent cross-tenant centroid contamination from common source_labels
     # (Notion, Confluence, GitHub, Slack, Web).
     """
-    from qdrant_client.models import FieldCondition, Filter, MatchValue
+    from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
 
     from retrieval_api.services.search import _get_client
 
     client = _get_client()
     centroids: dict[str, list[float]] = {}
+    kb_scope = sorted(set(kb_slugs)) if kb_slugs else None
 
     for entry in catalog:
         try:
@@ -200,16 +171,15 @@ async def _default_compute_centroids(
             # audit-tenant-isolation-2026-05-05 finding B-1: filter MUST include org_id
             # to prevent cross-tenant centroid contamination from common source_labels
             # (Notion, Confluence, GitHub, Slack, Web).
+            must = [
+                FieldCondition(key="source_label", match=MatchValue(value=entry.source_label)),
+                FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+            ]
+            if kb_scope:
+                must.append(FieldCondition(key="kb_slug", match=MatchAny(any=kb_scope)))
             points, _ = await client.scroll(
                 collection_name=settings.qdrant_collection,
-                scroll_filter=Filter(
-                    must=[
-                        FieldCondition(
-                            key="source_label", match=MatchValue(value=entry.source_label)
-                        ),
-                        FieldCondition(key="org_id", match=MatchValue(value=org_id)),
-                    ]
-                ),
+                scroll_filter=Filter(must=must),
                 limit=10,
                 with_payload=False,
                 with_vectors=["vector_chunk"],
@@ -243,39 +213,35 @@ async def route_to_sources(
     margin_dual: float = 0.08,
     llm_fallback: bool = False,
     centroid_ttl_seconds: int = 600,
+    kb_slugs: list[str] | None = None,
     # Centroid computation function injected for testability
     compute_centroid_fn=None,
     # LLM function injected for testability
     llm_fn=None,
 ) -> RoutingDecision:
-    """Three-layer query router.
+    """Two-layer query router.
 
-    Layer 1: Keyword matching (< 1ms)
-    Layer 2: Semantic margin (5-20ms with cache)
-    Layer 3: LLM fallback (500ms timeout, default OFF)
+    Layer 1: Semantic margin (5-20ms with cache)
+    Layer 2: LLM fallback (500ms timeout, default OFF)
     """
-    # Layer 1: keyword
-    keyword_map = _build_keyword_map(source_label_catalog)
-    matched = layer1_keyword(query_resolved, keyword_map)
-    if matched:
-        return RoutingDecision(
-            selected_source_labels=matched,
-            layer_used="keyword",
-        )
-
-    # Layer 2: semantic margin
+    # Layer 1: semantic margin
     # Check centroid cache
     cache_hit = False
     centroids: dict[str, list[float]] | None = None
-    cached = _centroid_cache.get(org_id)
+    kb_scope = tuple(sorted(set(kb_slugs))) if kb_slugs else None
+    catalog_scope = tuple(sorted(entry.source_label for entry in source_label_catalog))
+    cache_key = (org_id, kb_scope, catalog_scope)
+    cached = _centroid_cache.get(cache_key)
     if cached and (time.monotonic() - cached[1]) < centroid_ttl_seconds:
         centroids = cached[0]
         cache_hit = True
 
     if centroids is None:
-        fn = compute_centroid_fn or _default_compute_centroids
-        centroids = await fn(source_label_catalog, org_id)
-        _centroid_cache[org_id] = (centroids, time.monotonic())
+        if compute_centroid_fn:
+            centroids = await compute_centroid_fn(source_label_catalog, org_id)
+        else:
+            centroids = await _default_compute_centroids(source_label_catalog, org_id, kb_slugs)
+        _centroid_cache[cache_key] = (centroids, time.monotonic())
 
     if centroids:
         selected, margin = layer2_semantic(query_vector, centroids, margin_single, margin_dual)
@@ -287,7 +253,7 @@ async def route_to_sources(
                 cache_hit=cache_hit,
             )
 
-    # Layer 3: LLM fallback (default OFF)
+    # Layer 2: LLM fallback (default OFF)
     if llm_fallback and llm_fn:
         try:
             import asyncio
@@ -321,6 +287,7 @@ async def route_to_sources(
 def clear_centroid_cache(org_id: str | None = None) -> None:
     """Clear centroid cache. For testing and cache invalidation."""
     if org_id:
-        _centroid_cache.pop(org_id, None)
+        for cache_key in [key for key in _centroid_cache if key[0] == org_id]:
+            _centroid_cache.pop(cache_key, None)
     else:
         _centroid_cache.clear()

--- a/klai-retrieval-api/retrieval_api/util/scores.py
+++ b/klai-retrieval-api/retrieval_api/util/scores.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 def ranking_score(chunk: dict, *fallback_keys: str) -> float:
     """Return ``final_rank_score`` when present, else the first numeric fallback.
 
-    ``fallback_keys`` is each call site's PRE-contract sort key chain (e.g.
-    ``("score",)`` for the diversity sort, ``("reranker_score", "score")``
-    for the boost re-sorts) so shadow mode reproduces the legacy ordering
+    ``fallback_keys`` is each call site's PRE-contract sort key chain (for
+    example ``("reranker_score", "score")`` for diversity and boost re-sorts)
+    so shadow mode reproduces the legacy ordering
     exactly. isinstance-based on purpose: a legitimate ``0.0`` score must
     sort as 0.0, not fall through like the old ``or``-chains did.
     """

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -184,6 +184,8 @@ class TestRetrieveEndpoint:
         assert "https://docs.getklai.com/refunds" in decision_attrs
         assert "Refund policy" in decision_attrs
         assert "top_item_chunk_ids" in decision_attrs
+        assert decision_record.msg["confidence_band"] == "high"
+        assert decision_record.msg["confidence_band_corroborated"] == "medium"
 
     def test_retrieve_passes_effective_telemetry_level_to_coreference(
         self, client, sample_retrieve_request

--- a/klai-retrieval-api/tests/test_confidence_band.py
+++ b/klai-retrieval-api/tests/test_confidence_band.py
@@ -145,6 +145,49 @@ def test_band_handles_int_score() -> None:
     assert band == "high"
 
 
+def test_corroborated_band_caps_single_strong_hit_at_medium() -> None:
+    chunks = [
+        {"reranker_score": 0.87},
+        {"reranker_score": 0.28},
+        {"reranker_score": 0.21},
+    ]
+
+    authoritative = _compute_confidence_band(
+        chunks,
+        high_threshold=0.60,
+        low_threshold=0.30,
+        reranker_enabled=True,
+    )
+    corroborated = _compute_confidence_band(
+        chunks,
+        high_threshold=0.60,
+        low_threshold=0.30,
+        reranker_enabled=True,
+        require_corroboration=True,
+    )
+
+    assert authoritative == "high"
+    assert corroborated == "medium"
+
+
+def test_corroborated_band_is_high_with_two_strong_hits() -> None:
+    chunks = [
+        {"reranker_score": 0.87},
+        {"reranker_score": 0.72},
+        {"reranker_score": 0.21},
+    ]
+
+    corroborated = _compute_confidence_band(
+        chunks,
+        high_threshold=0.60,
+        low_threshold=0.30,
+        reranker_enabled=True,
+        require_corroboration=True,
+    )
+
+    assert corroborated == "high"
+
+
 # ---------------------------------------------------------------------------
 # REQ-3 — _apply_link_expand_boost
 # ---------------------------------------------------------------------------

--- a/klai-retrieval-api/tests/test_diversity.py
+++ b/klai-retrieval-api/tests/test_diversity.py
@@ -157,7 +157,7 @@ class TestBoundedPreference:
         assert meta["preferred_labels"] == ["preferred"]
         assert meta["boost"] == 0.05
 
-    def test_preference_never_inverts_a_gap_larger_than_boost(self):
+    def test_preference_never_inverts_a_gap_larger_than_boost_without_diversity(self):
         rng = random.Random(20260819)  # noqa: S311 - deterministic property test data
         boost = 0.05
 
@@ -183,6 +183,52 @@ class TestBoundedPreference:
                 for lower in chunks:
                     if higher["reranker_score"] > lower["reranker_score"] + boost:
                         assert position[higher["chunk_id"]] < position[lower["chunk_id"]]
+
+    def test_preference_displacement_is_bounded_with_production_diversity_cap(self):
+        rng = random.Random(20260820)  # noqa: S311 - deterministic property test data
+        boost = 0.05
+        labels = ("preferred", "other-a", "other-b")
+
+        for case in range(250):
+            chunks = [
+                _chunk(
+                    f"{case}-{index}",
+                    rng.choice(labels),
+                    rng.random(),
+                )
+                for index in range(rng.randint(3, 20))
+            ]
+            top_n = rng.randint(1, len(chunks))
+            baseline, _ = source_aware_select(
+                chunks,
+                top_n=top_n,
+                max_per_source=2,
+                source_preference_boost=boost,
+            )
+            preferred, _ = source_aware_select(
+                chunks,
+                top_n=top_n,
+                max_per_source=2,
+                preferred_labels={"preferred"},
+                source_preference_boost=boost,
+            )
+
+            baseline_ids = {chunk["chunk_id"] for chunk in baseline}
+            preferred_ids = {chunk["chunk_id"] for chunk in preferred}
+            suppressed = sorted(
+                (chunk for chunk in baseline if chunk["chunk_id"] not in preferred_ids),
+                key=lambda chunk: chunk["reranker_score"],
+                reverse=True,
+            )
+            promoted = sorted(
+                (chunk for chunk in preferred if chunk["chunk_id"] not in baseline_ids),
+                key=lambda chunk: chunk["reranker_score"],
+                reverse=True,
+            )
+
+            assert len(suppressed) == len(promoted)
+            for displaced, replacement in zip(suppressed, promoted, strict=True):
+                assert displaced["reranker_score"] <= replacement["reranker_score"] + boost + 1e-12
 
     def test_counterfactual_reports_no_suppression_for_incident_score_shape(self):
         reranked = [

--- a/klai-retrieval-api/tests/test_diversity.py
+++ b/klai-retrieval-api/tests/test_diversity.py
@@ -34,9 +34,7 @@ class TestDiversifyMode:
             _chunk("c1", "mitel-help", 0.82),
             _chunk("b2", "wiki.voys.nl", 0.80),
         ]
-        selected, meta = source_aware_select(
-            reranked, "hoe maak ik een gebruiker aan", top_n=5, max_per_source=2
-        )
+        selected, meta = source_aware_select(reranked, top_n=5, max_per_source=2)
         assert len(selected) == 5
         counts = meta["source_counts"]
         for count in counts.values():
@@ -45,7 +43,7 @@ class TestDiversifyMode:
 
     def test_fallback_when_few_sources(self):
         reranked = [_chunk(f"a{i}", "single-source", 0.9 - i * 0.1) for i in range(4)]
-        selected, meta = source_aware_select(reranked, "test", top_n=5, max_per_source=2)
+        selected, meta = source_aware_select(reranked, top_n=5, max_per_source=2)
         assert len(selected) == 4
         assert meta["source_select_mode"] == "diversify"
 
@@ -56,7 +54,7 @@ class TestDiversifyMode:
             _chunk("a2", "src-a", 0.85),
             _chunk("b2", "src-b", 0.80),
         ]
-        selected, _ = source_aware_select(reranked, "query", top_n=4, max_per_source=2)
+        selected, _ = source_aware_select(reranked, top_n=4, max_per_source=2)
         scores = [c["score"] for c in selected]
         assert scores == sorted(scores, reverse=True)
 
@@ -67,96 +65,19 @@ class TestDiversifyMode:
             {**_chunk("a2", "src-a", 0.85), "final_rank_score": 0.80},
             {**_chunk("b2", "src-b", 0.30), "final_rank_score": 0.70},
         ]
-        selected, _ = source_aware_select(reranked, "query", top_n=4, max_per_source=2)
+        selected, _ = source_aware_select(reranked, top_n=4, max_per_source=2)
         assert [c["chunk_id"] for c in selected] == ["b1", "a2", "b2", "a1"]
 
     def test_empty_input(self):
-        selected, meta = source_aware_select([], "query")
+        selected, meta = source_aware_select([])
         assert selected == []
         assert meta["source_select_mode"] == "empty"
-
-
-class TestMentionedMode:
-    """Source name in query → give that source all slots."""
-
-    def test_single_source_mentioned(self):
-        reranked = [
-            _chunk("m1", "mitel-help", 0.95),
-            _chunk("m2", "mitel-help", 0.90),
-            _chunk("m3", "mitel-help", 0.88),
-            _chunk("v1", "help.voys.nl", 0.85),
-            _chunk("v2", "help.voys.nl", 0.80),
-        ]
-        selected, meta = source_aware_select(
-            reranked, "mitel error X025", top_n=5, max_per_source=2
-        )
-        assert meta["source_select_mode"] == "mentioned"
-        assert "mitel-help" in meta["mentioned_sources"]
-        mitel_count = sum(1 for c in selected if c["source_label"] == "mitel-help")
-        assert mitel_count == 3  # all mitel chunks, no cap
-
-    def test_multiple_sources_mentioned(self):
-        reranked = [
-            _chunk("m1", "mitel-help", 0.95),
-            _chunk("m2", "mitel-help", 0.90),
-            _chunk("a1", "ascend-help", 0.85),
-            _chunk("a2", "ascend-help", 0.82),
-            _chunk("v1", "help.voys.nl", 0.75),
-        ]
-        selected, meta = source_aware_select(
-            reranked,
-            "verschil tussen mitel en ascend",
-            top_n=5,
-            max_per_source=1,
-        )
-        assert meta["source_select_mode"] == "mentioned"
-        assert "mitel-help" in meta["mentioned_sources"]
-        assert "ascend-help" in meta["mentioned_sources"]
-        # Both mentioned sources get all their chunks (no cap)
-        mitel = sum(1 for c in selected if c["source_label"] == "mitel-help")
-        ascend = sum(1 for c in selected if c["source_label"] == "ascend-help")
-        assert mitel == 2
-        assert ascend == 2
-
-    def test_mentioned_source_fills_with_others_if_short(self):
-        """If mentioned source has fewer chunks than top_n, fill with others."""
-        reranked = [
-            _chunk("m1", "mitel-help", 0.95),
-            _chunk("v1", "help.voys.nl", 0.85),
-            _chunk("v2", "help.voys.nl", 0.80),
-        ]
-        selected, _meta = source_aware_select(reranked, "mitel probleem", top_n=3, max_per_source=2)
-        assert len(selected) == 3
-        assert selected[0]["source_label"] == "mitel-help"  # mentioned first
-
-    def test_short_label_not_detected(self):
-        """Labels with len <= 3 should never trigger mention detection."""
-        reranked = [
-            _chunk("a1", "hr", 0.95),
-            _chunk("a2", "hr", 0.90),
-            _chunk("b1", "wiki-docs", 0.85),
-        ]
-        _selected, meta = source_aware_select(reranked, "hr beleid", top_n=2, max_per_source=1)
-        assert meta["source_select_mode"] == "diversify"  # not "mentioned"
-
-    def test_stop_words_not_detected(self):
-        """Generic words like 'help' should not trigger mention detection."""
-        reranked = [
-            _chunk("a1", "help.voys.nl", 0.95),
-            _chunk("a2", "help.voys.nl", 0.90),
-            _chunk("b1", "mitel-help", 0.85),
-        ]
-        _selected, meta = source_aware_select(
-            reranked, "ik heb help nodig", top_n=2, max_per_source=1
-        )
-        assert meta["source_select_mode"] == "diversify"  # "help" is a stop word
 
 
 class TestRouterIntegration:
     """Router passes selected sources as boost signal to source_aware_select."""
 
-    def test_router_selected_bypasses_cap(self):
-        """Router says 'mitel is relevant' (no keyword in query) → mitel gets all slots."""
+    def test_semantic_preference_is_recorded(self):
         reranked = [
             _chunk("m1", "mitel-help", 0.95),
             _chunk("m2", "mitel-help", 0.90),
@@ -167,35 +88,13 @@ class TestRouterIntegration:
         # Query does NOT mention "mitel" — but router identified it semantically
         selected, meta = source_aware_select(
             reranked,
-            "hoe stel ik een belgroep in",
             top_n=5,
             max_per_source=2,
-            router_selected={"mitel-help"},
+            preferred_labels={"mitel-help"},
         )
         assert meta["source_select_mode"] == "router"
         mitel_count = sum(1 for c in selected if c["source_label"] == "mitel-help")
         assert mitel_count == 3  # all mitel chunks, no cap
-
-    def test_router_plus_keyword_combined(self):
-        """Both router and keyword detect sources → union of both."""
-        reranked = [
-            _chunk("m1", "mitel-help", 0.95),
-            _chunk("m2", "mitel-help", 0.90),
-            _chunk("a1", "ascend-help", 0.85),
-            _chunk("a2", "ascend-help", 0.82),
-            _chunk("v1", "help.voys.nl", 0.75),
-        ]
-        # "mitel" in query (keyword), router adds "ascend-help" (semantic)
-        _selected, meta = source_aware_select(
-            reranked,
-            "mitel configuratie",
-            top_n=5,
-            max_per_source=1,
-            router_selected={"ascend-help"},
-        )
-        assert meta["source_select_mode"] == "keyword+router"
-        assert "mitel-help" in meta["mentioned_sources"]
-        assert "ascend-help" in meta["mentioned_sources"]
 
     def test_router_signal_respected_even_with_low_scores(self):
         """A router preference is a tiebreak, not permission to erase score gaps."""
@@ -208,10 +107,9 @@ class TestRouterIntegration:
         ]
         selected, meta = source_aware_select(
             reranked,
-            "generieke vraag",
             top_n=3,
             max_per_source=2,
-            router_selected={"mitel-help"},
+            preferred_labels={"mitel-help"},
         )
         assert meta["source_select_mode"] == "router"
         mitel_ids = [c["chunk_id"] for c in selected if c["source_label"] == "mitel-help"]
@@ -223,10 +121,10 @@ class TestRouterIntegration:
 class TestMetadata:
     def test_metadata_keys(self):
         reranked = [_chunk("a1", "src", 0.9)]
-        _, meta = source_aware_select(reranked, "query")
+        _, meta = source_aware_select(reranked)
         assert "source_select_mode" in meta
         assert "source_counts" in meta
-        assert "mentioned_sources" in meta
+        assert "preferred_labels" in meta
 
     def test_source_counts_accurate(self):
         reranked = [
@@ -234,7 +132,7 @@ class TestMetadata:
             _chunk("a2", "src-a", 0.90),
             _chunk("b1", "src-b", 0.85),
         ]
-        _, meta = source_aware_select(reranked, "query", top_n=3, max_per_source=2)
+        _, meta = source_aware_select(reranked, top_n=3, max_per_source=2)
         assert meta["source_counts"]["src-a"] == 2
         assert meta["source_counts"]["src-b"] == 1
 
@@ -248,10 +146,9 @@ class TestBoundedPreference:
 
         selected, meta = source_aware_select(
             reranked,
-            "query",
             top_n=2,
             max_per_source=2,
-            router_selected={"preferred"},
+            preferred_labels={"preferred"},
             source_preference_boost=0.05,
         )
 
@@ -275,10 +172,9 @@ class TestBoundedPreference:
             ]
             selected, _ = source_aware_select(
                 chunks,
-                "query",
                 top_n=len(chunks),
                 max_per_source=len(chunks),
-                router_selected={"preferred"},
+                preferred_labels={"preferred"},
                 source_preference_boost=boost,
             )
             position = {chunk["chunk_id"]: index for index, chunk in enumerate(selected)}
@@ -299,10 +195,9 @@ class TestBoundedPreference:
 
         selected, meta = source_aware_select(
             reranked,
-            "Voys trunk 404 Not Found",
             top_n=3,
             max_per_source=3,
-            router_selected={"help.voys.nl"},
+            preferred_labels={"help.voys.nl"},
             source_preference_boost=0.05,
         )
 
@@ -327,10 +222,9 @@ class TestBoundedPreference:
 
         selected, meta = source_aware_select(
             reranked,
-            "query",
             top_n=1,
             max_per_source=1,
-            router_selected={"preferred"},
+            preferred_labels={"preferred"},
             source_preference_boost=0.05,
         )
 
@@ -338,3 +232,31 @@ class TestBoundedPreference:
         assert meta["pack_without_preference"] == ["unpreferred"]
         assert meta["suppressed_count"] == 1
         assert meta["max_score_inversion"] == pytest.approx(0.03)
+
+
+class TestComparisonOnlyPreference:
+    def test_brand_token_does_not_prefer_matching_source_label(self):
+        reranked = [
+            _chunk("help-strong", "help.voys.nl", 0.866),
+            _chunk("notion-gold", "notion", 0.658),
+            _chunk("support-gold", "support", 0.616),
+            _chunk("help-weak", "help.voys.nl", 0.280),
+            _chunk("help-weaker", "help.voys.nl", 0.208),
+        ]
+
+        selected, meta = source_aware_select(
+            reranked,
+            top_n=3,
+            max_per_source=3,
+            preferred_labels=None,
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == [
+            "help-strong",
+            "notion-gold",
+            "support-gold",
+        ]
+        assert meta["preference_applied"] is False
+        assert meta["preferred_labels"] == []
+        assert meta["suppressed_count"] == 0

--- a/klai-retrieval-api/tests/test_diversity.py
+++ b/klai-retrieval-api/tests/test_diversity.py
@@ -260,3 +260,21 @@ class TestComparisonOnlyPreference:
         assert meta["preference_applied"] is False
         assert meta["preferred_labels"] == []
         assert meta["suppressed_count"] == 0
+
+    def test_pinned_org_preference_does_not_boost_personal_chunk_with_same_label(self):
+        reranked = [
+            {**_chunk("personal", "notion", 0.59), "kb_slug": "personal-user-1"},
+            {**_chunk("other", "support", 0.60), "kb_slug": "support"},
+            {**_chunk("org", "notion", 0.58), "kb_slug": "sip"},
+        ]
+
+        selected, _ = source_aware_select(
+            reranked,
+            top_n=3,
+            max_per_source=3,
+            preferred_labels={"notion"},
+            preferred_kb_slugs={"sip"},
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == ["org", "other", "personal"]

--- a/klai-retrieval-api/tests/test_diversity.py
+++ b/klai-retrieval-api/tests/test_diversity.py
@@ -4,6 +4,10 @@ source_aware_select() replaces the separate router + quota with one post-rerank
 step that uses actual reranker scores to decide source distribution.
 """
 
+import random
+
+import pytest
+
 from retrieval_api.services.diversity import source_aware_select
 
 
@@ -11,6 +15,7 @@ def _chunk(chunk_id: str, source_label: str | None, score: float) -> dict:
     return {
         "chunk_id": chunk_id,
         "source_label": source_label,
+        "reranker_score": score,
         "score": score,
         "text": f"c-{chunk_id}",
     }
@@ -193,12 +198,7 @@ class TestRouterIntegration:
         assert "ascend-help" in meta["mentioned_sources"]
 
     def test_router_signal_respected_even_with_low_scores(self):
-        """Router says 'mitel' but reranker gives mitel low scores → router signal wins.
-
-        This is correct: the router made a deliberate decision based on semantic
-        analysis. source_aware_select trusts that signal and gives mitel priority.
-        The reranker scores still order chunks within the selected set.
-        """
+        """A router preference is a tiebreak, not permission to erase score gaps."""
         reranked = [
             _chunk("v1", "help.voys.nl", 0.95),
             _chunk("v2", "help.voys.nl", 0.90),
@@ -214,9 +214,9 @@ class TestRouterIntegration:
             router_selected={"mitel-help"},
         )
         assert meta["source_select_mode"] == "router"
-        # Mitel chunks come first (router-selected), voys fills remainder
         mitel_ids = [c["chunk_id"] for c in selected if c["source_label"] == "mitel-help"]
-        assert len(mitel_ids) == 2
+        assert mitel_ids == ["m1"]
+        assert [chunk["chunk_id"] for chunk in selected[:2]] == ["v1", "v2"]
         assert len(selected) == 3
 
 
@@ -237,3 +237,104 @@ class TestMetadata:
         _, meta = source_aware_select(reranked, "query", top_n=3, max_per_source=2)
         assert meta["source_counts"]["src-a"] == 2
         assert meta["source_counts"]["src-b"] == 1
+
+
+class TestBoundedPreference:
+    def test_preference_cannot_invert_a_score_gap_larger_than_boost(self):
+        reranked = [
+            _chunk("strong", "other", 0.66),
+            _chunk("weak", "preferred", 0.28),
+        ]
+
+        selected, meta = source_aware_select(
+            reranked,
+            "query",
+            top_n=2,
+            max_per_source=2,
+            router_selected={"preferred"},
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == ["strong", "weak"]
+        assert meta["preference_applied"] is True
+        assert meta["preferred_labels"] == ["preferred"]
+        assert meta["boost"] == 0.05
+
+    def test_preference_never_inverts_a_gap_larger_than_boost(self):
+        rng = random.Random(20260819)  # noqa: S311 - deterministic property test data
+        boost = 0.05
+
+        for case in range(250):
+            chunks = [
+                _chunk(
+                    f"{case}-{index}",
+                    "preferred" if rng.random() < 0.5 else "other",
+                    rng.random(),
+                )
+                for index in range(rng.randint(2, 20))
+            ]
+            selected, _ = source_aware_select(
+                chunks,
+                "query",
+                top_n=len(chunks),
+                max_per_source=len(chunks),
+                router_selected={"preferred"},
+                source_preference_boost=boost,
+            )
+            position = {chunk["chunk_id"]: index for index, chunk in enumerate(selected)}
+
+            for higher in chunks:
+                for lower in chunks:
+                    if higher["reranker_score"] > lower["reranker_score"] + boost:
+                        assert position[higher["chunk_id"]] < position[lower["chunk_id"]]
+
+    def test_counterfactual_reports_no_suppression_for_incident_score_shape(self):
+        reranked = [
+            _chunk("help-strong", "help.voys.nl", 0.866),
+            _chunk("notion-gold", "notion", 0.658),
+            _chunk("support-gold", "support", 0.616),
+            _chunk("help-weak", "help.voys.nl", 0.280),
+            _chunk("help-weaker", "help.voys.nl", 0.208),
+        ]
+
+        selected, meta = source_aware_select(
+            reranked,
+            "Voys trunk 404 Not Found",
+            top_n=3,
+            max_per_source=3,
+            router_selected={"help.voys.nl"},
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == [
+            "help-strong",
+            "notion-gold",
+            "support-gold",
+        ]
+        assert meta["pack_without_preference"] == [
+            "help-strong",
+            "notion-gold",
+            "support-gold",
+        ]
+        assert meta["suppressed_count"] == 0
+        assert meta["max_score_inversion"] == 0.0
+
+    def test_counterfactual_reports_displacement_and_inversion_gap(self):
+        reranked = [
+            _chunk("unpreferred", "other", 0.61),
+            _chunk("preferred", "preferred", 0.58),
+        ]
+
+        selected, meta = source_aware_select(
+            reranked,
+            "query",
+            top_n=1,
+            max_per_source=1,
+            router_selected={"preferred"},
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == ["preferred"]
+        assert meta["pack_without_preference"] == ["unpreferred"]
+        assert meta["suppressed_count"] == 1
+        assert meta["max_score_inversion"] == pytest.approx(0.03)

--- a/klai-retrieval-api/tests/test_diversity.py
+++ b/klai-retrieval-api/tests/test_diversity.py
@@ -324,3 +324,21 @@ class TestComparisonOnlyPreference:
         )
 
         assert [chunk["chunk_id"] for chunk in selected] == ["org", "other", "personal"]
+
+    def test_unpinned_both_scope_preference_excludes_personal_kb(self):
+        reranked = [
+            {**_chunk("personal", "notion", 0.59), "kb_slug": "personal-user-1"},
+            {**_chunk("other", "support", 0.60), "kb_slug": "support"},
+            {**_chunk("org", "notion", 0.58), "kb_slug": "engineering"},
+        ]
+
+        selected, _ = source_aware_select(
+            reranked,
+            top_n=3,
+            max_per_source=3,
+            preferred_labels={"notion"},
+            excluded_preferred_kb_slugs={"personal-user-1"},
+            source_preference_boost=0.05,
+        )
+
+        assert [chunk["chunk_id"] for chunk in selected] == ["org", "other", "personal"]

--- a/klai-retrieval-api/tests/test_link_expand_config.py
+++ b/klai-retrieval-api/tests/test_link_expand_config.py
@@ -27,3 +27,16 @@ def test_link_expand_override(monkeypatch):
     s = cfg_mod.Settings()
     assert s.link_expand_enabled is False
     assert s.link_authority_boost == pytest.approx(0.10)
+
+
+def test_source_preference_boost_default():
+    from retrieval_api.config import Settings
+
+    assert Settings().source_preference_boost == pytest.approx(0.05)
+
+
+def test_source_preference_boost_env_override(monkeypatch):
+    monkeypatch.setenv("SOURCE_PREFERENCE_BOOST", "0.08")
+    from retrieval_api.config import Settings
+
+    assert Settings().source_preference_boost == pytest.approx(0.08)

--- a/klai-retrieval-api/tests/test_ranking_contract.py
+++ b/klai-retrieval-api/tests/test_ranking_contract.py
@@ -12,6 +12,7 @@ Covers the helpers that carry the contract:
 import pytest
 
 from retrieval_api.api.retrieve import (
+    _SHADOW_PREVIEW_KEYS,
     _ranking_contract_snapshot,
     _set_final_rank_scores,
 )
@@ -55,6 +56,18 @@ class TestSetFinalRankScores:
 
 
 class TestRankingContractSnapshot:
+    def test_shadow_preview_preserves_kb_scope_for_source_preference(self) -> None:
+        """Shadow replay must retain the tenant-safe source-preference key."""
+        chunk = {
+            "chunk_id": "c1",
+            "source_label": "Documentation",
+            "kb_slug": "pinned-org-kb",
+        }
+
+        preview = {key: chunk.get(key) for key in _SHADOW_PREVIEW_KEYS}
+
+        assert preview["kb_slug"] == "pinned-org-kb"
+
     def test_source_keys_are_distinct_and_capped_at_three(self) -> None:
         """Two chunks of the same source must occupy ONE source slot —
         first-N raw source_urls would double-count multi-chunk sources."""

--- a/klai-retrieval-api/tests/test_router.py
+++ b/klai-retrieval-api/tests/test_router.py
@@ -7,6 +7,8 @@ import pytest
 from retrieval_api.services.router import (
     KBEntry,
     _catalog_cache,
+    _centroid_cache,
+    clear_catalog_cache,
     clear_centroid_cache,
     fetch_source_catalog,
     layer2_semantic,
@@ -17,10 +19,10 @@ from retrieval_api.services.router import (
 @pytest.fixture(autouse=True)
 def _clear_cache():
     clear_centroid_cache()
-    _catalog_cache.clear()
+    clear_catalog_cache()
     yield
     clear_centroid_cache()
-    _catalog_cache.clear()
+    clear_catalog_cache()
 
 
 CATALOG = [
@@ -209,3 +211,53 @@ class TestSourceCatalogScope:
         assert pinned_conditions["kb_slug"].any == ["sip"]
         assert ("org-1", ("sip",)) in _catalog_cache
         assert ("org-1", None) in _catalog_cache
+
+    @pytest.mark.asyncio
+    async def test_transient_facet_failure_is_not_cached(self):
+        mock_client = AsyncMock()
+        mock_client.facet.side_effect = [
+            RuntimeError("temporary qdrant failure"),
+            SimpleNamespace(hits=[SimpleNamespace(value="notion")]),
+        ]
+
+        with patch("retrieval_api.services.search._get_client", return_value=mock_client):
+            assert await fetch_source_catalog("org-1") == []
+            recovered = await fetch_source_catalog("org-1")
+
+        assert [entry.source_label for entry in recovered] == ["notion"]
+        assert mock_client.facet.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_router_caches_are_bounded(self, monkeypatch):
+        monkeypatch.setattr("retrieval_api.services.router._ROUTER_CACHE_MAX_ENTRIES", 2)
+        mock_client = AsyncMock()
+        mock_client.facet.return_value = SimpleNamespace(hits=[])
+
+        with patch("retrieval_api.services.search._get_client", return_value=mock_client):
+            for org_id in ("org-1", "org-2", "org-3"):
+                await fetch_source_catalog(org_id)
+
+        async def compute(catalog, org_id):
+            return {"notion": [1.0, 0.0]}
+
+        catalog = [KBEntry(source_label="notion", name="Notion")]
+        for org_id in ("org-1", "org-2", "org-3"):
+            await route_to_sources(
+                "query",
+                [1.0, 0.0],
+                org_id,
+                catalog,
+                compute_centroid_fn=compute,
+            )
+
+        assert len(_catalog_cache) <= 2
+        assert len(_centroid_cache) <= 2
+
+    def test_catalog_cache_can_be_cleared_per_org(self):
+        _catalog_cache[("org-1", None)] = ([], 1.0)
+        _catalog_cache[("org-2", None)] = ([], 1.0)
+
+        clear_catalog_cache("org-1")
+
+        assert ("org-1", None) not in _catalog_cache
+        assert ("org-2", None) in _catalog_cache

--- a/klai-retrieval-api/tests/test_router.py
+++ b/klai-retrieval-api/tests/test_router.py
@@ -1,12 +1,14 @@
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from retrieval_api.services.router import (
     KBEntry,
-    _build_keyword_map,
+    _catalog_cache,
     clear_centroid_cache,
-    layer1_keyword,
+    fetch_source_catalog,
     layer2_semantic,
     route_to_sources,
 )
@@ -15,8 +17,10 @@ from retrieval_api.services.router import (
 @pytest.fixture(autouse=True)
 def _clear_cache():
     clear_centroid_cache()
+    _catalog_cache.clear()
     yield
     clear_centroid_cache()
+    _catalog_cache.clear()
 
 
 CATALOG = [
@@ -38,64 +42,6 @@ CATALOG = [
     ),
     KBEntry(source_label="notion-internal", name="Notion Wiki", description="Interne bedrijfswiki"),
 ]
-
-
-class TestBuildKeywordMap:
-    def test_splits_source_label_on_separators(self):
-        kmap = _build_keyword_map(CATALOG)
-        assert "mitel" in kmap
-        assert "help.mitel.nl" in kmap["mitel"]
-
-    def test_includes_name_words(self):
-        kmap = _build_keyword_map(CATALOG)
-        assert "voys" in kmap
-        assert "help.voys.nl" in kmap["voys"]
-
-    def test_skips_short_tokens(self):
-        kmap = _build_keyword_map(CATALOG)
-        assert "nl" not in kmap  # too short (2 chars)
-
-    def test_no_description_words_in_map(self):
-        """Description words should NOT be in keyword map (too generic)."""
-        kmap = _build_keyword_map(CATALOG)
-        # "documentatie" is in Mitel's description but should be filtered
-        assert "documentatie" not in kmap
-
-    def test_stop_words_filtered(self):
-        """Generic words like 'help', 'docs', 'wiki' should not be routing tokens."""
-        kmap = _build_keyword_map(CATALOG)
-        assert "help" not in kmap
-        assert "wiki" not in kmap
-
-    def test_collision_maps_to_both_sources(self):
-        """Two sources sharing a token should both be in the set."""
-        catalog = [
-            KBEntry(source_label="mitel-helpcenter", name="Mitel HC"),
-            KBEntry(source_label="mitel-wiki", name="Mitel Wiki"),
-        ]
-        kmap = _build_keyword_map(catalog)
-        assert "mitel" in kmap
-        assert "mitel-helpcenter" in kmap["mitel"]
-        assert "mitel-wiki" in kmap["mitel"]
-
-
-class TestLayer1Keyword:
-    def test_matches_brand_in_query(self):
-        kmap = _build_keyword_map(CATALOG)
-        result = layer1_keyword("hoe configureer ik mitel voip", kmap)
-        assert result is not None
-        assert "help.mitel.nl" in result
-
-    def test_no_match_returns_none(self):
-        kmap = _build_keyword_map(CATALOG)
-        result = layer1_keyword("hoe maak ik een gebruiker aan", kmap)
-        assert result is None
-
-    def test_multiple_brands_matched(self):
-        kmap = _build_keyword_map(CATALOG)
-        result = layer1_keyword("verschil tussen mitel en ascend", kmap)
-        assert result is not None
-        assert len(result) >= 2
 
 
 class TestLayer2Semantic:
@@ -140,15 +86,23 @@ class TestLayer2Semantic:
 
 class TestRouteToSources:
     @pytest.mark.asyncio
-    async def test_layer1_keyword_hit(self):
+    async def test_brand_name_does_not_override_semantic_abstention(self):
+        async def near_tie_centroids(catalog, org_id):
+            return {
+                "help.mitel.nl": [1.0, 0.0],
+                "help.voys.nl": [0.999, 0.001],
+                "redcactus-wiki": [0.998, 0.002],
+            }
+
         decision = await route_to_sources(
             "hoe configureer ik mitel voip",
-            query_vector=[0.5, 0.5],
+            query_vector=[1.0, 0.0],
             org_id="org-1",
-            source_label_catalog=CATALOG,
+            source_label_catalog=CATALOG[:3],
+            compute_centroid_fn=near_tie_centroids,
         )
-        assert decision.layer_used == "keyword"
-        assert "help.mitel.nl" in decision.selected_source_labels
+        assert decision.layer_used == "none"
+        assert decision.selected_source_labels is None
 
     @pytest.mark.asyncio
     async def test_layer2_with_compute_fn(self):
@@ -161,9 +115,9 @@ class TestRouteToSources:
                 "notion-internal": [0.2, 0.5, 0.3],
             }
 
-        # Query close to mitel
+        # Query close to Mitel; semantic similarity is the only routing signal.
         decision = await route_to_sources(
-            "hoe werkt een pbx systeem",  # no keyword match
+            "hoe werkt een pbx systeem",
             query_vector=[0.95, 0.1, 0.05],
             org_id="org-1",
             source_label_catalog=CATALOG,
@@ -174,19 +128,6 @@ class TestRouteToSources:
         assert "help.mitel.nl" in decision.selected_source_labels
 
     @pytest.mark.asyncio
-    async def test_user_override_skips_router(self):
-        """Router must NOT be called when user sets kb_slugs.
-        This is enforced at retrieve.py level, but we test the invariant here."""
-        # The router itself always runs when called — the skip is in retrieve.py
-        decision = await route_to_sources(
-            "anything",
-            query_vector=[0.5, 0.5],
-            org_id="org-1",
-            source_label_catalog=CATALOG,
-        )
-        # Router always returns a decision when called
-        assert decision is not None
-
     @pytest.mark.asyncio
     async def test_layer3_timeout_failopen(self):
         async def slow_llm(query, catalog):
@@ -249,3 +190,22 @@ class TestRouteToSources:
         )
         assert decision.selected_source_labels is None
         assert decision.layer_used == "none"
+
+
+class TestSourceCatalogScope:
+    @pytest.mark.asyncio
+    async def test_pinned_kb_filter_and_cache_key_are_scoped(self):
+        mock_client = AsyncMock()
+        mock_client.facet.return_value = SimpleNamespace(hits=[])
+
+        with patch("retrieval_api.services.search._get_client", return_value=mock_client):
+            await fetch_source_catalog("org-1", ["sip"])
+            await fetch_source_catalog("org-1")
+
+        assert mock_client.facet.await_count == 2
+        pinned_filter = mock_client.facet.await_args_list[0].kwargs["facet_filter"]
+        pinned_conditions = {condition.key: condition.match for condition in pinned_filter.must}
+        assert pinned_conditions["org_id"].value == "org-1"
+        assert pinned_conditions["kb_slug"].any == ["sip"]
+        assert ("org-1", ("sip",)) in _catalog_cache
+        assert ("org-1", None) in _catalog_cache

--- a/klai-retrieval-api/tests/test_router_centroid_org_filter.py
+++ b/klai-retrieval-api/tests/test_router_centroid_org_filter.py
@@ -183,6 +183,26 @@ class TestCentroidsFilterByOrg:
                 "Each scroll filter must also have a source_label FieldCondition"
             )
 
+    @pytest.mark.asyncio
+    async def test_pinned_kb_scope_is_present_beside_org_filter(self):
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = ([], None)
+
+        with patch("retrieval_api.services.search._get_client", return_value=mock_client):
+            await _default_compute_centroids(
+                [KBEntry(source_label="shared-domain", name="Shared")],
+                "org-a",
+                ["sip"],
+            )
+
+        conditions = {
+            condition.key: condition.match
+            for condition in mock_client.scroll.await_args.kwargs["scroll_filter"].must
+        }
+        assert conditions["org_id"].value == "org-a"
+        assert conditions["source_label"].value == "shared-domain"
+        assert conditions["kb_slug"].any == ["sip"]
+
 
 # ---------------------------------------------------------------------------
 # AC-4: Cache is keyed per org — two orgs must not share a cache entry
@@ -240,6 +260,35 @@ class TestCentroidCacheKeyedByOrg:
             f"Compute must be called once per org; got call_log={call_log}"
         )
         assert decision_a2.cache_hit is True, "Second call for org-a should be a cache hit"
+
+    @pytest.mark.asyncio
+    async def test_centroid_cache_isolated_by_catalog_scope(self):
+        call_log: list[tuple[str, ...]] = []
+
+        async def tracking_compute(catalog, org_id: str):
+            labels = tuple(entry.source_label for entry in catalog)
+            call_log.append(labels)
+            return {label: [1.0, 0.0] for label in labels}
+
+        await route_to_sources(
+            "query",
+            [1.0, 0.0],
+            "org-a",
+            [KBEntry(source_label="sip", name="SIP")],
+            compute_centroid_fn=tracking_compute,
+            kb_slugs=["sip"],
+        )
+        decision = await route_to_sources(
+            "query",
+            [1.0, 0.0],
+            "org-a",
+            [KBEntry(source_label="sip", name="SIP")],
+            compute_centroid_fn=tracking_compute,
+            kb_slugs=["support"],
+        )
+
+        assert call_log == [("sip",), ("sip",)]
+        assert decision.cache_hit is False
 
     @pytest.mark.asyncio
     async def test_different_orgs_get_different_centroids(self):

--- a/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
+++ b/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
@@ -1,0 +1,54 @@
+"""Prevent lexical source-label matching from returning to source selection."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SERVICE_ROOT = Path(__file__).resolve().parents[1] / "retrieval_api" / "services"
+_SOURCE_SELECTION_PATHS = (
+    _SERVICE_ROOT / "diversity.py",
+    _SERVICE_ROOT / "router.py",
+)
+_REMOVED_SYMBOLS = (
+    "STOP_WORDS",
+    "_detect_mentioned_sources",
+    "_build_keyword_map",
+    "layer1_keyword",
+)
+
+
+def _query_substring_comparisons(source: str) -> list[int]:
+    offenders: list[int] = []
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+        for operator, comparator in zip(node.ops, node.comparators, strict=True):
+            if not isinstance(operator, ast.In):
+                continue
+            compared_text = ast.unparse(comparator).lower()
+            if "query" in compared_text:
+                offenders.append(node.lineno)
+    return offenders
+
+
+def test_guard_detects_reintroduced_query_substring_match() -> None:
+    dangerous = "def select(term, query_resolved):\n    return term in query_resolved.lower()\n"
+    assert _query_substring_comparisons(dangerous) == [2]
+
+
+def test_source_selection_has_no_lexical_query_matching() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in _SOURCE_SELECTION_PATHS:
+        source = path.read_text(encoding="utf-8")
+        for symbol in _REMOVED_SYMBOLS:
+            assert symbol not in source, f"Removed lexical selector {symbol} returned in {path}"
+        lines = _query_substring_comparisons(source)
+        if lines:
+            offenders[path.name] = lines
+
+    assert not offenders, (
+        "Source-selection modules must compare candidates semantically; they may not "
+        f"select a source by substring-matching query text: {offenders}"
+    )

--- a/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
+++ b/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
@@ -6,10 +6,7 @@ import ast
 from pathlib import Path
 
 _SERVICE_ROOT = Path(__file__).resolve().parents[1] / "retrieval_api" / "services"
-_SOURCE_SELECTION_PATHS = (
-    _SERVICE_ROOT / "diversity.py",
-    _SERVICE_ROOT / "router.py",
-)
+_SOURCE_SELECTION_PATHS = tuple(sorted(_SERVICE_ROOT.glob("*.py")))
 _REMOVED_SYMBOLS = (
     "STOP_WORDS",
     "_detect_mentioned_sources",
@@ -19,23 +16,66 @@ _REMOVED_SYMBOLS = (
 
 
 def _query_substring_comparisons(source: str) -> list[int]:
-    offenders: list[int] = []
     tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Compare):
-            continue
-        for operator, comparator in zip(node.ops, node.comparators, strict=True):
-            if not isinstance(operator, ast.In):
-                continue
-            compared_text = ast.unparse(comparator).lower()
-            if "query" in compared_text:
-                offenders.append(node.lineno)
-    return offenders
+
+    def names(expr: ast.AST) -> set[str]:
+        return {node.id for node in ast.walk(expr) if isinstance(node, ast.Name)}
+
+    def is_query_name(name: str) -> bool:
+        return "query" in name.lower() or name.lower() in {"q", "text", "user_input"}
+
+    def is_source_name(name: str) -> bool:
+        lowered = name.lower()
+        return "source_label" in lowered or lowered in {"label", "token", "term", "keyword"}
+
+    query_names = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and is_query_name(node.id)
+    }
+    source_names = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and is_source_name(node.id)
+    }
+    assignments = [node for node in ast.walk(tree) if isinstance(node, ast.Assign)]
+    for _ in assignments:
+        for assignment in assignments:
+            target_names = {name for target in assignment.targets for name in names(target)}
+            value_names = names(assignment.value)
+            if value_names & query_names:
+                query_names.update(target_names)
+            if value_names & source_names:
+                source_names.update(target_names)
+
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare)
+        and any(isinstance(operator, ast.In) for operator in node.ops)
+        and names(node.left) & source_names
+        and any(names(comparator) & query_names for comparator in node.comparators)
+    ]
 
 
 def test_guard_detects_reintroduced_query_substring_match() -> None:
     dangerous = "def select(term, query_resolved):\n    return term in query_resolved.lower()\n"
     assert _query_substring_comparisons(dangerous) == [2]
+
+
+def test_guard_detects_query_alias_and_common_parameter_names() -> None:
+    dangerous = (
+        "def select(source_label, user_input):\n"
+        "    normalized = user_input.lower()\n"
+        "    token = source_label.split('.')[0]\n"
+        "    return token in normalized\n"
+    )
+    assert _query_substring_comparisons(dangerous) == [4]
+
+
+def test_guard_scans_every_service_module() -> None:
+    assert _SOURCE_SELECTION_PATHS == tuple(sorted(_SERVICE_ROOT.glob("*.py")))
+    assert len(_SOURCE_SELECTION_PATHS) > 2
 
 
 def test_source_selection_has_no_lexical_query_matching() -> None:

--- a/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
+++ b/klai-retrieval-api/tests/test_source_selection_lexical_drift.py
@@ -29,14 +29,10 @@ def _query_substring_comparisons(source: str) -> list[int]:
         return "source_label" in lowered or lowered in {"label", "token", "term", "keyword"}
 
     query_names = {
-        node.id
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Name) and is_query_name(node.id)
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and is_query_name(node.id)
     }
     source_names = {
-        node.id
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Name) and is_source_name(node.id)
+        node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and is_source_name(node.id)
     }
     assignments = [node for node in ast.walk(tree) if isinstance(node, ast.Assign)]
     for _ in assignments:


### PR DESCRIPTION
## Summary

Implements all phases of `SPEC-RAG-SOURCE-SELECTION-001` as one reviewable branch, per the explicit product-owner override of the four-PR handoff rule. Phase ordering remains preserved in separate commits.

- Phase 0: promote the closed decision-event set to warning without widening query telemetry
- Phase 1: replace hard source allocation with configurable bounded additive preference and counterfactual telemetry
- Phase 2: delete lexical source matching, run semantic routing for pinned KBs, and scope catalog/centroid caches by org and KB set
- Phase 3: emit corroborated confidence as shadow metadata while leaving the authoritative band unchanged
- Eval: keep one retrieval-testable brand-token canary; prove single-strong-hit confidence through the retrieval decision record
- Review hardening: prevent org router signals from boosting the canonical personal KB in scope=both, bound router caches, avoid caching facet failures, and broaden the lexical drift guard

## Phase commits

1. `ca137f885` Phase 0 observability
2. `a970652ac` Phase 1 bounded preference
3. `cf0f76e14` Phase 2 semantic-only source selection
4. `c342b5606` Phase 3 corroborated-confidence shadow
5. `4a86ebece` eval canaries
6. `24a5964db` source-selection specification
7. `0082760c2` tenant-safe pinned-KB preference
8. `023faf787` active/shadow KB-scope parity
9. `9bb870291` retrieval-flow documentation alignment
10. `a5b2611b9` production-cap invariant coverage and AC clarification
11. `112457eba` Claude review findings: scope, cache, eval, and drift hardening
12. `3a1edd612` CI formatter parity

## RED evidence captured before fixes

- Phase 1: `TypeError: source_aware_select() got an unexpected keyword argument preferred_labels`; config test also failed because `source_preference_boost` did not exist
- Phase 3 / AC-9: `TypeError: _compute_confidence_band() got an unexpected keyword argument require_corroboration`
- Eval: suite count failed as `42 != 40`, followed by the missing canary-mix assertion
- Tenant regression: `TypeError: source_aware_select() got an unexpected keyword argument preferred_kb_slugs`
- Ranking-shadow regression: `KeyError: kb_slug`
- Review delta: unpinned personal exclusion failed on an unknown argument; the alias drift guard returned `[]`; chat suite assertions failed `42 != 41`; router tests failed to import the missing catalog-cache invalidator

## Acceptance

| AC | Status | Evidence |
|---|---|---|
| AC-1 | Pending deploy | Unit coverage proves warning level and telemetry privacy; LogsQL with real traffic is external |
| AC-2 | Pass | bounded-preference two-score test |
| AC-3 | Pass | 250 randomized pure-order cases plus 250 `beta=0` vs `beta>0` cases with production `max_per_source=2` |
| AC-4 | Pass locally | incident-score replay retains 0.658/0.616 chunks with `suppressed_count == 0` |
| AC-5 | Pass | AST drift guard scans every retrieval service module, follows common query aliases, and rejects removed lexical symbols |
| AC-6 | Pass | `test_brand_name_does_not_override_semantic_abstention` returns `layer_used=none` |
| AC-7 | Pass | pinned facet has `org_id` and `kb_slug`; catalog and centroid caches are scope-isolated and bounded |
| AC-8 | Not run | Full live `chat.yaml` before/after needs the Klai runtime and production corpus; local preflight is blocked by missing runtime secrets and no local service stack |
| AC-9 | Pass | single strong hit: authoritative `high`, corroborated shadow `medium`, asserted on the decision record |
| AC-10 | Pass | two strong hits: corroborated shadow `high` |
| AC-11 | Pending deploy | Requires 48h production decision records |

The pinned-KB latency NFR is also post-deploy/runtime evidence and is not claimed here.

## Verification

- `klai-retrieval-api/.venv/bin/pytest -q && .venv/bin/ruff check . && .venv/bin/ruff format --check .` — 628 passed, 1 skipped; Ruff lint and format clean
- `klai-knowledge-ingest/.venv/bin/pytest -q && .venv/bin/ruff check .` — 1477 passed, 4 skipped; Ruff clean
- LiteLLM CI-equivalent command from `.github/workflows/litellm-tests.yml` — 639 passed
- Semgrep CI-equivalent scan — 551 rules, 1231 files, 0 findings
- `git diff --check` — clean

## Review

- Codex gpt-5.5 medium, tenant-isolation profile: active/pinned-KB and ranking-shadow deltas reviewed read-only; exit 0; final result no findings
- Codex gpt-5.5 medium, comprehensive recall profile: full `origin/main...a5b2611b9` reviewed read-only; two contract-clarity findings fixed; delta re-review exited 0 with no findings
- Claude Opus 5, comprehensive PR review at `a5b2611b9`: 9 findings. Seven concrete in-scope issues were corrected in `112457eba`; the single-chunk confidence behavior was confirmed as the explicit shadow contract; the broader user-visibility router geometry remains a documented follow-up risk.

## Explicitly not done

- No LLM router fallback activation
- No re-indexing, re-embedding, chunking, reranker, source-label, or answer-layer changes
- No per-user router catalogue/centroid redesign; serving-time Qdrant visibility filters remain authoritative
- No claim that AC-1, AC-8, AC-11, or the latency NFR passed without their required runtime evidence