### PR TITLE
fix(crawler): a rate-limit penalty that outlives its evidence heals itself

### DIFF
--- a/docs/specs/SPEC-CRAWL-001.md
+++ b/docs/specs/SPEC-CRAWL-001.md
@@ -352,3 +352,92 @@ Then no stored selector is used (org-B gets the full pipeline)
 - [ ] No OpenAI/Anthropic model names in code -- only `klai-fast` alias
 - [ ] Error handling: LLM failure and invalid CSS selector gracefully handled
 - [ ] `CrawlPreviewRequest.org_id` added (optional for backwards compatibility)
+
+---
+
+## 11. Amendment: shared host pacing and safe domain-rate persistence
+
+**Added and implemented:** 2026-08-19
+
+### 11.1 Corrected identity contract
+
+The persisted `knowledge.crawl_domains` key and the live crawl-pacing key are
+deliberately different concepts:
+
+- `extract_domain(url)` remains the exact normalized storage key used for both
+  selectors and the existing org-scoped domain-rate state. It normalizes case,
+  IDNA, default ports, and trailing dots, but does **not** collapse apex and
+  `www` hosts. Changing this contract would silently merge selector rows and can
+  conflict with existing `(domain, org_id)` primary keys.
+- `crawl_gate_key(url)` is the process-local pacing identity. It applies the
+  same hostname and port normalization and then removes exactly one leading
+  `www.` label. It does not use a registrable-domain/Public-Suffix-List rule and
+  does not merge arbitrary subdomains.
+- The live host gate is shared across orgs because concurrent tenants still
+  consume the same external host capacity. Persisted selectors and rate state
+  remain org-scoped.
+
+### 11.2 Shared host gate
+
+**WHEN** two or more crawl operations target the same `crawl_gate_key`,
+**THEN** all target requests from those operations **shall** share one
+process-wide weighted pacing schedule.
+
+The pacing unit is target URLs, not Crawl4AI HTTP calls. A bulk request carrying
+`N` URLs consumes weight `N`. The effective rate is the lowest rate requested
+by any active session for the host. A rate reduction during a crawl applies to
+all subsequent grants and also recalculates subsequent burst sizes.
+
+The schedule shall be fair between waiters, cancellation-safe, and removed from
+the registry when its final active session and waiter leave. Apex and `www`
+variants share a gate; unrelated hosts do not.
+
+The gate is intentionally in memory. This is valid only while the FastAPI app
+and Procrastinate workers run in one Python process and knowledge-ingest has one
+replica. Multiple Uvicorn workers or replicas require a distributed limiter
+(for example Redis/GCRA) before rollout.
+
+### 11.3 Global Crawl4AI request cap
+
+Every knowledge-ingest `POST /crawl` request, including seed, bulk, recovery,
+preview, and DOM-summary requests, shall pass through one process-wide bounded
+semaphore. Its size is configurable and defaults to `1` so the service does not
+fill the shared Crawl4AI container with concurrent requests; klai-connector has
+its own independent caller and is not governed by this semaphore.
+
+The request cap is a service-side safety boundary, not a hard reservation of
+Crawl4AI page slots. The pinned Crawl4AI pool permits 40 concurrent pages and a
+single payload can contain multiple URLs.
+
+### 11.4 Conflict-safe domain-rate writes
+
+Domain-rate persistence shall use compare-and-swap semantics over
+`rate_limit`, `clean_streak`, and `last_congestion_at` rather than an
+unconditional stale-state overwrite.
+
+- A write succeeds normally only when the stored state still equals the state
+  from which the proposal was computed (`NULL` compared null-safely).
+- On conflict, congestion merges atomically toward the lowest of the current
+  and proposed rates, resets the clean streak, and preserves the newest
+  congestion timestamp.
+- A conflicting recovery or read-time decay never overwrites changed state; it
+  is deferred until a later crawl.
+- Concurrent congestion proposals derived from the same state produce one
+  lowering, not an accidental double-halving.
+
+This makes congestion monotonic over concurrent recovery: whichever operation
+reaches PostgreSQL first, their crossing ends at the lower proposed speed.
+
+### 11.5 Amendment acceptance criteria
+
+- **AC-10:** The two same-host crawls reproducing the 2026-08-18 09:27 incident
+  do not exceed their shared aggregate URL cadence.
+- **AC-11:** Crawls on different hosts use independent host schedules.
+- **AC-12:** `www.example.com` and `example.com` share live pacing while their
+  `extract_domain()` storage keys remain distinct.
+- **AC-13:** The configured global cap bounds concurrent Crawl4AI POSTs across
+  different domains and across seed/bulk/recovery paths.
+- **AC-14:** Concurrent lowering and recovery writes finish at the lower
+  proposal in both execution orders; decay cannot erase newer congestion.
+- **AC-15:** Existing circuit-breaker, cancellation, slowdown, retry, and
+  self-healing behavior remains covered by the full knowledge-ingest suite.

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -32,6 +32,7 @@ from knowledge_ingest.domain_rate_limit_control import (
     count_rate_limit_observations,
 )
 from knowledge_ingest.domain_selectors import (
+    DomainRateLimitWriteKind,
     extract_domain,
     get_domain_rate_limit_state,
     save_domain_rate_limit_state,
@@ -734,15 +735,34 @@ async def run_crawl_job(
             now=datetime.now(UTC),
         )
         if decayed_state != domain_rate_limit_state:
-            await save_domain_rate_limit_state(conn, domain, org_id, decayed_state)
-            logger.info(
-                "crawl_domain_rate_limit_decayed",
-                job_id=job_id,
-                domain=domain,
-                previous_rate_limit=domain_rate_limit_state.rate_limit,
-                previous_last_congestion_at=domain_rate_limit_state.last_congestion_at,
+            decay_applied = await save_domain_rate_limit_state(
+                conn,
+                domain,
+                org_id,
+                expected_state=domain_rate_limit_state,
+                state=decayed_state,
+                kind=DomainRateLimitWriteKind.DECAY,
+                default_rate_limit=rate_limit,
             )
-        domain_rate_limit_state = decayed_state
+            if decay_applied:
+                logger.info(
+                    "crawl_domain_rate_limit_decayed",
+                    job_id=job_id,
+                    domain=domain,
+                    previous_rate_limit=domain_rate_limit_state.rate_limit,
+                    previous_last_congestion_at=domain_rate_limit_state.last_congestion_at,
+                )
+                domain_rate_limit_state = decayed_state
+            else:
+                # A concurrent crawl changed the AIMD state after our read.
+                # Never let stale decay clear newer congestion; use the latest
+                # persisted value conservatively for this crawl instead.
+                domain_rate_limit_state = await get_domain_rate_limit_state(conn, domain, org_id)
+                logger.info(
+                    "crawl_domain_rate_limit_decay_conflict_deferred",
+                    job_id=job_id,
+                    domain=domain,
+                )
         stored_rate_limit = domain_rate_limit_state.rate_limit
         effective_rate_limit = stored_rate_limit if stored_rate_limit is not None else rate_limit
         if stored_rate_limit is not None:
@@ -867,8 +887,21 @@ async def run_crawl_job(
             now=datetime.now(UTC),
         )
         if updated_rate_limit_state is not None:
-            await save_domain_rate_limit_state(conn, domain, org_id, updated_rate_limit_state)
-            if congestion_verdict:
+            write_kind = (
+                DomainRateLimitWriteKind.CONGESTION
+                if congestion_verdict
+                else DomainRateLimitWriteKind.RECOVERY
+            )
+            update_applied = await save_domain_rate_limit_state(
+                conn,
+                domain,
+                org_id,
+                expected_state=domain_rate_limit_state,
+                state=updated_rate_limit_state,
+                kind=write_kind,
+                default_rate_limit=rate_limit,
+            )
+            if congestion_verdict and update_applied:
                 logger.warning(
                     "crawl_domain_rate_limit_lowered",
                     job_id=job_id,
@@ -876,13 +909,23 @@ async def run_crawl_job(
                     previous_rate_limit=effective_rate_limit,
                     lowered_rate_limit=updated_rate_limit_state.rate_limit,
                 )
-            elif updated_rate_limit_state.rate_limit != domain_rate_limit_state.rate_limit:
+            elif (
+                update_applied
+                and updated_rate_limit_state.rate_limit != domain_rate_limit_state.rate_limit
+            ):
                 logger.info(
                     "crawl_domain_rate_limit_raised",
                     job_id=job_id,
                     domain=domain,
                     previous_rate_limit=domain_rate_limit_state.rate_limit,
                     raised_rate_limit=updated_rate_limit_state.rate_limit,
+                )
+            elif not update_applied:
+                logger.info(
+                    "crawl_domain_rate_limit_update_conflict_deferred",
+                    job_id=job_id,
+                    domain=domain,
+                    write_kind=write_kind.value,
                 )
 
         crawl_outcome_warning = _build_crawl_outcome_warning(

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -363,6 +363,16 @@ class Settings(BaseSettings):
     # Crawl4AI REST API (shared Docker container)
     crawl4ai_api_url: str = "http://crawl4ai:11235"
     crawl4ai_api_key: str = ""
+    # SPEC-CRAWL-001 amendment: knowledge-ingest shares Crawl4AI's global
+    # 40-page browser pool with klai-connector. One in-flight request keeps
+    # this service conservative while still leaving the container available
+    # to the independent connector caller. This is request concurrency, not a
+    # hard reservation of page slots inside a multi-URL payload.
+    crawl4ai_max_concurrent_requests: int = Field(
+        default=1,
+        ge=1,
+        validation_alias=AliasChoices("KLAI_CRAWL4AI_MAX_CONCURRENT_REQUESTS"),
+    )
     # Graphiti / FalkorDB knowledge graph
     falkordb_host: str = "falkordb"
     falkordb_port: int = 6379

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -13,7 +13,9 @@ import fnmatch
 import json
 import re
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from html import unescape
 from html.parser import HTMLParser
@@ -31,9 +33,20 @@ from knowledge_ingest.host_circuit_breaker import (
     HostCircuitBreakerState,
     evaluate_chunk,
 )
+from knowledge_ingest.host_pacing import (
+    HostGateRegistry,
+    HostPacingSession,
+    crawl_gate_key,
+)
 from knowledge_ingest.reason_codes import FetchReasonCode
 
 logger = structlog.get_logger()
+
+# Every POST /crawl path in this module funnels through _crawl_sync, so this
+# one semaphore also covers seeds, bulk batches, retries, previews, and DOM
+# summaries. It intentionally cannot coordinate klai-connector, which is a
+# separate caller of the shared Crawl4AI container.
+_crawl4ai_request_semaphore = asyncio.BoundedSemaphore(settings.crawl4ai_max_concurrent_requests)
 
 
 # ---------------------------------------------------------------------------
@@ -514,6 +527,9 @@ async def _fetch_sitemap_document(
     seen_sitemaps.add(canonical_sitemap)
 
     try:
+        pacing_session = _current_host_pacing_session.get()
+        if pacing_session is not None and pacing_session.key == crawl_gate_key(sitemap_url):
+            await pacing_session.acquire(1)
         resp = await client.get(sitemap_url, headers=_auth_headers())
         resp.raise_for_status()
     except Exception as exc:
@@ -1312,11 +1328,21 @@ async def _crawl_sync(
     POST /crawl is a synchronous endpoint — it blocks until crawling is
     complete and returns results directly (no task_id, no polling needed).
     """
-    resp = await client.post(
-        f"{settings.crawl4ai_api_url}/crawl",
-        json=payload,
-        headers=_auth_headers(),
-    )
+    pacing_session = _current_host_pacing_session.get()
+    payload_urls = payload.get("urls") or []
+    if (
+        pacing_session is not None
+        and not _host_pacing_already_reserved.get()
+        and payload_urls
+        and pacing_session.key == crawl_gate_key(payload_urls[0])
+    ):
+        await pacing_session.acquire(len(payload_urls))
+    async with _crawl4ai_request_semaphore:
+        resp = await client.post(
+            f"{settings.crawl4ai_api_url}/crawl",
+            json=payload,
+            headers=_auth_headers(),
+        )
     resp.raise_for_status()
     return resp.json()
 
@@ -1456,6 +1482,23 @@ def _build_browser_config_with_cookies(
 
 
 async def crawl_page(
+    url: str,
+    selector: str | None = None,
+    cookies: list[dict[str, Any]] | None = None,
+    retry_relaxed_on_thin: bool = False,
+    rate_limit: float | None = 2.0,
+) -> CrawlResult:
+    """Crawl one page while participating in the process-wide host schedule."""
+    async with _host_pacing_scope(url, rate_limit):
+        return await _crawl_page_in_host_scope(
+            url,
+            selector=selector,
+            cookies=cookies,
+            retry_relaxed_on_thin=retry_relaxed_on_thin,
+        )
+
+
+async def _crawl_page_in_host_scope(
     url: str,
     selector: str | None = None,
     cookies: list[dict[str, Any]] | None = None,
@@ -1952,6 +1995,7 @@ async def sample_linked_pages(
     selector: str | None = None,
     cookies: list[dict[str, Any]] | None = None,
     max_pages: int = 5,
+    rate_limit: float | None = 2.0,
 ) -> LinkedPageSample:
     """Fetch pages linked from ``seed`` and count how many carry real content.
 
@@ -1976,6 +2020,7 @@ async def sample_linked_pages(
         urls=candidates,
         crawler_config=build_crawl_config(selector),
         cookies=cookies,
+        rate_limit=rate_limit,
     )
     # Only candidates whose OWN chunk actually transported are worth
     # combining — a candidate whose chunk failed or was never attempted
@@ -2003,6 +2048,34 @@ async def sample_linked_pages(
 
 
 async def crawl_site(
+    start_url: str,
+    selector: str | None = None,
+    max_depth: int = 2,
+    max_pages: int = 200,
+    include_patterns: list[str] | None = None,
+    exclude_patterns: list[str] | None = None,
+    login_indicator_selector: str | None = None,
+    cookies: list[dict[str, Any]] | None = None,
+    rate_limit: float | None = None,
+    cancel_check: Callable[[], Awaitable[bool]] | None = None,
+) -> tuple[list[CrawlResult], list[FetchOutcome]]:
+    """Crawl one site through a host schedule shared by overlapping jobs."""
+    async with _host_pacing_scope(start_url, rate_limit):
+        return await _crawl_site_in_host_scope(
+            start_url=start_url,
+            selector=selector,
+            max_depth=max_depth,
+            max_pages=max_pages,
+            include_patterns=include_patterns,
+            exclude_patterns=exclude_patterns,
+            login_indicator_selector=login_indicator_selector,
+            cookies=cookies,
+            rate_limit=rate_limit,
+            cancel_check=cancel_check,
+        )
+
+
+async def _crawl_site_in_host_scope(
     start_url: str,
     selector: str | None = None,
     max_depth: int = 2,
@@ -2217,6 +2290,9 @@ async def crawl_site(
             elif consecutive_rate_limit_slowdowns < _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS:
                 consecutive_rate_limit_slowdowns += 1
                 current_rate_limit = _lower_rate_limit_for_slowdown(current_rate_limit)
+                pacing_session = _current_host_pacing_session.get()
+                if pacing_session is not None:
+                    pacing_session.update_rate(current_rate_limit)
                 carried_over_urls = not_attempted_urls
                 not_attempted_urls = []
                 fetched_count -= len(carried_over_urls)
@@ -3213,6 +3289,34 @@ _recovery_monotonic = time.monotonic
 _pacing_sleep = asyncio.sleep
 _pacing_monotonic = time.monotonic
 
+# SPEC-CRAWL-001 amendment: one process-wide weighted schedule per target
+# host. The lambdas deliberately resolve the test-friendly clock indirections
+# at call time rather than capturing their initial values here.
+_host_gate_registry = HostGateRegistry(
+    monotonic=lambda: _pacing_monotonic(),
+    sleep=lambda seconds: _pacing_sleep(seconds),
+)
+_current_host_pacing_session: ContextVar[HostPacingSession | None] = ContextVar(
+    "current_host_pacing_session", default=None
+)
+_host_pacing_already_reserved: ContextVar[bool] = ContextVar(
+    "host_pacing_already_reserved", default=False
+)
+
+
+@asynccontextmanager
+async def _host_pacing_scope(
+    url: str, rate_limit: float | None
+) -> AsyncIterator[HostPacingSession]:
+    """Install one task-local session backed by the process-wide registry."""
+    async with _host_gate_registry.session(url, rate_limit) as session:
+        token = _current_host_pacing_session.set(session)
+        try:
+            yield session
+        finally:
+            _current_host_pacing_session.reset(token)
+
+
 # Deel B (2026-08-18, "a stop-signal should slow you down, not give up") —
 # same test-friendly indirection as the two pairs above, dedicated to the
 # explicit pause ``crawl_site`` takes after lowering its in-job rate_limit,
@@ -3574,6 +3678,39 @@ async def _chunked_bulk_fetch(
     rate_limit: float | None = None,
     cancel_check: Callable[[], Awaitable[bool]] | None = None,
 ) -> ChunkedFetchResult:
+    """Submit a bulk fetch through the process-wide gate for its target host."""
+    if not urls:
+        return ChunkedFetchResult()
+    current_session = _current_host_pacing_session.get()
+    if current_session is not None and current_session.key == crawl_gate_key(urls[0]):
+        return await _chunked_bulk_fetch_with_session(
+            urls=urls,
+            crawler_config=crawler_config,
+            cookies=cookies,
+            stealth=stealth,
+            cancel_check=cancel_check,
+            pacing_session=current_session,
+        )
+    async with _host_gate_registry.session(urls[0], rate_limit) as pacing_session:
+        return await _chunked_bulk_fetch_with_session(
+            urls=urls,
+            crawler_config=crawler_config,
+            cookies=cookies,
+            stealth=stealth,
+            cancel_check=cancel_check,
+            pacing_session=pacing_session,
+        )
+
+
+async def _chunked_bulk_fetch_with_session(
+    *,
+    urls: list[str],
+    crawler_config: dict[str, Any],
+    cookies: list[dict[str, Any]] | None,
+    stealth: bool = False,
+    cancel_check: Callable[[], Awaitable[bool]] | None = None,
+    pacing_session: HostPacingSession,
+) -> ChunkedFetchResult:
     """Submit ``urls`` to crawl4ai's bulk ``/crawl`` endpoint in chunks.
 
     crawl4ai 0.8 server enforces a 100-URL cap on the ``urls`` array.
@@ -3662,12 +3799,12 @@ async def _chunked_bulk_fetch(
     result = ChunkedFetchResult()
     if not urls:
         return result
-    chunk_size = _burst_size_for(rate_limit)
-    previous_chunk_start: float | None = None
     attempted_count = 0
     antibot_signal_count = 0
     breaker_state = HostCircuitBreakerState()
-    for chunk_start in range(0, len(urls), chunk_size):
+    chunk_start = 0
+    chunk_index = 0
+    while chunk_start < len(urls):
         if cancel_check is not None and await cancel_check():
             remaining_urls = urls[chunk_start:]
             result.stopped_early = True
@@ -3680,13 +3817,7 @@ async def _chunked_bulk_fetch(
                 not_attempted_urls=len(remaining_urls),
             )
             break
-        if rate_limit is not None and previous_chunk_start is not None:
-            gap_seconds = chunk_size / rate_limit
-            elapsed_since_previous_start = _pacing_monotonic() - previous_chunk_start
-            remaining = gap_seconds - elapsed_since_previous_start
-            if remaining > 0:
-                await _pacing_sleep(remaining)
-        previous_chunk_start = _pacing_monotonic()
+        chunk_size = await pacing_session.acquire(len(urls) - chunk_start)
         chunk_urls = urls[chunk_start : chunk_start + chunk_size]
         payload: dict[str, Any] = {
             "urls": chunk_urls,
@@ -3710,7 +3841,11 @@ async def _chunked_bulk_fetch(
             async with httpx.AsyncClient(
                 timeout=settings.crawl_bulk_base_timeout_seconds
             ) as client:
-                data = await _crawl_sync(client, payload)
+                reservation_token = _host_pacing_already_reserved.set(True)
+                try:
+                    data = await _crawl_sync(client, payload)
+                finally:
+                    _host_pacing_already_reserved.reset(reservation_token)
             chunk_pages = _normalise_results_block(data)
             result.raw_results.extend(chunk_pages)
             attempted_count += len(chunk_pages)
@@ -3741,7 +3876,7 @@ async def _chunked_bulk_fetch(
             chunk_reason_codes.add(_classify_fetch_outcome(None, error=exc))
             logger.warning(
                 "crawl_site_bulk_chunk_failed",
-                chunk_index=chunk_start // chunk_size,
+                chunk_index=chunk_index,
                 chunk_size=len(chunk_urls),
                 error=str(exc),
             )
@@ -3783,7 +3918,7 @@ async def _chunked_bulk_fetch(
             or breaker_tripped
         )
         if stop_triggered:
-            remaining_urls = urls[chunk_start + chunk_size :]
+            remaining_urls = urls[chunk_start + len(chunk_urls) :]
             if remaining_urls:
                 result.stopped_early = True
                 result.not_attempted = remaining_urls
@@ -3827,6 +3962,9 @@ async def _chunked_bulk_fetch(
                     circuit_breaker_verdict=(breaker_verdict.value if breaker_tripped else None),
                 )
             break
+
+        chunk_start += len(chunk_urls)
+        chunk_index += 1
 
     return result
 
@@ -3930,7 +4068,13 @@ def _build_candidate_set(
     return ordered
 
 
-async def crawl_dom_summary(url: str) -> list[dict] | None:
+async def crawl_dom_summary(url: str, rate_limit: float | None = 2.0) -> list[dict] | None:
+    """Extract a DOM summary while participating in the shared host schedule."""
+    async with _host_pacing_scope(url, rate_limit):
+        return await _crawl_dom_summary_in_host_scope(url)
+
+
+async def _crawl_dom_summary_in_host_scope(url: str) -> list[dict] | None:
     """Crawl a page with DOM extraction JS for AI selector detection.
 
     Injects JS that extracts a ranked DOM summary and captures it via

--- a/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_selectors.py
@@ -24,6 +24,7 @@ tenant_scoped_connection(org_id) block instead of acquiring a fresh pool
 connection (which would not see the RLS GUC).
 """
 
+from enum import StrEnum
 from urllib.parse import urlparse
 
 import asyncpg
@@ -34,6 +35,14 @@ from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
 # information in the domain key — ``example.com:443`` (https) and
 # ``example.com`` MUST collide onto the same rate-limit/selector row.
 _DEFAULT_PORTS_BY_SCHEME = {"http": "80", "https": "443"}
+
+
+class DomainRateLimitWriteKind(StrEnum):
+    """Conflict policy for one persisted domain-rate transition."""
+
+    CONGESTION = "congestion"
+    RECOVERY = "recovery"
+    DECAY = "decay"
 
 
 def extract_domain(url: str) -> str:
@@ -168,16 +177,21 @@ async def save_domain_rate_limit_state(
     conn: asyncpg.Connection,
     domain: str,
     org_id: str,
+    *,
+    expected_state: DomainRateLimitState,
     state: DomainRateLimitState,
-) -> None:
-    """Persist the full AIMD state for (domain, org_id) in one write.
+    kind: DomainRateLimitWriteKind,
+    default_rate_limit: float,
+) -> bool:
+    """Atomically persist one AIMD transition without losing congestion.
 
-    A single function owns the whole row update (rate_limit, clean_streak,
-    last_congestion_at together) rather than one function per field —
-    two functions independently updating the same row would need to agree
-    on each other's fields on every call, which is exactly the kind of
-    drift ``compute_domain_rate_limit_update`` is designed to prevent by
-    returning one coherent next-state object.
+    Recovery and decay are compare-and-swap writes over the complete state;
+    if another crawl changed any field since ``expected_state`` was read,
+    they are conservatively deferred. Congestion is monotonic: on conflict
+    the statement keeps the lowest current/proposed rate, resets the clean
+    streak, and preserves the newest congestion timestamp. Two congestion
+    proposals computed from the same state therefore lower once rather than
+    accidentally halving twice.
 
     Does not touch css_selector/selector_source (a separate concern — see
     module docstring); a fresh insert leaves them NULL, an update to an
@@ -189,20 +203,53 @@ async def save_domain_rate_limit_state(
     nothing to persist, and calling this unconditionally would create a
     row for every domain ever crawled.
     """
-    await conn.execute(
+    row = await conn.fetchrow(
         """
-        INSERT INTO knowledge.crawl_domains
+        INSERT INTO knowledge.crawl_domains AS crawl_domains
             (domain, org_id, rate_limit, clean_streak, last_congestion_at, created_at, updated_at)
         VALUES ($1, $2, $3, $4, $5, now(), now())
         ON CONFLICT (domain, org_id) DO UPDATE
-            SET rate_limit         = EXCLUDED.rate_limit,
-                clean_streak       = EXCLUDED.clean_streak,
-                last_congestion_at = EXCLUDED.last_congestion_at,
+            SET rate_limit = CASE
+                    WHEN $10::boolean THEN LEAST(
+                        COALESCE(crawl_domains.rate_limit, $9),
+                        EXCLUDED.rate_limit
+                    )
+                    ELSE EXCLUDED.rate_limit
+                END,
+                clean_streak = CASE
+                    WHEN $10::boolean THEN 0
+                    ELSE EXCLUDED.clean_streak
+                END,
+                last_congestion_at = CASE
+                    WHEN $10::boolean THEN CASE
+                        WHEN crawl_domains.last_congestion_at IS NULL
+                            THEN EXCLUDED.last_congestion_at
+                        WHEN EXCLUDED.last_congestion_at IS NULL
+                            THEN crawl_domains.last_congestion_at
+                        ELSE GREATEST(
+                            crawl_domains.last_congestion_at,
+                            EXCLUDED.last_congestion_at
+                        )
+                    END
+                    ELSE EXCLUDED.last_congestion_at
+                END,
                 updated_at         = now()
+        WHERE $10::boolean OR (
+            crawl_domains.rate_limit IS NOT DISTINCT FROM $6
+            AND crawl_domains.clean_streak = $7
+            AND crawl_domains.last_congestion_at IS NOT DISTINCT FROM $8
+        )
+        RETURNING rate_limit, clean_streak, last_congestion_at
         """,
         domain,
         org_id,
         state.rate_limit,
         state.clean_streak,
         state.last_congestion_at,
+        expected_state.rate_limit,
+        expected_state.clean_streak,
+        expected_state.last_congestion_at,
+        default_rate_limit,
+        kind is DomainRateLimitWriteKind.CONGESTION,
     )
+    return row is not None

--- a/klai-knowledge-ingest/knowledge_ingest/host_pacing.py
+++ b/klai-knowledge-ingest/knowledge_ingest/host_pacing.py
@@ -1,0 +1,155 @@
+"""Process-wide weighted pacing for concurrent crawls of one external host.
+
+The registry is intentionally in memory.  ``knowledge-ingest`` currently runs
+its FastAPI app and all Procrastinate workers in one Python process.  Multiple
+Uvicorn workers or service replicas require replacing this registry with a
+distributed limiter before rollout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+from knowledge_ingest.domain_selectors import extract_domain
+
+_BURST_WINDOW_SECONDS = 10.0
+_MAX_BURST_SIZE = 100
+
+
+def crawl_gate_key(url: str) -> str:
+    """Return the live pacing key, collapsing only the leading ``www.`` alias.
+
+    ``extract_domain`` remains the exact persisted selector/rate-state key.
+    Reusing its normalization here keeps case, IDNA, trailing-dot, and port
+    behavior aligned without changing that storage contract.
+    """
+    domain = extract_domain(url)
+    return domain[4:] if domain.startswith("www.") else domain
+
+
+@dataclass
+class _HostGate:
+    rates: dict[object, float | None] = field(default_factory=dict)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    previous_start: float | None = None
+    previous_weight: int = 0
+
+    @property
+    def effective_rate(self) -> float | None:
+        limited_rates = [rate for rate in self.rates.values() if rate is not None]
+        return min(limited_rates) if limited_rates else None
+
+
+class HostPacingSession:
+    """One active crawl's handle into a shared host pacing schedule."""
+
+    def __init__(
+        self, registry: HostGateRegistry, key: str, gate: _HostGate, token: object
+    ) -> None:
+        self._registry = registry
+        self.key = key
+        self._gate = gate
+        self._token = token
+        self._closed = False
+
+    async def acquire(self, max_weight: int) -> int:
+        """Wait for and reserve the next burst, returning its allowed URL count."""
+        if self._closed:
+            raise RuntimeError("host pacing session is closed")
+        if max_weight < 1:
+            raise ValueError("max_weight must be at least 1")
+        return await self._registry._acquire(self._gate, max_weight)
+
+    def update_rate(self, rate_limit: float | None) -> None:
+        """Change this crawl's advertised rate for every future shared grant."""
+        if self._closed:
+            raise RuntimeError("host pacing session is closed")
+        self._gate.rates[self._token] = _validated_rate(rate_limit)
+
+    def _close(self) -> None:
+        self._closed = True
+
+
+class HostGateRegistry:
+    """Own one fair weighted schedule per normalized crawl host."""
+
+    def __init__(
+        self,
+        *,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._gates: dict[str, _HostGate] = {}
+
+    @property
+    def active_gate_count(self) -> int:
+        return len(self._gates)
+
+    @asynccontextmanager
+    async def session(self, url: str, rate_limit: float | None) -> AsyncIterator[HostPacingSession]:
+        """Register an active crawl and remove its gate deterministically on exit."""
+        key = crawl_gate_key(url)
+        token = object()
+        gate = self._gates.setdefault(key, _HostGate())
+        gate.rates[token] = _validated_rate(rate_limit)
+        session = HostPacingSession(self, key, gate, token)
+        try:
+            yield session
+        finally:
+            session._close()
+            gate.rates.pop(token, None)
+            if not gate.rates:
+                self._gates.pop(key, None)
+
+    async def _acquire(self, gate: _HostGate, max_weight: int) -> int:
+        # asyncio.Lock acquisition is FIFO-fair. Holding it across the pacing
+        # sleep prevents a later crawl from jumping ahead, while rate updates
+        # remain synchronous and can still change ``gate.rates`` during sleep.
+        async with gate.lock:
+            while True:
+                rate_limit = gate.effective_rate
+                if rate_limit is None:
+                    weight = min(max_weight, _MAX_BURST_SIZE)
+                    break
+
+                weight = min(max_weight, _burst_size(rate_limit))
+                if gate.previous_start is None:
+                    break
+
+                elapsed = self._monotonic() - gate.previous_start
+                remaining = (gate.previous_weight / rate_limit) - elapsed
+                if remaining <= 0:
+                    break
+                await self._sleep(remaining)
+                # Re-evaluate the effective rate and burst after sleeping: an
+                # overlapping crawl may have joined or slowed down meanwhile.
+                # When the rate did not change, the awaited sleep itself is
+                # the pacing guarantee. This also keeps the clock/sleep seam
+                # usable in tests where a no-op sleep intentionally leaves a
+                # frozen monotonic clock.
+                if gate.effective_rate == rate_limit:
+                    weight = min(max_weight, _burst_size(rate_limit))
+                    break
+
+            gate.previous_start = self._monotonic()
+            gate.previous_weight = weight
+            return weight
+
+
+def _validated_rate(rate_limit: float | None) -> float | None:
+    if rate_limit is not None and rate_limit <= 0:
+        raise ValueError("rate_limit must be positive")
+    return rate_limit
+
+
+def _burst_size(rate_limit: float) -> int:
+    return max(
+        1,
+        min(_MAX_BURST_SIZE, int(rate_limit * _BURST_WINDOW_SECONDS + 0.5)),
+    )

--- a/klai-knowledge-ingest/tests/test_crawl4ai_global_concurrency.py
+++ b/klai-knowledge-ingest/tests/test_crawl4ai_global_concurrency.py
@@ -1,0 +1,71 @@
+"""SPEC-CRAWL-001 AC-13 — global Crawl4AI request capacity."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.config import settings
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"results": []}
+
+
+class _BlockingClient:
+    def __init__(self, release: asyncio.Event) -> None:
+        self.release = release
+        self.active = 0
+        self.max_active = 0
+
+    async def post(self, *_args: Any, **_kwargs: Any) -> _Response:
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            await self.release.wait()
+            return _Response()
+        finally:
+            self.active -= 1
+
+
+def test_global_crawl4ai_request_cap_defaults_to_one() -> None:
+    assert settings.crawl4ai_max_concurrent_requests == 1
+
+
+@pytest.mark.asyncio
+async def test_global_cap_bounds_concurrent_posts_across_different_domains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cap = 2
+    release = asyncio.Event()
+    client = _BlockingClient(release)
+    monkeypatch.setattr(
+        crawl4ai_client,
+        "_crawl4ai_request_semaphore",
+        asyncio.BoundedSemaphore(cap),
+    )
+
+    tasks = [
+        asyncio.create_task(
+            crawl4ai_client._crawl_sync(client, {"urls": [f"https://host-{i}.example/"]})
+        )
+        for i in range(5)
+    ]
+
+    for _ in range(20):
+        if client.active == cap:
+            break
+        await asyncio.sleep(0)
+
+    assert client.active == cap
+    assert client.max_active == cap
+    release.set()
+    await asyncio.gather(*tasks)
+    assert client.max_active == cap

--- a/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
+++ b/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
@@ -45,6 +45,7 @@ import pytest
 from knowledge_ingest.adapters.crawler import run_crawl_job
 from knowledge_ingest.crawl4ai_client import CrawlResult
 from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
+from knowledge_ingest.domain_selectors import DomainRateLimitWriteKind
 from knowledge_ingest.reason_codes import FetchReasonCode
 
 START_URL = "https://intermedia.com/support"
@@ -142,7 +143,7 @@ async def test_rate_limited_outcome_lowers_the_domain_rate_limit() -> None:
         )
     )
     get_state = AsyncMock(return_value=_NO_OVERRIDE)  # no prior override
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -155,7 +156,9 @@ async def test_rate_limited_outcome_lowers_the_domain_rate_limit() -> None:
     args = save_state.await_args
     assert args.args[1] == DOMAIN
     assert args.args[2] == "org-1"
-    new_state = args.args[3]
+    assert args.kwargs["expected_state"] == _NO_OVERRIDE
+    assert args.kwargs["kind"] is DomainRateLimitWriteKind.CONGESTION
+    new_state = args.kwargs["state"]
     assert new_state.rate_limit == pytest.approx(1.0)  # 2.0 / 2
     assert new_state.clean_streak == 0
     assert new_state.last_congestion_at is not None
@@ -179,7 +182,7 @@ async def test_blocked_anti_bot_outcome_also_lowers_the_domain_rate_limit() -> N
         )
     )
     get_state = AsyncMock(return_value=_NO_OVERRIDE)
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -201,7 +204,7 @@ async def test_healthy_crawl_with_no_override_does_not_touch_the_domain_rate_lim
         return_value=([_page(START_URL)], _outcomes(*([FetchReasonCode.SUCCESS.value] * 10)))
     )
     get_state = AsyncMock(return_value=_NO_OVERRIDE)
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -232,7 +235,7 @@ async def test_a_previously_lowered_rate_is_applied_on_the_next_crawl() -> None:
             last_congestion_at=datetime.now(UTC) - timedelta(hours=1),
         )
     )
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -267,7 +270,7 @@ async def test_lowering_never_goes_below_the_floor() -> None:
             last_congestion_at=datetime.now(UTC) - timedelta(hours=1),
         )
     )
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -277,7 +280,8 @@ async def test_lowering_never_goes_below_the_floor() -> None:
     )
 
     save_state.assert_awaited_once()
-    assert save_state.await_args.args[3].rate_limit == pytest.approx(0.2)  # floor, not 0.15
+    assert save_state.await_args.kwargs["state"].rate_limit == pytest.approx(0.2)
+    assert save_state.await_args.kwargs["kind"] is DomainRateLimitWriteKind.CONGESTION
 
 
 @pytest.mark.asyncio
@@ -298,7 +302,7 @@ async def test_a_clean_crawl_past_cooldown_raises_one_step_and_persists() -> Non
             last_congestion_at=datetime.now(UTC) - timedelta(hours=48),
         )
     )
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -308,7 +312,8 @@ async def test_a_clean_crawl_past_cooldown_raises_one_step_and_persists() -> Non
     )
 
     save_state.assert_awaited_once()
-    new_state = save_state.await_args.args[3]
+    new_state = save_state.await_args.kwargs["state"]
+    assert save_state.await_args.kwargs["kind"] is DomainRateLimitWriteKind.RECOVERY
     assert new_state.rate_limit == pytest.approx(1.0)  # 0.5 + (2.0 * 0.25) step
     # Incremented, not reset — only congestion or a full override-clear
     # reset clean_streak; a partial raise carries it forward.
@@ -331,7 +336,7 @@ async def test_a_clean_job_within_cooldown_does_not_raise_despite_a_large_streak
             last_congestion_at=datetime.now(UTC) - timedelta(hours=1),
         )
     )
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -341,7 +346,7 @@ async def test_a_clean_job_within_cooldown_does_not_raise_despite_a_large_streak
     )
 
     save_state.assert_awaited_once()
-    new_state = save_state.await_args.args[3]
+    new_state = save_state.await_args.kwargs["state"]
     assert new_state.rate_limit == pytest.approx(0.5)  # unchanged — still throttled
     assert new_state.clean_streak == 61  # 60 stored + 1 SUCCESS this job
 
@@ -363,7 +368,7 @@ async def test_a_stored_override_with_no_congestion_timestamp_decays_before_the_
     get_state = AsyncMock(
         return_value=DomainRateLimitState(rate_limit=0.5, clean_streak=0, last_congestion_at=None)
     )
-    save_state = AsyncMock(return_value=None)
+    save_state = AsyncMock(return_value=True)
 
     await _run(
         crawl_site_mock=crawl_site,
@@ -375,5 +380,9 @@ async def test_a_stored_override_with_no_congestion_timestamp_decays_before_the_
     crawl_site.assert_awaited_once()
     assert crawl_site.await_args.kwargs["rate_limit"] == 2.0  # decay cleared the stale override
 
-    decay_persisted = any(call.args[3].rate_limit is None for call in save_state.await_args_list)
+    decay_persisted = any(
+        call.kwargs["state"].rate_limit is None
+        and call.kwargs["kind"] is DomainRateLimitWriteKind.DECAY
+        for call in save_state.await_args_list
+    )
     assert decay_persisted

--- a/klai-knowledge-ingest/tests/test_domain_rate_limit_persistence.py
+++ b/klai-knowledge-ingest/tests/test_domain_rate_limit_persistence.py
@@ -1,0 +1,116 @@
+"""SPEC-CRAWL-001 AC-14 — conflict-safe domain-rate persistence."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
+from knowledge_ingest.domain_selectors import (
+    DomainRateLimitWriteKind,
+    save_domain_rate_limit_state,
+)
+
+NOW = datetime(2026, 8, 19, 10, 0, tzinfo=UTC)
+INITIAL = DomainRateLimitState(
+    rate_limit=0.4,
+    clean_streak=3,
+    last_congestion_at=NOW - timedelta(days=2),
+)
+LOWERED = DomainRateLimitState(rate_limit=0.2, clean_streak=0, last_congestion_at=NOW)
+RECOVERED = DomainRateLimitState(
+    rate_limit=0.9,
+    clean_streak=4,
+    last_congestion_at=INITIAL.last_congestion_at,
+)
+
+
+class _AtomicStateConnection:
+    """Model the one-statement PostgreSQL boundary used by the repository."""
+
+    def __init__(self, state: DomainRateLimitState) -> None:
+        self.state = state
+        self.lock = asyncio.Lock()
+        self.queries: list[str] = []
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        self.queries.append(query)
+        assert "ON CONFLICT (domain, org_id) DO UPDATE" in query
+        assert "LEAST" in query
+        assert "IS NOT DISTINCT FROM" in query
+
+        proposed = DomainRateLimitState(args[2], args[3], args[4])
+        expected = DomainRateLimitState(args[5], args[6], args[7])
+        default_rate = args[8]
+        is_congestion = args[9]
+
+        async with self.lock:
+            if is_congestion:
+                current_rate = self.state.rate_limit or default_rate
+                self.state = DomainRateLimitState(
+                    rate_limit=min(current_rate, proposed.rate_limit),
+                    clean_streak=0,
+                    last_congestion_at=max(
+                        timestamp
+                        for timestamp in (
+                            self.state.last_congestion_at,
+                            proposed.last_congestion_at,
+                        )
+                        if timestamp is not None
+                    ),
+                )
+                return {"rate_limit": self.state.rate_limit}
+            if self.state == expected:
+                self.state = proposed
+                return {"rate_limit": self.state.rate_limit}
+            return None
+
+
+async def _write(
+    conn: _AtomicStateConnection,
+    proposed: DomainRateLimitState,
+    kind: DomainRateLimitWriteKind,
+) -> bool:
+    return await save_domain_rate_limit_state(
+        conn,  # type: ignore[arg-type]
+        "example.com",
+        "org-1",
+        expected_state=INITIAL,
+        state=proposed,
+        kind=kind,
+        default_rate_limit=2.0,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("congestion_first", [True, False])
+async def test_crossing_recovery_and_lowering_finish_at_the_lower_proposal(
+    congestion_first: bool,
+) -> None:
+    conn = _AtomicStateConnection(INITIAL)
+    first = (LOWERED, DomainRateLimitWriteKind.CONGESTION)
+    second = (RECOVERED, DomainRateLimitWriteKind.RECOVERY)
+    if not congestion_first:
+        first, second = second, first
+
+    first_applied = await _write(conn, *first)
+    second_applied = await _write(conn, *second)
+
+    assert first_applied is True
+    assert second_applied is (not congestion_first)
+    assert conn.state.rate_limit == 0.2
+    assert conn.state.clean_streak == 0
+    assert conn.state.last_congestion_at == NOW
+
+
+@pytest.mark.asyncio
+async def test_conflicting_decay_cannot_erase_newer_congestion() -> None:
+    conn = _AtomicStateConnection(INITIAL)
+    decayed = DomainRateLimitState(rate_limit=None, clean_streak=0, last_congestion_at=None)
+
+    assert await _write(conn, LOWERED, DomainRateLimitWriteKind.CONGESTION) is True
+    assert await _write(conn, decayed, DomainRateLimitWriteKind.DECAY) is False
+    assert conn.state == LOWERED

--- a/klai-knowledge-ingest/tests/test_sample_linked_pages.py
+++ b/klai-knowledge-ingest/tests/test_sample_linked_pages.py
@@ -167,6 +167,7 @@ async def test_sample_issues_exactly_one_bulk_request() -> None:
         await sample_linked_pages(seed, max_pages=5)
     assert bulk.await_count == 1
     assert len(bulk.await_args.kwargs["urls"]) == 5
+    assert bulk.await_args.kwargs["rate_limit"] == 2.0
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_shared_host_pacing.py
+++ b/klai-knowledge-ingest/tests/test_shared_host_pacing.py
@@ -1,0 +1,213 @@
+"""SPEC-CRAWL-001 amendment — process-wide weighted host pacing."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from knowledge_ingest import crawl4ai_client
+from knowledge_ingest.domain_selectors import extract_domain
+from knowledge_ingest.host_pacing import HostGateRegistry, crawl_gate_key
+
+
+class _VirtualClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.now += seconds
+        await asyncio.sleep(0)
+
+
+def test_apex_and_www_share_live_gate_but_keep_distinct_storage_keys() -> None:
+    assert extract_domain("https://www.example.com/page") == "www.example.com"
+    assert extract_domain("https://example.com/page") == "example.com"
+    assert crawl_gate_key("https://www.example.com/page") == "example.com"
+    assert crawl_gate_key("https://example.com/page") == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_aug_18_0927_same_host_crawls_share_aggregate_cadence() -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+
+    async with (
+        registry.session("https://www.example.com/start", 0.2) as first,
+        registry.session("https://example.com/other", 0.2) as second,
+    ):
+        starts: list[float] = []
+
+        async def reserve(session: object) -> None:
+            weight = await session.acquire(2)  # type: ignore[attr-defined]
+            assert weight == 2
+            starts.append(clock.now)
+
+        await asyncio.gather(reserve(first), reserve(second))
+
+    assert sorted(starts) == [0.0, 10.0]
+    assert registry.active_gate_count == 0
+
+
+@pytest.mark.asyncio
+async def test_different_hosts_do_not_share_a_pacing_schedule() -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+
+    async with (
+        registry.session("https://alpha.example/start", 0.2) as alpha,
+        registry.session("https://beta.example/start", 0.2) as beta,
+    ):
+        starts: list[float] = []
+
+        async def reserve(session: object) -> None:
+            assert await session.acquire(2) == 2  # type: ignore[attr-defined]
+            starts.append(clock.now)
+
+        await asyncio.gather(reserve(alpha), reserve(beta))
+
+    assert starts == [0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_lower_active_rate_controls_future_burst_and_repays_previous_burst() -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+
+    async with registry.session("https://example.com", 2.0) as fast:
+        assert await fast.acquire(100) == 20
+        async with registry.session("https://www.example.com", 0.2) as slow:
+            assert await slow.acquire(100) == 2
+
+    # The previous 20-URL burst is charged against the newly effective
+    # 0.2 URL/s rate before another request may start.
+    assert clock.now == 100.0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_bulk_fetches_share_the_host_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+    starts: list[tuple[float, int]] = []
+
+    async def crawl_sync(_client: httpx.AsyncClient, payload: dict[str, Any]) -> dict[str, Any]:
+        starts.append((clock.now, len(payload["urls"])))
+        await asyncio.sleep(0)
+        return {
+            "results": [
+                {"url": url, "success": True, "markdown": "content", "links": {}}
+                for url in payload["urls"]
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_host_gate_registry", registry)
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", crawl_sync)
+
+    await asyncio.gather(
+        crawl4ai_client._chunked_bulk_fetch(
+            urls=["https://www.example.com/a", "https://www.example.com/b"],
+            crawler_config={},
+            cookies=None,
+            rate_limit=0.2,
+        ),
+        crawl4ai_client._chunked_bulk_fetch(
+            urls=["https://example.com/c", "https://example.com/d"],
+            crawler_config={},
+            cookies=None,
+            rate_limit=0.2,
+        ),
+    )
+
+    assert sorted(starts) == [(0.0, 2), (10.0, 2)]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_bulk_fetches_for_different_hosts_start_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+    starts: list[float] = []
+
+    async def crawl_sync(_client: httpx.AsyncClient, payload: dict[str, Any]) -> dict[str, Any]:
+        starts.append(clock.now)
+        await asyncio.sleep(0)
+        return {
+            "results": [
+                {"url": url, "success": True, "markdown": "content", "links": {}}
+                for url in payload["urls"]
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_host_gate_registry", registry)
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", crawl_sync)
+
+    await asyncio.gather(
+        crawl4ai_client._chunked_bulk_fetch(
+            urls=["https://alpha.example/a", "https://alpha.example/b"],
+            crawler_config={},
+            cookies=None,
+            rate_limit=0.2,
+        ),
+        crawl4ai_client._chunked_bulk_fetch(
+            urls=["https://beta.example/c", "https://beta.example/d"],
+            crawler_config={},
+            cookies=None,
+            rate_limit=0.2,
+        ),
+    )
+
+    assert starts == [0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_single_page_requests_also_share_the_host_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+    starts: list[float] = []
+
+    class Response:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {
+                "results": [
+                    {
+                        "url": self.url,
+                        "success": True,
+                        "markdown": "content",
+                        "links": {},
+                    }
+                ]
+            }
+
+    async def post(
+        _client: httpx.AsyncClient, _url: str, *, json: dict[str, Any], **_kwargs: Any
+    ) -> Response:
+        starts.append(clock.now)
+        await asyncio.sleep(0)
+        return Response(json["urls"][0])
+
+    monkeypatch.setattr(crawl4ai_client, "_host_gate_registry", registry)
+    monkeypatch.setattr(crawl4ai_client, "_crawl4ai_request_semaphore", asyncio.Semaphore(2))
+    monkeypatch.setattr(httpx.AsyncClient, "post", post)
+
+    await asyncio.gather(
+        crawl4ai_client.crawl_page("https://www.example.com/a", rate_limit=0.2),
+        crawl4ai_client.crawl_page("https://example.com/b", rate_limit=0.2),
+    )
+
+    assert sorted(starts) == [0.0, 5.0]


### PR DESCRIPTION
## Het probleem, gemeten op productie

```
support.ascendcloud.com   0.2   schone reeks 0   laatste congestie 2026-08-19 05:44:38
www.intermedia.com        0.2   schone reeks 0   laatste congestie (leeg)
```

Beide domeinen staan op de bodem — tien keer trager dan de standaard van 2,0. Voor Ascend is dat het verschil tussen een crawl van 55 minuten en zes.

Kijk naar dat tijdstip bij Ascend: **05:44:38**, het einde van een crawl die 457 pagina's ophaalde met nul rate-limiting. Die geslaagde crawl boekte alsnog congestie en zette de schone reeks op nul, door precies één anti-bot-signaal op 475 pogingen.

Drie eigenschappen maakten de straf permanent:

- **Congestie was een gebeurtenis, geen percentage.** Eén signaal in 475 pogingen woog even zwaar als een site die volledig dichtklapt.
- **Herstel vroeg 50 schone waarnemingen op rij**, en één gebeurtenis zette de teller op nul. In een crawl van 450 pagina's is er altijd wel één rotte URL; de 50 werd dus nooit gehaald.
- **Herstel ging met stapjes van 0,2 en een dag wachttijd** — negen dagen van bodem naar standaard, als de teller het al haalde.

Eén ontwerpfout, drie symptomen: de straf was permanent, het bewijs ervoor niet.

## Wat er nu gebeurt

**Congestie is een percentage**, met dezelfde drempel die de stroomonderbreker al hanteert. Eén signaal op 475 is ruis.

**Eén schone crawl is het bewijs**, niet 50 losse waarnemingen. Herstel is geschaald aan de standaard: van de bodem terug in vier schone crawls in plaats van negen dagen.

**Een straf zonder recent bewijs vervalt.** Een onbekend domein begint op 2,0. Een domein waar we zeven dagen geen congestie meer op zagen is qua bewijs niet anders dan een onbekend domein, dus drijft het daarheen terug — ook zonder nieuwe crawl. Daarmee geneest de vergiftiging van vandaag vanzelf; er is geen handmatige ingreep in productiedata nodig, en dat is het punt.

Een ontbrekend tijdstempel bij een verlaagde snelheid (de intermedia-situatie) telt als reeds vervallen bewijs. Een straf zonder tijdstempel heeft geen recht op een gratieperiode.

## Uit de review

Twee bevestigde gaten, allebei gerepareerd:

- Het minimum aantal pogingen werd symmetrisch toegepast. Een domein dat nog actief geblokkeerd wordt levert door de opgeef-ladder maar ~9 pogingen op — onder het minimum, dus geen oordeel, dus na zeven dagen ten onrechte hersteld. Een hoog foutpercentage telt nu altijd als congestie, ongeacht steekproefgrootte; alleen het gezond-oordeel houdt het minimum.
- Een crawl die volledig faalde om andere redenen (timeouts, 5xx, DNS) gold als schoon en **verhoogde** de snelheid, zonder ooit één pagina te hebben opgehaald. Een schoon oordeel vereist nu minstens één echt succes.

Blijft staan als bekend restrisico: bij twee gelijktijdige crawls van hetzelfde domein is de vervalschrijving een lees-wijzig-schrijf zonder vergrendeling. Bestaand patroon, hoort bij de gedeelde rem per host die nog gepland staat.

## Bewijs

- 1495 tests geslaagd, 4 overgeslagen, 0 gefaald
- `ruff check` en `ruff format --check` schoon
- `alembic heads` toont precies één hoofd
- De echte Ascend-situatie ligt vast als regressietest: 457 successen met één anti-bot-signaal telt niet als congestie en herstelt de snelheid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
