### PR TITLE
fix(kb): let kb_manager delete any source, not just connectors

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -27,7 +27,12 @@ from app.models.knowledge_bases import PortalGroupKBAccess, PortalKnowledgeBase,
 from app.models.portal import PortalUser
 from app.models.retrieval_gaps import PortalRetrievalGap
 from app.services import docs_client, knowledge_ingest_client
-from app.services.access import get_user_role_for_kb, is_personal_kb, require_connector_manage_access
+from app.services.access import (
+    get_user_role_for_kb,
+    grants_kb_source_manage,
+    is_personal_kb,
+    require_connector_manage_access,
+)
 from app.services.audit import log_event
 from app.services.connector_credentials import credential_store
 from app.services.kb_quota import assert_can_create_org_kb, assert_can_create_personal_kb
@@ -1540,9 +1545,10 @@ async def delete_kb_upload(
 ) -> None:
     """Delete a direct-upload from the KB, handling both lifecycle stages.
 
-    Owners may delete any upload.
-    Contributors may only delete their own uploads (ownership enforced by
-    knowledge-ingest via X-User-ID check for done artifacts; by created_by
+    Owners — and kb_manager+ on an org KB, see ``grants_kb_source_manage`` —
+    may delete any upload.
+    Plain contributors may only delete their own uploads (ownership enforced
+    by knowledge-ingest via X-User-ID check for done artifacts; by created_by
     check on the KBUpload row for in-flight uploads).
     Viewers get 403.
 
@@ -1578,20 +1584,25 @@ async def delete_kb_upload(
         kb_org_id=kb.org_id,
         kb_created_by=kb.created_by,
     )
-    if role not in ("contributor", "owner"):
+    # Same pad as connector CRUD: KB owner, platform admin, or kb_manager+
+    # holding contributor access on an org KB. Without this a kb_manager could
+    # delete the Notion connector but not the plain-text file listed under it,
+    # because the upload was created by a colleague.
+    manages_all_sources = grants_kb_source_manage(kb, perms, role)
+    if not manages_all_sources and role != "contributor":
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Contributor or owner access required",
         )
 
-    # Contributors: pass user_id so knowledge-ingest enforces ownership.
-    # Owners: omit user_id to allow cross-user deletes.
-    caller_user_id = perms.user_id if role == "contributor" else None
+    # Plain contributors: pass user_id so knowledge-ingest enforces ownership.
+    # Source managers: omit user_id to allow cross-user deletes.
+    caller_user_id = None if manages_all_sources else perms.user_id
 
     async def delete_tracked_upload(upload: KBUpload) -> None:
         # Contributor ownership check for in-flight uploads — mirrors
         # knowledge-ingest's X-User-ID gate on the artifact-side delete.
-        if role == "contributor" and upload.created_by != perms.user_id:
+        if not manages_all_sources and upload.created_by != perms.user_id:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="you can only delete your own uploads",

--- a/klai-portal/backend/app/services/access.py
+++ b/klai-portal/backend/app/services/access.py
@@ -237,6 +237,53 @@ async def get_user_role_for_kb(
     return max(roles, key=lambda r: role_rank.get(r, 0))
 
 
+def grants_kb_source_manage(
+    kb: PortalKnowledgeBase,
+    perms: object,
+    kb_role: str | None,
+) -> bool:
+    """Return True iff the caller may manage EVERY source on this KB.
+
+    "Manage every source" means: not restricted to the sources the caller
+    happens to have created. It is the owner-equivalent pad — the thing that
+    separates "may add my own upload" from "may remove the source someone
+    else added".
+
+    Pure predicate over an already-resolved ``kb_role`` (see
+    ``get_user_role_for_kb``) so callers that already paid for that query do
+    not issue a second one.
+
+    True when one of:
+      1. platform admin (existing bypass, unchanged);
+      2. KB-role resolves to owner (creator, explicit grant or group grant);
+      3. org-owned KB + KB-role contributor + effective capability
+         KB_CONNECTORS_EXTERNAL (kb_manager and above — NOT the basic
+         KB_CONNECTORS capability, which personal/company also hold for
+         url/upload types). A resolved *viewer* KB-role still restricts:
+         intersection with the KB-role layer is preserved.
+
+    Reads ``perms.effective_capabilities`` rather than re-deriving the
+    capability set from the profile role. That is the same source
+    ``require_capability`` gates on, so a (kb_manager, CHAT-seat) caller —
+    reachable via the ``PATCH /seat`` escape hatch, where
+    ``app.core.seats.effective_capabilities`` deliberately drops
+    KB_CONNECTORS_EXTERNAL — is denied here too. ``profiles.has_capability``
+    would have re-granted it by looking only at the role.
+
+    Personal KBs stay owner-only for non-platform-admins; the
+    ``get_kb_with_access`` route firewall already 404s other users'
+    personal KBs before this check runs.
+    """
+    from app.core.profiles import Capability
+
+    if getattr(perms, "is_platform_admin", False):
+        return True
+    if kb_role == "owner":
+        return True
+    effective_caps = getattr(perms, "effective_capabilities", frozenset())
+    return kb.owner_type == "org" and kb_role == "contributor" and Capability.KB_CONNECTORS_EXTERNAL in effective_caps
+
+
 async def require_connector_manage_access(
     kb: PortalKnowledgeBase,
     perms: object,
@@ -253,22 +300,11 @@ async def require_connector_manage_access(
     own. On a default_org_role=contributor KB that locked out every
     kb_manager except the KB creator (Voys/Ascend incident).
 
-    Allowed when one of:
-      1. platform admin (existing bypass, unchanged);
-      2. KB-role resolves to owner (creator, explicit grant or group grant);
-      3. org-owned KB + KB-role contributor + profile capability
-         KB_CONNECTORS_EXTERNAL (kb_manager and above — NOT the basic
-         KB_CONNECTORS capability, which personal/company also hold for
-         url/upload types). An explicit *viewer* grant still restricts:
-         intersection with the KB-role layer is preserved.
-
-    Personal KBs stay owner-only for non-platform-admins; the
-    ``get_kb_with_access`` route firewall already 404s other users'
-    personal KBs before this check runs.
+    The rule itself lives in ``grants_kb_source_manage`` — shared with the
+    upload-delete path so a kb_manager cannot remove a connector but be
+    stuck on the plain-text file sitting next to it in the same Sources list.
     """
     from fastapi import HTTPException, status
-
-    from app.core.profiles import Capability, has_capability
 
     if getattr(perms, "is_platform_admin", False):
         return
@@ -281,9 +317,7 @@ async def require_connector_manage_access(
         kb_org_id=kb.org_id,
         kb_created_by=kb.created_by,
     )
-    if role == "owner":
-        return
-    if kb.owner_type == "org" and role == "contributor" and has_capability(perms, Capability.KB_CONNECTORS_EXTERNAL):
+    if grants_kb_source_manage(kb, perms, role):
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,

--- a/klai-portal/backend/tests/test_connector_manage_access.py
+++ b/klai-portal/backend/tests/test_connector_manage_access.py
@@ -17,7 +17,13 @@ and auth-probe. Matrix under test:
 | platform admin                           | allowed                      | allowed     |
 | KB owner (explicit grant / creator)      | allowed                      | allowed     |
 | kb_manager, contributor via default      | allowed  (the fix)           | 403         |
-| kb_manager, explicit viewer grant        | 403 (KB-role layer wins)     | 403         |
+| kb_manager, resolved viewer KB-role      | 403 (KB-role layer wins)     | 403         |
+
+Caveat on that last row: ``get_user_role_for_kb`` returns
+max(explicit grant, default_org_role), so on a KB with
+``default_org_role='contributor'`` an explicit viewer grant does NOT resolve
+to viewer and therefore does not restrict. What is pinned below is the
+resolved role, not the grant.
 | company profile, contributor via default | 403 (no capability)          | 403         |
 """
 

--- a/klai-portal/backend/tests/test_kb_upload_permissions.py
+++ b/klai-portal/backend/tests/test_kb_upload_permissions.py
@@ -35,13 +35,14 @@ def _make_org() -> MagicMock:
     return org
 
 
-def _make_kb() -> MagicMock:
+def _make_kb(*, owner_type: str = "org", default_org_role: str | None = "viewer") -> MagicMock:
     kb = MagicMock()
     kb.id = 42
     kb.slug = _KB_SLUG
     kb.org_id = _ORG_ID
     kb.created_by = _OWNER_USER_ID
-    kb.default_org_role = "viewer"
+    kb.owner_type = owner_type
+    kb.default_org_role = default_org_role
     return kb
 
 
@@ -619,6 +620,288 @@ async def test_delete_stale_done_upload_by_artifact_id_treats_ingest_404_as_succ
 
     assert result is None
     mock_delete.assert_awaited_once()
+    db.delete.assert_awaited_once_with(upload)
+    db.commit.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# delete_kb_upload — kb_manager source-manage pad (2026-08-19)
+#
+# A kb_manager could already delete a CONNECTOR on an org KB it did not create
+# (require_connector_manage_access, Voys/Ascend fix 2026-08-14) but not the
+# upload sitting next to it in the same Sources list, because the upload's
+# delete forwarded user_id and knowledge-ingest rejected the cross-user delete.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_kb_manager_contributor_on_org_kb_passes_none_user_id() -> None:
+    """kb_manager with contributor access on an org KB deletes ANY upload.
+
+    Regression: previously user_id was forwarded, so knowledge-ingest 403'd
+    on a source uploaded by a colleague.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb(default_org_role="contributor")
+    perms = make_perms(role="kb_manager", user_id="user-kb-manager", org_id=_ORG_ID)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        result = await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=_ARTIFACT_ID,
+            perms=perms,
+            db=_make_db(),
+        )
+
+    assert result is None
+    mock_delete.assert_awaited_once_with(
+        org.zitadel_org_id,
+        kb.slug,
+        _ARTIFACT_ID,
+        user_id=None,  # cross-user delete allowed
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_kb_manager_resolved_viewer_role_still_403() -> None:
+    """A resolved viewer KB-role still wins — the KB-role layer is preserved.
+
+    Note the resolver, not the grant, is what this pins. ``get_user_role_for_kb``
+    returns max(explicit grant, default_org_role), so on a KB with
+    ``default_org_role='contributor'`` an explicit viewer grant does NOT
+    resolve to viewer. That is a pre-existing property of the resolver shared
+    with connector CRUD, not something this gate can compensate for.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb()
+    perms = make_perms(role="kb_manager", user_id="user-kb-manager", org_id=_ORG_ID)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="viewer"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_kb_upload(
+                kb_slug=_KB_SLUG,
+                upload_or_artifact_id=_ARTIFACT_ID,
+                perms=perms,
+                db=_make_db(),
+            )
+
+    assert exc_info.value.status_code == 403
+    mock_delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_kb_manager_on_chat_seat_stays_own_uploads_only() -> None:
+    """Seat filtering applies: a kb_manager on a CHAT seat loses the widening.
+
+    ``app.core.seats.effective_capabilities`` drops KB_CONNECTORS_EXTERNAL for
+    (kb_manager, CHAT) — reachable via the PATCH /seat escape hatch. The gate
+    must read ``perms.effective_capabilities`` (what ``require_capability``
+    gates on), not re-derive capabilities from the profile role.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb(default_org_role="contributor")
+    perms = make_perms(
+        role="kb_manager",
+        seat_type="chat",
+        user_id="user-kb-manager",
+        org_id=_ORG_ID,
+    )
+    assert "kb.connectors.external" not in perms.effective_capabilities
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=_ARTIFACT_ID,
+            perms=perms,
+            db=_make_db(),
+        )
+
+    mock_delete.assert_awaited_once_with(
+        org.zitadel_org_id,
+        kb.slug,
+        _ARTIFACT_ID,
+        user_id="user-kb-manager",  # still ownership-scoped
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_kb_manager_on_personal_kb_stays_own_uploads_only() -> None:
+    """Personal KBs get no kb_manager widening — owner_type='user' is excluded."""
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb(owner_type="user", default_org_role=None)
+    perms = make_perms(role="kb_manager", user_id="user-kb-manager", org_id=_ORG_ID)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=_ARTIFACT_ID,
+            perms=perms,
+            db=_make_db(),
+        )
+
+    mock_delete.assert_awaited_once_with(
+        org.zitadel_org_id,
+        kb.slug,
+        _ARTIFACT_ID,
+        user_id="user-kb-manager",  # still ownership-scoped
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_upload_company_profile_contributor_still_own_uploads_only() -> None:
+    """A company profile lacks KB_CONNECTORS_EXTERNAL — no widening for it."""
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb(default_org_role="contributor")
+    perms = make_perms(role="company", user_id=_USER_ID, org_id=_ORG_ID)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.knowledge_ingest_client.delete_kb_upload",
+            new=AsyncMock(return_value=None),
+        ) as mock_delete,
+    ):
+        await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=_ARTIFACT_ID,
+            perms=perms,
+            db=_make_db(),
+        )
+
+    mock_delete.assert_awaited_once_with(
+        org.zitadel_org_id,
+        kb.slug,
+        _ARTIFACT_ID,
+        user_id=_USER_ID,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_processing_upload_kb_manager_deletes_other_users_row() -> None:
+    """kb_manager may delete a colleague's still-processing kb_uploads row.
+
+    The in-flight branch has its own created_by check; it must follow the same
+    pad as the artifact branch or the two disagree mid-lifecycle.
+    """
+    from app.api.app_knowledge_bases import delete_kb_upload
+
+    org = _make_org()
+    kb = _make_kb(default_org_role="contributor")
+    perms = make_perms(role="kb_manager", user_id="user-kb-manager", org_id=_ORG_ID)
+    upload = _make_kb_upload(created_by=_USER_ID)  # someone else's upload
+    db = _make_db(kb_upload=upload)
+
+    with (
+        patch(
+            "app.api.app_knowledge_bases._load_org_or_500",
+            new=AsyncMock(return_value=org),
+        ),
+        patch(
+            "app.api.app_knowledge_bases._get_kb_or_404",
+            new=AsyncMock(return_value=kb),
+        ),
+        patch(
+            "app.api.app_knowledge_bases.get_user_role_for_kb",
+            new=AsyncMock(return_value="contributor"),
+        ),
+    ):
+        result = await delete_kb_upload(
+            kb_slug=_KB_SLUG,
+            upload_or_artifact_id=str(upload.id),
+            perms=perms,
+            db=db,
+        )
+
+    assert result is None
     db.delete.assert_awaited_once_with(upload)
     db.commit.assert_awaited()
 


### PR DESCRIPTION
Een `kb_manager` mocht op een org-KB wel een connector verwijderen die iemand anders had aangemaakt, maar niet het bestand ernaast in dezelfde Bronnenlijst: `DELETE /uploads/{id}` stuurde `user_id` mee zodra de KB-rol `contributor` was, wat op een KB met `default_org_role='contributor'` precies is wat een kb_manager krijgt — knowledge-ingest gaf dan 403 "you can only delete your own uploads". Deze PR trekt de regel die connector-CRUD al bestuurde uit `require_connector_manage_access` naar het gedeelde predicaat `grants_kb_source_manage`, en past het toe op beide takken van `delete_kb_upload` (afgerond artifact én nog-in-flight `kb_uploads`-rij) zodat die niet halverwege de lifecycle uiteenlopen. Het predicaat leest nu `perms.effective_capabilities` in plaats van capabilities te herleiden uit de profielrol via `has_capability` — dezelfde bron waar `require_capability` op gate't — waardoor een `(kb_manager, CHAT-seat)` caller ook hier geweigerd wordt en het connector-pad meeverstrakt. Personal KB's, viewers en company/personal-profielen veranderen niet, en er is geen frontend-wijziging nodig omdat de delete-actie al werd getoond. Twee nieuwe tests falen aantoonbaar op de oude broncode en slagen na de fix (geverifieerd met een revert-run); volledige suite 3606 passed, ruff en pyright clean, en GPT-5.6 Sol reviewde in twee passes met 0 openstaande findings.

**Bekende beperking, pre-existing en bewust niet aangeraakt:** `get_user_role_for_kb` neemt `max(expliciete grant, default_org_role)`, dus op een KB met `default_org_role='contributor'` kan een expliciete viewer-grant een kb_manager niet uitsluiten van deze delete — dat geldt voor het hele KB-rechtenmodel, niet alleen dit endpoint. De docstrings en testmatrix die ten onrechte het tegendeel beweerden zijn wel gecorrigeerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)