### PR TITLE
fix(deploy): fail closed across compose changes

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -258,24 +258,6 @@ jobs:
             sync_and_recreate alloy       deploy/alloy/config.alloy     /opt/klai/alloy/config.alloy
             sync_and_recreate searxng     deploy/searxng/settings.yml   /opt/klai/searxng/settings.yml
 
-            # Re-apply the firewall after compose has settled.
-            #
-            # klai-harden-firewall.service is After=docker.service / WantedBy=
-            # multi-user.target — it runs at boot and never again. The bot
-            # isolation rules (SPEC-SEC-022 REQ-2) carry the vexa12-bots subnet,
-            # read from Docker at the time they were installed. A compose change
-            # that recreates that network can hand it a different subnet, and the
-            # rules then match nothing at all: bots regain the host until the next
-            # reboot, silently.
-            #
-            # That is not hypothetical — recreating the network on 2026-08-17 is
-            # what surfaced this, and the rules had to be re-applied by hand.
-            # A deploy is exactly when the network can change, so a deploy is when
-            # the rules get rewritten.
-            echo "Re-applying firewall rules (network definitions may have changed) ..."
-            sudo systemctl restart klai-harden-firewall.service
-            systemctl is-active --quiet klai-harden-firewall.service \
-              || { echo "::error::klai-harden-firewall failed to re-apply"; exit 1; }
             clear_librechat_config_cache() {
               local pattern="${1:-configs:*}"
               docker compose --project-directory /opt/klai exec -T redis sh -lc '
@@ -347,10 +329,54 @@ jobs:
             # serving-container recreate.
             echo "::group::SPEC-MCP-RETRIEVAL-001 follow-up — compose up -d for env-drift recreate"
             cd /opt/klai
-            COMPOSE_ENV_DRIFT_SERVICES="$(docker compose config --services | grep -vx 'litellm' | tr '\n' ' ')"
+            set -o pipefail
+            COMPOSE_ENV_DRIFT_SERVICES="$(docker compose config --services | awk '$0 != "litellm"' | tr '\n' ' ')"
+            if [ -z "$COMPOSE_ENV_DRIFT_SERVICES" ]; then
+              echo "::error::no env-drift services resolved; refusing an all-services compose up"
+              exit 1
+            fi
+
+            # Docker can recreate a network before a later container fails. Arm
+            # the EXIT trap only after config/list validation, then clear it once
+            # compose succeeds so both success and failure paths re-apply exactly
+            # once. The failure handler preserves compose's original exit code.
+            reapply_firewall() {
+              echo "Re-applying firewall rules (network definitions may have changed) ..."
+              if ! sudo systemctl restart klai-harden-firewall.service; then
+                echo "::error::klai-harden-firewall failed to restart"
+                return 1
+              fi
+              systemctl is-active --quiet klai-harden-firewall.service \
+                || { echo "::error::klai-harden-firewall failed to re-apply"; return 1; }
+            }
+            on_compose_exit() {
+              local compose_exit="$1"
+              trap - EXIT
+              reapply_firewall || exit 1
+              exit "$compose_exit"
+            }
+            trap 'on_compose_exit "$?"' EXIT
+
             # shellcheck disable=SC2086
-            docker compose up -d --remove-orphans $COMPOSE_ENV_DRIFT_SERVICES 2>&1 | tail -50 || echo "compose up -d returned non-zero; check logs"
+            docker compose up -d --remove-orphans $COMPOSE_ENV_DRIFT_SERVICES 2>&1 | tail -50
+            trap - EXIT
             echo "::endgroup::"
+
+            # Re-apply the firewall after compose has settled.
+            #
+            # klai-harden-firewall.service is After=docker.service / WantedBy=
+            # multi-user.target — it runs at boot and never again. The bot
+            # isolation rules (SPEC-SEC-022 REQ-2) carry the vexa12-bots subnet,
+            # read from Docker at the time they were installed. A compose change
+            # that recreates that network can hand it a different subnet, and the
+            # rules then match nothing at all: bots regain the host until the next
+            # reboot, silently.
+            #
+            # That is not hypothetical — recreating the network on 2026-08-17 is
+            # what surfaced this, and the rules had to be re-applied by hand.
+            # A deploy is exactly when the network can change, so a deploy is when
+            # the rules get rewritten.
+            reapply_firewall
 
             # SPEC-SEC-024 M4.3 — non-blocking post-deploy smoke-test. Prints
             # [OK]/[FAIL] per probe; warns on non-zero exit but does NOT

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     paths:
       - 'deploy/scripts/**'
+      - '.github/workflows/deploy-compose.yml'
       - 'deploy/librechat/tests/**'
       - '**/Dockerfile'
       - '**/Dockerfile.*'
@@ -28,6 +29,7 @@ on:
     branches: [main]
     paths:
       - 'deploy/scripts/**'
+      - '.github/workflows/deploy-compose.yml'
       - 'deploy/librechat/tests/**'
       - '**/Dockerfile'
       - '**/Dockerfile.*'
@@ -82,6 +84,9 @@ jobs:
 
       - name: bot host-isolation suite (SPEC-SEC-022)
         run: bash deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+
+      - name: backup retention suite
+        run: bash deploy/scripts/tests/backup-retention.test.sh
 
       - name: container-hygiene preflight suite
         run: bash .claude/hooks/klai/tests/container-hygiene-preflight.test.sh

--- a/deploy/scripts/backup.sh
+++ b/deploy/scripts/backup.sh
@@ -682,9 +682,13 @@ main() {
     kuma_push up "OK - $(artifact_size "${BACKUP_DIR}")"
   fi
 
-  CURRENT_STEP="local retention"
-  if ! local_retention; then
-    log "Local retention failed (non-fatal; backup artifacts were already produced)"
+  if [ ${#FAILED_STEPS[@]} -gt 0 ]; then
+    log "Local retention skipped because this backup has failed steps"
+  else
+    CURRENT_STEP="local retention"
+    if ! local_retention; then
+      log "Local retention failed (non-fatal; backup artifacts were already produced)"
+    fi
   fi
 
   CURRENT_STEP="summary"

--- a/deploy/scripts/check-dockerfile-security-updates.sh
+++ b/deploy/scripts/check-dockerfile-security-updates.sh
@@ -109,9 +109,19 @@ for file in "${files[@]}"; do
         *slim*|*debian*|*ubuntu*|*bookworm*|*trixie*|*bullseye*)
             want='apt-get upgrade'
             ;;
-        *)
-            echo "  skip  $file (base '$base' is neither Debian- nor Alpine-based)"
+        node:*|*/node:*|python:*|*/python:*|postgres:*|*/postgres:*|golang:*|*/golang:*)
+            # The unsuffixed official tags currently default to Debian. Keep
+            # them explicit so a plain `node:22` cannot bypass the guard.
+            want='apt-get upgrade'
+            ;;
+        scratch)
+            echo "  skip  $file (scratch has no OS package manager)"
             skipped=$((skipped + 1))
+            continue
+            ;;
+        *)
+            echo "  FAIL  $file — cannot classify base '$base'; add an explicit allow-list entry with a reason if it cannot be patched" >&2
+            failures=$((failures + 1))
             continue
             ;;
     esac

--- a/deploy/scripts/harden-docker-user.sh
+++ b/deploy/scripts/harden-docker-user.sh
@@ -85,39 +85,42 @@ BOTS_NET="${BOTS_NET:-vexa12-bots}"
 BOTS_CIDR="$(docker network inspect "$BOTS_NET" \
     --format '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)"
 
-if [ -n "$BOTS_CIDR" ]; then
-    echo ""
-    echo "Restricting $BOTS_NET ($BOTS_CIDR) → host ..."
-
-    MEETING_API_IP="$(docker inspect klai-core-vexa12-meeting-api-1 \
-        --format '{{range $k,$v := .NetworkSettings.Networks}}{{if eq $k "vexa12-bots"}}{{$v.IPAddress}}{{end}}{{end}}' \
-        2>/dev/null || true)"
-
-    # Idempotent: the unit re-runs on every boot and after every deploy. Clear the
-    # whole-subnet form too — it is what this script installed before the pin
-    # existed, and leaving it behind would keep every bot excepted.
-    while iptables -D INPUT -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
-    [ -n "$MEETING_API_IP" ] && \
-        while iptables -D INPUT -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
-    while iptables -D INPUT -s "$BOTS_CIDR" -j DROP 2>/dev/null; do :; done
-
-    # Order matters: the exception has to sit above the deny.
-    iptables -I INPUT 1 -s "$BOTS_CIDR" -j DROP
-    if [ -n "$MEETING_API_IP" ]; then
-        iptables -I INPUT 1 -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT
-        echo "  transcription exception: $MEETING_API_IP only"
-    else
-        echo "  WARNING: vexa12-meeting-api has no vexa12-bots address — transcription" >&2
-        echo "           exception NOT installed. Meetings will fail until this resolves." >&2
-    fi
-
-    echo "Done. INPUT rules for $BOTS_CIDR:"
-    iptables -L INPUT -n --line-numbers | grep -E "^(num|[0-9]+ .*${BOTS_CIDR//./\\.})" || true
-else
+if [ -z "$BOTS_CIDR" ]; then
     echo ""
     echo "WARNING: docker network '$BOTS_NET' not found — host-isolation rules NOT applied." >&2
     echo "         Bots can reach every host-bound port until this is resolved." >&2
+    exit 1
 fi
+
+echo ""
+echo "Restricting $BOTS_NET ($BOTS_CIDR) → host ..."
+
+MEETING_API_IP="$(docker inspect klai-core-vexa12-meeting-api-1 \
+    --format '{{range $k,$v := .NetworkSettings.Networks}}{{if eq $k "vexa12-bots"}}{{$v.IPAddress}}{{end}}{{end}}' \
+    2>/dev/null || true)"
+
+# Idempotent: the unit re-runs on every boot and after every deploy. Clear the
+# whole-subnet form too — it is what this script installed before the pin
+# existed, and leaving it behind would keep every bot excepted.
+while iptables -D INPUT -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
+[ -n "$MEETING_API_IP" ] && \
+    while iptables -D INPUT -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
+while iptables -D INPUT -s "$BOTS_CIDR" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; do :; done
+while iptables -D INPUT -s "$BOTS_CIDR" -j DROP 2>/dev/null; do :; done
+
+# Rules are inserted at position 1, so later inserts land above earlier ones.
+iptables -I INPUT 1 -s "$BOTS_CIDR" -j DROP
+iptables -I INPUT 1 -s "$BOTS_CIDR" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+if [ -z "$MEETING_API_IP" ]; then
+    echo "  WARNING: vexa12-meeting-api has no vexa12-bots address — transcription" >&2
+    echo "           exception NOT installed. Meetings will fail until this resolves." >&2
+    exit 1
+fi
+iptables -I INPUT 1 -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT
+echo "  transcription exception: $MEETING_API_IP only"
+
+echo "Done. INPUT rules for $BOTS_CIDR:"
+iptables -L INPUT -n --line-numbers | grep -E "^(num|[0-9]+ .*${BOTS_CIDR//./\\.})" || true
 
 echo ""
 echo "Persisting rules to /etc/iptables/rules.v4 ..."

--- a/deploy/scripts/tests/backup-retention.test.sh
+++ b/deploy/scripts/tests/backup-retention.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression test: a partial failed backup must not evict a complete local one.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/deploy/scripts/backup.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+BACKUP_ROOT="$TMP/backups"
+COMPOSE_DIR="$TMP/compose"
+mkdir -p "$BACKUP_ROOT" "$COMPOSE_DIR/secrets" "$TMP/bin"
+printf 'test-only\n' >"$COMPOSE_DIR/secrets/mongo_root_password.txt"
+touch "$COMPOSE_DIR/.env"
+
+# Thirty-one known-good backups make retention observable: a failed current run
+# must leave the oldest sentinel intact.
+for day in $(seq -w 1 31); do
+    mkdir -p "$BACKUP_ROOT/2026-07-$day"
+    touch "$BACKUP_ROOT/2026-07-$day/complete"
+done
+
+cat >"$TMP/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *".Config.Env"* && "$*" == *"klai-core-redis-1"* ]]; then
+    echo 'REDIS_PASSWORD=test-only'
+    exit 0
+fi
+if [[ "$*" == *".State.Running"* && "$*" == *"klai-core-vexa12-redis-1"* ]]; then
+    echo 'true'
+    exit 0
+fi
+exit 1
+STUB
+cat >"$TMP/bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+cat >"$TMP/bin/rsync" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$TMP/bin/docker" "$TMP/bin/sleep" "$TMP/bin/rsync"
+
+set +e
+PATH="$TMP/bin:$PATH" \
+BACKUP_DATE=2026-08-20 \
+BACKUP_ROOT="$BACKUP_ROOT" \
+COMPOSE_DIR="$COMPOSE_DIR" \
+STORAGEBOX_HOST=invalid.test \
+STORAGEBOX_USER=test-only \
+bash "$SCRIPT" >"$TMP/out" 2>&1
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: deliberately failed backup reported success" >&2
+    exit 1
+fi
+
+if [ ! -f "$BACKUP_ROOT/2026-07-01/complete" ]; then
+    echo "FAIL: failed backup ran local retention and evicted the oldest complete backup" >&2
+    sed 's/^/  /' "$TMP/out" >&2
+    exit 1
+fi
+
+if ! grep -qi "retention.*skip\|skip.*retention" "$TMP/out"; then
+    echo "FAIL: failed backup did not explain that local retention was skipped" >&2
+    sed 's/^/  /' "$TMP/out" >&2
+    exit 1
+fi
+
+echo "backup retention after failed steps: OK"

--- a/deploy/scripts/tests/check-dockerfile-security-updates.test.sh
+++ b/deploy/scripts/tests/check-dockerfile-security-updates.test.sh
@@ -54,6 +54,18 @@ f=$(fixture Dockerfile.debian_missing \
     'COPY app app')
 run_guard "$f"; check "debian base without the upgrade -> fail" 1 "$rc"
 
+for base in node:22 python:3.12 postgres:16 golang:1.25; do
+    f=$(fixture "Dockerfile.plain-${base%%:*}" \
+        "FROM $base" \
+        'RUN echo shipped-without-security-updates')
+    run_guard "$f"; check "plain Debian-family base $base without apt upgrade -> fail" 1 "$rc"
+done
+
+f=$(fixture Dockerfile.plain_debian_ok \
+    'FROM node:22' \
+    'RUN apt-get update && apt-get upgrade -y --no-install-recommends')
+run_guard "$f"; check "plain Debian-family base with apt upgrade -> pass" 0 "$rc"
+
 f=$(fixture Dockerfile.alpine_ok \
     'FROM node:22-alpine' \
     'RUN apk update && apk upgrade --no-cache')
@@ -110,6 +122,17 @@ if grep -q "skip" "$work/out"; then
     echo "  ok     says it skipped rather than passing silently"
 else
     echo "  FAIL   skipped without saying so"
+    failures=$((failures + 1))
+fi
+
+f=$(fixture Dockerfile.unknown \
+    'FROM vendor/custom-runtime:1.0' \
+    'RUN echo unknown-package-manager')
+run_guard "$f"; check "unclassifiable base -> fail loudly" 1 "$rc"
+if grep -q "cannot classify" "$work/out"; then
+    echo "  ok     explains that the base needs classification or an allow-list entry"
+else
+    echo "  FAIL   unclassifiable base failed without an actionable reason"
     failures=$((failures + 1))
 fi
 

--- a/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+++ b/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SCRIPT="$REPO_ROOT/deploy/scripts/harden-docker-user.sh"
+WORKFLOW="$REPO_ROOT/.github/workflows/deploy-compose.yml"
 FAIL=0
 
 run_script() {
@@ -58,7 +59,11 @@ exit 0
 STUB
     chmod +x "$tmp/docker" "$tmp/iptables" "$tmp/iptables-save"
 
-    PATH="$tmp:$PATH" bash "$SCRIPT" eth0 >"$tmp/out" 2>"$tmp/err" || true
+    # Redirect persistence into the fixture directory while preserving every
+    # executable branch of the production script.
+    sed "s|/etc/iptables/rules.v4|$tmp/rules.v4|g" "$SCRIPT" \
+        | PATH="$tmp:$PATH" bash -s -- eth0 >"$tmp/out" 2>"$tmp/err"
+    LAST_RC=$?
     cat "$tmp/calls.log" 2>/dev/null > "$tmp/calls.final"
     LAST_OUT="$(cat "$tmp/out" "$tmp/err" 2>/dev/null)"
     LAST_CALLS="$(cat "$tmp/calls.final" 2>/dev/null)"
@@ -73,6 +78,9 @@ check() {
 echo "── bot host-isolation guard ──"
 
 run_script "172.29.0.0/16"
+
+check "a resolved network and pin exit successfully" \
+    test "$LAST_RC" -eq 0
 
 check "subnet comes from Docker, not a literal" \
     bash -c 'echo "$0" | grep -q -- "-s 172.29.0.0/16"' "$LAST_CALLS"
@@ -100,8 +108,17 @@ check "the exception is inserted after the DROP, so it lands above it" \
       acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.10 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
       [ -n "$drop" ] && [ -n "$acc" ] && [ "$acc" -gt "$drop" ]' "$LAST_CALLS"
 
+check "established host-initiated connections are accepted above the DROP" \
+    bash -c '
+      drop=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP" | tail -1 | cut -d: -f1)
+      established=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" | tail -1 | cut -d: -f1)
+      [ -n "$drop" ] && [ -n "$established" ] && [ "$established" -gt "$drop" ]' "$LAST_CALLS"
+
 check "existing rules are cleared first, so re-runs do not stack" \
     bash -c 'echo "$0" | grep -q -- "-D INPUT -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
+
+check "the established-connection rule is cleared first on re-run" \
+    bash -c 'echo "$0" | grep -q -- "-D INPUT -s 172.29.0.0/16 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"' "$LAST_CALLS"
 
 # Network gone: the script must say so rather than quietly leaving bots exposed.
 run_script ""
@@ -111,6 +128,9 @@ check "a missing bot network produces no INPUT rules" \
 
 check "a missing bot network warns loudly" \
     bash -c 'echo "$0" | grep -qi "WARNING.*not found"' "$LAST_OUT"
+
+check "a missing bot network fails the firewall unit" \
+    test "$LAST_RC" -ne 0
 
 # The pin disappearing must fail CLOSED: deny stays, exception is not installed,
 # and it says so. Silently widening back to the subnet would undo the whole point.
@@ -126,6 +146,85 @@ check "a missing pin installs NO exception (fails closed)" \
 
 check "a missing pin warns loudly" \
     bash -c 'echo "$0" | grep -qi "WARNING.*transcription"' "$LAST_OUT"
+
+check "a missing pin fails the firewall unit" \
+    test "$LAST_RC" -ne 0
+
+# Execute the real tail of the embedded deploy script with boundary commands
+# stubbed. This catches ordering and exit-code bugs without SSH or Docker.
+run_workflow_tail() {
+    local scenario="$1"
+    local tmp; tmp="$(mktemp -d)"
+
+    awk '
+      /echo "::group::SPEC-MCP-RETRIEVAL-001 follow-up/ { capture=1 }
+      capture && /# SPEC-SEC-024 M4.3 — non-blocking post-deploy smoke-test/ { exit }
+      capture { sub(/^            /, ""); print }
+    ' "$WORKFLOW" | sed 's|cd /opt/klai|cd "$WORK_DIR"|' >"$tmp/workflow-tail.sh"
+
+    cat >"$tmp/docker" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  "compose config --services")
+    case "$SCENARIO" in
+      config_fail) printf 'portal\nlitellm\n'; exit 23 ;;
+      empty)       printf 'litellm\n'; exit 0 ;;
+      *)           printf 'portal\nlitellm\n'; exit 0 ;;
+    esac
+    ;;
+  compose\ up\ -d\ --remove-orphans*)
+    echo "compose-up $*" >>"$CALLS"
+    [ "$SCENARIO" = compose_fail ] && exit 42
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+    cat >"$tmp/sudo" <<'STUB'
+#!/usr/bin/env bash
+echo "sudo $*" >>"$CALLS"
+exit 0
+STUB
+    cat >"$tmp/systemctl" <<'STUB'
+#!/usr/bin/env bash
+echo "systemctl $*" >>"$CALLS"
+exit 0
+STUB
+    chmod +x "$tmp/docker" "$tmp/sudo" "$tmp/systemctl"
+
+    set +e
+    PATH="$tmp:$PATH" SCENARIO="$scenario" CALLS="$tmp/calls" WORK_DIR="$tmp" \
+        bash -e "$tmp/workflow-tail.sh" >"$tmp/out" 2>&1
+    WORKFLOW_RC=$?
+    set -e
+    WORKFLOW_OUT="$(cat "$tmp/out")"
+    WORKFLOW_CALLS="$(cat "$tmp/calls" 2>/dev/null || true)"
+    rm -rf "$tmp"
+}
+
+run_workflow_tail config_fail
+check "a compose-config pipeline failure aborts before compose up" \
+    test "$WORKFLOW_RC" -eq 23
+check "a compose-config failure cannot trigger an all-services recreate" \
+    bash -c '! grep -q "compose-up" <<<"$0"' "$WORKFLOW_CALLS"
+
+run_workflow_tail empty
+check "an empty env-drift service list fails loudly" \
+    bash -c '[ "$1" -ne 0 ] && grep -qi "no env-drift services" <<<"$0"' "$WORKFLOW_OUT" "$WORKFLOW_RC"
+check "an empty service list never reaches compose up" \
+    bash -c '! grep -q "compose-up" <<<"$0"' "$WORKFLOW_CALLS"
+
+run_workflow_tail compose_fail
+check "a failed main compose retains its original exit code" \
+    test "$WORKFLOW_RC" -eq 42
+check "a failed main compose still re-applies the firewall exactly once" \
+    bash -c '[ "$(grep -c "^sudo systemctl restart klai-harden-firewall.service$" <<<"$0")" -eq 1 ]' "$WORKFLOW_CALLS"
+check "the env-drift compose call still excludes litellm" \
+    bash -c 'grep -q "compose-up .* portal" <<<"$0" && ! grep -q "compose-up .* litellm" <<<"$0"' "$WORKFLOW_CALLS"
+
+run_workflow_tail success
+check "a successful main compose re-applies the firewall exactly once" \
+    bash -c '[ "$1" -eq 0 ] && [ "$(grep -c "^sudo systemctl restart klai-harden-firewall.service$" <<<"$0")" -eq 1 ]' "$WORKFLOW_CALLS" "$WORKFLOW_RC"
 
 echo "──────────────────────────────"
 if [ "$FAIL" -eq 0 ]; then

--- a/deploy/scripts/tests/verify-alert-datasource-access.test.sh
+++ b/deploy/scripts/tests/verify-alert-datasource-access.test.sh
@@ -86,21 +86,15 @@ else
   bad "expected exit 2, got $rc: $(cat "$TMP/out2")"
 fi
 
-# ── 3. The allowlist is empty, and its validator rejects rot ──────────────
+# ── 3. Every allowlist entry is valid, and its validator rejects rot ───────
 # KNOWN_BLIND records rules we know are blind. Two ways it goes bad: an entry
 # whose rule no longer exists (a lie), and an entry nobody ever revisits (a
 # permanent exception wearing a reason). Both must fail CI.
 echo "3. KNOWN_BLIND hygiene"
-if "$PYTHON" -c "
-import pathlib, sys
-src = pathlib.Path('$SCRIPT').read_text()
-ns = {}
-exec(compile(src.split('def _validate_allowlist')[0], 'chk', 'exec'), ns)
-sys.exit(0 if ns['KNOWN_BLIND'] == {} else 1)
-" 2>/dev/null; then
-  ok "allowlist is empty (every rule reads its own data)"
+if plan "$REPO_ROOT/deploy/grafana/provisioning/alerting" >/dev/null; then
+  ok "all current exemptions pass live-uid, statement and expiry validation"
 else
-  bad "allowlist is non-empty -- each entry needs a live uid, a >=40-char statement and a future expired_at"
+  bad "one or more current exemptions are malformed, expired or stale"
 fi
 
 # Drive the validator directly with hostile entries; building fixture YAML for
@@ -154,6 +148,44 @@ if [ "$rc" -eq 0 ]; then
   ok "accepts a well-formed exemption"
 else
   bad "a live uid with a long statement and a near-future expiry should pass"
+fi
+
+# The deploy invokes the checker without --plan. Keep that real mode behind the
+# same validator; otherwise CI can validate exemptions while production ignores
+# an entry that expired between review and deploy.
+mkdir -p "$TMP/runtime"
+cat >"$TMP/runtime/rules.yaml" <<'YAML'
+apiVersion: 1
+groups:
+  - name: runtime
+    rules:
+      - uid: live-rule
+        data:
+          - model:
+              datasource:
+                type: postgres
+              rawSql: SELECT count(*) FROM live_table
+YAML
+cat >"$TMP/run.py" <<'PY'
+import json, pathlib, sys
+src = pathlib.Path(sys.argv[1]).read_text()
+ns = {}
+exec(compile(src, "chk", "exec"), ns)
+ns["KNOWN_BLIND"].clear()
+ns["KNOWN_BLIND"].update(json.loads(sys.argv[3]))
+ns["_check_rule"] = lambda _uid, _sql: []
+sys.exit(ns["main"](["chk", sys.argv[2]]))
+PY
+
+set +e
+out="$($PYTHON "$TMP/run.py" "$SCRIPT" "$TMP/runtime" \
+  "{\"live-rule\": {\"statement\": \"$LONG\", \"expired_at\": \"$PAST\"}}" 2>&1)"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qi "expired on"; then
+  ok "real run mode rejects an expired exemption before datasource checks"
+else
+  bad "real run mode should reject an expired exemption (rc=$rc): $out"
 fi
 
 # ── 4. Schema-qualified names and aliases survive extraction ──────────────

--- a/deploy/scripts/verify-alert-datasource-access.py
+++ b/deploy/scripts/verify-alert-datasource-access.py
@@ -64,10 +64,10 @@ POSTGRES_CONTAINER = "klai-core-postgres-1"
 # Rules known to be blind, keyed by uid. An entry does NOT make a rule work --
 # it records that we looked, understood, and chose not to fix it in that change.
 #
-# Empty, and worth keeping that way. The one entry this started with
+# Currently empty. The one entry this started with
 # (spec-priv-001-tenant-stuck-full) was retired on 2026-08-17 by giving the rule
-# a superuser-owned view over the telemetry transitions it needs, rather than by
-# writing a better excuse.
+# a superuser-owned view over the telemetry transitions it needs. Future entries
+# are permitted only while they satisfy the validation below.
 #
 # The shape mirrors .trivyignore.yaml deliberately, because that file solved the
 # harder half of this problem: an exception with only a reason lives forever, so
@@ -291,16 +291,17 @@ def main(argv: list[str]) -> int:
         print("report success on an empty check.")
         return 2
 
+    problems = _validate_allowlist({uid for _f, uid, _s in rules})
+    if problems:
+        print("ERROR: KNOWN_BLIND is not valid:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
     if plan_only:
         for _file, uid, raw_sql in rules:
             for rel in referenced_relations(raw_sql):
                 print(f"{uid}\t{rel}")
-        problems = _validate_allowlist({uid for _f, uid, _s in rules})
-        if problems:
-            print("ERROR: KNOWN_BLIND is not valid:", file=sys.stderr)
-            for problem in problems:
-                print(f"  - {problem}", file=sys.stderr)
-            return 1
         return 0
 
     exit_code = 0


### PR DESCRIPTION
## Summary

- re-apply bot-network firewall rules after the final Compose reconciliation, including when Compose fails after recreating a network
- fail the deploy on Compose/config resolution errors and refuse an empty env-drift service list
- fail firewall setup when Docker network state cannot be resolved and preserve host-initiated established connections
- validate alert exemptions in deploy mode, skip retention after partial backups, and fail unknown Docker base classification
- add regression coverage and CI wiring for all affected deploy guards

## Verification

- `uv run --with pyyaml -- bash -c 'for test in deploy/scripts/tests/*.test.sh; do bash "$test"; done'`
- `for test in deploy/scripts/tests/*.test.mjs; do node "$test"; done`
- `bash scripts/test-alerting-guards.sh`
- `shellcheck -e SC2188,SC1003,SC2016,SC2329 ...` on all edited shell scripts
- Bash syntax, Python compile, YAML parse, and `git diff --check`

The workflow regression harness executes the embedded deploy tail with stubbed boundaries. It proves config failure aborts before Compose, an empty list cannot become an all-services recreate, Compose exit 42 stays exit 42, and firewall re-apply runs exactly once on both failure and success.

## Deliberately not included

- meeting-api/bot-network authorization redesign (network removal versus scoped per-request secret)
- host-owned `klai-harden-firewall.service` changes in the private infra repository
- the pre-existing `backup.sh run_step`/`set -e` interaction, which needs a separate focused fix