### PR TITLE
fix(crawler): address pacing and frontier review findings

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -24,7 +24,12 @@ from klai_image_storage import ImageStore, download_and_upload_crawl_images
 
 from knowledge_ingest import pg_store, qdrant_store
 from knowledge_ingest.config import settings
-from knowledge_ingest.crawl4ai_client import CrawlResult, _canonicalise_url, crawl_site
+from knowledge_ingest.crawl4ai_client import (
+    CrawlRateLimitState,
+    CrawlResult,
+    _canonicalise_url,
+    crawl_site,
+)
 from knowledge_ingest.crawl_checkpoint import (
     ConnectionFactory,
     CrawlExecutionBusy,
@@ -422,6 +427,7 @@ def _build_crawl_outcome_warning(
         outcome
         for outcome in fetch_outcomes
         if str(outcome.get("reason_code") or "").startswith(_NOT_FETCHED_REASON_PREFIX)
+        and not _outcome_is_deliberately_filtered(outcome)
     ]
     if not omitted:
         return None
@@ -443,6 +449,13 @@ def _build_crawl_outcome_warning(
     }
 
 
+def _outcome_is_deliberately_filtered(outcome: dict) -> bool:
+    """Return whether a not-fetched outcome records an intentional URL filter."""
+    return outcome.get("reason_code") == FetchReasonCode.NOT_FETCHED_EXCLUDED.value and bool(
+        outcome.get("filter_reason")
+    )
+
+
 def _crawl_fully_fetched(fetch_outcomes: list[dict]) -> bool:
     """True only when every discovered candidate URL was actually fetched.
 
@@ -460,8 +473,9 @@ def _crawl_fully_fetched(fetch_outcomes: list[dict]) -> bool:
 
     Reconciliation may only run when every discovered URL was demonstrably
     resolved (``success`` or ``non_content_listing_page``) — never on a
-    real fetch failure, and never on a deliberately-unfetched
-    ``not_fetched_*`` scheduling omission (budget/depth/exclude/duplicate).
+    real fetch failure, and never on an unresolved ``not_fetched_*`` scheduling
+    omission (budget/depth/exclude/duplicate). An explicit filtered-seed outcome
+    is resolved by policy and therefore does not block reconciliation.
     This is intentionally conservative: a crawl with any incompleteness at
     all skips reconciliation entirely rather than trying to distinguish
     "gone" from "not reached this run" — the more precise three-way split
@@ -469,6 +483,8 @@ def _crawl_fully_fetched(fetch_outcomes: list[dict]) -> bool:
     follow-up.
     """
     for outcome in fetch_outcomes:
+        if _outcome_is_deliberately_filtered(outcome):
+            continue
         reason = str(outcome.get("reason_code") or "")
         if reason in _FETCH_FAILURE_REASON_CODES:
             return False
@@ -659,8 +675,16 @@ async def _apply_domain_rate_limit_effect_once(
     domain_rate_limit_state: DomainRateLimitState,
     effective_rate_limit: float,
     default_rate_limit: float,
+    final_rate_limit: float | None = None,
 ) -> None:
-    """Apply this crawl's AIMD observation atomically with its replay marker."""
+    """Apply this crawl's AIMD observation atomically with its replay marker.
+
+    Deel B already halves the live rate in response to this job's congestion.
+    For a congested crawl, persist the lower of the normal AIMD result and
+    that final live rate. This carries the actual pacing state into the next
+    crawl without halving it a second time for the same observations. Clean
+    crawls do not use this clamp, so additive recovery remains possible.
+    """
     async with conn.transaction():
         command = await conn.execute(
             """
@@ -707,6 +731,17 @@ async def _apply_domain_rate_limit_effect_once(
         )
         if updated_state is None:
             return
+        if (
+            congestion_verdict
+            and final_rate_limit is not None
+            and updated_state.rate_limit is not None
+            and final_rate_limit < updated_state.rate_limit
+        ):
+            updated_state = DomainRateLimitState(
+                rate_limit=final_rate_limit,
+                clean_streak=updated_state.clean_streak,
+                last_congestion_at=updated_state.last_congestion_at,
+            )
 
         write_kind = (
             DomainRateLimitWriteKind.CONGESTION
@@ -933,6 +968,7 @@ async def run_crawl_job(
         # one entry per discovered candidate URL — written to
         # ``crawl_jobs.fetch_outcomes`` so operators can answer "where did
         # the missing pages go?" without log forensics.
+        crawl_rate_limit_state = CrawlRateLimitState(effective_rate_limit)
         results, fetch_outcomes = await crawl_site(
             start_url=start_url,
             selector=content_selector,
@@ -945,6 +981,7 @@ async def run_crawl_job(
             rate_limit=effective_rate_limit,
             cancel_check=cancel_check,
             checkpoint=primary_checkpoint,
+            rate_limit_state=crawl_rate_limit_state,
         )
 
         # 2026-08-19 (crawl-cancel): detected purely from the reason code
@@ -986,6 +1023,8 @@ async def run_crawl_job(
                 discovery_seed_url=discovery_seed_url,
                 primary_pages=len(results),
             )
+            seed_starting_rate_limit = crawl_rate_limit_state.current_rate_limit
+            seed_rate_limit_state = CrawlRateLimitState(seed_starting_rate_limit)
             seed_results, seed_outcomes = await crawl_site(
                 start_url=discovery_seed_url,
                 selector=content_selector,
@@ -995,7 +1034,7 @@ async def run_crawl_job(
                 exclude_patterns=exclude_patterns,
                 login_indicator_selector=login_indicator_selector,
                 cookies=cookies,
-                rate_limit=effective_rate_limit,
+                rate_limit=seed_starting_rate_limit,
                 cancel_check=cancel_check,
                 checkpoint=PostgresCrawlCheckpoint(
                     connection_factory,
@@ -1004,7 +1043,14 @@ async def run_crawl_job(
                     scope="discovery_seed",
                     generation=execution_generation,
                 ),
+                rate_limit_state=seed_rate_limit_state,
             )
+            if seed_rate_limit_state.current_rate_limit is not None and (
+                crawl_rate_limit_state.current_rate_limit is None
+                or seed_rate_limit_state.current_rate_limit
+                < crawl_rate_limit_state.current_rate_limit
+            ):
+                crawl_rate_limit_state.current_rate_limit = seed_rate_limit_state.current_rate_limit
             seen = {_canonicalise_url(r.url) for r in results}
             for seed_result in seed_results:
                 canon = _canonicalise_url(seed_result.url)
@@ -1047,6 +1093,7 @@ async def run_crawl_job(
                 domain_rate_limit_state=domain_rate_limit_state,
                 effective_rate_limit=effective_rate_limit,
                 default_rate_limit=rate_limit,
+                final_rate_limit=crawl_rate_limit_state.current_rate_limit,
             )
 
         crawl_outcome_warning = _build_crawl_outcome_warning(

--- a/klai-knowledge-ingest/knowledge_ingest/app.py
+++ b/klai-knowledge-ingest/knowledge_ingest/app.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from knowledge_ingest import db, kb_config, org_config, qdrant_store
 from knowledge_ingest._patch_graphiti import apply as _apply_graphiti_patch
 from knowledge_ingest.config import settings
+from knowledge_ingest.host_pacing import ensure_single_process_host_pacing
 from knowledge_ingest.logging_setup import RequestContextMiddleware, setup_logging
 from knowledge_ingest.middleware.auth import InternalSecretMiddleware
 from knowledge_ingest.routes import (
@@ -30,6 +31,7 @@ _apply_graphiti_patch()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):  # noqa: ARG001 — FastAPI lifespan contract requires this param
+    ensure_single_process_host_pacing()
     logger.info("starting_knowledge_ingest_service")
     await qdrant_store.ensure_collection()
     logger.info("qdrant_collection_ready")

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -173,6 +173,13 @@ class CrawlResult:
     raw_error_text: str | None = None
 
 
+@dataclass
+class CrawlRateLimitState:
+    """Mutable handoff of the rate actually in effect when ``crawl_site`` ends."""
+
+    current_rate_limit: float | None
+
+
 DiscoverySourceKind = Literal["start", "sitemap", "page_link"]
 DiscoveryStatus = Literal["queued", "fetched", "omitted"]
 
@@ -308,9 +315,11 @@ def _url_has_non_html_extension(url: str) -> bool:
 # what the site's HTML attribute contained, un-rendered placeholder syntax
 # included. Such a link is never a real page: fetching it 404s with a tiny
 # error body, and crawl4ai's structural anti-bot heuristic then misreads the
-# small page as a block (see ``_classify_fetch_outcome``), which — because
-# BLOCKED_ANTI_BOT stops the rest of the crawl (``_STOP_CHUNKING_REASON_CODES``)
-# — aborted 192 real pages over four bogus template links in production.
+# small page as a block (see ``_classify_fetch_outcome``). At the time,
+# BLOCKED_ANTI_BOT unconditionally stopped chunking, so four bogus template
+# links aborted 192 real pages in production. Since 2026-08-18 anti-bot stops
+# use a crawl-wide ratio+floor gate instead; filtering bogus URLs remains the
+# correct way to keep them out of both the ratio and the network path.
 #
 # Checked against both the raw URL and its percent-decoded form: some sites'
 # JS builds the href through something like ``encodeURIComponent`` before
@@ -418,8 +427,8 @@ def build_crawl_config(
     difference. Both keys pass crawl4ai's untrusted-config boundary
     (HTTP 200), which is why the original fix looked like it worked in
     testing — the server silently accepts and discards them. Real pacing
-    happens client-side in ``_chunked_bulk_fetch`` (burst size via
-    ``_burst_size_for`` + inter-chunk sleep), not here.
+    happens client-side through ``host_pacing.HostGateRegistry`` and
+    ``HostPacingSession.acquire``, not here.
     """
     md_gen: dict[str, Any] = {
         "type": "DefaultMarkdownGenerator",
@@ -2107,8 +2116,33 @@ async def crawl_site(
     rate_limit: float | None = None,
     cancel_check: Callable[[], Awaitable[bool]] | None = None,
     checkpoint: CrawlCheckpoint | None = None,
+    rate_limit_state: CrawlRateLimitState | None = None,
 ) -> tuple[list[CrawlResult], list[FetchOutcome]]:
-    """Crawl one site through a host schedule shared by overlapping jobs."""
+    """Crawl one site through a host schedule shared by overlapping jobs.
+
+    A filtered seed is never fetched. Unlike a filtered discovered link, the
+    caller explicitly supplied the seed, so return ``not_fetched_excluded``
+    with a ``filter_reason`` instead of silently dropping it. This makes the
+    invalid job input visible without introducing a second reason-code enum.
+    """
+    filter_reason: str | None = None
+    if _url_has_non_html_extension(start_url):
+        filter_reason = "non_html_extension"
+    elif _url_has_unrendered_template_syntax(start_url):
+        filter_reason = "unrendered_template_syntax"
+    if filter_reason is not None:
+        logger.warning(
+            "crawl_seed_url_filtered",
+            start_url=start_url,
+            filter_reason=filter_reason,
+        )
+        outcome = _outcome_for_not_attempted_url(
+            start_url,
+            reason_code=FetchReasonCode.NOT_FETCHED_EXCLUDED.value,
+        )
+        outcome["filter_reason"] = filter_reason
+        return [], [outcome]
+
     async with _host_pacing_scope(start_url, rate_limit):
         return await _crawl_site_in_host_scope(
             start_url=start_url,
@@ -2122,6 +2156,7 @@ async def crawl_site(
             rate_limit=rate_limit,
             cancel_check=cancel_check,
             checkpoint=checkpoint,
+            rate_limit_state=rate_limit_state,
         )
 
 
@@ -2137,6 +2172,7 @@ async def _crawl_site_in_host_scope(
     rate_limit: float | None = None,
     cancel_check: Callable[[], Awaitable[bool]] | None = None,
     checkpoint: CrawlCheckpoint | None = None,
+    rate_limit_state: CrawlRateLimitState | None = None,
 ) -> tuple[list[CrawlResult], list[FetchOutcome]]:
     """Crawl a site with a Klai-owned deterministic frontier.
 
@@ -2145,8 +2181,8 @@ async def _crawl_site_in_host_scope(
     ``not_fetched_*`` outcome, so page-budget/depth limits fail loudly.
 
     ``rate_limit`` (requests/second, optional) paces the bulk-fetch chunks
-    client-side — see ``_chunked_bulk_fetch`` / ``_burst_size_for`` for the
-    mechanism, and ``build_crawl_config``'s docstring for why crawl4ai's own
+    client-side — see ``host_pacing.HostGateRegistry`` for the mechanism,
+    and ``build_crawl_config``'s docstring for why crawl4ai's own
     ``CrawlerRunConfig`` pacing knobs (``semaphore_count`` / ``mean_delay``)
     cannot do this: the REST server ignores them.
 
@@ -2175,6 +2211,15 @@ async def _crawl_site_in_host_scope(
         login_indicator_selector=login_indicator_selector,
     )
     restored = await checkpoint.load() if checkpoint is not None else None
+    current_rate_limit = restored.get("current_rate_limit", rate_limit) if restored else rate_limit
+    if rate_limit_state is not None:
+        rate_limit_state.current_rate_limit = current_rate_limit
+    pacing_session = _current_host_pacing_session.get()
+    if pacing_session is not None and current_rate_limit != rate_limit:
+        # ``crawl_site`` opens the host gate before loading its checkpoint.
+        # Keep the live traffic schedule aligned with the restored slowdown,
+        # not only the mutable state handed back to the adapter.
+        pacing_session.update_rate(current_rate_limit)
     if restored is not None:
         if restored.get("version") != 1 or restored.get("start_url") != start_url:
             raise ValueError("crawl checkpoint does not match this crawl")
@@ -2241,13 +2286,14 @@ async def _crawl_site_in_host_scope(
     # Deel B (2026-08-18) — the in-job rate_limit actually used for the NEXT
     # ``_chunked_bulk_fetch`` call. Starts at the caller's ``rate_limit`` and
     # only ever moves DOWN, via ``_lower_rate_limit_for_slowdown``, after an
-    # observed RATE_LIMITED stop signal — never persisted, never raised back
-    # up within this call (the persisted domain-level AIMD controller in
-    # ``domain_rate_limit_control`` owns raising it back up, once, after the
-    # job completes, for the NEXT crawl). ``consecutive_rate_limit_slowdowns``
+    # observed RATE_LIMITED stop signal — never raised back up within this
+    # call. The final value is handed to the adapter through
+    # ``rate_limit_state`` and clamps the persisted AIMD congestion result, so
+    # the NEXT crawl starts at the rate this one actually reached. The
+    # domain-level controller still owns later additive recovery.
+    # ``consecutive_rate_limit_slowdowns``
     # bounds how many times in a row that can happen before giving up — see
     # ``_MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS``.
-    current_rate_limit = restored.get("current_rate_limit", rate_limit) if restored else rate_limit
     consecutive_rate_limit_slowdowns = int(
         restored.get("consecutive_rate_limit_slowdowns", 0) if restored else 0
     )
@@ -2414,6 +2460,8 @@ async def _crawl_site_in_host_scope(
             elif consecutive_rate_limit_slowdowns < _MAX_CONSECUTIVE_RATE_LIMIT_SLOWDOWNS:
                 consecutive_rate_limit_slowdowns += 1
                 current_rate_limit = _lower_rate_limit_for_slowdown(current_rate_limit)
+                if rate_limit_state is not None:
+                    rate_limit_state.current_rate_limit = current_rate_limit
                 pacing_session = _current_host_pacing_session.get()
                 if pacing_session is not None:
                     pacing_session.update_rate(current_rate_limit)
@@ -3319,15 +3367,8 @@ async def _recover_thin_bulk_results(
 # belief that crawl4ai's own RateLimiter enforced our ``rate_limit``
 # server-side. Measured 2026-08-18 (see build_crawl_config's docstring):
 # it does not — ``mean_delay``/``semaphore_count`` are silently ignored by
-# the REST server. That formula is removed; pacing lives entirely in
-# ``_chunked_bulk_fetch`` now.
-
-
-# crawl4ai 0.8 server enforces ``List should have at most 100 items after
-# validation`` on POST /crawl ``urls``. The constant lives here so it can
-# be raised in lock-step with any future crawl4ai schema relaxation.
-# Discovered live on help.voys.nl (208 sitemap entries → 422 → 1 ingested).
-_BULK_CHUNK_SIZE = 100
+# the REST server. That formula is removed; pacing lives in
+# ``host_pacing.HostGateRegistry`` now.
 
 # Client-side pacing (2026-08-18, fix/client-side-crawl-pacing): measured
 # live against the running crawl4ai server that ``mean_delay`` /
@@ -3337,37 +3378,9 @@ _BULK_CHUNK_SIZE = 100
 # ``mean_delay=2.0`` finished in 3.2s instead of the predicted 16s, and
 # ``semaphore_count`` 1 vs 8 made no measurable difference. Separately, a
 # single bulk chunk IS one burst on the target site: 16 URLs in one request
-# completed within 330ms of each other. Real rate limiting can therefore
-# only happen client-side, via the two knobs we actually control: how many
-# URLs go in one request (the burst — see ``_burst_size_for``) and how long
-# we wait between requests (the gap — see ``_chunked_bulk_fetch``).
-#
-# ``_BURST_WINDOW_SECONDS`` is the size of that accounting window: how much
-# a site is allowed to receive within one window, at the requested
-# rate_limit. A larger window produces bigger bursts with longer pauses
-# between them (fewer HTTP round-trips, coarser pacing); a smaller window
-# is smoother traffic but costs more round-trips for the same rate.
-_BURST_WINDOW_SECONDS = 10.0
-
-
-def _burst_size_for(rate_limit: float | None) -> int:
-    """Translate a requests/second rate limit into a per-request burst size.
-
-    ``rate_limit is None`` means no client-side pacing was requested: keep
-    the historical fixed chunk size (``_BULK_CHUNK_SIZE``), so crawls
-    without a rate_limit are completely unaffected by this function.
-
-    Uses ``int(x + 0.5)``, deliberately NOT ``round()``. Python's
-    ``round()`` uses banker's rounding to the nearest even integer —
-    ``round(0.5) == 0`` and ``round(2.5) == 2`` — which already caused a
-    real bug in this codebase (``build_crawl_config``'s
-    ``semaphore_count = max(1, min(round(rate_limit), 8))`` collapsed
-    ``rate_limit=0.5`` down to 1 instead of the intended 2). Do not
-    reintroduce ``round()`` here.
-    """
-    if rate_limit is None:
-        return _BULK_CHUNK_SIZE
-    return max(1, min(_BULK_CHUNK_SIZE, int(rate_limit * _BURST_WINDOW_SECONDS + 0.5)))
+# completed within 330ms of each other. Real rate limiting therefore happens
+# client-side through ``host_pacing.HostGateRegistry``. That module is the
+# single owner of burst sizing and the gap between weighted requests.
 
 
 # Total budget (per crawl_site call) for sequential one-URL-at-a-time
@@ -3408,8 +3421,8 @@ _CRAWL4AI_RATE_LIMIT_BACKOFF_CEILING_SECONDS = 3 * 60.0
 _recovery_sleep = asyncio.sleep
 _recovery_monotonic = time.monotonic
 
-# Same indirection, dedicated to the client-side bulk-chunk pacing in
-# ``_chunked_bulk_fetch`` (see ``_burst_size_for`` above). Kept separate
+# Same indirection, dedicated to the client-side host pacing used by
+# ``_chunked_bulk_fetch``. Kept separate
 # from ``_recovery_sleep`` / ``_recovery_monotonic`` — they pace an
 # unrelated loop (sequential 5xx recovery) and patching one must not
 # silently affect the other.
@@ -3479,12 +3492,11 @@ def _lower_rate_limit_for_slowdown(current_rate_limit: float | None) -> float:
     """Halve ``current_rate_limit`` after an observed RATE_LIMITED stop.
 
     Reuses ``domain_rate_limit_control.MIN_DOMAIN_RATE_LIMIT`` as the floor
-    instead of inventing a second, arbitrary one — keeps this ephemeral,
-    in-job backoff consistent with the persisted domain-level halving that
-    already uses that floor. This one is NEVER persisted: it only affects
-    the rest of THIS ``crawl_site`` call, and the domain-level controller
-    (applied once, after the job completes, for the NEXT crawl) is
-    untouched and unaffected — see ``compute_domain_rate_limit_update``.
+    instead of inventing a second, arbitrary one — keeps this in-job backoff
+    consistent with the persisted domain-level halving that already uses that
+    floor. ``crawl_site`` hands the final value back through
+    ``CrawlRateLimitState``; the adapter uses it as an upper cap on the
+    normal congestion update without applying a second halving.
     """
     baseline = (
         current_rate_limit
@@ -3695,6 +3707,52 @@ async def _bfs_deep_crawl(
 # (config.py) for the production evidence and the replacement, crawl-wide
 # ratio+floor gate applied further down in this function.
 _STOP_CHUNKING_REASON_CODES = frozenset({FetchReasonCode.RATE_LIMITED.value})
+_NON_STOP_CHUNKING_REASON_CODES = frozenset(
+    {
+        FetchReasonCode.SUCCESS.value,
+        FetchReasonCode.HTTP_4XX.value,
+        FetchReasonCode.HTTP_5XX.value,
+        FetchReasonCode.TIMEOUT.value,
+        FetchReasonCode.DNS_ERROR.value,
+        FetchReasonCode.CONNECTION_ERROR.value,
+        FetchReasonCode.AUTH_ERROR.value,
+        FetchReasonCode.PARSE_ERROR.value,
+        FetchReasonCode.NON_CONTENT_LISTING_PAGE.value,
+        FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value,
+        FetchReasonCode.NOT_FETCHED_DEPTH_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_DISCOVERY_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_EXCLUDED.value,
+        FetchReasonCode.NOT_FETCHED_DUPLICATE.value,
+        FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+        FetchReasonCode.UNKNOWN_EXCEPTION.value,
+        # BLOCKED_ANTI_BOT only stops through the separate crawl-wide ratio
+        # gate; one occurrence is deliberately not an unconditional stop.
+        FetchReasonCode.BLOCKED_ANTI_BOT.value,
+        FetchReasonCode.REFUSED.value,
+        FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value,
+        FetchReasonCode.NOT_FETCHED_CANCELLED.value,
+    }
+)
+_overlapping_stop_chunking_reason_codes = (
+    _STOP_CHUNKING_REASON_CODES & _NON_STOP_CHUNKING_REASON_CODES
+)
+if _overlapping_stop_chunking_reason_codes:  # pragma: no cover - import-time guard
+    raise RuntimeError(
+        "FetchReasonCode values overlap the stop-chunking/non-stop-chunking "
+        f"classification: {sorted(_overlapping_stop_chunking_reason_codes)}."
+    )
+_uncategorized_stop_chunking_reason_codes = (
+    {reason.value for reason in FetchReasonCode}
+    - _STOP_CHUNKING_REASON_CODES
+    - _NON_STOP_CHUNKING_REASON_CODES
+)
+if _uncategorized_stop_chunking_reason_codes:  # pragma: no cover - import-time guard
+    raise RuntimeError(
+        "FetchReasonCode values missing from the stop-chunking/non-stop-chunking "
+        f"classification: {sorted(_uncategorized_stop_chunking_reason_codes)}. "
+        "Add each to _STOP_CHUNKING_REASON_CODES or "
+        "_NON_STOP_CHUNKING_REASON_CODES in knowledge_ingest/crawl4ai_client.py."
+    )
 
 
 @dataclass
@@ -3736,18 +3794,13 @@ class ChunkedFetchResult:
             chose not to ask".
         stopped_early: True when ``not_attempted`` is non-empty for the
             reason described above.
-        stop_trigger_reason_code: which of ``_STOP_CHUNKING_REASON_CODES``
-            actually caused ``stopped_early`` — ``None`` when
-            ``stopped_early`` is False. Lets a caller (``crawl_site``,
-            Deel B) tell "the site asked us to slow down" (RATE_LIMITED)
-            apart from "the site blocked us outright" (BLOCKED_ANTI_BOT):
-            slowing down helps the former and does nothing for the
-            latter. BLOCKED_ANTI_BOT wins when a single chunk somehow
-            observes both (a block is the more severe signal). Also set
-            to BLOCKED_ANTI_BOT when ``circuit_breaker_triggered`` is True
-            (see below) — both breaker verdicts mean "further attempts
-            will not help", the same give-up semantics as a confirmed
-            block.
+        stop_trigger_reason_code: which stop policy actually caused
+            ``stopped_early`` — the unconditional RATE_LIMITED set, the
+            crawl-wide BLOCKED_ANTI_BOT ratio gate, or the circuit breaker;
+            ``None`` when ``stopped_early`` is False. Lets a caller
+            (``crawl_site``, Deel B) distinguish slowdown from give-up.
+            BLOCKED_ANTI_BOT wins when a chunk observes both signals, and
+            is also used for an aborting circuit-breaker verdict.
         circuit_breaker_triggered: True when
             ``knowledge_ingest.host_circuit_breaker`` returned an ABORT
             verdict (persistent failure or repeated refusal — onderdeel 2,
@@ -3847,17 +3900,12 @@ async def _chunked_bulk_fetch_with_session(
     remaining chunks from shipping — partial coverage beats zero coverage.
     The one exception is a confirmed rate-limit/anti-bot signal — see below.
 
-    ``rate_limit`` (requests/second, optional) additionally paces the
-    chunks client-side. crawl4ai's server ignores our ``mean_delay`` /
-    ``semaphore_count`` config (see ``_burst_size_for``'s docstring for the
-    measurement), so real rate limiting can only happen here: the chunk
-    size itself becomes the burst (``_burst_size_for``), and the gap
-    between the START of one chunk and the START of the next is held to
-    ``chunk_size / rate_limit`` seconds — crediting whatever time the
-    chunk's own request already consumed, so we never add avoidable
-    latency on top of a slow response. ``rate_limit is None`` disables all
-    pacing: chunk size reverts to the historical fixed ``_BULK_CHUNK_SIZE``
-    and no sleep is ever inserted, matching pre-pacing behaviour exactly.
+    ``pacing_session`` additionally paces the chunks client-side. crawl4ai's
+    server ignores our ``mean_delay`` / ``semaphore_count`` config, so
+    ``host_pacing.HostGateRegistry`` owns the real weighted-burst schedule.
+    ``HostPacingSession.acquire`` returns the allowed chunk size after
+    enforcing the gap from the prior request; an unpaced session retains the
+    historical chunk size.
 
     Each chunk request uses the fixed
     ``settings.crawl_bulk_base_timeout_seconds`` httpx timeout — see that

--- a/klai-knowledge-ingest/knowledge_ingest/domain_rate_limit_control.py
+++ b/klai-knowledge-ingest/knowledge_ingest/domain_rate_limit_control.py
@@ -82,6 +82,47 @@ MIN_DOMAIN_RATE_LIMIT = 0.2
 _CONGESTION_REASON_CODES = frozenset(
     {FetchReasonCode.RATE_LIMITED.value, FetchReasonCode.BLOCKED_ANTI_BOT.value}
 )
+_NON_CONGESTION_REASON_CODES = frozenset(
+    {
+        FetchReasonCode.SUCCESS.value,
+        FetchReasonCode.HTTP_4XX.value,
+        FetchReasonCode.HTTP_5XX.value,
+        FetchReasonCode.TIMEOUT.value,
+        FetchReasonCode.DNS_ERROR.value,
+        FetchReasonCode.CONNECTION_ERROR.value,
+        FetchReasonCode.AUTH_ERROR.value,
+        FetchReasonCode.PARSE_ERROR.value,
+        FetchReasonCode.NON_CONTENT_LISTING_PAGE.value,
+        FetchReasonCode.NOT_FETCHED_BUDGET_EXHAUSTED.value,
+        FetchReasonCode.NOT_FETCHED_DEPTH_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_DISCOVERY_LIMIT.value,
+        FetchReasonCode.NOT_FETCHED_EXCLUDED.value,
+        FetchReasonCode.NOT_FETCHED_DUPLICATE.value,
+        FetchReasonCode.NOT_FETCHED_RATE_LIMIT_STOP.value,
+        FetchReasonCode.UNKNOWN_EXCEPTION.value,
+        FetchReasonCode.REFUSED.value,
+        FetchReasonCode.NOT_FETCHED_CIRCUIT_BREAKER_STOP.value,
+        FetchReasonCode.NOT_FETCHED_CANCELLED.value,
+    }
+)
+_overlapping_congestion_reason_codes = _CONGESTION_REASON_CODES & _NON_CONGESTION_REASON_CODES
+if _overlapping_congestion_reason_codes:  # pragma: no cover - import-time guard
+    raise RuntimeError(
+        "FetchReasonCode values overlap the congestion/non-congestion "
+        f"classification: {sorted(_overlapping_congestion_reason_codes)}."
+    )
+_uncategorized_congestion_reason_codes = (
+    {reason.value for reason in FetchReasonCode}
+    - _CONGESTION_REASON_CODES
+    - _NON_CONGESTION_REASON_CODES
+)
+if _uncategorized_congestion_reason_codes:  # pragma: no cover - import-time guard
+    raise RuntimeError(
+        "FetchReasonCode values missing from the congestion/non-congestion "
+        f"classification: {sorted(_uncategorized_congestion_reason_codes)}. "
+        "Add each to _CONGESTION_REASON_CODES or _NON_CONGESTION_REASON_CODES "
+        "in knowledge_ingest/domain_rate_limit_control.py."
+    )
 
 # URLs that were never actually sent — not an attempt, not a signal either
 # way. See the module docstring's counting-rule paragraph.

--- a/klai-knowledge-ingest/knowledge_ingest/host_pacing.py
+++ b/klai-knowledge-ingest/knowledge_ingest/host_pacing.py
@@ -9,15 +9,71 @@ distributed limiter before rollout.
 from __future__ import annotations
 
 import asyncio
+import os
+import sys
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
 from knowledge_ingest.domain_selectors import extract_domain
 
 _BURST_WINDOW_SECONDS = 10.0
+# crawl4ai 0.8 rejects POST /crawl payloads containing more than 100 URLs.
+# Keep that transport ceiling next to the burst calculation that enforces it;
+# raise it only in lock-step with a verified crawl4ai schema relaxation.
 _MAX_BURST_SIZE = 100
+
+
+def ensure_single_process_host_pacing(
+    *,
+    environ: Mapping[str, str] | None = None,
+    argv: Sequence[str] | None = None,
+) -> None:
+    """Refuse startup when an in-memory host gate would be process-local.
+
+    Resolve worker count with Uvicorn's precedence: the last explicit
+    ``--workers`` flag, then ``UVICORN_WORKERS``, then ``WEB_CONCURRENCY``.
+    Replicas cannot be detected from inside one container; deployment
+    configuration must keep replicas at one until this registry is replaced
+    by a distributed limiter.
+    """
+    active_environ = os.environ if environ is None else environ
+    active_argv = sys.argv if argv is None else argv
+    configured_worker: tuple[str, str] | None = None
+
+    for index, argument in enumerate(active_argv):
+        if argument.startswith("--workers="):
+            configured_worker = ("--workers", argument.split("=", 1)[1])
+        elif argument == "--workers":
+            value = active_argv[index + 1] if index + 1 < len(active_argv) else ""
+            configured_worker = ("--workers", value)
+
+    if configured_worker is None:
+        for name in ("UVICORN_WORKERS", "WEB_CONCURRENCY"):
+            value = active_environ.get(name)
+            if value:
+                configured_worker = (name, value)
+                break
+
+    if configured_worker is None:
+        return
+
+    source, raw_value = configured_worker
+    try:
+        worker_count = int(raw_value)
+    except ValueError as exc:
+        raise RuntimeError(
+            "Host pacing requires single-process knowledge-ingest; "
+            f"cannot verify {source}={raw_value!r} as a worker count."
+        ) from exc
+    if worker_count > 1:
+        rendered = f"{source}={raw_value}" if source != "--workers" else f"--workers={raw_value}"
+        raise RuntimeError(
+            "Host pacing requires single-process knowledge-ingest; "
+            f"detected {rendered}. Use exactly one web worker until "
+            "HostGateRegistry has a distributed backend."
+        )
 
 
 def crawl_gate_key(url: str) -> str:

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_404_not_antibot.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_404_not_antibot.py
@@ -5,10 +5,10 @@ Four un-rendered-template-syntax links (see
 each 404'd with a tiny error body. crawl4ai's structural anti-bot heuristic
 misread each one as ``blocked_anti_bot`` (see
 ``tests/test_crawl_site_reconcile.py::TestClassifyFetchOutcome`` for the
-classification-level fix), and because BLOCKED_ANTI_BOT is a
-``_STOP_CHUNKING_REASON_CODES`` member, ``_chunked_bulk_fetch`` stopped
-sending further chunks after the FIRST such 404 — 192 real pages were never
-even attempted.
+classification-level fix). At the time, BLOCKED_ANTI_BOT unconditionally
+stopped chunking, so the FIRST such 404 prevented 192 real pages from being
+attempted. Since 2026-08-18 it stops only through the crawl-wide ratio+floor
+gate.
 
 This test proves the actual incident is fixed, not just its two
 contributing symptoms in isolation: four exact-production-shape 404 pages,
@@ -27,7 +27,7 @@ from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
 from knowledge_ingest.reason_codes import FetchReasonCode
 
-# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# At 0.05 req/s, the host gate's 10-second window allows one URL per request — one
 # URL per chunk, so each URL below produces its own distinct HTTP request
 # (matches the pattern in test_chunked_bulk_fetch_rate_limit_stop.py).
 _ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_antibot_ratio_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_antibot_ratio_stop.py
@@ -33,7 +33,7 @@ from knowledge_ingest.config import settings
 from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
 
 # Same derivation as test_chunked_bulk_fetch_rate_limit_stop.py:
-# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# At 0.05 req/s, the host gate's 10-second window allows one URL per request — one
 # URL per chunk, so N urls produce N distinct HTTP requests we can fail
 # independently and observe the running crawl-wide tally accumulate.
 _ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
@@ -109,9 +109,8 @@ async def test_four_antibot_signals_on_400_plus_pages_does_not_stop(
 
     monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
 
-    # rate_limit=None -> fixed _BULK_CHUNK_SIZE (100) chunking, no pacing
-    # sleep is ever invoked (see _chunked_bulk_fetch: the inter-chunk sleep
-    # is gated on `rate_limit is not None`).
+    # rate_limit=None -> HostGateRegistry's 100-URL transport ceiling, with
+    # no pacing sleep between grants.
     fetch = await _chunked_bulk_fetch(urls=urls, crawler_config={}, cookies=None)
 
     # Every URL was actually requested — nothing skipped.

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_circuit_breaker_stop.py
@@ -19,7 +19,7 @@ from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
 from knowledge_ingest.reason_codes import FetchReasonCode
 
-# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# At 0.05 req/s, the host gate's 10-second window allows one URL per request — one
 # URL per chunk, so N urls produce N distinct HTTP requests we can fail
 # independently and observe the breaker's running tally accumulate.
 _ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05

--- a/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
+++ b/klai-knowledge-ingest/tests/test_chunked_bulk_fetch_rate_limit_stop.py
@@ -21,7 +21,7 @@ from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
 from knowledge_ingest.reason_codes import FetchReasonCode
 
-# _burst_size_for(0.05) == max(1, min(100, int(0.05 * 10 + 0.5))) == 1 — one
+# At 0.05 req/s, the host gate's 10-second window allows one URL per request — one
 # URL per chunk, so three URLs produce three distinct HTTP requests.
 _ONE_URL_PER_CHUNK_RATE_LIMIT = 0.05
 

--- a/klai-knowledge-ingest/tests/test_client_side_pacing.py
+++ b/klai-knowledge-ingest/tests/test_client_side_pacing.py
@@ -19,39 +19,6 @@ import httpx
 import pytest
 
 from knowledge_ingest import crawl4ai_client
-from knowledge_ingest.crawl4ai_client import _burst_size_for, _chunked_bulk_fetch
-
-# ---------------------------------------------------------------------------
-# A. _burst_size_for — pure function, no mocking needed
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("rate_limit", "expected_burst"),
-    [
-        (None, 100),
-        (2.0, 20),
-        (1.0, 10),
-        (0.5, 5),
-        (0.25, 3),
-        # Bankers-rounding regression guard: round(0.5) == 0 and
-        # round(2.5) == 2 in Python. int(x + 0.5) must NOT collapse these.
-        (0.05, 1),  # 0.05 * 10 + 0.5 = 1.0 -> int() = 1, never 0
-    ],
-)
-def test_burst_size_for_expected_values(rate_limit: float | None, expected_burst: int) -> None:
-    assert _burst_size_for(rate_limit) == expected_burst
-
-
-def test_burst_size_for_never_exceeds_bulk_chunk_size() -> None:
-    """crawl4ai's server 422s on more than 100 URLs per request regardless
-    of how permissive rate_limit is."""
-    assert _burst_size_for(1000.0) == crawl4ai_client._BULK_CHUNK_SIZE
-
-
-def test_burst_size_for_never_drops_below_one() -> None:
-    assert _burst_size_for(0.0001) == 1
-
 
 # ---------------------------------------------------------------------------
 # Test doubles for _chunked_bulk_fetch's pacing clock/sleep, mirroring the
@@ -129,14 +96,13 @@ async def test_chunked_bulk_fetch_honours_rate_limit_cadence(
     clock = _install_virtual_clock(monkeypatch)
     monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync_factory(clock))
 
-    burst = _burst_size_for(rate_limit)
     # Enough chunks that the fencepost effect (N chunks only have N-1 gaps
     # between them, so a handful of chunks measures slightly above nominal)
     # washes out within the margin below.
-    num_urls = burst * 50
+    num_urls = 1000
     urls = [f"https://example.com/p{i}" for i in range(num_urls)]
 
-    fetch = await _chunked_bulk_fetch(
+    fetch = await crawl4ai_client._chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
@@ -163,7 +129,7 @@ async def test_slow_chunk_is_not_further_delayed(monkeypatch: pytest.MonkeyPatch
     than the required gap, no additional sleep must be inserted."""
     clock = _install_virtual_clock(monkeypatch)
     rate_limit = 1.0
-    burst = _burst_size_for(rate_limit)  # 10 -> gap = 10s
+    burst = 10
     gap = burst / rate_limit
     # Chunk itself "takes" longer than the gap.
     monkeypatch.setattr(
@@ -174,7 +140,7 @@ async def test_slow_chunk_is_not_further_delayed(monkeypatch: pytest.MonkeyPatch
 
     urls = [f"https://example.com/p{i}" for i in range(burst * 2)]
 
-    await _chunked_bulk_fetch(
+    await crawl4ai_client._chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
@@ -192,7 +158,7 @@ async def test_fast_chunk_sleeps_exactly_the_remaining_gap(
     exactly the difference — not the full gap again."""
     clock = _install_virtual_clock(monkeypatch)
     rate_limit = 1.0
-    burst = _burst_size_for(rate_limit)  # 10 -> gap = 10s
+    burst = 10
     gap = burst / rate_limit
     chunk_duration = 2.0
     monkeypatch.setattr(
@@ -203,7 +169,7 @@ async def test_fast_chunk_sleeps_exactly_the_remaining_gap(
 
     urls = [f"https://example.com/p{i}" for i in range(burst * 2)]
 
-    await _chunked_bulk_fetch(
+    await crawl4ai_client._chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
@@ -246,7 +212,7 @@ async def test_no_rate_limit_means_no_behaviour_change(monkeypatch: pytest.Monke
     num_urls = 250  # spans 3 chunks at the historical fixed size of 100
     urls = [f"https://example.com/p{i}" for i in range(num_urls)]
 
-    fetch = await _chunked_bulk_fetch(
+    fetch = await crawl4ai_client._chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,
@@ -291,10 +257,10 @@ async def test_no_request_exceeds_the_computed_burst_size(
     monkeypatch.setattr(crawl4ai_client, "_crawl_sync", _fake_crawl_sync)
 
     rate_limit = 0.25
-    expected_burst = _burst_size_for(rate_limit)
+    expected_burst = 3
     urls = [f"https://example.com/p{i}" for i in range(expected_burst * 4 + 1)]
 
-    await _chunked_bulk_fetch(
+    await crawl4ai_client._chunked_bulk_fetch(
         urls=urls,
         crawler_config={},
         cookies=None,

--- a/klai-knowledge-ingest/tests/test_crawl_cancel_chunked_fetch.py
+++ b/klai-knowledge-ingest/tests/test_crawl_cancel_chunked_fetch.py
@@ -28,7 +28,7 @@ from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.crawl4ai_client import _chunked_bulk_fetch
 from knowledge_ingest.reason_codes import FetchReasonCode
 
-# _burst_size_for(0.5) == max(1, min(100, int(0.5 * 10 + 0.5))) == 5 — five
+# At 0.5 req/s, the host gate's 10-second window allows five URLs per request — five
 # URLs per chunk, so 20 URLs produce exactly four chunks.
 _FIVE_URLS_PER_CHUNK_RATE_LIMIT = 0.5
 

--- a/klai-knowledge-ingest/tests/test_crawl_discovery_seed_fallback.py
+++ b/klai-knowledge-ingest/tests/test_crawl_discovery_seed_fallback.py
@@ -88,6 +88,48 @@ async def test_empty_primary_falls_back_to_discovery_seed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discovery_seed_inherits_primary_in_job_slowdown() -> None:
+    """A same-host seed retry must not restart at the pre-slowdown rate."""
+
+    async def _crawl_side_effect(**kwargs):
+        if kwargs["start_url"] == HUB:
+            kwargs["rate_limit_state"].current_rate_limit = 0.5
+            return [], []
+        return [_page(ARTICLE)], []
+
+    crawl_site = AsyncMock(side_effect=_crawl_side_effect)
+    await _run(crawl_site, discovery_seed_url=ARTICLE, rate_limit=2.0)
+
+    seed_call = crawl_site.await_args_list[1].kwargs
+    assert seed_call["rate_limit"] == 0.5
+    assert seed_call["rate_limit_state"].current_rate_limit == 0.5
+
+
+@pytest.mark.asyncio
+async def test_primary_and_seed_slowdowns_persist_the_lowest_rate() -> None:
+    """Persistence receives the lowest rate reached across both crawl passes."""
+
+    async def _crawl_side_effect(**kwargs):
+        state = kwargs["rate_limit_state"]
+        if kwargs["start_url"] == HUB:
+            state.current_rate_limit = 0.5
+            return [], []
+        assert state.current_rate_limit == 0.5
+        state.current_rate_limit = 0.25
+        return [_page(ARTICLE)], []
+
+    rate_effect = AsyncMock(return_value=None)
+    crawl_site = AsyncMock(side_effect=_crawl_side_effect)
+    with patch(
+        "knowledge_ingest.adapters.crawler._apply_domain_rate_limit_effect_once",
+        new=rate_effect,
+    ):
+        await _run(crawl_site, discovery_seed_url=ARTICLE, rate_limit=2.0)
+
+    assert rate_effect.await_args.kwargs["final_rate_limit"] == 0.25
+
+
+@pytest.mark.asyncio
 async def test_primary_that_reached_the_seed_skips_the_seed_pass() -> None:
     """A healthy site whose BFS reached the seed page pays for one crawl only."""
     crawl_site = AsyncMock(return_value=([_page(HUB + "a"), _page(ARTICLE)], []))

--- a/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
+++ b/klai-knowledge-ingest/tests/test_crawl_domain_rate_limit.py
@@ -24,29 +24,28 @@ punishment has gone stale, should not stay throttled forever.
   (``domain_selectors.save_domain_rate_limit_state``) — unless the
   regelwet says nothing needs persisting.
 
-These tests mock ``crawl_site`` entirely — the crawl4ai wiring itself is
-covered by tests/test_build_crawl_config.py and
-tests/test_crawl_site_reconcile.py. The pure regelwet itself (hysteresis,
-floor, ceiling, table-cleanliness edge cases, decay) is covered
-exhaustively, without any mocking, in
-tests/test_domain_rate_limit_control.py. Here the concern is purely the
-wiring: does run_crawl_job read the stored state, decay it correctly, feed
-the right observations into the regelwet, and persist exactly what the
-regelwet returned.
+Most tests mock ``crawl_site`` to isolate adapter wiring. The Deel B
+regression deliberately keeps the real ``crawl_site`` state machine and
+mocks only its network/checkpoint boundaries, proving that every in-job
+halving reaches persistence. The pure regelwet itself (hysteresis, floor,
+ceiling, table-cleanliness edge cases, decay) is covered exhaustively,
+without mocking, in tests/test_domain_rate_limit_control.py.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.adapters.crawler import (
     _apply_domain_rate_limit_effect_once,
     run_crawl_job,
 )
-from knowledge_ingest.crawl4ai_client import CrawlResult
+from knowledge_ingest.crawl4ai_client import ChunkedFetchResult, CrawlResult
 from knowledge_ingest.crawl_checkpoint import CrawlExecutionSuperseded
 from knowledge_ingest.domain_rate_limit_control import DomainRateLimitState
 from knowledge_ingest.domain_selectors import DomainRateLimitWriteKind
@@ -281,6 +280,127 @@ async def test_rate_limited_outcome_lowers_the_domain_rate_limit() -> None:
     assert new_state.rate_limit == pytest.approx(1.0)  # 2.0 / 2
     assert new_state.clean_streak == 0
     assert new_state.last_congestion_at is not None
+
+
+@pytest.mark.asyncio
+async def test_in_job_slowdown_rate_is_persisted_for_the_next_crawl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The persisted rate must include every halving performed by Deel B."""
+    urls = [f"https://intermedia.com/support/{index}" for index in range(5)]
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="Seed content",
+            raw_markdown="Seed content",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+            links={"internal": [{"href": url, "text": ""} for url in urls]},
+        )
+
+    async def _no_sitemap(_start_url: str) -> list[str]:
+        return []
+
+    observed_rates: list[float | None] = []
+
+    async def _fake_bulk_fetch(
+        *, urls: list[str], rate_limit: float | None, **_kwargs: Any
+    ) -> ChunkedFetchResult:
+        observed_rates.append(rate_limit)
+        if len(observed_rates) <= 3:
+            return ChunkedFetchResult(
+                raw_results=[
+                    {
+                        "url": urls[0],
+                        "success": False,
+                        "status_code": 429,
+                        "error_message": "Too Many Requests",
+                        "markdown": "",
+                        "html": "",
+                    }
+                ],
+                not_attempted=urls[1:],
+                stopped_early=True,
+                stop_trigger_reason_code=FetchReasonCode.RATE_LIMITED.value,
+            )
+        return ChunkedFetchResult(
+            raw_results=[
+                {
+                    "url": url,
+                    "success": True,
+                    "status_code": 200,
+                    "markdown": "Recovered content",
+                    "html": "<html></html>",
+                    "links": {"internal": []},
+                }
+                for url in urls
+            ]
+        )
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    class _NoopCheckpoint:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        async def load(self) -> None:
+            return None
+
+        async def save(self, _snapshot: dict[str, Any]) -> None:
+            return None
+
+        async def ensure_active(self) -> None:
+            return None
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+    monkeypatch.setattr(crawl4ai_client, "_chunked_bulk_fetch", _fake_bulk_fetch)
+    monkeypatch.setattr(crawl4ai_client, "_slowdown_sleep", _no_sleep)
+
+    conn = _mock_conn()
+    get_state = AsyncMock(return_value=_NO_OVERRIDE)
+    save_state = AsyncMock(return_value=True)
+    with (
+        patch(
+            "knowledge_ingest.adapters.crawler.PostgresCrawlCheckpoint",
+            new=_NoopCheckpoint,
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler.get_domain_rate_limit_state",
+            new=get_state,
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler.save_domain_rate_limit_state",
+            new=save_state,
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler.pg_store.get_crawled_page_hashes",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler._build_link_graph",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "knowledge_ingest.adapters.crawler._ingest_crawl_result",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await run_crawl_job(
+            connection_factory=connection_factory_for(conn),
+            job_id="job-1",
+            org_id="org-1",
+            kb_slug="support",
+            start_url=START_URL,
+            rate_limit=2.0,
+        )
+
+    assert observed_rates == [2.0, 1.0, 0.5, 0.25]
+    persisted_state = save_state.await_args.kwargs["state"]
+    assert persisted_state.rate_limit == pytest.approx(0.25)
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_crawl_frontier_document_extensions.py
+++ b/klai-knowledge-ingest/tests/test_crawl_frontier_document_extensions.py
@@ -46,6 +46,7 @@ from knowledge_ingest.adapters.crawler import (
     decide_fetch_failure_terminal_status,
 )
 from knowledge_ingest.crawl4ai_client import CrawlLedger, CrawlResult
+from knowledge_ingest.reason_codes import FetchReasonCode
 
 
 def _ledger(**overrides: Any) -> CrawlLedger:
@@ -220,13 +221,52 @@ async def test_crawl_site_never_submits_pdf_links_to_crawl4ai(
     assert any(r.url == "https://example.com/products/widget" for r in results)
 
 
+@pytest.mark.asyncio
+async def test_pdf_start_url_is_reported_without_being_fetched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    start_url = "https://example.com/manual.pdf"
+    fetched: list[str] = []
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        fetched.append(start_url)
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="PDF content",
+            raw_markdown="PDF content",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+        )
+
+    async def _no_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+
+    results, outcomes = await crawl4ai_client.crawl_site(start_url=start_url)
+
+    assert fetched == []
+    assert results == []
+    assert outcomes[0]["url"] == start_url
+    assert outcomes[0]["reason_code"] == FetchReasonCode.NOT_FETCHED_EXCLUDED.value
+    assert outcomes[0]["filter_reason"] == "non_html_extension"
+
+
 def test_a_skipped_pdf_does_not_mark_the_crawl_failed_partial() -> None:
     """The valkuil: a URL we deliberately never wanted to crawl is not
-    'incomplete coverage'. Since the excluded URL never produces an
-    outcome at all (see the ledger-level tests above), the existing
-    not_fetched_* / failure-ratio guards downstream must see a perfectly
-    clean, fully-fetched crawl."""
+    'incomplete coverage'. A filtered start URL does produce an explicit
+    outcome, so downstream coverage guards must distinguish that deliberate
+    exclusion from an unfinished frontier."""
     fetch_outcomes = [
+        {
+            "url": "https://example.com/manual.pdf",
+            "reason_code": "not_fetched_excluded",
+            "status_code": None,
+            "content_length": 0,
+            "filter_reason": "non_html_extension",
+        },
         {
             "url": "https://example.com",
             "reason_code": "success",
@@ -249,3 +289,21 @@ def test_a_skipped_pdf_does_not_mark_the_crawl_failed_partial() -> None:
     )
     assert status == ""
     assert summary is None
+
+
+def test_a_filtered_seed_without_any_success_still_fails_loudly() -> None:
+    warning = _build_crawl_outcome_warning(
+        [
+            {
+                "url": "https://example.com/manual.pdf",
+                "reason_code": "not_fetched_excluded",
+                "status_code": None,
+                "content_length": 0,
+                "filter_reason": "non_html_extension",
+            }
+        ],
+        max_pages=200,
+    )
+
+    assert warning is not None
+    assert warning["reason"] == "crawl_fetch_failed"

--- a/klai-knowledge-ingest/tests/test_crawl_frontier_template_urls.py
+++ b/klai-knowledge-ingest/tests/test_crawl_frontier_template_urls.py
@@ -9,10 +9,11 @@ framework's JS never ran, or crawl4ai captured the DOM before it mounted):
 
 That is never a real page. Fetching it 404s with a tiny error body, and
 crawl4ai's structural anti-bot heuristic (``_classify_fetch_outcome``)
-misreads the small page as a block, which — because BLOCKED_ANTI_BOT is a
-``_STOP_CHUNKING_REASON_CODES`` member — aborted the rest of that crawl:
-four template-syntax URLs cost 192 real pages that were never even
-attempted (production incident, 2026-08-18).
+misreads the small page as a block. At the time, BLOCKED_ANTI_BOT
+unconditionally stopped chunking, so four template-syntax URLs cost 192
+real pages that were never attempted (production incident, 2026-08-18).
+Anti-bot stops now use a crawl-wide ratio+floor gate, but these bogus URLs
+still must not consume requests or distort that ratio.
 
 These URLs are filtered at the frontier (``CrawlLedger.add``), before a
 single network request is made — same mechanism and same contract as
@@ -30,12 +31,14 @@ from typing import Any
 
 import pytest
 
+from knowledge_ingest import crawl4ai_client
 from knowledge_ingest.adapters.crawler import (
     _build_crawl_outcome_warning,
     _crawl_fully_fetched,
     decide_fetch_failure_terminal_status,
 )
-from knowledge_ingest.crawl4ai_client import CrawlLedger
+from knowledge_ingest.crawl4ai_client import CrawlLedger, CrawlResult
+from knowledge_ingest.reason_codes import FetchReasonCode
 
 # The exact production URL (2026-08-18, support.ascendcloud.com).
 _PRODUCTION_TEMPLATE_URL = (
@@ -143,13 +146,18 @@ def test_real_url_next_to_a_template_url_is_still_added() -> None:
 
 def test_a_crawl_with_only_skipped_template_urls_is_not_failed_partial() -> None:
     """The valkuil: a URL we deliberately never wanted to crawl is not
-    'incomplete coverage'. Since the excluded URL never produces an
-    outcome at all (see the ledger-level tests above), the existing
-    not_fetched_* / failure-ratio guards downstream must see a perfectly
-    clean, fully-fetched crawl — mirrors
+    'incomplete coverage'. A filtered start URL produces an explicit outcome,
+    so downstream coverage guards must ignore that deliberate exclusion — mirrors
     test_a_skipped_pdf_does_not_mark_the_crawl_failed_partial in
     test_crawl_frontier_document_extensions.py."""
     fetch_outcomes = [
+        {
+            "url": "https://support.ascendcloud.com/{{article.url}}",
+            "reason_code": "not_fetched_excluded",
+            "status_code": None,
+            "content_length": 0,
+            "filter_reason": "unrendered_template_syntax",
+        },
         {
             "url": "https://support.ascendcloud.com",
             "reason_code": "success",
@@ -172,3 +180,37 @@ def test_a_crawl_with_only_skipped_template_urls_is_not_failed_partial() -> None
     )
     assert status == ""
     assert summary is None
+
+
+@pytest.mark.asyncio
+async def test_template_start_url_is_reported_without_being_fetched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fetched: list[str] = []
+
+    async def _fake_seed(*, start_url: str, **_kwargs: Any) -> CrawlResult:
+        fetched.append(start_url)
+        return CrawlResult(
+            url=start_url,
+            fit_markdown="Template content",
+            raw_markdown="Template content",
+            html="<html></html>",
+            word_count=2,
+            success=True,
+        )
+
+    async def _no_sitemap(_base: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(crawl4ai_client, "_fetch_seed_page", _fake_seed)
+    monkeypatch.setattr(crawl4ai_client, "_fetch_sitemap_urls", _no_sitemap)
+
+    results, outcomes = await crawl4ai_client.crawl_site(
+        start_url=_PRODUCTION_TEMPLATE_URL,
+    )
+
+    assert fetched == []
+    assert results == []
+    assert outcomes[0]["url"] == _PRODUCTION_TEMPLATE_URL
+    assert outcomes[0]["reason_code"] == FetchReasonCode.NOT_FETCHED_EXCLUDED.value
+    assert outcomes[0]["filter_reason"] == "unrendered_template_syntax"

--- a/klai-knowledge-ingest/tests/test_shared_host_pacing.py
+++ b/klai-knowledge-ingest/tests/test_shared_host_pacing.py
@@ -4,13 +4,72 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 
-from knowledge_ingest import crawl4ai_client
+from knowledge_ingest import crawl4ai_client, host_pacing
 from knowledge_ingest.domain_selectors import extract_domain
 from knowledge_ingest.host_pacing import HostGateRegistry, crawl_gate_key
+
+
+def test_multi_worker_environment_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match=r"single-process.*WEB_CONCURRENCY=2"):
+        host_pacing.ensure_single_process_host_pacing(
+            environ={"WEB_CONCURRENCY": "2"},
+            argv=["uvicorn", "knowledge_ingest.app:app"],
+        )
+
+
+def test_multi_worker_uvicorn_argument_is_rejected() -> None:
+    with pytest.raises(RuntimeError, match=r"single-process.*--workers=3"):
+        host_pacing.ensure_single_process_host_pacing(
+            environ={},
+            argv=["uvicorn", "knowledge_ingest.app:app", "--workers=3"],
+        )
+
+
+def test_single_worker_configuration_is_allowed() -> None:
+    host_pacing.ensure_single_process_host_pacing(
+        environ={"WEB_CONCURRENCY": "1", "UVICORN_WORKERS": "1"},
+        argv=["uvicorn", "knowledge_ingest.app:app", "--workers", "1"],
+    )
+
+
+def test_explicit_single_worker_argument_overrides_environment_defaults() -> None:
+    host_pacing.ensure_single_process_host_pacing(
+        environ={"WEB_CONCURRENCY": "3", "UVICORN_WORKERS": "2"},
+        argv=["uvicorn", "knowledge_ingest.app:app", "--workers", "1"],
+    )
+
+
+def test_uvicorn_worker_environment_overrides_web_concurrency() -> None:
+    host_pacing.ensure_single_process_host_pacing(
+        environ={"WEB_CONCURRENCY": "3", "UVICORN_WORKERS": "1"},
+        argv=["uvicorn", "knowledge_ingest.app:app"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_startup_rejects_multi_worker_mode_before_external_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from knowledge_ingest import app as app_module
+
+    ensure_collection = AsyncMock(return_value=None)
+    get_pool = AsyncMock(return_value=object())
+    monkeypatch.setenv("WEB_CONCURRENCY", "2")
+    monkeypatch.setattr(app_module.qdrant_store, "ensure_collection", ensure_collection)
+    monkeypatch.setattr(app_module.db, "get_pool", get_pool)
+    monkeypatch.setattr(app_module.settings, "enrichment_enabled", False)
+
+    with pytest.raises(RuntimeError, match=r"single-process.*WEB_CONCURRENCY=2"):
+        async with app_module.lifespan(app_module.app):
+            pass
+
+    ensure_collection.assert_not_awaited()
+    get_pool.assert_not_awaited()
 
 
 class _VirtualClock:
@@ -87,6 +146,69 @@ async def test_lower_active_rate_controls_future_burst_and_repays_previous_burst
     # The previous 20-URL burst is charged against the newly effective
     # 0.2 URL/s rate before another request may start.
     assert clock.now == 100.0
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_restored_rate_controls_the_active_crawl_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A resumed crawl must pace traffic at its checkpointed slowdown rate."""
+    start_url = "https://example.com/"
+    ledger = crawl4ai_client.CrawlLedger(
+        start_url=start_url,
+        base_domain="example.com",
+        include_patterns=None,
+        exclude_patterns=None,
+        max_depth=1,
+    )
+    ledger.add_start()
+    ledger.add_sitemap_urls(["https://example.com/a", "https://example.com/b"])
+
+    class _Checkpoint:
+        async def load(self) -> dict[str, Any]:
+            return {
+                "version": 1,
+                "start_url": start_url,
+                "complete": False,
+                "ledger": ledger.snapshot(),
+                "results": [],
+                "outcomes": [],
+                "fetched_count": 0,
+                "current_rate_limit": 0.2,
+                "consecutive_rate_limit_slowdowns": 1,
+            }
+
+        async def ensure_active(self) -> None:
+            return None
+
+        async def save(self, _state: dict[str, Any]) -> None:
+            return None
+
+    clock = _VirtualClock()
+    registry = HostGateRegistry(monotonic=clock.monotonic, sleep=clock.sleep)
+    request_sizes: list[int] = []
+
+    async def crawl_sync(_client: httpx.AsyncClient, payload: dict[str, Any]) -> dict[str, Any]:
+        request_sizes.append(len(payload["urls"]))
+        return {
+            "results": [
+                {"url": url, "success": True, "markdown": "content", "links": {}}
+                for url in payload["urls"]
+            ]
+        }
+
+    monkeypatch.setattr(crawl4ai_client, "_host_gate_registry", registry)
+    monkeypatch.setattr(crawl4ai_client, "_crawl_sync", crawl_sync)
+
+    await crawl4ai_client.crawl_site(
+        start_url=start_url,
+        max_depth=1,
+        max_pages=3,
+        rate_limit=2.0,
+        checkpoint=_Checkpoint(),
+    )
+
+    assert request_sizes == [2, 1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- persist the final in-job AIMD slowdown and carry it through checkpoint resumes and discovery-seed retries
- filter document/template seed URLs without turning successful fallback crawls into partial failures
- remove the dead duplicate pacing helper/constants and keep host pacing in `HostGateRegistry`
- add exhaustive, disjoint reason-code partitions and a fail-loud single-process startup guard with Uvicorn precedence
- add regression coverage for the real slowdown ladder, checkpoint pacing, filtered seeds, worker precedence, and primary/seed min-rate persistence

## Verification

- `uv run --frozen --extra dev pytest -q --tb=short -n auto` — 1543 passed, 6 skipped
- focused crawler contract suite — 94 passed
- `uv run --frozen --extra dev ruff format --check .` — 285 files formatted
- `uv run --frozen --extra dev ruff check .` — all checks passed
- `git diff --check` — passed
- independent Codex CLI review (gpt-5.5, medium) — no remaining actionable correctness issues

## Deliberately out of scope

- splitting `crawl4ai_client.py` into modules
- folding the anti-bot ratio gate into the circuit breaker
- renaming crawler test files
