### PR TITLE
fix(privacy): gate query-derived operational logs

### DIFF
--- a/deploy/litellm/klai_knowledge.py
+++ b/deploy/litellm/klai_knowledge.py
@@ -604,10 +604,9 @@ class KlaiKnowledgeHook(CustomLogger):
             _append_final_language_reminder(messages, include_kb_reminder=False)
             data["messages"] = messages
             logger.info(
-                "meta_query_detected org_id=%s user_id=%s query=%r",
+                "meta_query_detected org_id=%s user_id=%s",
                 org_id,
                 librechat_user_id,
-                query[:80],
             )
             return data
 

--- a/deploy/litellm/tests/test_klai_knowledge_meta_query.py
+++ b/deploy/litellm/tests/test_klai_knowledge_meta_query.py
@@ -29,6 +29,7 @@ These tests guard those three points:
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -285,6 +286,27 @@ async def test_meta_query_injects_meta_prompt_and_skips_retrieval(monkeypatch):
     assert "knowledge base chunks provided" not in sys_content, (
         "GROUNDED prompt leaked into the meta-question path"
     )
+
+
+@pytest.mark.asyncio
+async def test_meta_query_log_does_not_persist_query_text(monkeypatch, caplog):
+    """Meta-query detection remains observable without persisting chat text."""
+    mod = _load_hook(monkeypatch)
+    hook = mod.KlaiKnowledgeHook()
+    query = "what can I do here?"
+    data = {
+        "user": "aabbcc112233445566778899",
+        "messages": [{"role": "user", "content": query}],
+    }
+
+    with caplog.at_level(logging.INFO, logger="klai_knowledge"):
+        await hook.async_pre_call_hook(
+            _make_user_api_key(), _make_cache(), data, "completion"
+        )
+
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    assert "meta_query_detected" in rendered
+    assert query not in rendered
 
 
 @pytest.mark.asyncio

--- a/klai-portal/backend/app/services/gap_rescorer.py
+++ b/klai-portal/backend/app/services/gap_rescorer.py
@@ -19,6 +19,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.models.portal import PortalOrg
 from app.models.retrieval_gaps import PortalRetrievalGap
 from app.services.gap_classification import classify_gap
 from app.trace import get_trace_headers
@@ -38,13 +39,19 @@ def _open_gap_queries_stmt(org_id: int, kb_slug: str | None, cutoff: datetime):
             PortalRetrievalGap.query_text.label("query_text"),
             PortalRetrievalGap.gap_type.label("gap_type"),
             func.max(PortalRetrievalGap.occurred_at).label("last_occurred"),
+            PortalOrg.telemetry_level.label("telemetry_level"),
         )
+        .join(PortalOrg, PortalOrg.id == PortalRetrievalGap.org_id)
         .where(
             PortalRetrievalGap.org_id == org_id,
             PortalRetrievalGap.resolved_at.is_(None),
             PortalRetrievalGap.occurred_at >= cutoff,
         )
-        .group_by(PortalRetrievalGap.query_text, PortalRetrievalGap.gap_type)
+        .group_by(
+            PortalRetrievalGap.query_text,
+            PortalRetrievalGap.gap_type,
+            PortalOrg.telemetry_level,
+        )
         .order_by(func.max(PortalRetrievalGap.occurred_at).desc())
         .limit(MAX_QUERIES_PER_TRIGGER)
     )
@@ -140,13 +147,16 @@ async def rescore_open_gaps(
                     logger.warning(
                         "gap_rescorer: retrieval API returned %s for query=%r -- skipping",
                         resp.status_code,
-                        row.query_text[:60],
+                        row.query_text[:60] if row.telemetry_level == "full" else "<redacted>",
                     )
                     continue
                 chunks = resp.json().get("chunks", [])
             except Exception as exc:
                 logger.warning(
-                    "gap_rescorer: retrieval API error for query=%r: %s", row.query_text[:60], exc, exc_info=True
+                    "gap_rescorer: retrieval API error for query=%r: %s",
+                    row.query_text[:60] if row.telemetry_level == "full" else "<redacted>",
+                    exc,
+                    exc_info=True,
                 )
                 continue
 
@@ -165,7 +175,7 @@ async def rescore_open_gaps(
                 resolved_count += 1
                 logger.info(
                     "gap_rescorer: resolved gap query=%r org_id=%s",
-                    row.query_text[:60],
+                    row.query_text[:60] if row.telemetry_level == "full" else "<redacted>",
                     org_id,
                 )
 

--- a/klai-portal/backend/tests/test_gap_rescorer.py
+++ b/klai-portal/backend/tests/test_gap_rescorer.py
@@ -3,6 +3,7 @@
 Pure unit tests -- no real DB or HTTP calls. All async sessions and httpx are mocked.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +23,8 @@ def test_rescore_gap_query_uses_grouped_recent_ordering() -> None:
 
     assert "SELECT DISTINCT" not in compiled
     assert "max(portal_retrieval_gaps.occurred_at)" in compiled
+    assert "JOIN portal_orgs" in compiled
+    assert "portal_orgs.telemetry_level" in compiled
     assert "GROUP BY portal_retrieval_gaps.query_text, portal_retrieval_gaps.gap_type" in compiled
     assert "ORDER BY max(portal_retrieval_gaps.occurred_at) DESC" in compiled
 
@@ -258,6 +261,53 @@ async def test_rescore_skips_on_retrieval_error() -> None:
 
     assert result == 0
     mock_db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("telemetry_level", "query_visible"),
+    [("off", False), ("shadow", False), ("full", True)],
+)
+async def test_rescore_query_log_respects_telemetry_level(
+    caplog,
+    telemetry_level: str,
+    query_visible: bool,
+) -> None:
+    """Background re-scoring only logs stored query text in full telemetry."""
+    from app.services.gap_rescorer import rescore_open_gaps
+
+    secret_query = "PRIVATE_CUSTOMER_QUERY_7f3c"
+    mock_row = MagicMock(query_text=secret_query, gap_type="hard")
+    mock_row.telemetry_level = telemetry_level
+    mock_result = MagicMock()
+    mock_result.all.return_value = [mock_row]
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_db.commit = AsyncMock()
+
+    mock_response = MagicMock(is_success=False, status_code=500)
+    with (
+        patch("app.services.gap_rescorer.settings") as mock_settings,
+        patch("app.services.gap_rescorer.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_settings.knowledge_retrieve_url = "http://test-retrieve:8000"
+        mock_settings.internal_secret = ""
+        mock_client = AsyncMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with caplog.at_level(logging.INFO, logger="app.services.gap_rescorer"):
+            await rescore_open_gaps(
+                org_id=1,
+                zitadel_org_id="z1",
+                kb_slug=None,
+                db=mock_db,
+            )
+
+    rendered = " ".join(record.getMessage() for record in caplog.records)
+    assert "gap_rescorer: retrieval API returned" in rendered
+    assert (secret_query in rendered) is query_visible
 
 
 @pytest.mark.asyncio

--- a/rules/tests/test_query_logging_privacy.py
+++ b/rules/tests/test_query_logging_privacy.py
@@ -1,0 +1,133 @@
+"""Guard direct query log arguments behind full tenant telemetry."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUERY_LOG_SOURCES = (
+    REPO_ROOT / "deploy/litellm/klai_knowledge.py",
+    REPO_ROOT / "klai-portal/backend/app/services/gap_rescorer.py",
+)
+LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
+QUERY_NAMES = {"query", "query_text", "raw_query", "rewritten_query", "dropped"}
+
+
+def _identifier(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _contains_query_text(node: ast.AST) -> bool:
+    if isinstance(node, ast.Call) and _identifier(node.func) == "len":
+        return False
+    return any(
+        (_identifier(child) or "").lower() in QUERY_NAMES for child in ast.walk(node)
+    )
+
+
+def _is_full_telemetry_gate(node: ast.AST) -> bool:
+    if (
+        not isinstance(node, ast.Compare)
+        or len(node.ops) != 1
+        or len(node.comparators) != 1
+    ):
+        return False
+    if not isinstance(node.ops[0], ast.Eq):
+        return False
+    sides = (node.left, node.comparators[0])
+    return {_identifier(side) for side in sides} >= {"telemetry_level"} and any(
+        isinstance(side, ast.Constant) and side.value == "full" for side in sides
+    )
+
+
+def _safe_conditional(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.IfExp)
+        and _is_full_telemetry_gate(node.test)
+        and _contains_query_text(node.body)
+        and not _contains_query_text(node.orelse)
+    )
+
+
+def _inside_full_telemetry_gate(
+    call: ast.Call, parents: dict[ast.AST, ast.AST]
+) -> bool:
+    current: ast.AST = call
+    while current in parents:
+        parent = parents[current]
+        if (
+            isinstance(parent, ast.If)
+            and current in parent.body
+            and _is_full_telemetry_gate(parent.test)
+        ):
+            return True
+        current = parent
+    return False
+
+
+def _query_log_violations(source: str) -> list[int]:
+    tree = ast.parse(source)
+    parents = {
+        child: parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    violations: list[int] = []
+
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+        if (
+            not isinstance(call.func, ast.Attribute)
+            or call.func.attr not in LOG_METHODS
+            or _identifier(call.func.value) != "logger"
+        ):
+            continue
+        query_args = [arg for arg in call.args if _contains_query_text(arg)]
+        query_args.extend(
+            keyword.value
+            for keyword in call.keywords
+            if _contains_query_text(keyword.value)
+        )
+        if not query_args or _inside_full_telemetry_gate(call, parents):
+            continue
+        if not all(_safe_conditional(arg) for arg in query_args):
+            violations.append(call.lineno)
+
+    return violations
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        'logger.info("query=%r", query)',
+        'logger.info(f"query={query}")',
+        'logger.info("query=%r", query if telemetry_level == "full" or debug else "<redacted>")',
+    ],
+)
+def test_guard_rejects_unguarded_query_logging(statement: str) -> None:
+    assert _query_log_violations(
+        f"def handle(query, telemetry_level, debug):\n    {statement}\n"
+    ) == [2]
+
+
+def test_guard_accepts_full_telemetry_conditional() -> None:
+    source = """
+def handle(query, telemetry_level):
+    logger.info("query=%r", query if telemetry_level == "full" else "<redacted>")
+"""
+    assert _query_log_violations(source) == []
+
+
+@pytest.mark.parametrize("source_path", QUERY_LOG_SOURCES, ids=lambda path: path.name)
+def test_direct_query_logs_require_full_telemetry(source_path: Path) -> None:
+    violations = _query_log_violations(source_path.read_text())
+    assert violations == [], (
+        f"{source_path.relative_to(REPO_ROOT)} directly logs query text without "
+        f"telemetry_level == 'full' at lines {violations}"
+    )


### PR DESCRIPTION
## Summary

- remove literal chat text from `meta_query_detected` events
- expose gap query text only for tenants with `telemetry_level == "full"`
- add focused runtime regressions and a narrow AST guard for the two affected sources

## Verification

- LiteLLM: 693 passed, 1 existing warning
- portal backend: 3621 passed, 9 deselected, 1 xfailed, 35 warnings
- focused meta-query tests: 65 passed
- focused gap-rescorer tests: 12 passed
- rules tests: 30 passed
- targeted Ruff checks: passed

## Not verified

Production LogsQL proof for a non-full tenant requires this change to be merged and deployed.