### PR TITLE
fix(rag): address LiteLLM review findings

### DIFF
--- a/.github/workflows/litellm-tests.yml
+++ b/.github/workflows/litellm-tests.yml
@@ -11,6 +11,9 @@ on:
     branches: [main]
     paths:
       - 'deploy/litellm/**'
+      # The behavioral failover tests execute against the LiteLLM version
+      # pinned by the production image in this Compose file.
+      - 'deploy/docker-compose.yml'
       - 'klai-libs/citations/**'
       - 'klai-libs/service-auth/**'
       # chat-prompts is compared byte-for-byte against the vendored
@@ -21,6 +24,7 @@ on:
   pull_request:
     paths:
       - 'deploy/litellm/**'
+      - 'deploy/docker-compose.yml'
       - 'klai-libs/citations/**'
       - 'klai-libs/service-auth/**'
       - 'klai-libs/chat-prompts/**'
@@ -44,7 +48,7 @@ jobs:
         run: >
           uv run --no-project --python 3.13
           --with pytest --with pytest-asyncio --with httpx --with structlog
-          --with pyyaml
+          --with pyyaml --with litellm==1.96.2
           --with ../../klai-libs/citations
           --with ../../klai-libs/service-auth
           python -m pytest tests/ -q --tb=short

--- a/deploy/grafana/provisioning/dashboards/rag-quality.json
+++ b/deploy/grafana/provisioning/dashboards/rag-quality.json
@@ -325,6 +325,15 @@
                     "expr": "sum(rate(retrieval_confidence_band_total{band=~\"low|unknown\",org_id=\"$org_id\"}[$__rate_interval])) / sum(rate(retrieval_confidence_band_total{org_id=\"$org_id\"}[$__rate_interval]))",
                     "legendFormat": "low+unknown share",
                     "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "victoriametrics"
+                    },
+                    "expr": "sum by (band) (rate(retrieval_confidence_band_corroborated_total{org_id=\"$org_id\"}[$__rate_interval]))",
+                    "legendFormat": "corroborated {{band}} (shadow)",
+                    "refId": "D"
                 }
             ]
         }

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -103,6 +103,10 @@ search_tools:
       api_base: os.environ/SEARXNG_API_BASE
 
 router_settings:
+  # LiteLLM v1.96.2 filters to the lowest deployment order before applying
+  # simple-shuffle, then advances on any failure except context-window and
+  # content-policy errors, which follow their dedicated fallback paths.
+  # Behavioral coverage: tests/test_litellm_mistral_failover.py.
   routing_strategy: simple-shuffle
   # klai-primary and klai-fast share the same upstream Mistral Small quota.
   # If that pool hits TPM/RPM limits, fall back to Mistral Medium instead of

--- a/deploy/litellm/eval_suites/chat.yaml
+++ b/deploy/litellm/eval_suites/chat.yaml
@@ -503,6 +503,7 @@ queries:
   - id: chat-pasted-correspondence-short-ticket
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
+    kb_slugs: [support, sip]
     query: |
       Kun je hier naar kijken?
 
@@ -522,10 +523,15 @@ queries:
   - id: chat-pasted-correspondence-control-plain-question
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
+    # Pin this control to the same curated corpus slice as the positive SIP
+    # canary. The exact answer-bearing heading below must occur in both the
+    # retrieval window and evidence pack; a sibling heading or filename is
+    # deliberately not enough.
+    kb_slugs: [support, sip]
     query: "Wat betekent een SIP 404 Not Found?"
     reference_answer: "Leg uit dat een SIP 404 Not Found betekent dat de gebelde gebruiker of het toestel niet gevonden is of niet is toegewezen, op basis van de kennisbank."
     expected_topics: [sip, 404, responscode]
-    expected_chunks: ["08_algemene_sip_instellingen.md"]
+    expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
     expected_answer_sections: []
     mix: pasted_correspondence
     # Negative-class control (REQ-6): a plain short question with NO pasted

--- a/deploy/litellm/klai_answer_epistemics.py
+++ b/deploy/litellm/klai_answer_epistemics.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
 from klai_citations import evidence_chunks_from_chunks, extract_salient_query_tokens
+
 from klai_pasted_correspondence import (
     ANSWER_CONTRACT_MARKERS,
     extract_pasted_correspondence_text,
 )
+
+logger = logging.getLogger(__name__)
 
 _EVIDENCE_TOKEN_FIELDS = (
     "title",
@@ -43,12 +47,25 @@ _KNOWN_SECTION_MARKER_RE = re.compile(
 )
 
 
-def _normalize_known_section_markers(answer: str) -> str:
+def _normalize_known_section_markers(answer: str) -> tuple[str, int]:
     """Canonicalize known sections while leaving unknown markers observable."""
-    return _KNOWN_SECTION_MARKER_RE.sub(
-        lambda match: _ANSWER_CONTRACT_MARKERS_BY_SUFFIX[match.group(1).upper()],
-        answer,
-    )
+    normalized_marker_count = 0
+
+    def _canonical_marker(match: re.Match[str]) -> str:
+        nonlocal normalized_marker_count
+        canonical = _ANSWER_CONTRACT_MARKERS_BY_SUFFIX[match.group(1).upper()]
+        if match.group(0) != canonical:
+            normalized_marker_count += 1
+        return canonical
+
+    normalized = _KNOWN_SECTION_MARKER_RE.sub(_canonical_marker, answer)
+    if normalized_marker_count:
+        logger.warning(
+            "answer_contract_marker_normalized normalized_marker_count=%d",
+            normalized_marker_count,
+            extra={"normalized_marker_count": normalized_marker_count},
+        )
+    return normalized, normalized_marker_count
 
 
 def _evidence_tokens(evidence_chunks: list[dict]) -> set[str]:
@@ -104,9 +121,15 @@ def inspect_answer_epistemics(
 
     result: dict[str, Any] = {"claim_provenance": provenance}
     if correspondence_detected:
-        result["answer_contract"] = _verify_answer_contract(
-            _normalize_known_section_markers(answer), evidence_chunks
+        normalized_answer, normalized_marker_count = _normalize_known_section_markers(
+            answer
         )
+        answer_contract = _verify_answer_contract(normalized_answer, evidence_chunks)
+        if normalized_marker_count:
+            # This travels with the existing request-correlated epistemics log,
+            # while the dedicated warning above remains useful as a drift counter.
+            answer_contract["normalized_marker_count"] = normalized_marker_count
+        result["answer_contract"] = answer_contract
     return result
 
 

--- a/deploy/litellm/tests/test_answer_epistemics.py
+++ b/deploy/litellm/tests/test_answer_epistemics.py
@@ -222,7 +222,8 @@ def test_well_formed_contract_is_verified_and_markers_are_stripped():
     assert all(marker not in rendered for marker in _MARKERS)
 
 
-def test_known_section_suffix_recovers_misspelled_internal_prefix():
+def test_known_section_suffix_recovers_misspelled_internal_prefix(caplog):
+    caplog.set_level("INFO", logger="klai_answer_epistemics")
     answer = _contract_answer().replace(
         "[[KLAI_CORRESPONDENCE_SENDER_STATEMENTS]]",
         "[[KLAI_CORRESPONSE_SENDER_STATEMENTS]]",
@@ -238,7 +239,33 @@ def test_known_section_suffix_recovers_misspelled_internal_prefix():
     rendered = strip_answer_contract_markers(answer)
 
     assert result["answer_contract"]["satisfied"] is True
+    assert result["answer_contract"]["normalized_marker_count"] == 1
     assert "[[KLAI_" not in rendered
+    drift_records = [
+        record
+        for record in caplog.records
+        if "answer_contract_marker_normalized" in record.getMessage()
+    ]
+    assert len(drift_records) == 1
+    assert drift_records[0].levelname == "WARNING"
+    assert drift_records[0].normalized_marker_count == 1
+
+
+def test_canonical_section_markers_do_not_emit_drift_event(caplog):
+    caplog.set_level("INFO", logger="klai_answer_epistemics")
+
+    inspect_answer_epistemics(
+        _contract_answer(),
+        user_turn=_INCIDENT_QUERY,
+        evidence_chunks=_EVIDENCE,
+        correspondence_detected=True,
+        telemetry_level="shadow",
+    )
+
+    assert not any(
+        "answer_contract_marker_normalized" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_missing_section_is_observed_without_rewriting_answer_prose():
@@ -349,8 +376,10 @@ def test_non_correspondence_marker_like_text_is_byte_identical():
 
 
 def test_multipart_correspondence_keeps_part_boundary_for_sender_tokens():
-    user_turn = "Please analyse this: ---------- Forwarded message ---------- " \
+    user_turn = (
+        "Please analyse this: ---------- Forwarded message ---------- "
         "Sender-only hypothesis"
+    )
 
     result = inspect_answer_epistemics(
         "Sender-only hypothesis",
@@ -389,9 +418,7 @@ def test_correspondence_suppressed_stream_strips_markers_and_evidence_labels():
         suppress_kb_citations=True,
     )
     item = {
-        "choices": [
-            {"delta": {"content": _contract_answer()}, "finish_reason": "stop"}
-        ]
+        "choices": [{"delta": {"content": _contract_answer()}, "finish_reason": "stop"}]
     }
 
     compose_streaming_kb_response(item, kb_meta, flush_stream=True)
@@ -506,9 +533,7 @@ def test_open_stream_without_trusted_sources_is_unchanged_but_measured(caplog):
 def test_correspondence_stream_without_trusted_sources_strips_internal_tokens():
     kb_meta = _grounded_meta(trusted_sources=[])
     answer = _contract_answer()
-    item = {
-        "choices": [{"delta": {"content": answer}, "finish_reason": "stop"}]
-    }
+    item = {"choices": [{"delta": {"content": answer}, "finish_reason": "stop"}]}
 
     compose_streaming_kb_response(item, kb_meta, flush_stream=True)
 
@@ -524,9 +549,7 @@ def test_correspondence_stream_without_evidence_still_strips_markers():
         "De kennisbank zegt dat 404 een onbekend toestel kan betekenen (E1).",
         "De kennisbank bevat geen bewijs over deze situatie.",
     )
-    item = {
-        "choices": [{"delta": {"content": answer}, "finish_reason": "stop"}]
-    }
+    item = {"choices": [{"delta": {"content": answer}, "finish_reason": "stop"}]}
 
     compose_streaming_kb_response(item, kb_meta, flush_stream=True)
 

--- a/deploy/litellm/tests/test_correspondence_eval.py
+++ b/deploy/litellm/tests/test_correspondence_eval.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
 from klai_correspondence_eval import (
     CorrespondenceCanary,
     answer_shape_matches_expectation,
@@ -90,15 +91,21 @@ class TestLoadPastedCorrespondenceCanaries:
             by_id["chat-pasted-correspondence-short-ticket"].expected_answer_sections
             == expected_sections
         )
+        assert by_id["chat-pasted-correspondence-short-ticket"].kb_slugs == [
+            "support",
+            "sip",
+        ]
         assert (
             by_id[
                 "chat-pasted-correspondence-control-plain-question"
             ].expected_answer_sections
             == []
         )
-        assert by_id[
-            "chat-pasted-correspondence-control-plain-question"
-        ].expected_chunks == ["08_algemene_sip_instellingen.md"]
+        control = by_id["chat-pasted-correspondence-control-plain-question"]
+        assert control.kb_slugs == ["support", "sip"]
+        assert control.expected_chunks == [
+            "Gebruiker/toestel bestaat niet, of extensie niet gevonden"
+        ]
 
     def test_missing_file_raises_file_not_found(self, tmp_path: Path):
         with pytest.raises(FileNotFoundError):

--- a/deploy/litellm/tests/test_litellm_compose_mounts.py
+++ b/deploy/litellm/tests/test_litellm_compose_mounts.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LITELLM_DIR = REPO_ROOT / "deploy" / "litellm"
 COMPOSE_FILE = REPO_ROOT / "deploy" / "docker-compose.yml"
 COMPOSE_UP_SCRIPT = REPO_ROOT / "deploy" / "scripts" / "compose-up.sh"
 DEPLOY_COMPOSE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-compose.yml"
-LITELLM_DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "litellm-hook-deploy.yml"
+LITELLM_DEPLOY_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "litellm-hook-deploy.yml"
+)
 
 
 def test_all_litellm_top_level_python_modules_are_mounted_in_compose():
@@ -43,4 +44,7 @@ def test_litellm_prisma_migrations_are_preflight_gated():
     assert '[[ "$SERVICE" == "litellm" ]]' in compose_up_text
     assert '[[ -z "$SERVICE" || "$SERVICE" == "litellm" ]]' not in compose_up_text
     assert "- 'deploy/docker-compose.yml'" in litellm_deploy_text
-    assert "grep -vx 'litellm'" in deploy_compose_text
+    assert "awk '$0 != \"litellm\"'" in deploy_compose_text
+    assert "no env-drift services resolved; refusing an all-services compose up" in (
+        deploy_compose_text
+    )

--- a/deploy/litellm/tests/test_litellm_config_provider_guard.py
+++ b/deploy/litellm/tests/test_litellm_config_provider_guard.py
@@ -2,8 +2,17 @@ from pathlib import Path
 
 import yaml
 
-
 TEXT_ALIASES = {"klai-primary", "klai-fast", "klai-large", "klai-medium"}
+
+
+def test_litellm_tests_run_when_the_runtime_image_pin_changes() -> None:
+    workflow_path = (
+        Path(__file__).resolve().parents[3] / ".github/workflows/litellm-tests.yml"
+    )
+    workflow = yaml.load(workflow_path.read_text(), Loader=yaml.BaseLoader)
+
+    for event in ("push", "pull_request"):
+        assert "deploy/docker-compose.yml" in workflow["on"][event]["paths"]
 
 
 def test_text_aliases_use_mistral_provider_only() -> None:
@@ -22,22 +31,15 @@ def test_text_aliases_use_mistral_provider_only() -> None:
     assert set(models) == TEXT_ALIASES
     for alias, deployments in models.items():
         assert len(deployments) == 2, alias
-        deployments_by_order = {
-            params["order"]: params for params in deployments
-        }
+        deployments_by_order = {params["order"]: params for params in deployments}
         assert set(deployments_by_order) == {1, 2}, alias
+        assert deployments_by_order[1]["api_key"] == "os.environ/MISTRAL_API_KEY", alias
         assert (
-            deployments_by_order[1]["api_key"]
-            == "os.environ/MISTRAL_API_KEY"
+            deployments_by_order[2]["api_key"] == "os.environ/MISTRAL_API_KEY_BACKUP"
         ), alias
-        assert (
-            deployments_by_order[2]["api_key"]
-            == "os.environ/MISTRAL_API_KEY_BACKUP"
-        ), alias
-        assert all(
-            params["model"].startswith("mistral/")
-            for params in deployments
-        ), alias
+        assert all(params["model"].startswith("mistral/") for params in deployments), (
+            alias
+        )
 
 
 def test_litellm_compose_scopes_primary_and_backup_mistral_keys() -> None:
@@ -46,7 +48,4 @@ def test_litellm_compose_scopes_primary_and_backup_mistral_keys() -> None:
     environment = compose["services"]["litellm"]["environment"]
 
     assert environment["MISTRAL_API_KEY"] == "${MISTRAL_API_KEY}"
-    assert (
-        environment["MISTRAL_API_KEY_BACKUP"]
-        == "${MISTRAL_API_KEY_BACKUP}"
-    )
+    assert environment["MISTRAL_API_KEY_BACKUP"] == "${MISTRAL_API_KEY_BACKUP}"

--- a/deploy/litellm/tests/test_litellm_mistral_failover.py
+++ b/deploy/litellm/tests/test_litellm_mistral_failover.py
@@ -1,0 +1,204 @@
+"""Behavioral coverage for ordered Mistral-key failover in LiteLLM."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import re
+import sys
+from importlib.metadata import version
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+_DEPLOY_DIR = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = _DEPLOY_DIR / "litellm" / "config.yaml"
+_COMPOSE_PATH = _DEPLOY_DIR / "docker-compose.yml"
+_ALIAS = "klai-medium"
+_PRIMARY_ALIAS = "klai-primary"
+_PRIMARY_KEY = "primary-test-key"
+_BACKUP_KEY = "backup-test-key"
+_TEXT_ALIASES = {"klai-primary", "klai-fast", "klai-large", "klai-medium"}
+
+
+@pytest.fixture(scope="module")
+def real_litellm():
+    """Temporarily replace older test modules' LiteLLM stubs with the pinned package."""
+    existing_modules = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name == "litellm" or name.startswith("litellm.")
+    }
+    for name in existing_modules:
+        sys.modules.pop(name, None)
+    try:
+        module = importlib.import_module("litellm")
+        yield module
+    finally:
+        for name in list(sys.modules):
+            if name == "litellm" or name.startswith("litellm."):
+                sys.modules.pop(name, None)
+        sys.modules.update(existing_modules)
+
+
+def _pinned_router(real_litellm: Any):
+    config = yaml.safe_load(_CONFIG_PATH.read_text())
+    deployments = [
+        entry for entry in config["model_list"] if entry["model_name"] in _TEXT_ALIASES
+    ]
+    for deployment in deployments:
+        order = deployment["litellm_params"]["order"]
+        deployment["litellm_params"]["api_key"] = (
+            _PRIMARY_KEY if order == 1 else _BACKUP_KEY
+        )
+    real_litellm.num_retries = config["litellm_settings"]["num_retries"]
+    return real_litellm.Router(
+        model_list=deployments,
+        **config["router_settings"],
+    )
+
+
+def _response(real_litellm: Any, model: str):
+    return real_litellm.ModelResponse(
+        model=model,
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "backup response"},
+                "finish_reason": "stop",
+            }
+        ],
+    )
+
+
+def test_behavior_runs_against_runtime_pinned_litellm_version() -> None:
+    compose = yaml.safe_load(_COMPOSE_PATH.read_text())
+    image = compose["services"]["litellm"]["image"]
+    image_match = re.fullmatch(r".+/litellm:v(?P<version>[0-9][^@/\s]*)", image)
+
+    assert image_match is not None, f"unsupported LiteLLM image reference: {image!r}"
+    pinned_version = image_match.group("version")
+
+    assert version("litellm") == pinned_version
+
+
+@pytest.mark.asyncio
+async def test_healthy_primary_order_is_not_randomly_load_balanced(
+    real_litellm,
+) -> None:
+    calls: list[str] = []
+
+    async def provider_completion(**kwargs):
+        calls.append(kwargs["api_key"])
+        return _response(real_litellm, kwargs["model"])
+
+    router = _pinned_router(real_litellm)
+    try:
+        with patch("litellm.acompletion", side_effect=provider_completion):
+            for _ in range(8):
+                await router.acompletion(
+                    model=_PRIMARY_ALIAS,
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+    finally:
+        router.reset()
+
+    assert calls == [_PRIMARY_KEY] * 8
+
+
+@pytest.mark.asyncio
+async def test_primary_alias_falls_back_to_medium_after_both_keys_fail(
+    real_litellm,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    async def provider_completion(**kwargs):
+        calls.append((kwargs["model"], kwargs["api_key"]))
+        if kwargs["model"] == "mistral/mistral-small-2603":
+            raise real_litellm.RateLimitError(
+                "rate limited",
+                llm_provider="mistral",
+                model=kwargs["model"],
+            )
+        return _response(real_litellm, kwargs["model"])
+
+    router = _pinned_router(real_litellm)
+    try:
+        with patch("litellm.acompletion", side_effect=provider_completion):
+            response = await router.acompletion(
+                model=_PRIMARY_ALIAS,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+    finally:
+        router.reset()
+
+    assert response.choices[0].message.content == "backup response"
+    assert calls == [
+        ("mistral/mistral-small-2603", _PRIMARY_KEY),
+        ("mistral/mistral-small-2603", _PRIMARY_KEY),
+        ("mistral/mistral-small-2603", _BACKUP_KEY),
+        ("mistral/mistral-small-2603", _BACKUP_KEY),
+        ("mistral/mistral-medium-3.5", _BACKUP_KEY),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_primary_429_uses_backup_key(real_litellm) -> None:
+    calls: list[str] = []
+
+    async def provider_completion(**kwargs):
+        calls.append(kwargs["api_key"])
+        if kwargs["api_key"] == _PRIMARY_KEY:
+            raise real_litellm.RateLimitError(
+                "rate limited",
+                llm_provider="mistral",
+                model=kwargs["model"],
+            )
+        return _response(real_litellm, kwargs["model"])
+
+    router = _pinned_router(real_litellm)
+    try:
+        with patch("litellm.acompletion", side_effect=provider_completion):
+            response = await router.acompletion(
+                model=_ALIAS,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+    finally:
+        router.reset()
+
+    assert response.choices[0].message.content == "backup response"
+    assert calls == [_PRIMARY_KEY, _PRIMARY_KEY, _BACKUP_KEY]
+
+
+@pytest.mark.asyncio
+async def test_both_keys_exhaust_to_bounded_terminal_error(real_litellm) -> None:
+    calls: list[str] = []
+
+    async def provider_completion(**kwargs):
+        calls.append(kwargs["api_key"])
+        raise real_litellm.RateLimitError(
+            "rate limited",
+            llm_provider="mistral",
+            model=kwargs["model"],
+        )
+
+    router = _pinned_router(real_litellm)
+    try:
+        with (
+            patch("litellm.acompletion", side_effect=provider_completion),
+            pytest.raises(real_litellm.RateLimitError, match="rate limited"),
+        ):
+            await asyncio.wait_for(
+                router.acompletion(
+                    model=_ALIAS,
+                    messages=[{"role": "user", "content": "hello"}],
+                ),
+                timeout=10,
+            )
+    finally:
+        router.reset()
+
+    assert calls == [_PRIMARY_KEY, _PRIMARY_KEY, _BACKUP_KEY, _BACKUP_KEY]

--- a/klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py
@@ -139,6 +139,7 @@ async def run_evaluation(suite: str, variant: str | None = None) -> dict:
             query=query.query,
             org_zitadel_id=query.org_zitadel_id,
             user_zitadel_id=query.user_zitadel_id,
+            kb_slugs=query.kb_slugs,
         )
 
         if isinstance(retrieval, RetrievalFailure):

--- a/klai-knowledge-ingest/knowledge_ingest/eval/retrieval_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/retrieval_client.py
@@ -57,6 +57,7 @@ async def retrieve_chunks(
     org_zitadel_id: str,
     user_zitadel_id: str | None,
     *,
+    kb_slugs: list[str] | None = None,
     _transport: httpx.AsyncBaseTransport | None = None,
 ) -> RetrievalResult | RetrievalFailure:
     """Call /retrieve on klai-retrieval-api and return chunks or a failure record.
@@ -69,6 +70,8 @@ async def retrieve_chunks(
         Tenant identifier used for scoped retrieval.
     user_zitadel_id:
         Optional user identifier; ``None`` for org-only scope.
+    kb_slugs:
+        Optional knowledge-base scope pinned by the evaluation suite.
     _transport:
         Optional httpx transport override — used in tests to inject mock responses
         without spinning up a real HTTP server.
@@ -87,6 +90,7 @@ async def retrieve_chunks(
         "org_id": org_zitadel_id,
         "user_id": user_zitadel_id,
         "conversation_history": [],
+        "kb_slugs": kb_slugs,
     }
 
     t0 = time.monotonic()

--- a/klai-knowledge-ingest/knowledge_ingest/eval/suite_loader.py
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/suite_loader.py
@@ -31,6 +31,7 @@ class SuiteQuery:
     reference_answer: str | None = None
     expected_topics: list[str] = field(default_factory=list)
     expected_chunks: list[str] = field(default_factory=list)
+    kb_slugs: list[str] | None = None
 
 
 @dataclass
@@ -103,6 +104,7 @@ def load_suite(path: Path, *, require_reference_answer: bool = False) -> Suite:
                 reference_answer=reference_answer,
                 expected_topics=list(q.get("expected_topics") or []),
                 expected_chunks=list(q.get("expected_chunks") or []),
+                kb_slugs=list(q["kb_slugs"]) if q.get("kb_slugs") is not None else None,
             )
         )
 

--- a/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
+++ b/klai-knowledge-ingest/knowledge_ingest/eval/suites/chat.yaml
@@ -503,6 +503,7 @@ queries:
   - id: chat-pasted-correspondence-short-ticket
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
+    kb_slugs: [support, sip]
     query: |
       Kun je hier naar kijken?
 
@@ -522,10 +523,15 @@ queries:
   - id: chat-pasted-correspondence-control-plain-question
     org_zitadel_id: "368884765035593759"
     user_zitadel_id: null
+    # Pin this control to the same curated corpus slice as the positive SIP
+    # canary. The exact answer-bearing heading below must occur in both the
+    # retrieval window and evidence pack; a sibling heading or filename is
+    # deliberately not enough.
+    kb_slugs: [support, sip]
     query: "Wat betekent een SIP 404 Not Found?"
     reference_answer: "Leg uit dat een SIP 404 Not Found betekent dat de gebelde gebruiker of het toestel niet gevonden is of niet is toegewezen, op basis van de kennisbank."
     expected_topics: [sip, 404, responscode]
-    expected_chunks: ["08_algemene_sip_instellingen.md"]
+    expected_chunks: ["Gebruiker/toestel bestaat niet, of extensie niet gevonden"]
     expected_answer_sections: []
     mix: pasted_correspondence
     # Negative-class control (REQ-6): a plain short question with NO pasted

--- a/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
+++ b/klai-knowledge-ingest/knowledge_ingest/llm_throttle.py
@@ -35,13 +35,11 @@ Usage::
 module POSTs to ``chat/completions`` without referencing this limiter.
 
 ``TokenBucketLimiter`` itself lives in the shared ``klai_llm_throttle``
-package (klai-libs/llm-throttle), not here — the SAME class of bug (an
-uncoordinated direct caller of this shared budget) recurred in a second,
-independent service (``deploy/litellm/klai_kb_query_rewrite.py``,
-2026-08-18) precisely because the fix lived only inside this
-knowledge-ingest-local module. This module now only owns the
-knowledge-ingest-specific singleton wiring (its own settings, its own
-lazy-init getter); the reusable rate-limiting logic is shared.
+package (klai-libs/llm-throttle), not here. The former direct-Mistral
+LiteLLM consumer now routes through the proxy and no longer imports this
+package, leaving knowledge-ingest as its only runtime consumer. This module
+owns the knowledge-ingest-specific singleton wiring (its own settings and
+lazy-init getter).
 """
 
 from __future__ import annotations

--- a/klai-knowledge-ingest/tests/eval/test_ragas_runner.py
+++ b/klai-knowledge-ingest/tests/eval/test_ragas_runner.py
@@ -328,6 +328,7 @@ async def test_expected_chunks_canary_fails_when_missing():
         org_zitadel_id="org-1",
         expected_topics=["bubble"],
         expected_chunks=["Bubble troubleshoot"],
+        kb_slugs=["support", "sip"],
     )
     mock_suite = Suite(name="chat", description="", queries=[query])
     rows: list[dict] = []
@@ -353,7 +354,7 @@ async def test_expected_chunks_canary_fails_when_missing():
                     total_tokens=10,
                 )
             ),
-        ),
+        ) as mock_retrieve,
         patch("knowledge_ingest.eval.judge_client.generate_answer", AsyncMock()) as mock_answer,
         patch("knowledge_ingest.eval.judge_client.evaluate_query", AsyncMock()) as mock_metrics,
         patch(
@@ -384,3 +385,9 @@ async def test_expected_chunks_canary_fails_when_missing():
     assert "canary_failed: missing expected_chunks: Bubble troubleshoot" in row["meta"]["errors"]
     mock_answer.assert_not_awaited()
     mock_metrics.assert_not_awaited()
+    mock_retrieve.assert_awaited_once_with(
+        query="Waar staat Bubble troubleshoot?",
+        org_zitadel_id="org-1",
+        user_zitadel_id=None,
+        kb_slugs=["support", "sip"],
+    )

--- a/klai-knowledge-ingest/tests/eval/test_retrieval_client.py
+++ b/klai-knowledge-ingest/tests/eval/test_retrieval_client.py
@@ -11,6 +11,7 @@ Coverage:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -39,11 +40,12 @@ class _MockTransport(httpx.AsyncBaseTransport):
         self._status_code = status_code
         self._json_body = json_body or {}
         self._raise_exc = raise_exc
+        self.last_request: httpx.Request | None = None
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.last_request = request
         if self._raise_exc is not None:
             raise self._raise_exc
-        import json
 
         content = json.dumps(self._json_body).encode()
         return httpx.Response(
@@ -80,6 +82,7 @@ async def test_retrieve_success_returns_chunks() -> None:
             query="Hoe troubleshoot ik Bubble?",
             org_zitadel_id="111",
             user_zitadel_id=None,
+            kb_slugs=["support", "sip"],
             _transport=transport,
         )
 
@@ -87,6 +90,8 @@ async def test_retrieve_success_returns_chunks() -> None:
     assert len(result.chunks) == 2
     assert result.chunks[0]["id"] == "c1"
     assert result.retrieval_ms >= 0
+    assert transport.last_request is not None
+    assert json.loads(transport.last_request.content)["kb_slugs"] == ["support", "sip"]
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/eval/test_suite_loader.py
+++ b/klai-knowledge-ingest/tests/eval/test_suite_loader.py
@@ -134,11 +134,36 @@ def test_load_handles_optional_fields(tmp_path: Path) -> None:
     q = suite.queries[0]
     # expected_chunks must default to [] not None
     assert q.expected_chunks == []
+    assert q.kb_slugs is None
     assert q.reference_answer is None
     # user_zitadel_id can be None
     assert q.user_zitadel_id is None
     # org_zitadel_id is a required field
     assert q.org_zitadel_id == "222"
+
+
+def test_load_preserves_retrieval_scope(tmp_path: Path) -> None:
+    """A suite query's corpus pin is available to the evaluation runner."""
+    suite_file = tmp_path / "scoped.yaml"
+    suite_file.write_text(
+        textwrap.dedent(
+            """\
+            suite: scoped
+            queries:
+              - id: scoped-q-1
+                org_zitadel_id: "222"
+                query: "What does SIP 404 mean?"
+                kb_slugs: [support, sip]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    from knowledge_ingest.eval.suite_loader import load_suite
+
+    suite = load_suite(suite_file)
+
+    assert suite.queries[0].kb_slugs == ["support", "sip"]
 
 
 def test_load_strict_requires_reference_answer(tmp_path: Path) -> None:

--- a/klai-libs/llm-throttle/tests/test_token_bucket_limiter.py
+++ b/klai-libs/llm-throttle/tests/test_token_bucket_limiter.py
@@ -1,11 +1,9 @@
 """Tests for klai_llm_throttle.TokenBucketLimiter.
 
-Extracted from knowledge_ingest/llm_throttle.py (2026-08-14 incident fix)
-into a shared package after the SAME class of bug recurred in a second,
-independent service (deploy/litellm/klai_kb_query_rewrite.py, 2026-08-18) —
-a direct-to-Mistral caller with no shared rate accounting, invisible to the
-first fix because it lived in a different process/package entirely. See the
-package README for the full incident history.
+Extracted from knowledge_ingest/llm_throttle.py during the 2026-08-14
+incident fix. The former direct-Mistral LiteLLM consumer was removed; the
+knowledge-ingest service is now the package's only runtime consumer. See the
+package README for the incident history.
 """
 
 from __future__ import annotations

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -24,6 +24,7 @@ from retrieval_api.config import settings
 from retrieval_api.metrics import (
     quality_floor_filtered_total,
     retrieval_chunks_total,
+    retrieval_confidence_band_corroborated_total,
     retrieval_confidence_band_total,
     retrieval_graph_top_k_total,
     retrieval_link_expand_top_k_total,
@@ -983,6 +984,13 @@ async def retrieve(
         decision_record["confidence_band"] = confidence_band
         decision_record["confidence_band_corroborated"] = confidence_band_corroborated
         retrieval_confidence_band_total.labels(band=confidence_band, org_id=req.org_id).inc()
+        retrieval_confidence_band_corroborated_total.labels(
+            band=confidence_band_corroborated, org_id=req.org_id
+        ).inc()
+        # TODO(2026-08-22): Evaluate the 48h corroboration shadow window and
+        # decide to promote or remove this signal + metric. Do not leave it in
+        # indefinite shadow like the gate_shadow_mode/evidence_shadow_mode precedent.
+        # Compare primary vs shadow bands in Grafana's RAG quality Low-Confidence panel.
 
     evidence_query = (
         f"{req.raw_query}\n{query_resolved}"

--- a/klai-retrieval-api/retrieval_api/metrics.py
+++ b/klai-retrieval-api/retrieval_api/metrics.py
@@ -100,6 +100,11 @@ retrieval_confidence_band_total = Counter(
     "Retrieval responses bucketed by reranker-score confidence band",
     ["band", "org_id"],
 )
+retrieval_confidence_band_corroborated_total = Counter(
+    "retrieval_confidence_band_corroborated_total",
+    "Shadow retrieval responses bucketed by corroborated confidence band",
+    ["band", "org_id"],
+)
 
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-3 / REQ-8 — link-expansion
 # survival rate. ``hit`` = at least one expanded chunk made the served

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -49,7 +49,12 @@ class TestRetrieveEndpoint:
         """Happy path: mock all external calls, verify response structure."""
         import logging
 
+        from retrieval_api.metrics import retrieval_confidence_band_corroborated_total
+
         caplog.set_level(logging.INFO)
+        corroborated_before = retrieval_confidence_band_corroborated_total.labels(
+            band="medium", org_id=sample_retrieve_request["org_id"]
+        )._value.get()  # type: ignore[attr-defined]
 
         with (
             patch(
@@ -188,6 +193,10 @@ class TestRetrieveEndpoint:
         assert "top_item_chunk_ids" in decision_attrs
         assert decision_record.msg["confidence_band"] == "high"
         assert decision_record.msg["confidence_band_corroborated"] == "medium"
+        corroborated_after = retrieval_confidence_band_corroborated_total.labels(
+            band="medium", org_id=sample_retrieve_request["org_id"]
+        )._value.get()  # type: ignore[attr-defined]
+        assert corroborated_after == corroborated_before + 1
 
     def test_retrieve_passes_effective_telemetry_level_to_coreference(
         self, client, sample_retrieve_request


### PR DESCRIPTION
## Summary
- restore the correspondence canary to an answer-bearing heading and pin its retrieval scope to `support` + `sip`
- add pinned LiteLLM 1.96.2 behavioral failover coverage for primary 429, backup exhaustion, and model fallback
- update stale throttle ownership docs and expose marker normalization drift through structured logs
- add the corroborated confidence-band Prometheus shadow metric and dashboard series

## Root-cause evidence
The canary instability came from the eval path silently ignoring per-query KB scoping, leaving retrieval tenant-wide. The original answer-bearing heading still exists in the documented corpus/spec state; there is no evidence that chunking or corpus drift removed it. The query schema, loader, runner, and retrieval payload now propagate an explicit `kb_slugs` pin, with regression coverage and an explanatory comment.

For LiteLLM 1.96.2, Router source filters deployments to the lowest `order` before applying `simple-shuffle`; deployment fallback advances to the next order. The tests exercise that actual pinned Router behavior.

## Verification
- LiteLLM: 691 passed
- retrieval-api: 633 passed, 1 skipped
- knowledge-ingest eval/throttle: 80 passed
- llm-throttle library: 7 passed
- Ruff check and format check: passed for all changed Python files
- dashboard JSON, alerting guards, YAML parity, and git diff checks: passed
- Codex recall-pass review of the complete 22-file delta: no findings

## Deliberately deferred follow-ups
- replace literal correspondence markers with the existing claim-provenance contract in a separate SPEC/session
- extract the duplicated post-rerank pipeline in a separate refactor session
- consider folding `klai_llm_throttle` back into knowledge-ingest; repository search found no other runtime consumer

## Residual
The current live corpus contents were not queried locally; the meaningful canary is pinned to the documented support/SIP corpus contract and will be exercised by CI/runtime evaluation.