### PR TITLE
fix(portal): keep long crawls in progress

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -14,10 +14,11 @@ import * as m from '@/paraglide/messages'
 import type { Source } from './-sources-types'
 
 /**
- * Threshold (minutes) after which a 'pending' source is considered stuck.
+ * Threshold (minutes) after which a pending upload is considered stuck.
  * Below this we just show "Bezig sinds Xm" as informational; at/above it
  * the badge flips to a warning ("Hangt al Xm") so the user knows to retry.
  *
+ * Connectors are excluded because long crawls can legitimately exceed it.
  * This is a frontend-only indicator, not enforcement: the backend reaper
  * (knowledge-ingest `stale_pending_artifact_reaper`) auto-fails artifacts
  * stuck in 'pending' for over 30 minutes, running every 15 minutes. This
@@ -126,13 +127,16 @@ export function StatusBadge({ source }: { source: Source }) {
     )
   }
 
-  // Stale-indicator for sources stuck in 'pending'. last_sync_at is the
-  // best signal of "when did this attempt start" — falls back to created_at
-  // for sources that have never completed a sync yet (the common case for
-  // the bug this fixes: a freshly-added URL that never finished ingesting).
+  // Only uploads have a backend reaper that turns stale pending work into a
+  // failure. Website crawls can legitimately run longer than this threshold,
+  // so elapsed time alone must not present them as stuck.
   if (status === 'pending') {
     const minutes = elapsedMinutes(source.last_sync_at ?? source.created_at)
-    if (minutes !== null && minutes >= STUCK_THRESHOLD_MINUTES) {
+    if (
+      source.kind === 'upload'
+      && minutes !== null
+      && minutes >= STUCK_THRESHOLD_MINUTES
+    ) {
       return (
         <Badge
           variant="destructive"

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-status-badge.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/__tests__/sources-status-badge.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/paraglide/messages', () => ({
   kb_status_probleem: () => 'Probleem',
@@ -32,7 +32,25 @@ function uploadSource(overrides: Partial<Source> = {}): Source {
   }
 }
 
+function connectorSource(overrides: Partial<Source> = {}): Source {
+  return {
+    kind: 'connector',
+    id: 'connector-1',
+    name: 'Example website',
+    type_label: 'Website',
+    connector_type: 'web_crawler',
+    items_count: 0,
+    chunks_count: 0,
+    status: 'running',
+    last_sync_at: '2026-08-19T12:00:00.000Z',
+    created_at: '2026-08-19T12:00:00.000Z',
+    ...overrides,
+  }
+}
+
 describe('StatusBadge', () => {
+  afterEach(() => vi.useRealTimers())
+
   it('shows a destructive Probleem badge for failed uploads instead of neutral Leeg', () => {
     // Regression: index_status='failed' uploads rendered the neutral "Leeg"
     // badge, so a permanently failed source went unnoticed for 8 days.
@@ -47,5 +65,26 @@ describe('StatusBadge', () => {
   it('still shows Klaar for synced uploads', () => {
     render(<StatusBadge source={uploadSource({ index_status: 'synced', chunks_count: 3 })} />)
     expect(screen.getByText('Klaar')).toBeTruthy()
+  })
+
+  it('shows an old running website crawl as busy instead of stuck', () => {
+    vi.setSystemTime(new Date('2026-08-19T13:00:00.000Z'))
+
+    render(<StatusBadge source={connectorSource()} />)
+
+    expect(screen.getByText('Bezig')).toBeTruthy()
+    expect(screen.getByText('60m')).toBeTruthy()
+    expect(screen.queryByText('Hangt al 60m')).toBeNull()
+  })
+
+  it('still shows an old pending upload as stuck', () => {
+    vi.setSystemTime(new Date('2026-08-19T13:00:00.000Z'))
+
+    render(<StatusBadge source={uploadSource({
+      index_status: 'pending',
+      created_at: '2026-08-19T12:00:00.000Z',
+    })} />)
+
+    expect(screen.getByText('Hangt al 60m')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Probleem

De bronnenlijst markeerde iedere connector na tien minuten als rood en vastgelopen. Een websitecrawl kan gezond veel langer duren; tijdsduur alleen is geen bewijs dat de worker vastzit.

## Wijziging

- Lopende connectors blijven `Bezig · Xm` tonen, ook na tien minuten.
- De rode `Hangt al Xm`-waarschuwing blijft alleen gelden voor uploads, waarvoor de backend daadwerkelijk een stale-pending reaper heeft.
- Regressietests dekken beide toestanden.

## Bewijs

- `npm test`: 507 tests geslaagd
- `npm run lint -- --quiet`: schoon
- `npm run build`: geslaagd
- Lokale browsercheck niet uitgevoerd: de workspace-preflight meldt geen frontend/backendlisteners en een onjuiste proxydoelpoort.