### PR TITLE
fix(rag): resolve orphaned shadow experiments

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -410,7 +410,8 @@ services:
       # thresholds for klai_citations (path A). Portal-api carries the SAME
       # three vars for path B; keep them in sync or the two chat surfaces
       # show diverging citations for identical KB answers.
-      CITATION_RESCUE_MODE: ${CITATION_RESCUE_MODE:-shadow}
+      # Graduated 2026-08-20 after 25 unique production shadow cases over 23 days.
+      CITATION_RESCUE_MODE: ${CITATION_RESCUE_MODE:-active}
       RESCUE_ANSWER_SCORE_THRESHOLD: ${RESCUE_ANSWER_SCORE_THRESHOLD:-19}
       RESCUE_RETRIEVAL_RATIO: ${RESCUE_RETRIEVAL_RATIO:-0.4}
     depends_on:
@@ -821,7 +822,8 @@ services:
       # SPEC-RAG-EVIDENCE-INTEGRITY-001 REQ-CIT — citation-rescue config
       # for klai_citations on path B (widget/partner chat). Mirrors the
       # litellm block (path A); keep the two in sync.
-      CITATION_RESCUE_MODE: ${CITATION_RESCUE_MODE:-shadow}
+      # Keep path B aligned with the graduated LiteLLM citation behavior.
+      CITATION_RESCUE_MODE: ${CITATION_RESCUE_MODE:-active}
       RESCUE_ANSWER_SCORE_THRESHOLD: ${RESCUE_ANSWER_SCORE_THRESHOLD:-19}
       RESCUE_RETRIEVAL_RATIO: ${RESCUE_RETRIEVAL_RATIO:-0.4}
       # ─── Mailer (notifications, onboarding drip) ────────────────
@@ -1246,6 +1248,12 @@ services:
       GRAPHITI_LLM_MODEL: ${GRAPHITI_LLM_MODEL:-klai-fast}
       RERANKER_ENABLED: "true"
       RERANKER_TIMEOUT: "60.0"
+      # The gate's 30d shadow run produced 3 unique would-bypass decisions
+      # (~0.07%), all low-confidence. Keep it off: risk exceeds saved work.
+      RETRIEVAL_GATE_ENABLED: "false"
+      # Evidence-tier shadow ordering changed ranks but never measured answer
+      # quality. Stop paying deepcopy/scoring cost on every request.
+      EVIDENCE_SHADOW_MODE: "disabled"
       OPENAI_API_KEY: "dummy"
       SPARSE_SIDECAR_URL: http://172.18.0.1:8001
       PORTAL_EVENTS_HOST: postgres

--- a/deploy/grafana/provisioning/dashboards/rag-quality.json
+++ b/deploy/grafana/provisioning/dashboards/rag-quality.json
@@ -325,15 +325,44 @@
                     "expr": "sum(rate(retrieval_confidence_band_total{band=~\"low|unknown\",org_id=\"$org_id\"}[$__rate_interval])) / sum(rate(retrieval_confidence_band_total{org_id=\"$org_id\"}[$__rate_interval]))",
                     "legendFormat": "low+unknown share",
                     "refId": "C"
+                }
+            ]
+        },
+        {
+            "id": 7,
+            "title": "Citation rescue events",
+            "description": "Answers where the active citation-rescue rule exposed at least one extra source, split by chat surface.",
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 32
+            },
+            "type": "timeseries",
+            "datasource": {
+                "type": "victoriametrics-logs-datasource",
+                "uid": "victorialogs"
+            },
+            "targets": [
+                {
+                    "refId": "A",
+                    "datasource": {
+                        "type": "victoriametrics-logs-datasource",
+                        "uid": "victorialogs"
+                    },
+                    "expr": "service:litellm AND _msg:\"citation_rescue_applied\"",
+                    "queryType": "stats",
+                    "legendFormat": "LiteLLM"
                 },
                 {
+                    "refId": "B",
                     "datasource": {
-                        "type": "prometheus",
-                        "uid": "victoriametrics"
+                        "type": "victoriametrics-logs-datasource",
+                        "uid": "victorialogs"
                     },
-                    "expr": "sum by (band) (rate(retrieval_confidence_band_corroborated_total{org_id=\"$org_id\"}[$__rate_interval]))",
-                    "legendFormat": "corroborated {{band}} (shadow)",
-                    "refId": "D"
+                    "expr": "service:portal-api AND event:citation_rescue_applied",
+                    "queryType": "stats",
+                    "legendFormat": "Portal API"
                 }
             ]
         }

--- a/deploy/litellm/klai_kb_citation_render.py
+++ b/deploy/litellm/klai_kb_citation_render.py
@@ -64,14 +64,12 @@ class KbCitationRenderStats:
     epistemics_measured: bool = False
     citation_decisions: list[dict[str, Any]] = field(default_factory=list)
 
-    def merge(self, other: "KbCitationRenderStats") -> None:
+    def merge(self, other: KbCitationRenderStats) -> None:
         self.mutated_messages += other.mutated_messages
         self.rendered_messages += other.rendered_messages
         self.rendered_sources = max(self.rendered_sources, other.rendered_sources)
         self.no_citable_sources = self.no_citable_sources or other.no_citable_sources
-        self.epistemics_measured = (
-            self.epistemics_measured or other.epistemics_measured
-        )
+        self.epistemics_measured = self.epistemics_measured or other.epistemics_measured
         self.citation_decisions.extend(other.citation_decisions)
 
 
@@ -486,7 +484,9 @@ def _format_kb_scope_text(kb_meta: dict[str, Any], *, language: str = "nl") -> s
             else "all organization knowledge bases"
         )
     if scope_mode == "personal":
-        return "persoonlijke kennisbank" if language == "nl" else "personal knowledge base"
+        return (
+            "persoonlijke kennisbank" if language == "nl" else "personal knowledge base"
+        )
     return ""
 
 
@@ -682,7 +682,9 @@ def _format_visible_agent_activity(
 
     kb_scope_text = _format_kb_scope_text(kb_meta, language=language)
     if kb_scope_text:
-        label = "Kennisbanken in scope" if language == "nl" else "Knowledge bases in scope"
+        label = (
+            "Kennisbanken in scope" if language == "nl" else "Knowledge bases in scope"
+        )
         lines.append(f"- {label}: {kb_scope_text}.")
 
     kbs_with_results = _format_limited_label_list(
@@ -751,7 +753,11 @@ def _format_visible_agent_activity(
 
     if isinstance(confidence_band, str) and confidence_band:
         if sources:
-            suffix = "bronfragmenten gekoppeld" if language == "nl" else "source chunks linked"
+            suffix = (
+                "bronfragmenten gekoppeld"
+                if language == "nl"
+                else "source chunks linked"
+            )
             lines.append(f"- Retrieval score: {confidence_band}; {suffix}.")
         else:
             lines.append(f"- Retrieval score: {confidence_band}.")
@@ -814,12 +820,23 @@ def log_kb_citation_render(
     for decision in stats.citation_decisions:
         if not isinstance(decision, dict):
             continue
-        for entry in (decision.get("rejected") or []) + (decision.get("selected") or []):
+        for entry in (decision.get("rejected") or []) + (
+            decision.get("selected") or []
+        ):
             if not isinstance(entry, dict):
                 continue
             reason = entry.get("reason")
             if isinstance(reason, str) and reason:
                 reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    rescued_sources = reason_counts.get("rescued", 0)
+
+    if rescued_sources:
+        logger.warning(
+            "citation_rescue_applied org_id=%s request_id=%s rescued_sources=%d",
+            kb_meta.get("org_id"),
+            kb_meta.get("request_id"),
+            rescued_sources,
+        )
 
     telemetry_level = kb_meta.get("telemetry_level")
     citation_decisions = stats.citation_decisions
@@ -855,9 +872,7 @@ def log_kb_citation_render(
         provenance.get("answer_tokens_unsupported_by_evidence"),
         provenance.get("correspondence_detected"),
         provenance.get("sender_only_tokens", "<redacted>"),
-        provenance.get(
-            "answer_tokens_unsupported_by_evidence_values", "<redacted>"
-        ),
+        provenance.get("answer_tokens_unsupported_by_evidence_values", "<redacted>"),
         kb_meta.get("answer_contract"),
     )
 
@@ -869,12 +884,8 @@ def _record_answer_epistemics(
 ) -> str:
     """Record measurement-only answer telemetry; never block rendering."""
     try:
-        correspondence_detected = bool(
-            kb_meta.get("pasted_correspondence_detected")
-        )
-        latest_turn_detected = kb_meta.get(
-            "latest_turn_pasted_correspondence_detected"
-        )
+        correspondence_detected = bool(kb_meta.get("pasted_correspondence_detected"))
+        latest_turn_detected = kb_meta.get("latest_turn_pasted_correspondence_detected")
         if latest_turn_detected is None:
             latest_turn_detected = correspondence_detected
         inspection = inspect_answer_epistemics(
@@ -1120,10 +1131,7 @@ def compose_streaming_kb_response(
         return stats
 
     kb_narrow = _kb_meta_is_strict(kb_meta)
-    strict_no_sources = (
-        not trusted_sources
-        and (force_no_citable or kb_narrow)
-    )
+    strict_no_sources = not trusted_sources and (force_no_citable or kb_narrow)
     telemetry_only_stream = bool(
         citation_chunks
         and not trusted_sources
@@ -1211,14 +1219,10 @@ def compose_streaming_kb_response(
         content_for_render = content
         if correspondence_detected:
             if isinstance(content, str) and content:
-                raw_parts = kb_meta.setdefault(
-                    "_answer_contract_stream_raw_parts", []
-                )
+                raw_parts = kb_meta.setdefault("_answer_contract_stream_raw_parts", [])
                 raw_parts.append(content)
             marker_buffer = kb_meta.get("_answer_contract_stream_buffer") or ""
-            marker_input = marker_buffer + (
-                content if isinstance(content, str) else ""
-            )
+            marker_input = marker_buffer + (content if isinstance(content, str) else "")
             content_for_render, marker_buffer = pop_answer_contract_stream_text(
                 marker_input, final=should_flush
             )

--- a/deploy/litellm/tests/test_answer_epistemics.py
+++ b/deploy/litellm/tests/test_answer_epistemics.py
@@ -10,6 +10,7 @@ from klai_answer_epistemics import (
     strip_answer_contract_markers,
 )
 from klai_kb_citation_render import (
+    KbCitationRenderStats,
     _render_kb_citation_content,
     compose_non_streaming_kb_response,
     compose_streaming_kb_response,
@@ -159,6 +160,34 @@ def test_structured_log_emits_counts_but_redacts_token_values(caplog):
     assert "correspondence_detected=True" in caplog.text
     assert "sender_only_tokens=<redacted>" in caplog.text
     assert "fraudeblokkade" not in caplog.text
+
+
+def test_citation_rescue_application_emits_actionable_event(caplog):
+    stats = KbCitationRenderStats(
+        rendered_messages=1,
+        rendered_sources=2,
+        citation_decisions=[
+            {
+                "selected": [
+                    {"reason": "supported"},
+                    {"reason": "rescued"},
+                ],
+                "rejected": [],
+            }
+        ],
+    )
+    kb_meta = _grounded_meta()
+
+    with caplog.at_level(logging.WARNING):
+        log_kb_citation_render(
+            logging.getLogger("test-citation-rescue"),
+            kb_meta,
+            stats,
+            stream=False,
+        )
+
+    assert "citation_rescue_applied" in caplog.text
+    assert "rescued_sources=1" in caplog.text
 
 
 def test_grounded_answer_logs_epistemics_when_no_citation_is_rendered(caplog):

--- a/docs/architecture/klai-knowledge-architecture.md
+++ b/docs/architecture/klai-knowledge-architecture.md
@@ -10,7 +10,7 @@
 >
 > *2026-06-08 (doc-vs-code drift audit): §0 infra table corrected (gpu-01 models, Graphiti live, PG schema populated, gap inbox live, Mistral stack). Several sections that described a richer design than the code now carry an **Intended vs. current** callout pointing to [`product-gaps-backlog.md`](product-gaps-backlog.md) — notably §8 gap detection (GAP-LOOP-*), §6 taxonomy (GAP-TAX-*), §3.3/§5 provenance (GAP-PROV-*), §7.4/§3.2 evidence weighting (GAP-EVID-*), §5.1 multitenancy (GAP-TENANCY-01), §9.2 MCP read tools (GAP-MCP-01), §10 personal-knowledge enrichment (GAP-PRIV-01). The temporal-validity filter has a field-name bug — see [the retro](../retros/2026-06-08-temporal-filter-field-mismatch.md).*
 >
-> *2026-06-11 (per-claim re-verification): the temporal field-name bug is **fixed** on the serving path (dual-contract filter + delete-then-upsert; see §5.2 callout and the retro addendum); `is_tenant=True` now ships for new collections (existing collection needs the one-time upgrade script — §5.1 callout); evidence-tier assertion weights are no longer flat (conservative profile, shadow-gated — §7.4 callout); GAP-INGEST-02 (`chunk_type`) was closed by removal. Refreshed gap states: [`product-gaps-backlog.md`](product-gaps-backlog.md); improvement plan: [`knowledge-rag-improvement-plan.md`](knowledge-rag-improvement-plan.md).*
+> *2026-08-20 (experiment resolution): evidence-tier scoring is disabled in production after its online order diff lacked a paired answer-quality outcome; the calibrated citation-rescue rule is active. The temporal and ingest corrections from the 2026-06-11 re-verification remain in force. Refreshed gap states: [`product-gaps-backlog.md`](product-gaps-backlog.md); improvement plan: [`knowledge-rag-improvement-plan.md`](knowledge-rag-improvement-plan.md).*
 
 ---
 
@@ -821,9 +821,9 @@ Step 5: Cross-encoder reranking
   Top 5 chunks selected for context injection
   │
   ▼
-Step 6: Evidence tier scoring (shadow mode)
-  Adjusts scores by content_type weight + temporal decay
-  Currently logs only — does not reorder results (EVIDENCE_SHADOW_MODE=true)
+Step 6: Evidence tier scoring (disabled in production)
+  Available for controlled evaluation; flat reranker order is served
+  without shadow computation (EVIDENCE_SHADOW_MODE=disabled)
   │
   ▼
 System message injection → model
@@ -847,11 +847,11 @@ Bi-encoder retrieval (top-20) → Cross-encoder reranking (top-5) → LLM classi
 
 The cross-encoder reads query + document together and assesses relevance at claim level, not topic level. This is what distinguishes "Windows vs. Mac" when the topic is the same but the coverage is not.
 
-### 7.4 Evidence-weighted scoring [LIVE — shadow mode]
+### 7.4 Evidence-weighted scoring [EVALUATION-ONLY — production disabled]
 
-> Research backing: [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md). Activation track: [`SPEC-EVIDENCE-001-FOLLOWUP-001`](../../.moai/specs/SPEC-EVIDENCE-001-FOLLOWUP-001/spec.md). User-facing flow: [knowledge-retrieval-flow.md § Evidence tier scoring](knowledge-retrieval-flow.md#step-6-evidence-tier-scoring-shadow-mode).
+> Research backing: [Evidence-Weighted Knowledge Retrieval: Research Synthesis](../research/README.md). Activation track: [`SPEC-EVIDENCE-001-FOLLOWUP-001`](../../.moai/specs/SPEC-EVIDENCE-001-FOLLOWUP-001/spec.md). User-facing flow: [knowledge-retrieval-flow.md § Evidence tier scoring](knowledge-retrieval-flow.md#step-6-evidence-tier-scoring-production-disabled).
 
-Evidence-weighted scoring runs in Step 6 of the retrieval pipeline. Currently in shadow mode (`EVIDENCE_SHADOW_MODE=true`): scores are computed and logged but do not reorder results. This is a **post-retrieval scoring adjustment**, not a replacement for semantic search.
+Evidence-weighted scoring is available in Step 6 of the retrieval pipeline for explicit evaluation. Production uses `EVIDENCE_SHADOW_MODE=disabled`, so scores are not computed and the flat reranker order is served. This is a **post-retrieval scoring adjustment**, not a replacement for semantic search.
 
 **Four scoring dimensions (multiplicative, each per-dimension feature-flagged):**
 
@@ -860,20 +860,19 @@ Evidence-weighted scoring runs in Step 6 of the retrieval pipeline. Currently in
 | Content type | `content_type` (kb_article, pdf_document, web_crawl, ...) | Per-type weight, see table below | `EVIDENCE_CONTENT_TYPE_ENABLED` (default `true`) |
 | Temporal decay | `ingested_at` age | Step function across <30d / 30-180d / 180-365d / >365d brackets | `EVIDENCE_TEMPORAL_DECAY_ENABLED` (default `true`) |
 | PageRank | `entity_pagerank_max` from FalkorDB | `1 + 0.20 * log1p(pagerank * 100)` — capped ~+25% | `EVIDENCE_PAGERANK_ENABLED` (default `true`) |
-| Assertion mode | `assertion_mode` (factual, procedural, ...) | **Conservative profile** (factual/procedural 1.00, quoted 0.98, unknown 0.97, belief 0.95, hypothesis 0.90) — go-live via `SPEC-EVIDENCE-002` | `EVIDENCE_ASSERTION_MODE_ENABLED` (default `true`; shadow mode keeps it measured-not-served) |
+| Assertion mode | `assertion_mode` (factual, procedural, ...) | **Conservative profile** (factual/procedural 1.00, quoted 0.98, unknown 0.97, belief 0.95, hypothesis 0.90) — go-live via `SPEC-EVIDENCE-002` | `EVIDENCE_ASSERTION_MODE_ENABLED` (only evaluated when evidence-tier mode is explicitly enabled) |
 
-> **Intended vs. current (GAP-EVID-01/02, updated 2026-06-11).** The whole evidence-tier
-> remains shadow-mode (`EVIDENCE_SHADOW_MODE=true`: weighted order is computed and
-> logged as `shadow_eval`, the flat reranker order is served). Two corrections to the
-> earlier callout:
+> **Resolution (GAP-EVID-01/02, updated 2026-08-20).** The evidence-tier is flags-off
+> (`EVIDENCE_SHADOW_MODE=disabled`). Its 30-day online shadow changed order in
+> 2,186/8,946 logged runs but captured no paired answer-quality outcome, so it could not
+> establish an improvement and the per-request `deepcopy + apply()` cost was stopped.
 > - `_assertion_weight()` no longer returns a constant: it reads the conservative
 >   profile above from `DEFAULT_EVIDENCE_PROFILE` (`evidence_tier.py:43-67,125-148`;
 >   spread 0.10 per the weights research, unmapped modes fall back to `unknown`).
->   Still measured-not-served while shadow mode is on.
+>   It remains available for controlled evaluation.
 > - The deciding RAGAS A/B (SPEC-EVIDENCE-001-FOLLOWUP-001 variants
 >   `evidence_tier_full` / `evidence_tier_temporal_only`) was **never built** — the eval
->   harness only knows `baseline` — and the SPEC's 30-day decision deadline has lapsed
->   while the shadow `deepcopy + apply()` CPU cost is paid per request.
+>   harness only knows `baseline`; that is why the flags-off terminal state was selected.
 >
 > The 3-into-5 epistemic grouping from §3.2 (assertion / speculation / procedure) is
 > still **not implemented anywhere**. content_type / temporal / pagerank are real
@@ -898,7 +897,7 @@ final_score = reranker_score × content_type_weight × assertion_mode_weight × 
 | `web_crawl` | 0.65 |
 | `unknown` (fallback) | 0.55 |
 
-**Activation track (post-audit, SPEC-EVIDENCE-001-FOLLOWUP-001):** the shadow mode has been the default since 2026-03-30. The follow-up SPEC sets a 30-day deadline to choose one of four terminal states using a 7-day RAGAS A/B (`baseline` vs. `evidence_tier_full` vs. `evidence_tier_temporal_only`):
+**Resolved activation track (SPEC-EVIDENCE-001-FOLLOWUP-001):** the shadow mode ran from 2026-03-30 through 2026-08-20. The follow-up SPEC defined four terminal states:
 
 1. **Activate** — staged 5%/50%/100% rollout with auto-revert on quality regression
 2. **Activate temporal-only** — narrow rollout of the dimension with strongest theoretical justification
@@ -907,7 +906,10 @@ final_score = reranker_score × content_type_weight × assertion_mode_weight × 
 
 Decision criteria: ≥+0.02 mean uplift on RAGAS Context Precision **and** Faithfulness with Wilcoxon paired `p<0.05` against baseline on the 50-curated query subset.
 
-**Assertion mode weight activation** is governed by a separate SPEC (`SPEC-EVIDENCE-002`) — it remains flat-1.00 in V1 even after the FOLLOWUP-001 decision because the multiplicative compounding risk (4 dimensions at ~85% classifier accuracy → 48% chance of misclassification per chunk) demands its own calibration cycle. See [Assertion Mode Weights research](../research/assertion-modes/assertion-mode-weights.md).
+The required paired A/B was never implemented, so no uplift could be proven. Terminal
+state 4 (retain-flags-off) is active; there is no production shadow experiment.
+
+**Assertion mode weight activation** is governed by a separate SPEC (`SPEC-EVIDENCE-002`) — it remains inactive in production because the multiplicative compounding risk (4 dimensions at ~85% classifier accuracy → 48% chance of misclassification per chunk) demands its own calibration cycle. See [Assertion Mode Weights research](../research/assertion-modes/assertion-mode-weights.md).
 
 **Corroboration scoring: deferred.** Cross-source corroboration requires three prerequisites not yet met: near-duplicate detection (SemHash), source-level grouping, and entity resolution validation (>90% precision, >85% recall). See [Corroboration Scoring research](../research/corroboration/corroboration-scoring.md).
 

--- a/docs/architecture/knowledge-ingest-flow.md
+++ b/docs/architecture/knowledge-ingest-flow.md
@@ -17,8 +17,7 @@
 > naming); the per-chunk `chunk_type` classification was **removed** 2026-06-08
 > (GAP-INGEST-02 closed); `org_id` ships `is_tenant=True` for new collections (existing
 > collections need the one-time upgrade script); the Part-6 assertion-mode status table
-> was refreshed (payload + retrieval response are done; weighting is shadow-gated, no
-> longer flat).
+> was refreshed (payload + retrieval response are done; production weighting is disabled).
 >
 > For the research backing these design decisions, see
 > [knowledge-system-fundamentals.md](../research/knowledge-system-fundamentals.md).
@@ -1376,7 +1375,7 @@ rarely be reached in practice. See SPEC-KB-015 §Design notes for full rationale
 |---|---|
 | MCP read tools (full semantic surface) | `search_knowledge` is live; `related_concepts` / `belief_evolution` / `provenance_chain` / `recent` are not (GAP-MCP-01) |
 | Transcript → gap-candidate arm | scribe transcripts are ingested as documents, but emit no gap events; only low-confidence chat retrieval feeds the gap registry (GAP-LOOP-05) |
-| Assertion mode active in retrieval | `_assertion_weight` now reads a conservative profile (factual/procedural 1.00 … hypothesis 0.90) but remains **shadow-gated** (`EVIDENCE_SHADOW_MODE=true`) — measured, never served. Go-live deferred to SPEC-EVIDENCE-002; the deciding evidence-tier A/B from SPEC-EVIDENCE-001-FOLLOWUP-001 has not been built (GAP-EVID-01, updated 2026-06-11) |
+| Assertion mode active in retrieval | Not active. `EVIDENCE_SHADOW_MODE=disabled` since 2026-08-20 because the unbuilt paired A/B meant production order diffs could not measure answer quality. |
 | ~~Content profile chunk sizes wired to chunker~~ | Fixed 2026-03-31: `chunk_tokens_max` from profile now passed to `chunker.py` (`tokens * 4` → chars) |
 | ~~Docling migration for binary parsing~~ | **Shipped** (SPEC-KB-FILE-UPLOAD-001): portal uploads stream to docling-serve's async queue and submit pre-chunked. Unstructured.io is now connector-only. |
 | Self-maintaining taxonomy (periodic re-cluster) | No periodic re-clustering task is registered — bootstrap is manual-only (GAP-TAX-01) |
@@ -1411,13 +1410,12 @@ axes (alongside provenance type and synthesis depth) described in the architectu
 | HyPE/LLM classification | Not built — enrichment does not classify assertion mode (value comes from author frontmatter or connector hint only) |
 | Qdrant payload | **Done** (corrected 2026-06-11) — `assertion_mode` is in `_ALLOWED_METADATA_FIELDS` (`qdrant_store.py:450`) and written from `extra_payload` at ingest |
 | Retrieval API response | **Done** (corrected 2026-06-11) — read back from the payload in `search.py:339,414` and exposed on the chunk model (`models.py:91`) |
-| Evidence-tier weighting | **Shadow-gated** — conservative profile in `evidence_tier.py` (`factual`/`procedural` 1.00, `quoted` 0.98, `unknown` 0.97, `belief` 0.95, `hypothesis` 0.90); computed + logged, never served while `EVIDENCE_SHADOW_MODE=true`. Go-live: SPEC-EVIDENCE-002. |
+| Evidence-tier weighting | **Disabled in production** — the conservative profile remains available for explicit evaluation, but `EVIDENCE_SHADOW_MODE=disabled` performs no per-request scoring. |
 
-**Summary (updated 2026-06-11):** Storage, ingest parsing, Qdrant payload, and retrieval
+**Summary (updated 2026-08-20):** Storage, ingest parsing, Qdrant payload, and retrieval
 response all carry `assertion_mode` end-to-end. The consumption side computes
-conservative weights in evidence-tier scoring but serves nothing yet — everything is
-shadow-gated pending SPEC-EVIDENCE-002 (and the never-run SPEC-EVIDENCE-001-FOLLOWUP-001
-A/B, see GAP-EVID-01).
+conservative weights only in explicitly requested evaluation runs; production scoring is
+disabled after the required paired A/B was never built (see GAP-EVID-01).
 
 ### Industry landscape
 

--- a/docs/architecture/knowledge-rag-improvement-plan.md
+++ b/docs/architecture/knowledge-rag-improvement-plan.md
@@ -57,10 +57,10 @@ dead-man alert, and two actionable items:
 | Gap | Backlog claim | Actual state 2026-06-11 |
 |---|---|---|
 | `GAP-TEMPORAL-01` | retrieval filters on never-written `invalid_at` | **Fixed on the serving path** (re-verified 2026-06-11): `search.py:71-112` has a dual-contract `must_not` over `invalid_at`/`valid_until`/`valid_at`/`valid_from`, with a passing integration test (`test_search.py:129-218`). The retro's open question is **answered**: both `qdrant_store.upsert_chunks` and `upsert_enriched_chunks` delete all points for `(org, kb, path)` before upserting — same-path re-ingest leaves no stale points (the random `uuid4` point IDs are harmless; delete-by-path-filter is the mechanism, not overwrite-by-ID). Temporal hygiene is now also covered in code: replacement ingests link the just-closed PG artifact row via `superseded_by`, and `valid_from`/`valid_until` get Qdrant integer payload indexes. Remaining risk: a failed Qdrant delete after PG commit is silent divergence (→ H1 / GAP-SYNC-01). |
-| `GAP-RETR-01` | gate inert, reference file missing | `gate_reference.jsonl` **exists** (16-line generic stub) and the gate runs in **shadow mode** (`retrieval_gate_shadow=True`, `config.py:28`), logging `gate_would_bypass` per request; strict mode skips the gate by design (`gate_skipped_reason=strict_mode`, `retrieve.py:213-220`). Blocker is now corpus quality, not existence. |
+| `GAP-RETR-01` | gate inert, reference file missing | **Resolved flags-off 2026-08-20:** the 16-line stub's 30-day shadow run yielded 3 unique would-bypass decisions across ~4.5k requests, all low-confidence. `RETRIEVAL_GATE_ENABLED=false`; no production shadow compute. |
 | `GAP-TENANCY-01` | `is_tenant` missing | Code sets `is_tenant=True` for **new** collections (`qdrant_store.py:85-102`); the existing prod collection awaits a one-time online migration via `scripts/upgrade_org_id_tenant_index.py`. |
 | `GAP-INGEST-02` | `chunk_type` classified but never read | **Resolved by removal** on 2026-06-08 (`enrichment.py:10-14`, rationale in `docs/research/chunk-type-retrieval-value.md`). Close the gap. ⚠️ The v1 plan's "chunk_type serving experiment" (its quick win #5 and theme 7) is based on this stale claim and has been **dropped** from the merged plan. |
-| `GAP-EVID-01` | assertion-mode weight is constant 1.00 | `_assertion_weight` now returns profile weights (factual/procedural 1.00, hypothesis 0.90, unknown 0.97; `evidence_tier.py:130-145`) — still shadow-gated, **and the RAGAS A/B from SPEC-EVIDENCE-001-FOLLOWUP-001 was never built** (no `evidence_tier_full` / `evidence_tier_temporal_only` variant anywhere in the eval code; only `baseline` is used). The 30-day decision deadline has lapsed. |
+| `GAP-EVID-01` | assertion-mode weight is constant 1.00 | **Resolved flags-off 2026-08-20:** weights exist, but the online shadow had no answer-quality outcome. `EVIDENCE_SHADOW_MODE=disabled` stops per-request scoring; explicit modes remain for controlled evaluation only. |
 
 All other gaps (`LOOP-*`, `PROV-*`, `SYNC-01`, `TAX-*`, `MCP-01`, `PRIV-01`, `EVAL-01/02`, `ROUTE-*`) were re-confirmed today exactly as described **[code ✓]**.
 
@@ -120,7 +120,7 @@ Key files: `routes/ingest.py`, `pg_store.py`, `qdrant_store.py`, `enrichment.py`
 
 LibreChat / Partner API / widget → LiteLLM `KlaiKnowledgeHook` (`deploy/litellm/klai_knowledge.py` + `klai_kb_*` modules): trivial check → feature/scope lookup (30s/300s two-level cache) → taxonomy trees+coverage (Redis) → combined rewrite+classify in one `QUERY_REWRITE_MODEL` call → `retrieval-api /retrieve` (`api/retrieve.py::retrieve`):
 
-identity verify → coreference (skipped when caller pre-resolved) → dense+sparse embed → **gate (shadow)** → **router** (semantic source-label centroids; optional LLM fallback disabled by default) → Qdrant native RRF (`FusionQuery`, prefetch `max(candidates×4, 20)`; 2–5 legs + parallel Graphiti leg) → link expansion + authority boost → Infinity rerank (top 20) → quality floor → source-aware select (bounded router preference + diversity) → quality boost (≥3 votes, ±10%) → parent expansion → **evidence-tier shadow scoring** → EvidencePack.
+identity verify → coreference (skipped when caller pre-resolved) → dense+sparse embed → **gate disabled** → **router** (semantic source-label centroids; optional LLM fallback disabled by default) → Qdrant native RRF (`FusionQuery`, prefetch `max(candidates×4, 20)`; 2–5 legs + parallel Graphiti leg) → link expansion + authority boost → Infinity rerank (top 20) → quality floor → source-aware select (bounded router preference + diversity) → quality boost (≥3 votes, ±10%) → parent expansion → **evidence-tier disabled** → EvidencePack.
 
 ### Citation path **[doc]**
 
@@ -192,10 +192,9 @@ scribe-api `POST /v1/transcriptions/{id}/ingest` (`transcribe.py::ingest_transcr
 
 ### Theme B — Retrieval gate / routing / latency
 
-#### B1. Gate: corpus + shadow evaluation + controlled activation (remainder of GAP-RETR-01)
+#### B1. Gate: closed as not worth activating (GAP-RETR-01)
 
-- **Problem:** gate runs shadow with a 16-line generic stub corpus; bypass never happens, so every trivial query pays embed + 5-leg + rerank (GPU + 300–500ms).
-- **Target:** (1) generate the full corpus (script: 200 queries, 100 no-retrieval + 100 retrieval-needed, 6 languages NL/EN/DE/FR/PT/ES), versioned (corpus version field — v1); (2) 1–2 weeks of `gate_would_bypass` telemetry vs real queries, **per-tenant and per-language false-bypass metrics** (v1 — adopted; multilingual mismatch is a real failure mode); (3) only then `retrieval_gate_shadow=false`. Strict mode stays gate-free (already enforced).
+- **Decision (2026-08-20):** disabled, not activated. Thirty days produced 3 unique recommendations across ~4,500 requests (~0.07%), all low-confidence. Building a 1,200-query corpus and false-bypass review process for that saving is not proportionate.
 - **Research [online]:** training-free gating evidence: TARG (logit-margin on draft prefix) reaches 70–90% fewer retrievals at matched EM/F1 ([arXiv:2511.09803](https://arxiv.org/abs/2511.09803)); production frameworks (LangGraph/LlamaIndex) default to a cheap structured-output LLM router. For Klai, the embedding-margin gate is fine as v1; a later upgrade can piggyback a `needs_retrieval` field on the existing rewrite call (zero extra roundtrip).
 - **Code:** `services/gate.py`, `scripts/generate_gate_reference.py`, `data/gate_reference.jsonl`, deploy step that ships the corpus. Tests: existing `test_gate.py` (8) + corpus snapshot tests, NL/EN trivial-bypass expectations, strict-never-bypasses (v1 list — adopted).
 - **Failure modes:** false bypass in open mode = silently no KB context → manual review of a 50-query would-bypass sample before activation; corpus overfit to generic assistant tasks (v1).
@@ -301,15 +300,14 @@ The chat path already sends `taxonomy_node_ids` when coverage exists (SPEC-RAG-T
 
 ### Theme G — Evidence scoring / assertion mode
 
-#### G1. Force the shadow-mode decision (SPEC-EVIDENCE-001-FOLLOWUP-001, lapsed)
+#### G1. Evidence-tier decision — CLOSED flags-off 2026-08-20
 
-- **Problem:** shadow running >2 months, `deepcopy+apply()` CPU per request, decision A/B never built **[code ✓]**.
-- **Target:** (1) D1/D2 first; (2) implement the `evidence_tier_full` / `evidence_tier_temporal_only` variants (retrieval-api must accept a variant parameter or per-run env); (3) 7 nights, Wilcoxon, decide per the four predefined outcomes (activate staged 5/50/100% / temporal-only / decommission / flags-off). **Activation criteria (merged, v1):** unknown-fraction acceptable, per-content-type lift positive, canaries don't regress, ≥+0.02 on precision AND faithfulness at p<0.05. If nobody runs the A/B: **flags-off as default** — the honest minimal outcome that stops the CPU cost.
-- **Effort: M.** Dependency: D1/D2.
+- **Decision:** flags-off. Production no longer pays `deepcopy+apply()` per request.
+  The implementation remains available only for explicit controlled evaluation.
 
 #### G2. Assertion-mode activation (GAP-EVID-01/02) — DEFER
 
-Plumbing is ready (profile weights exist, shadow-gated). Activation is SPEC-EVIDENCE-002 with its own research preconditions (3-group taxonomy, max spread 0.20, never user-facing labels, label-quality audit first — frontmatter-authored assertion labels are inconsistent, v1). **Effort at activation: S; the calibration is the work.**
+Plumbing is ready (profile weights exist, production disabled). Activation is SPEC-EVIDENCE-002 with its own research preconditions (3-group taxonomy, max spread 0.20, never user-facing labels, label-quality audit first — frontmatter-authored assertion labels are inconsistent, v1). **Effort at activation: S; the calibration is the work.**
 
 #### chunk_type — closed
 

--- a/docs/architecture/knowledge-retrieval-flow.md
+++ b/docs/architecture/knowledge-retrieval-flow.md
@@ -8,16 +8,19 @@
 >
 > Places where this doc describes a *more capable* design than the code currently implements (the retrieval gate, the router LLM fallback) carry an **Intended vs. current** callout pointing to [`product-gaps-backlog.md`](product-gaps-backlog.md).
 >
+> **2026-08-20 experiment resolution:** the retrieval gate is disabled after 30 days
+> produced only 3 unique would-bypass decisions across roughly 4,500 requests (all
+> low-confidence); evidence-tier production shadow computation is also disabled because
+> order diffs did not measure answer quality. The calibrated citation-rescue rule is active.
+>
 > **2026-06-11 corrections (per-claim source re-verification):** (1) the retrieval gate
-> now ships a reference file (16-line stub) and runs in **shadow mode** by default
-> (`retrieval_gate_shadow=True`) — it logs `gate_would_bypass` but never acts; (2) the
+> ships a 16-line reference stub; (2) the
 > temporal filter is **dual-contract** (legacy `valid_at`/`invalid_at` + current
 > `valid_from`/`valid_until`) — the 2026-06-08 field-mismatch bug is fixed on the
 > serving path; (3) RRF fusion is Qdrant-native (`FusionQuery(fusion=RRF)`) with
 > prefetch `max(candidates × 4, 20)` — there is no hand-rolled `k=60` formula in code;
-> (4) evidence-tier assertion-mode weights are no longer flat 1.00 (conservative
-> profile, still shadow-gated), and the SPEC-EVIDENCE-001-FOLLOWUP-001 deciding A/B has
-> **not** been built — its 30-day deadline lapsed.
+> (4) evidence-tier assertion-mode weights are no longer flat 1.00, but production
+> scoring is now disabled because the required paired A/B was never built.
 >
 > For how knowledge is *stored* (ingestion, chunking, embedding), see
 > [knowledge-ingest-flow.md](knowledge-ingest-flow.md).
@@ -449,25 +452,14 @@ hook receives `retrieval_bypassed: true` and injects nothing into the model's co
 When bypassed, the metadata `gate_bypassed: true` is attached to the request so
 downstream hooks can observe the decision.
 
-> **Intended vs. current ([`GAP-RETR-01`](product-gaps-backlog.md), updated 2026-06-11).**
-> The gate above describes the *intended* behaviour. In production it still never
-> bypasses, but for different reasons than the original gap claimed:
+> **Resolution 2026-08-20.** The gate above is retained for explicit evaluation but is
+> disabled in production (`RETRIEVAL_GATE_ENABLED=false`). Its 30-day shadow run emitted
+> only 3 unique would-bypass decisions across roughly 4,500 requests (~0.07%), all with
+> low retrieval confidence. The negligible saving does not justify the risk of silently
+> dropping all KB context. The 16-line corpus remains an insufficient activation basis.
 >
-> 1. **Shadow mode is the default** (`retrieval_gate_shadow=True` in `config.py`): the
->    gate computes and logs its decision (`gate_would_bypass`, `gate_margin` in the
->    decision record) but `bypassed` is forced `false`. Deliberate: a wrong bypass
->    silently drops all KB context, so the gate stays in shadow until production data
->    confirms the corpus only catches non-KB queries.
-> 2. **The reference corpus is a 16-line stub** (`retrieval_api/data/gate_reference.jsonl`:
->    meta-title / translate / summarize queries in NL+EN), not the 200-query ×
->    6-language corpus that `scripts/generate_gate_reference.py` generates.
-> 3. **Strict KB mode skips the gate entirely by design** — `retrieve.py` sets
+> **Strict KB mode skips the gate entirely by design** — `retrieve.py` sets
 >    `gate_skipped_reason=strict_mode` so a strict request always runs retrieval.
->
-> Closing the gap = generate + commit the full corpus, analyze 1–2 weeks of
-> `gate_would_bypass` telemetry (false-bypass rate per language/tenant), then set
-> `retrieval_gate_shadow=false`. Gate logic itself is tested (`tests/test_gate.py`,
-> incl. shadow-mode cases).
 
 ---
 
@@ -754,13 +746,11 @@ knowledge_ingest/rebuild_tasks.py`.
 
 ---
 
-### Step 6: Evidence tier scoring (shadow mode)
+### Step 6: Evidence tier scoring (production disabled)
 
-**Simple:** A work-in-progress layer that re-weights results by source quality, recency,
-and graph centrality before optionally reordering for the LLM. It runs silently today —
-the weighted scores are computed and logged, but the flat reranker order is what gets
-served. A nightly RAGAS A/B will decide whether to activate it, recalibrate, or
-decommission.
+**Simple:** An evaluation-only layer that can re-weight results by source quality,
+recency, and graph centrality. Production skips the calculation and serves the flat
+reranker order because the earlier online shadow did not measure answer quality.
 
 **Technical:** Implemented in
 [`evidence_tier.apply()`](../../klai-retrieval-api/retrieval_api/services/evidence_tier.py).
@@ -790,10 +780,11 @@ showed >30% performance degradation when the strongest evidence sat in the middl
 the prompt. Whether this still holds for modern frontier LLMs is part of what the
 RAGAS A/B will measure.
 
-**Shadow-mode contract:** `EVIDENCE_SHADOW_MODE=true` (default) computes the
-weighted/U-shape order, logs both orders side-by-side as `shadow_eval`, and serves the
-**flat reranker order**. The CPU cost (`copy.deepcopy(reranked) + apply()`) is paid on
-every request.
+**Production contract (resolved 2026-08-20):** `EVIDENCE_SHADOW_MODE=disabled` serves
+the flat reranker order and does not run `copy.deepcopy + apply`. The preceding 30-day
+shadow run changed the top ordering in 2,186/8,946 logged runs, but captured no paired
+answer-quality outcome and therefore could not determine whether those changes helped.
+`shadow` and `active` remain explicit evaluation modes; neither is the production default.
 
 **Activation path (SPEC-EVIDENCE-001-FOLLOWUP-001):** the shadow mode has been the
 default since 2026-03-30. RAGAS infrastructure landed 2026-05-05 (#369). The follow-up
@@ -810,13 +801,11 @@ The RAGAS A/B uses three `RAG_EVAL_VARIANT` values (`baseline`, `evidence_tier_f
 `evidence_tier_temporal_only`) over 7 consecutive days. Decision criteria: ≥+0.02 on
 RAGAS Context Precision AND Faithfulness with Wilcoxon `p<0.05` against baseline.
 
-> **Status 2026-06-11: the A/B was never built and the deadline lapsed.** The eval
+> **Status 2026-08-20: retained-flags-off was selected.** The eval
 > harness reads `RAG_EVAL_VARIANT` but only `baseline` exists — there is no
 > `evidence_tier_full` / `evidence_tier_temporal_only` code path anywhere in
-> `knowledge_ingest/eval/`. Meanwhile the shadow `copy.deepcopy + apply()` CPU cost is
-> paid on every `/retrieve` request. The pending decision (activate / temporal-only /
-> decommission / flags-off) is tracked as Phase 0 work in
-> [`knowledge-rag-improvement-plan.md`](knowledge-rag-improvement-plan.md).
+> `knowledge_ingest/eval/`. Production therefore stopped the inconclusive shadow CPU
+> cost instead of leaving an ownerless experiment running.
 
 ---
 
@@ -1013,12 +1002,12 @@ Trailing punctuation and whitespace are ignored. "Ok!" and "Oké." are both triv
 | `KNOWLEDGE_RETRIEVE_TIMEOUT` | `3.0` | Retrieval API timeout (seconds) |
 | `KLAI_GAP_SOFT_THRESHOLD` | `0.4` | Reranker score below which gap is "soft" |
 | `KLAI_GAP_DENSE_THRESHOLD` | `0.35` | Dense score fallback for gap detection |
-| `RETRIEVAL_GATE_ENABLED` | `true` | Enable/disable the retrieval gate |
+| `RETRIEVAL_GATE_ENABLED` | `false` | Gate disabled after negligible 30-day shadow yield; enable only for explicit evaluation. |
 | `RETRIEVAL_GATE_THRESHOLD` | `0.1` | Cosine margin threshold for gate bypass |
-| `RETRIEVAL_GATE_SHADOW` | `true` | Shadow mode: gate computes + logs `gate_would_bypass` but never acts. Set `false` to go live (only after corpus + telemetry validation — see GAP-RETR-01). |
+| `RETRIEVAL_GATE_SHADOW` | `true` | Applies only when the disabled gate is explicitly enabled for evaluation; records recommendations without acting. |
 | `retrieval_candidates` | `60` | Raw candidates fetched from Qdrant |
 | `reranker_candidates` | `20` | Top-N sent to cross-encoder |
-| `EVIDENCE_SHADOW_MODE` | `true` | Compute weighted score + U-shape order, log as `shadow_eval`, serve flat reranker order. Activation gated by SPEC-EVIDENCE-001-FOLLOWUP-001 (RAGAS A/B + 30-day deadline). |
+| `EVIDENCE_SHADOW_MODE` | `disabled` | Production skips evidence-tier computation. Explicit `shadow`/`active` modes are evaluation-only. |
 | `EVIDENCE_CONTENT_TYPE_ENABLED` | `true` | Per-dimension flag for content_type weights. |
 | `EVIDENCE_TEMPORAL_DECAY_ENABLED` | `true` | Per-dimension flag for temporal decay. |
 | `EVIDENCE_PAGERANK_ENABLED` | `true` | Per-dimension flag for entity_pagerank_max boost. |

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -358,7 +358,10 @@ The most consequential finding: adding contextual metadata at storage time reduc
 
 Fully automated extraction produces 20–45% errors on standard business documents. The hybrid approach: 90% of documents are processed automatically; only the 10–15% where the system itself has low confidence are flagged for human review. Near-human quality at 500× less effort.
 
-**In Klai:** `assertion_mode` is `shadow` in Phase 2. Full hybrid review is a Phase 3 target — tracked in `klai-knowledge-architecture.md §7.4`.
+**In Klai:** evidence-tier scoring is disabled in production after an inconclusive
+online shadow run: it changed retrieval order but had no paired answer-quality outcome.
+The implementation remains available for controlled evaluation. Full hybrid review is
+a Phase 3 target — tracked in `klai-knowledge-architecture.md §7.4`.
 
 ### Three storage layers — each wins at something different
 

--- a/docs/architecture/product-gaps-backlog.md
+++ b/docs/architecture/product-gaps-backlog.md
@@ -1,12 +1,10 @@
 # Product Gaps Backlog — where the docs describe more than the code does
 
 > Created 2026-06-08 from a doc-vs-code drift audit of `docs/architecture/`.
-> **Updated 2026-06-11** after per-gap re-verification against source: five entries
-> shifted — `GAP-TEMPORAL-01` is fixed on the serving path (filter + delete-then-upsert),
-> `GAP-RETR-01` and `GAP-TENANCY-01` are partially closed (shadow gate + stub corpus;
-> `is_tenant` for new collections, existing collection needs the one-time upgrade script),
-> `GAP-EVID-01` shifted (conservative weights exist, shadow-gated; the deciding A/B was
-> never built), and `GAP-INGEST-02` is **closed by removal**. See
+> **Updated 2026-08-20** after the production experiment audit: `GAP-RETR-01` and
+> `GAP-EVID-01` are closed flags-off; `GAP-TEMPORAL-01` remains fixed;
+> `GAP-TENANCY-01` still needs its existing-collection upgrade; and `GAP-INGEST-02`
+> remains closed by removal. See
 > [`knowledge-rag-improvement-plan.md`](knowledge-rag-improvement-plan.md) for the plan
 > built on this refreshed state.
 > This file captures **Type-B drift**: places where an architecture document
@@ -64,9 +62,9 @@ History: [`docs/retros/2026-06-08-temporal-filter-field-mismatch.md`](../retros/
 
 | Gap | One-liner (state per 2026-06-11) | Verif |
 |---|---|---|
-| `GAP-RETR-01` | Gate now runs in **shadow mode** with a 16-line stub corpus → never bypasses in practice; remaining work = generate the full 200-query corpus + analyze `gate_would_bypass` telemetry + activate | ✓✓ 06-11 |
+| `GAP-RETR-01` | **CLOSED flags-off 2026-08-20** — 30d shadow yielded 3 unique recommendations/~4.5k requests; gate disabled | ✓ 08-20 |
 | `GAP-TENANCY-01` | `is_tenant=True` ships for **new** collections; the existing prod collection still needs the one-time online upgrade (`scripts/upgrade_org_id_tenant_index.py`) | ✓✓ 06-11 |
-| `GAP-EVID-01` | Assertion-mode weights are no longer flat (conservative profile, shadow-gated); the deciding RAGAS A/B (SPEC-EVIDENCE-001-FOLLOWUP-001) was **never built** and its 30-day deadline lapsed | ✓✓ 06-11 |
+| `GAP-EVID-01` | **CLOSED flags-off 2026-08-20** — no paired answer-quality A/B existed; production scoring disabled | ✓ 08-20 |
 | `GAP-MCP-01` | MCP `search_knowledge` hardcodes `scope: "both"` (no org-only / personal-only / type / time filters) | ✓✓ |
 | ~~`GAP-INGEST-02`~~ | **CLOSED** — `chunk_type` classification removed 2026-06-08 (`enrichment.py`, rationale in `docs/research/chunk-type-retrieval-value.md`) | ✓✓ 06-11 |
 | ~~`GAP-TEMPORAL-01`~~ | **FIXED** on the serving path — dual-contract filter + delete-then-upsert; see section above | ✓✓ 06-11 |
@@ -221,20 +219,19 @@ is a threshold classifier writing an exact-string event log to Postgres.
 
 ## Cluster 3 — Epistemic / evidence scoring (§3.2, §7.4)
 
-### GAP-EVID-01 — Assertion-mode weights exist but the deciding A/B was never run  ·  S  ·  ✓✓ (updated 2026-06-11)
+### GAP-EVID-01 — Resolved flags-off  ·  ✓ (updated 2026-08-20)
 - **Intended (§7.4):** assertion-mode is one of four multiplicative scoring
   dimensions (`final = reranker × content_type × assertion_mode × temporal ×
   pagerank`) with its own default-true flag.
-- **Reality (2026-06-11):** `_assertion_weight()` now reads a **conservative
+- **Resolution:** `_assertion_weight()` reads a **conservative
   profile** from `DEFAULT_EVIDENCE_PROFILE["assertion_mode_weights"]`
   (factual/procedural 1.00, hypothesis 0.90, unknown 0.97 — spread 0.10 per the
-  weights research). Everything stays **shadow-gated** (`EVIDENCE_SHADOW_MODE=true`):
-  computed and logged, never served. The real gap has moved: the RAGAS A/B that
+  weights research). The required RAGAS A/B
   SPEC-EVIDENCE-001-FOLLOWUP-001 requires to decide activate / temporal-only /
   decommission / flags-off (variants `evidence_tier_full`,
   `evidence_tier_temporal_only`) **does not exist in the eval harness** — only
-  `baseline` is ever used — and the SPEC's 30-day deadline has lapsed while the
-  shadow `deepcopy + apply()` CPU cost is paid on every request.
+  `baseline` is ever used. Production now uses `EVIDENCE_SHADOW_MODE=disabled`, so the
+  flat reranker stays authoritative and no shadow CPU cost is paid.
 - **Evidence:** `klai-retrieval-api/retrieval_api/services/evidence_tier.py:43-67,125-148`;
   `klai-knowledge-ingest/knowledge_ingest/eval/ragas_runner.py:38-51` (variant env
   read, no evidence_tier variants defined anywhere).
@@ -286,21 +283,15 @@ is a threshold classifier writing an exact-string event log to Postgres.
 
 ## Cluster 5 — Retrieval gate & routing
 
-### GAP-RETR-01 — Gate in shadow mode with a stub corpus  ·  S  ·  ✓✓ (updated 2026-06-11)
+### GAP-RETR-01 — Closed flags-off  ·  ✓ (updated 2026-08-20)
 - **Intended (knowledge-retrieval-flow §Gate):** a semantic gate that skips KB
   lookup for general-knowledge queries (`RETRIEVAL_GATE_ENABLED=true`).
-- **Reality (2026-06-11):** materially better than the 06-08 claim, but still
-  not bypassing in practice. `data/gate_reference.jsonl` **exists** — a 16-line
-  stub of meta/utility queries (titles, translate, summarize in NL/EN), not the
-  200-query × 6-language corpus `scripts/generate_gate_reference.py` produces.
-  The gate now also runs in **shadow mode by default**
-  (`retrieval_gate_shadow=True`, `config.py`): it computes and logs
-  `gate_would_bypass` per request but never acts. Strict KB mode skips the gate
-  entirely by design (`gate_skipped_reason=strict_mode`, `retrieve.py`).
-- **Why it matters:** every query still pays the full embed + multi-leg + rerank
-  pipeline. Closing the gap = (1) generate + commit the full corpus, (2) analyze
-  1–2 weeks of `gate_would_bypass` telemetry (false-bypass rate per language),
-  (3) flip `retrieval_gate_shadow=false`.
+- **Resolution:** the 16-line stub's 30-day production shadow run yielded only
+  3 unique would-bypass decisions across roughly 4,500 requests (~0.07%), all
+  with low retrieval confidence. That saving does not justify either the
+  false-bypass risk or building/maintaining a 1,200-query multilingual corpus.
+  Production now sets `RETRIEVAL_GATE_ENABLED=false`; explicit evaluation can
+  still enable the retained implementation.
 - **Evidence:** `klai-retrieval-api/retrieval_api/services/gate.py`;
   `retrieval_api/config.py:21-28`; `retrieval_api/data/gate_reference.jsonl`
   (16 lines); `retrieve.py` strict-mode gate block; `tests/test_gate.py`
@@ -455,12 +446,12 @@ is a threshold classifier writing an exact-string event log to Postgres.
 | GAP-PROV-01 | provenance DAG/entities | L | ⊙ | knowledge-architecture §3,§5 |
 | GAP-PROV-02 | derived_from/confidence | L | · | knowledge-architecture §3 |
 | GAP-SYNC-01 | dual-store outbox | L | ⊙ | knowledge-architecture §5 |
-| GAP-EVID-01 | evidence-tier A/B never run (weights exist, shadow-gated) | S/M | ✓✓ | knowledge-architecture §7.4 |
+| ~~GAP-EVID-01~~ | evidence-tier — **CLOSED flags-off 2026-08-20** | — | ✓ | knowledge-architecture §7.4 |
 | GAP-EVID-02 | 3-into-5 grouping | M | ✓ | knowledge-architecture §3.2 |
 | GAP-TAX-01 | taxonomy re-cluster | M | ✓✓ | knowledge-architecture §6 |
 | GAP-TAX-02 | binary coverage | M | · | knowledge-architecture §6 |
 | GAP-TAX-03 | taxonomy write-only | L | · | knowledge-architecture §6 / roadmap |
-| GAP-RETR-01 | gate shadow-mode + stub corpus (activation pending) | S | ✓✓ | knowledge-retrieval-flow |
+| ~~GAP-RETR-01~~ | retrieval gate — **CLOSED flags-off 2026-08-20** | — | ✓ | knowledge-retrieval-flow |
 | GAP-ROUTE-01 | complexity router | L | ✓✓ | platform |
 | GAP-ROUTE-02 | medium tier unused | M | ✓ | platform |
 | GAP-ROUTE-03 | router LLM fallback | M | · | knowledge-retrieval-flow |

--- a/docs/specs/SPEC-RAG-ANSWER-EPISTEMICS-001/spec.md
+++ b/docs/specs/SPEC-RAG-ANSWER-EPISTEMICS-001/spec.md
@@ -281,12 +281,10 @@ degradation notice — is specified in v0.2 of this SPEC, gated on:
 
 - the REQ-4 violation rate over a real traffic window;
 - the REQ-1 provenance distribution;
-- the SPEC-RAG-SOURCE-SELECTION-001 REQ-9 band-disagreement data, since a stricter band
-  may remove much of the pressure on its own.
+- any future confidence-policy change that has a real downstream behavioral effect.
 
-Shipping measurement before enforcement is the same discipline the sibling SPEC applies
-to the confidence band, and the same one already used by `gate_shadow_mode`,
-`evidence_shadow_mode`, and `citation_rescue_mode`.
+The 2026-08-20 shadow audit removed the earlier corroborated-band dependency because its
+`high` → `medium` change affected no current policy and did not measure independent sources.
 
 ## Non-Functional Requirements
 

--- a/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
+++ b/docs/specs/SPEC-RAG-SOURCE-SELECTION-001/spec.md
@@ -367,6 +367,15 @@ Enforcement is a separate, later change, gated on a shadow-period comparison of 
 the two disagree and what that would have done to the Strict abstain rate. Flipping
 enforcement in the same PR is out of scope.
 
+> **Resolution 2026-08-20:** REQ-8/9 were decommissioned after production verification.
+> The candidate changed only `high` to `medium`, while every current downstream policy
+> reacts exclusively to `low`/`unknown`; it therefore had no behavioral outcome to
+> evaluate. It also counted two high-scoring chunks rather than independent sources, so
+> “corroborated” overstated the signal. The shadow field, metric, dashboard series, and
+> helper branch were removed instead of leaving an ownerless experiment running.
+> The gate and evidence-tier precedents were disabled in the same audit; citation rescue
+> graduated to active behavior.
+
 ## Non-Functional Requirements
 
 - **Latency**: Phase 2 adds the router to the pinned-KB path. Layer 2 is 5–20 ms with a
@@ -397,9 +406,9 @@ enforcement in the same PR is out of scope.
 | AC-6 | Unit: `route_to_sources` on a catalogue whose labels are all semantically similar (Voys-shaped) | Returns `selected_source_labels=None`, `layer_used="none"` — abstains rather than committing |
 | AC-7 | Unit: `fetch_source_catalog` with `kb_slugs=["sip"]` | Facet filter carries both `org_id` and `kb_slug`; cache key differs from the unscoped call |
 | AC-8 | Full `chat.yaml` suite before vs. after Phase 2 | Aggregate `context_recall` MUST NOT decrease; aggregate `context_precision` MUST NOT decrease by more than 0.02. Per-canary deltas reported in the PR body regardless of outcome |
-| AC-9 | Unit: `_compute_confidence_band` with scores `[0.87, 0.28, 0.21]` | `confidence_band_corroborated == "medium"`; `confidence_band` (old) still `high` in shadow |
-| AC-10 | Unit: same function with `[0.87, 0.72, 0.21]` | `confidence_band_corroborated == "high"` |
-| AC-11 | Post-deploy, 48h of `retrieval_decision_record` | `suppressed_count` distribution reported; disagreement rate between the two bands reported. Both are inputs to the enforcement decision deferred by REQ-9 |
+| AC-9 | Historical; decommissioned 2026-08-20 | Candidate had no downstream behavioral effect |
+| AC-10 | Historical; decommissioned 2026-08-20 | Candidate did not establish independent-source corroboration |
+| AC-11 | Historical; decommissioned 2026-08-20 | The observed band disagreement could not change current serving policy, so no enforcement decision remained |
 
 ## Risks and Mitigations
 

--- a/klai-libs/citations/klai_citations/__init__.py
+++ b/klai-libs/citations/klai_citations/__init__.py
@@ -623,9 +623,9 @@ def strip_model_citation_artifacts(
     kept_lines: list[str] = []
     skipping_footer_section = False
     for index, line in enumerate(lines):
-        if (
-            _SOURCE_HEADING_RE.match(line) or _ACTIVITY_HEADING_RE.match(line)
-        ) and _heading_starts_footer_section(lines, index):
+        if (_SOURCE_HEADING_RE.match(line) or _ACTIVITY_HEADING_RE.match(line)) and _heading_starts_footer_section(
+            lines, index
+        ):
             skipping_footer_section = True
             continue
         if skipping_footer_section:
@@ -657,9 +657,7 @@ def strip_model_citation_artifacts(
     return cleaned.strip()
 
 
-def strip_injected_evidence_labels(
-    text: str, *, evidence_ids: set[str] | None = None
-) -> str:
+def strip_injected_evidence_labels(text: str, *, evidence_ids: set[str] | None = None) -> str:
     """Remove only prompt-internal evidence labels, preserving answer content."""
     if not evidence_ids:
         return text
@@ -670,13 +668,9 @@ def strip_injected_evidence_labels(
         tokens = _EVIDENCE_ID_TOKEN_RE.findall(match.group(0))
         if tokens and all(token.upper() in normalised_evidence_ids for token in tokens):
             start, end = match.span()
-            if start > 0 and text[start - 1] in " \t" and (
-                end == len(text) or text[end] in " \t.,;:!?"
-            ):
+            if start > 0 and text[start - 1] in " \t" and (end == len(text) or text[end] in " \t.,;:!?"):
                 start -= 1
-            elif (
-                start == 0 or text[start - 1] in "\r\n"
-            ) and end < len(text) and text[end] in " \t":
+            elif (start == 0 or text[start - 1] in "\r\n") and end < len(text) and text[end] in " \t":
                 end += 1
             removable_spans.append((start, end))
 
@@ -779,10 +773,10 @@ def _resolve_rescue_settings(
     retrieval_ratio: float | None = None,
 ) -> _RescueSettings:
     if mode is None:
-        mode = os.getenv("CITATION_RESCUE_MODE", "shadow")
+        mode = os.getenv("CITATION_RESCUE_MODE", "active")
     mode = mode.strip().lower()
     if mode not in {"shadow", "active"}:
-        mode = "shadow"
+        raise ValueError(f"invalid citation rescue mode: {mode!r}; require 'shadow' or 'active'")
     if answer_score_threshold is None:
         answer_score_threshold = _env_float(
             "RESCUE_ANSWER_SCORE_THRESHOLD",

--- a/klai-libs/citations/tests/test_citations.py
+++ b/klai-libs/citations/tests/test_citations.py
@@ -1,3 +1,5 @@
+import pytest
+
 from klai_citations import (
     CitationSource,
     _select_supported_sources_with_decision,
@@ -52,6 +54,7 @@ def test_supported_source_decision_labels_keep_ratio_overflow() -> None:
         _decision_sources(),
         query_text="hubspot freedom",
         max_sources=4,
+        rescue_mode="shadow",
     )
 
     assert [source.title for source in selected] == ["Alpha"]
@@ -106,6 +109,33 @@ def test_citation_rescue_active_selects_with_rescued_reason(monkeypatch) -> None
     assert decision["selected"][1]["reason"] == "rescued"
     assert decision["selected"][1]["would_rescue"] is True
     assert len(selected) <= 4
+
+
+def test_citation_rescue_is_active_by_default(monkeypatch) -> None:
+    """The calibrated rescue rule is production behavior, not a shadow experiment."""
+    monkeypatch.delenv("CITATION_RESCUE_MODE", raising=False)
+
+    selected, decision = _select_supported_sources_with_decision(
+        _long_answer(),
+        _decision_sources(),
+        query_text="hubspot freedom",
+        max_sources=4,
+    )
+
+    assert [source.title for source in selected] == ["Alpha", "Beta"]
+    assert decision["citation_rescue_mode"] == "active"
+    assert decision["selected"][1]["reason"] == "rescued"
+
+
+def test_citation_rescue_rejects_invalid_mode() -> None:
+    with pytest.raises(ValueError, match="invalid citation rescue mode"):
+        _select_supported_sources_with_decision(
+            _long_answer(),
+            _decision_sources(),
+            query_text="hubspot freedom",
+            max_sources=4,
+            rescue_mode="bogus",
+        )
 
 
 def test_citation_rescue_mode_via_parameter_overrides_env(monkeypatch) -> None:
@@ -1457,14 +1487,9 @@ def test_strip_keeps_e_numbers_outside_injected_evidence_ids() -> None:
     label-shaped tokens when the number was never an injected evidence id."""
     from klai_citations import strip_model_citation_artifacts
 
-    text = (
-        "De E19 richting Antwerpen (E19) is dicht; tank geen E10.\n"
-        "Foutcode (E42) staat los van de kennisbank."
-    )
+    text = "De E19 richting Antwerpen (E19) is dicht; tank geen E10.\nFoutcode (E42) staat los van de kennisbank."
 
-    cleaned = strip_model_citation_artifacts(
-        text, evidence_ids={"E1", "E2", "E3"}
-    )
+    cleaned = strip_model_citation_artifacts(text, evidence_ids={"E1", "E2", "E3"})
     assert "E19" in cleaned
     assert "(E19)" in cleaned
     assert "E10" in cleaned

--- a/klai-portal/backend/app/services/partner_chat.py
+++ b/klai-portal/backend/app/services/partner_chat.py
@@ -1564,6 +1564,28 @@ def _compose_backend_managed_answer(
     return composed.content, sources, decision
 
 
+def _count_citation_rescues(decision: dict[str, Any]) -> int:
+    """Count applied rescues across the separate KB and web trust tiers."""
+    count = sum(
+        1 for entry in decision.get("selected", []) if isinstance(entry, dict) and entry.get("reason") == "rescued"
+    )
+    web_decision = decision.get("web")
+    if isinstance(web_decision, dict):
+        count += _count_citation_rescues(web_decision)
+    return count
+
+
+def _log_citation_rescues(decision: dict[str, Any], *, org_id: int | str | None) -> None:
+    """Emit one dashboardable event when active rescue exposed extra sources."""
+    rescued_sources = _count_citation_rescues(decision)
+    if rescued_sources:
+        logger.info(
+            "citation_rescue_applied",
+            org_id=org_id,
+            rescued_sources=rescued_sources,
+        )
+
+
 def _renumber_sources(sources: list[dict]) -> list[dict]:
     """Give a merged KB+web source list a single contiguous label sequence."""
     for index, source in enumerate(sources, start=1):
@@ -1671,6 +1693,7 @@ async def _chat_completion_streaming_with_composed_citations(
         selected_count=len(sources),
         decision=decision,
     )
+    _log_citation_rescues(decision, org_id=org_id)
     if citation_chunks:
         yield _sse_activity_delta(
             [
@@ -2088,6 +2111,7 @@ async def chat_completion_non_streaming(
                     selected_count=len(sources),
                     decision=decision,
                 )
+                _log_citation_rescues(decision, org_id=org_id)
                 message["content"] = rendered_content
                 message["sources"] = sources
         stripped_links = 0

--- a/klai-portal/backend/tests/test_partner_chat_web_search.py
+++ b/klai-portal/backend/tests/test_partner_chat_web_search.py
@@ -289,6 +289,35 @@ def test_compose_keeps_kb_and_web_as_separate_tiers():
     assert [s["label"] for s in sources] == [str(i) for i in range(1, len(sources) + 1)]
 
 
+def test_count_citation_rescues_includes_web_tier() -> None:
+    from app.services.partner_chat import _count_citation_rescues
+
+    decision = {
+        "selected": [{"reason": "rescued"}, {"reason": "supported"}],
+        "web": {"selected": [{"reason": "rescued"}]},
+    }
+
+    assert _count_citation_rescues(decision) == 2
+
+
+def test_log_citation_rescues_emits_one_actionable_event() -> None:
+    from app.services import partner_chat
+
+    decision = {
+        "selected": [{"reason": "rescued"}],
+        "web": {"selected": [{"reason": "rescued"}]},
+    }
+
+    with patch.object(partner_chat.logger, "info") as log_info:
+        partner_chat._log_citation_rescues(decision, org_id="org-42")
+
+    log_info.assert_called_once_with(
+        "citation_rescue_applied",
+        org_id="org-42",
+        rescued_sources=2,
+    )
+
+
 def test_compose_web_only_not_refused():
     from app.services.partner_chat import _compose_backend_managed_answer
 

--- a/klai-retrieval-api/evaluation/eval_runner.py
+++ b/klai-retrieval-api/evaluation/eval_runner.py
@@ -170,7 +170,7 @@ async def run_baseline(
 
     # Disable all evidence tier dimensions for baseline
     env_overrides = {
-        "EVIDENCE_SHADOW_MODE": "false",
+        "EVIDENCE_SHADOW_MODE": "active",
         "EVIDENCE_CONTENT_TYPE_ENABLED": "false",
         "EVIDENCE_TEMPORAL_DECAY_ENABLED": "false",
         "EVIDENCE_ASSERTION_MODE_ENABLED": "false",
@@ -235,7 +235,7 @@ async def run_evidence_tier(
 
     # Enable evidence tier with specified dimensions
     dim_config = config.get("dimensions", {})
-    env_overrides = {"EVIDENCE_SHADOW_MODE": "false"}
+    env_overrides = {"EVIDENCE_SHADOW_MODE": "active"}
 
     if dimensions is not None:
         for dim_name, enabled in dimensions.items():

--- a/klai-retrieval-api/retrieval_api/api/ranking.py
+++ b/klai-retrieval-api/retrieval_api/api/ranking.py
@@ -23,7 +23,6 @@ def _compute_confidence_band(
     high_threshold: float,
     low_threshold: float,
     reranker_enabled: bool,
-    require_corroboration: bool = False,
 ) -> ConfidenceBand:
     """SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1: bucket the served result by
     the max post-rerank ranking score. Driven by the litellm-hook
@@ -40,8 +39,7 @@ def _compute_confidence_band(
     Returns:
         - ``unknown`` when reranker is disabled, every chunk's reranker_score
           is None (fallback path), or the served list is empty
-        - ``high`` when max ≥ high_threshold; when corroboration is required,
-          at least two scores must meet that threshold
+        - ``high`` when max ≥ high_threshold
         - ``low`` when max < low_threshold
         - ``medium`` otherwise
 
@@ -59,9 +57,7 @@ def _compute_confidence_band(
     if not valid_scores:
         return "unknown"
     max_score = max(valid_scores)
-    if max_score >= high_threshold and (
-        not require_corroboration or sum(score >= high_threshold for score in valid_scores) >= 2
-    ):
+    if max_score >= high_threshold:
         return "high"
     if max_score < low_threshold:
         return "low"

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -24,7 +24,6 @@ from retrieval_api.config import settings
 from retrieval_api.metrics import (
     quality_floor_filtered_total,
     retrieval_chunks_total,
-    retrieval_confidence_band_corroborated_total,
     retrieval_confidence_band_total,
     retrieval_graph_top_k_total,
     retrieval_link_expand_top_k_total,
@@ -512,13 +511,14 @@ async def retrieve(
 
     # 3. Gate check. Strict KB mode must never skip retrieval: a wrong bypass
     # would turn "answer only from selected KBs" into a plain model answer.
-    # Shadow mode (default) computes + logs the decision but never acts on it.
+    # When explicitly enabled in shadow mode, the gate logs its decision but
+    # never acts on it. Production leaves the low-yield gate disabled.
     if req.kb_narrow:
         gate_decision = gate.GateDecision(
             would_bypass=False,
             bypassed=False,
             margin=None,
-            shadow=settings.retrieval_gate_shadow,
+            shadow=settings.retrieval_gate_enabled and settings.retrieval_gate_shadow,
         )
         decision_record["gate_skipped_reason"] = "strict_mode"
     else:
@@ -823,23 +823,37 @@ async def retrieve(
                 )
             ranking_shadow_preview = quality_boost(ranking_shadow_preview, contract_active=True)
 
-        # @MX:NOTE: [AUTO] Shadow mode (R9): runs evidence scoring on every
-        # request but serves flat results. Diffs logged as shadow_eval to
-        # VictoriaLogs for offline analysis.
-        # @MX:NOTE: Set EVIDENCE_SHADOW_MODE=false to activate evidence-tier
-        # scoring for users.
-        # @MX:SPEC: SPEC-EVIDENCE-001 R9. Disable shadow mode after RAGAS
-        # validation confirms improvement.
+        # Evidence-tier was disabled in production on 2026-08-20: its online
+        # shadow changed ordering but never measured answer quality, so it
+        # could not select a winner. Explicit shadow/active modes remain for
+        # controlled evaluation runs; disabled pays no deepcopy/scoring cost.
         # 6. Evidence tier scoring + U-shape ordering (SPEC-EVIDENCE-001, R7)
-        shadow_mode = os.environ.get("EVIDENCE_SHADOW_MODE", "true").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-        decision_record["evidence_shadow_mode"] = shadow_mode
-        scored = evidence_tier.apply(copy.deepcopy(reranked))
+        evidence_mode_raw = os.environ.get("EVIDENCE_SHADOW_MODE", "disabled").strip().lower()
+        evidence_mode = {
+            "disabled": "disabled",
+            "off": "disabled",
+            "shadow": "shadow",
+            "true": "shadow",
+            "1": "shadow",
+            "yes": "shadow",
+            "active": "active",
+            "false": "active",
+            "0": "active",
+            "no": "active",
+        }.get(evidence_mode_raw)
+        if evidence_mode is None:
+            raise RuntimeError(
+                "invalid EVIDENCE_SHADOW_MODE: "
+                f"{evidence_mode_raw!r}; require disabled, shadow, or active"
+            )
+        decision_record["evidence_tier_mode"] = evidence_mode
 
-        if shadow_mode:
+        if evidence_mode == "disabled":
+            serving = reranked
+        else:
+            scored = evidence_tier.apply(copy.deepcopy(reranked))
+
+        if evidence_mode == "shadow":
             # R9: Log shadow results but serve original flat scoring
             logger.info(
                 "shadow_eval",
@@ -855,7 +869,7 @@ async def retrieve(
                 ],
             )
             serving = reranked
-        else:
+        elif evidence_mode == "active":
             serving = scored
 
         # REQ-RANK-04 shadow diff: "old" is the ACTUAL served list (this
@@ -974,23 +988,8 @@ async def retrieve(
             low_threshold=settings.confidence_band_low_threshold,
             reranker_enabled=settings.reranker_enabled,
         )
-        confidence_band_corroborated = _compute_confidence_band(
-            serving,
-            high_threshold=settings.confidence_band_high_threshold,
-            low_threshold=settings.confidence_band_low_threshold,
-            reranker_enabled=settings.reranker_enabled,
-            require_corroboration=True,
-        )
         decision_record["confidence_band"] = confidence_band
-        decision_record["confidence_band_corroborated"] = confidence_band_corroborated
         retrieval_confidence_band_total.labels(band=confidence_band, org_id=req.org_id).inc()
-        retrieval_confidence_band_corroborated_total.labels(
-            band=confidence_band_corroborated, org_id=req.org_id
-        ).inc()
-        # TODO(2026-08-22): Evaluate the 48h corroboration shadow window and
-        # decide to promote or remove this signal + metric. Do not leave it in
-        # indefinite shadow like the gate_shadow_mode/evidence_shadow_mode precedent.
-        # Compare primary vs shadow bands in Grafana's RAG quality Low-Confidence panel.
 
     evidence_query = (
         f"{req.raw_query}\n{query_resolved}"

--- a/klai-retrieval-api/retrieval_api/config.py
+++ b/klai-retrieval-api/retrieval_api/config.py
@@ -18,13 +18,13 @@ class Settings(BaseSettings):
     litellm_url: str = "http://litellm:4000"
     litellm_api_key: str = ""
 
-    retrieval_gate_enabled: bool = True
+    # Disabled after 30d of production shadow data: only 3 unique would-bypass
+    # decisions across ~4.5k requests (0.07%), all on low-confidence retrievals.
+    # That negligible saving does not justify the risk of dropping all KB context.
+    retrieval_gate_enabled: bool = False
     retrieval_gate_threshold: float = 0.1
-    # Shadow mode (default ON): the gate computes + logs its bypass decision
-    # (gate_would_bypass) but never acts on it, so retrieval always runs. A
-    # wrong bypass silently drops all citations, so the gate stays in shadow
-    # until production data confirms the reference corpus only catches non-KB
-    # queries. Set to False to go live.
+    # When explicitly enabled for evaluation, shadow mode computes + logs the
+    # bypass decision without acting. Production keeps the gate disabled.
     retrieval_gate_shadow: bool = True
     retrieval_candidates: int = 60
     reranker_candidates: int = 20  # top-N from retrieval sent to reranker (CPU budget)
@@ -70,11 +70,9 @@ class Settings(BaseSettings):
     source_preference_boost: float = 0.05
 
     # SPEC-RAG-EVIDENCE-INTEGRITY-001 REQ-RANK-04 — ranking-contract rollout
-    # flag. "shadow" (default) serves the pre-contract behavior byte-identical
-    # and logs old/new orderings in the decision record; "active" serves by
-    # the post-rerank ``final_rank_score`` contract. Flip via the
-    # RANKING_CONTRACT_MODE env var after ≥7 days of shadow-diff review.
-    ranking_contract_mode: str = "shadow"
+    # flag. The contract graduated to "active" on 2026-07-08 after its shadow
+    # review. "shadow" remains an explicit rollback/evaluation mode only.
+    ranking_contract_mode: str = "active"
 
     # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-07 — defence-in-depth floor.
     # Chunks with ``quality_score < retrieval_quality_floor`` are removed

--- a/klai-retrieval-api/retrieval_api/metrics.py
+++ b/klai-retrieval-api/retrieval_api/metrics.py
@@ -100,12 +100,6 @@ retrieval_confidence_band_total = Counter(
     "Retrieval responses bucketed by reranker-score confidence band",
     ["band", "org_id"],
 )
-retrieval_confidence_band_corroborated_total = Counter(
-    "retrieval_confidence_band_corroborated_total",
-    "Shadow retrieval responses bucketed by corroborated confidence band",
-    ["band", "org_id"],
-)
-
 # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-3 / REQ-8 — link-expansion
 # survival rate. ``hit`` = at least one expanded chunk made the served
 # top-K. ``miss`` = link-expand ran (added ≥ 1 chunk to candidates) but

--- a/klai-retrieval-api/retrieval_api/quality_boost.py
+++ b/klai-retrieval-api/retrieval_api/quality_boost.py
@@ -9,7 +9,7 @@ Missing fields default to quality_score=0.5, feedback_count=0 (no boost).
 SPEC-RAG-EVIDENCE-INTEGRITY-001 REQ-RANK-03: behavior is mode-dependent via
 ``contract_active``.
 
-- ``contract_active=False`` (ranking-contract shadow, the default): the exact
+- ``contract_active=False`` (explicit ranking-contract shadow mode): the exact
   pre-contract behavior — boost mutates the raw ``score`` and the list is
   ALWAYS re-sorted by ``score``. Byte-identical serving per REQ-RANK-04.
 - ``contract_active=True``: boost mutates ``final_rank_score`` (the single

--- a/klai-retrieval-api/retrieval_api/services/evidence_tier.py
+++ b/klai-retrieval-api/retrieval_api/services/evidence_tier.py
@@ -7,8 +7,9 @@ Feature flags (environment variables):
 - EVIDENCE_CONTENT_TYPE_ENABLED (default: true)
 - EVIDENCE_TEMPORAL_DECAY_ENABLED (default: true)
 - EVIDENCE_ASSERTION_MODE_ENABLED (default: true; conservative 0.10-spread weights,
-  shadow-gated — computed and logged for measurement, never changes served ordering
-  while EVIDENCE_SHADOW_MODE=true. See docs/research/assertion-modes/assertion-mode-weights.md.)
+  available for explicit offline evaluation. Production sets
+  EVIDENCE_SHADOW_MODE=disabled and pays no scoring/deep-copy cost. See
+  docs/research/assertion-modes/assertion-mode-weights.md.)
 """
 
 from __future__ import annotations
@@ -53,8 +54,8 @@ DEFAULT_EVIDENCE_PROFILE: EvidenceProfile = {
     # Conservative profile (spread 0.10, within the safe range for an ~85%
     # classifier) per docs/research/assertion-modes/assertion-mode-weights.md §6.1.
     # unknown=0.97 ("benefit of the doubt"; never penalize absent metadata).
-    # Shadow-gated: only affects served order once EVIDENCE_SHADOW_MODE=false,
-    # which should NOT happen until assertion_mode is LLM-derived (not author
+    # Evaluation-only: production keeps EVIDENCE_SHADOW_MODE=disabled. Active
+    # serving should NOT happen until assertion_mode is LLM-derived (not author
     # frontmatter) and the unknown-fraction is measured (research §8-9).
     "assertion_mode_weights": {
         "factual": 1.00,
@@ -124,8 +125,8 @@ def _pagerank_weight(pagerank_max: float | None) -> float:
 
 
 # @MX:NOTE: [AUTO] assertion_mode now applies the conservative weight table from
-# @MX:NOTE: DEFAULT_EVIDENCE_PROFILE, but stays shadow-gated at the retrieve.py caller
-# @MX:NOTE: (EVIDENCE_SHADOW_MODE=true) so it is measured, not served.
+# @MX:NOTE: DEFAULT_EVIDENCE_PROFILE; production disables the retrieve.py caller
+# @MX:NOTE: (EVIDENCE_SHADOW_MODE=disabled) after an inconclusive shadow run.
 # @MX:SPEC: SPEC-EVIDENCE-002 — go-live preconditions in
 # @MX:SPEC: docs/research/assertion-modes/assertion-mode-weights.md §8-9.
 def _assertion_weight(assertion_mode: str | None, profile: EvidenceProfile) -> float:

--- a/klai-retrieval-api/retrieval_api/services/gate.py
+++ b/klai-retrieval-api/retrieval_api/services/gate.py
@@ -122,16 +122,13 @@ async def should_bypass(query_vector: list[float]) -> tuple[bool, float | None]:
 async def evaluate(query_vector: list[float]) -> GateDecision:
     """Compute the gate recommendation and apply shadow-mode policy.
 
-    A wrong bypass silently drops every citation (the user gets a
-    model-only answer with no sources), so the gate runs in shadow by
-    default: ``would_bypass`` is computed and logged, but ``bypassed`` is
-    forced ``False`` so retrieval always runs. Keep shadow on until the
-    production ``gate_would_bypass`` rate confirms the reference corpus
-    only fires on non-KB queries, then set ``retrieval_gate_shadow`` to
-    ``False`` to go live.
+    The gate is disabled by default after its 30-day production shadow run
+    found negligible potential savings (3 unique recommendations across
+    roughly 4,500 requests). Explicit evaluation can still enable it; shadow
+    mode then records recommendations without acting on them.
     """
     would_bypass, margin = await should_bypass(query_vector)
-    shadow = settings.retrieval_gate_shadow
+    shadow = settings.retrieval_gate_enabled and settings.retrieval_gate_shadow
     return GateDecision(
         would_bypass=would_bypass,
         bypassed=would_bypass and not shadow,

--- a/klai-retrieval-api/tests/conftest.py
+++ b/klai-retrieval-api/tests/conftest.py
@@ -25,11 +25,11 @@ os.environ.setdefault("RATE_LIMIT_RPM", "600")
 # `_auto_allow_identity_assert` below.
 os.environ.setdefault("PORTAL_API_URL", "http://portal-api.test.local:8010")
 os.environ.setdefault("PORTAL_INTERNAL_SECRET", "test-portal-internal-secret")
-# Production defaults ``retrieval_gate_shadow`` to True (compute + log the gate
-# decision but never act on it). The pipeline tests force a bypass — patching
+# The production gate is disabled after its 30d shadow run. Pipeline tests that
+# exercise the legacy bypass contract patch
 # ``gate.should_bypass`` -> (True, ...) to skip the heavy qdrant/rerank path —
 # which only takes effect when the gate ACTS. Run the suite with the gate in
-# acting mode; shadow-suppression itself is covered explicitly in test_gate.py.
+# acting mode; the disabled production default is covered in test_gate.py.
 os.environ.setdefault("RETRIEVAL_GATE_SHADOW", "false")
 
 import pytest

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -49,12 +49,7 @@ class TestRetrieveEndpoint:
         """Happy path: mock all external calls, verify response structure."""
         import logging
 
-        from retrieval_api.metrics import retrieval_confidence_band_corroborated_total
-
         caplog.set_level(logging.INFO)
-        corroborated_before = retrieval_confidence_band_corroborated_total.labels(
-            band="medium", org_id=sample_retrieve_request["org_id"]
-        )._value.get()  # type: ignore[attr-defined]
 
         with (
             patch(
@@ -192,11 +187,7 @@ class TestRetrieveEndpoint:
         assert "Refund policy" in decision_attrs
         assert "top_item_chunk_ids" in decision_attrs
         assert decision_record.msg["confidence_band"] == "high"
-        assert decision_record.msg["confidence_band_corroborated"] == "medium"
-        corroborated_after = retrieval_confidence_band_corroborated_total.labels(
-            band="medium", org_id=sample_retrieve_request["org_id"]
-        )._value.get()  # type: ignore[attr-defined]
-        assert corroborated_after == corroborated_before + 1
+        assert "confidence_band_corroborated" not in decision_record.msg
 
     def test_retrieve_passes_effective_telemetry_level_to_coreference(
         self, client, sample_retrieve_request
@@ -988,7 +979,7 @@ class TestLinkExpandInstrumentation:
 
     def test_link_expanded_flag_survives_evidence_tier_deep_copy(self):
         """The instrumentation tag MUST survive `copy.deepcopy(reranked)`
-        inside ``evidence_tier.apply`` so that when EVIDENCE_SHADOW_MODE=false
+        inside ``evidence_tier.apply`` so that when EVIDENCE_SHADOW_MODE=active
         flips on (per SPEC-EVIDENCE-001-FOLLOWUP-001) the deep-copied scored
         chunks STILL carry the flag for ``decision_record.link_expand``.
 

--- a/klai-retrieval-api/tests/test_confidence_band.py
+++ b/klai-retrieval-api/tests/test_confidence_band.py
@@ -145,49 +145,6 @@ def test_band_handles_int_score() -> None:
     assert band == "high"
 
 
-def test_corroborated_band_caps_single_strong_hit_at_medium() -> None:
-    chunks = [
-        {"reranker_score": 0.87},
-        {"reranker_score": 0.28},
-        {"reranker_score": 0.21},
-    ]
-
-    authoritative = _compute_confidence_band(
-        chunks,
-        high_threshold=0.60,
-        low_threshold=0.30,
-        reranker_enabled=True,
-    )
-    corroborated = _compute_confidence_band(
-        chunks,
-        high_threshold=0.60,
-        low_threshold=0.30,
-        reranker_enabled=True,
-        require_corroboration=True,
-    )
-
-    assert authoritative == "high"
-    assert corroborated == "medium"
-
-
-def test_corroborated_band_is_high_with_two_strong_hits() -> None:
-    chunks = [
-        {"reranker_score": 0.87},
-        {"reranker_score": 0.72},
-        {"reranker_score": 0.21},
-    ]
-
-    corroborated = _compute_confidence_band(
-        chunks,
-        high_threshold=0.60,
-        low_threshold=0.30,
-        reranker_enabled=True,
-        require_corroboration=True,
-    )
-
-    assert corroborated == "high"
-
-
 # ---------------------------------------------------------------------------
 # REQ-3 — _apply_link_expand_boost
 # ---------------------------------------------------------------------------

--- a/klai-retrieval-api/tests/test_evidence_pipeline.py
+++ b/klai-retrieval-api/tests/test_evidence_pipeline.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import os
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 
 class TestEvidenceTierInPipeline:
     """Verify evidence_tier.apply() is called after reranking."""
 
-    def test_retrieve_calls_evidence_tier(self, client, sample_retrieve_request):
-        """evidence_tier.apply() is called in the retrieve pipeline (R7)."""
+    def test_active_mode_applies_and_invalid_mode_fails_loud(self, client, sample_retrieve_request):
+        """Active mode applies scoring; an unknown mode cannot silently fallback."""
         reranked_chunk = {
             "chunk_id": "c1",
             "text": "policy text",
@@ -75,11 +77,17 @@ class TestEvidenceTierInPipeline:
 
             resp = client.post("/retrieve", json=sample_retrieve_request)
 
+            os.environ["EVIDENCE_SHADOW_MODE"] = "bogus"
+            with pytest.raises(RuntimeError, match="invalid EVIDENCE_SHADOW_MODE"):
+                client.post("/retrieve", json=sample_retrieve_request)
+
         assert resp.status_code == 200
         mock_apply.assert_called_once()
 
-    def test_shadow_mode_serves_flat_scoring(self, client, sample_retrieve_request):
-        """Shadow mode: serves flat scoring, logs evidence results (R9)."""
+    def test_disabled_mode_serves_flat_scoring_without_shadow_compute(
+        self, client, sample_retrieve_request
+    ):
+        """Disabled mode pays no production CPU cost for an inconclusive experiment."""
         reranked_chunk = {
             "chunk_id": "c1",
             "text": "policy text",
@@ -126,13 +134,17 @@ class TestEvidenceTierInPipeline:
                 new_callable=AsyncMock,
                 return_value=[reranked_chunk],
             ),
-            patch.dict(os.environ, {"EVIDENCE_SHADOW_MODE": "true"}),
+            patch(
+                "retrieval_api.api.retrieve.evidence_tier.apply",
+                return_value=[{**reranked_chunk, "final_score": 0.95}],
+            ) as mock_apply,
+            patch.dict(os.environ, {"EVIDENCE_SHADOW_MODE": "disabled"}),
         ):
             resp = client.post("/retrieve", json=sample_retrieve_request)
 
         assert resp.status_code == 200
         data = resp.json()
-        # In shadow mode, the served chunks should NOT have final_score
-        # because we serve the original reranked results
+        # Disabled mode serves the original reranked results.
         chunk = data["chunks"][0]
         assert chunk["final_score"] is None or chunk.get("evidence_tier_metadata") is None
+        mock_apply.assert_not_called()

--- a/klai-retrieval-api/tests/test_gate.py
+++ b/klai-retrieval-api/tests/test_gate.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from retrieval_api.config import Settings
 from retrieval_api.services import gate
 
 
@@ -18,6 +19,11 @@ def reset_gate_cache():
 
 
 class TestGate:
+    def test_gate_is_disabled_by_default(self, monkeypatch):
+        """The unvalidated classifier must not run in production by default."""
+        monkeypatch.delenv("RETRIEVAL_GATE_ENABLED", raising=False)
+        assert Settings().retrieval_gate_enabled is False
+
     @pytest.mark.asyncio
     async def test_gate_disabled_returns_false(self):
         """When gate is disabled, always returns (False, None)."""
@@ -25,6 +31,17 @@ class TestGate:
             bypass, margin = await gate.should_bypass([0.1, 0.2, 0.3])
             assert bypass is False
             assert margin is None
+
+    @pytest.mark.asyncio
+    async def test_gate_disabled_is_not_reported_as_shadow(self):
+        """Flags-off means no experiment is reported in decision telemetry."""
+        with (
+            patch.object(gate.settings, "retrieval_gate_enabled", False),
+            patch.object(gate.settings, "retrieval_gate_shadow", True),
+        ):
+            decision = await gate.evaluate([0.1, 0.2, 0.3])
+
+        assert decision.shadow is False
 
     @pytest.mark.asyncio
     async def test_no_reference_file_returns_false(self):

--- a/klai-retrieval-api/tests/test_ranking_contract.py
+++ b/klai-retrieval-api/tests/test_ranking_contract.py
@@ -107,9 +107,9 @@ class TestRankingContractSnapshot:
 
 
 class TestRankingContractModeSetting:
-    def test_default_is_shadow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_is_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("RANKING_CONTRACT_MODE", raising=False)
-        assert Settings().ranking_contract_mode == "shadow"
+        assert Settings().ranking_contract_mode == "active"
 
     def test_active_is_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("RANKING_CONTRACT_MODE", " Active ")


### PR DESCRIPTION
## Outcome

Resolves every currently running RAG/LiteLLM quality shadow path to a terminal state:

- disables the low-yield retrieval gate and stops reporting it as shadow;
- disables evidence-tier scoring and its per-request copy/scoring cost;
- removes the behaviorally inert corroborated confidence signal;
- graduates citation rescue to active on both chat surfaces and logs actual use;
- aligns the ranking-contract code default with the already-active production config;
- updates stale architecture/spec status.

No alert workflow or future decision process was added. Privacy shadow telemetry remains because it is a retention/privacy mode, not a ranking experiment.

## Production evidence

- Gate: 3 unique would-bypass decisions across about 4,500 requests in 30d, all low-confidence.
- Evidence tier: 2,186 changed orderings across 8,946 logged runs, but no paired answer-quality outcome.
- Citation rescue: 25 unique plausible production cases over 23d.
- Corroborated confidence: only high-to-medium changes; current downstream policy reacts only to low/unknown, and the signal counted chunks rather than independent sources.

## Verification

- retrieval-api: 633 passed, 1 skipped
- LiteLLM: 693 passed
- citations: 72 passed
- portal partner chat: 130 passed
- ruff check + format check passed
- env-scope guard: 2 passed, 11 subtests
- dashboard JSON and VictoriaLogs queries validated
- Claude Opus full review: exit 0, no medium/high findings
- Claude Opus follow-up delta review: DELTA PASS, exit 0