### PR TITLE
fix(ci): restore Renovate package lookups

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,11 +51,18 @@ jobs:
 
       - uses: actions/checkout@v7
 
+      - name: Validate Renovate configuration contracts
+        run: sh scripts/test-renovate-config.sh
+
       - uses: renovatebot/github-action@v46.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
         env:
           RENOVATE_REPOSITORIES: '["GetKlai/klai"]'
+          # Provision Docker hostRules for ghcr.io from the short-lived app
+          # token. The app installation has Packages: read; without this flag
+          # the Docker datasource still makes anonymous private-image lookups.
+          RENOVATE_X_GITHUB_HOST_RULES: 'true'
           # At info level a skipped update is indistinguishable from no update
           # at all — the 28-week no-op looked exactly like "nothing to do".
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -79,6 +79,36 @@
 
   packageRules: [
     {
+      description:
+        'Klai LibreChat is intentionally digest-only and has no latest tag. Its \
+        digest is produced by librechat-image-build.yml and enforced by the \
+        deploy digest guard, so Docker tag discovery is not applicable.',
+      matchManagers: ['docker-compose'],
+      matchDatasources: ['docker'],
+      matchPackageNames: ['ghcr.io/getklai/librechat'],
+      enabled: false,
+    },
+    {
+      description:
+        'Aqua blocks organization GitHub App tokens with its IP allowlist. Use \
+        the public Git transport so action digest updates remain discoverable.',
+      matchManagers: ['github-actions'],
+      matchPackageNames: ['aquasecurity/setup-trivy'],
+      overrideDatasource: 'git-tags',
+      overridePackageName: 'https://github.com/aquasecurity/setup-trivy.git',
+      minimumReleaseAge: '0 days',
+    },
+    {
+      description:
+        'Aqua blocks organization GitHub App tokens with its IP allowlist. Use \
+        the public Git transport for the Trivy version passed to setup-trivy.',
+      matchManagers: ['github-actions'],
+      matchPackageNames: ['aquasecurity/trivy'],
+      overrideDatasource: 'git-tags',
+      overridePackageName: 'https://github.com/aquasecurity/trivy.git',
+      minimumReleaseAge: '0 days',
+    },
+    {
       description: 'Auto-merge patch and minor updates once CI is green',
       matchUpdateTypes: ['patch', 'minor'],
       automerge: true,

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+workflow="$repo_root/.github/workflows/renovate.yml"
+config="$repo_root/renovate.json5"
+
+assert_contains() {
+  file=$1
+  expected=$2
+  message=$3
+
+  if ! grep -Fq "$expected" "$file"; then
+    echo "FAIL: $message" >&2
+    exit 1
+  fi
+}
+
+assert_contains "$workflow" \
+  "RENOVATE_X_GITHUB_HOST_RULES: 'true'" \
+  'Renovate must pass its GitHub App token to GitHub Packages lookups'
+
+assert_contains "$config" \
+  "matchPackageNames: ['ghcr.io/getklai/librechat']" \
+  'the digest-only Klai LibreChat image must have an explicit Renovate policy'
+assert_contains "$config" \
+  "matchPackageNames: ['aquasecurity/setup-trivy']" \
+  'setup-trivy must have an IP-allowlist-safe lookup policy'
+assert_contains "$config" \
+  "overrideDatasource: 'git-tags'" \
+  'Aqua dependencies must bypass the authenticated GitHub API'
+assert_contains "$config" \
+  "overridePackageName: 'https://github.com/aquasecurity/setup-trivy.git'" \
+  'setup-trivy must use its public Git repository for lookups'
+assert_contains "$config" \
+  "matchPackageNames: ['aquasecurity/trivy']" \
+  'Trivy must have an IP-allowlist-safe lookup policy'
+assert_contains "$config" \
+  "overridePackageName: 'https://github.com/aquasecurity/trivy.git'" \
+  'Trivy must use its public Git repository for lookups'
+assert_contains "$config" \
+  "minimumReleaseAge: '0 days'" \
+  'Aqua Git-tag lookups without timestamps must not remain pending forever'
+
+echo 'Renovate configuration contracts: PASS'


### PR DESCRIPTION
## Summary

- authenticate Renovate Docker lookups against GHCR with its short-lived GitHub App installation token
- bypass AquaSecurity's GitHub API IP-allowlist failure through public Git tag lookups
- exclude the intentionally digest-only Klai LibreChat image from inapplicable `latest` discovery
- add a workflow-level regression contract check

## Evidence

- run #168 showed anonymous GHCR access for `getklai/crawl4ai`, authenticated GitHub GraphQL 403s for both Aqua dependencies, and an implicit missing `librechat:latest` lookup
- `sh scripts/test-renovate-config.sh` passes
- `yq eval '.' .github/workflows/renovate.yml` passes
- `sh deploy/scripts/tests/check-klai-librechat-digest.test.sh` passes
- anonymous `git ls-remote` resolves the expected tags for both Aqua repositories

## Deliberate trade-off

Git tags do not expose release timestamps, so the 7-day stability delay is disabled only for `aquasecurity/setup-trivy` and the `version` input package `aquasecurity/trivy`. CI still gates their resulting PRs.