### PR TITLE
fix(portal): scope quota denials to the scope they were raised for

### DIFF
--- a/klai-portal/frontend/src/hooks/__tests__/useKBQuota.test.ts
+++ b/klai-portal/frontend/src/hooks/__tests__/useKBQuota.test.ts
@@ -30,4 +30,3 @@ describe('resolvePersonalKBLimit', () => {
   })
 
 })
-

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/step-confirm-submit-gate.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/step-confirm-submit-gate.test.tsx
@@ -67,6 +67,36 @@ describe('StepConfirm submit gate', () => {
     ).toBe(true)
   })
 
+  // Regression: errorKey is only cleared on submit, so a denial that outlived
+  // its scope disabled the very button that clears it. Switching to a personal
+  // KB after an org denial left the wizard dead until a page reload.
+  it('re-enables submit when the user switches scope after an org denial', () => {
+    const button = renderConfirm({
+      data: { ...personalForm, ownerType: 'user' },
+      errorKey: 'org_not_allowed',
+    })
+
+    expect(button.disabled).toBe(false)
+  })
+
+  it('drops the org denial message once the scope is personal', () => {
+    renderConfirm({
+      data: { ...personalForm, ownerType: 'user' },
+      errorKey: 'org_not_allowed',
+    })
+
+    expect(screen.queryByText(/organisatie-kennisbanken|organisation knowledge bases/i)).toBeNull()
+  })
+
+  it('re-enables submit when the user switches to org after a personal quota denial', () => {
+    const button = renderConfirm({
+      data: { ...personalForm, ownerType: 'org' },
+      errorKey: 'personal_quota',
+    })
+
+    expect(button.disabled).toBe(false)
+  })
+
   it('stays enabled after a generic failure, which is retryable', () => {
     expect(renderConfirm({ errorKey: 'generic' }).disabled).toBe(false)
   })

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
@@ -26,7 +26,14 @@ export function StepConfirm({
   // These two 403s are permanent for the current role/plan, so re-submitting
   // can only produce the same denial. The cached KB list may still be stale
   // below the cap, which is why this does not rely on `personalQuotaReached`.
-  const permanentlyDenied = errorKey === 'org_not_allowed' || errorKey === 'personal_quota'
+  //
+  // Each denial applies only to the scope it was raised for. `errorKey` is
+  // cleared on submit, so a denial that outlived its scope would disable the
+  // very button that clears it — switching to a personal KB after an org
+  // denial left the wizard dead until a page reload.
+  const orgDenied = errorKey === 'org_not_allowed' && data.ownerType === 'org'
+  const personalDenied = errorKey === 'personal_quota' && data.ownerType === 'user'
+  const permanentlyDenied = orgDenied || personalDenied
   const visibilityLabel =
     data.visibilityMode === 'public'
       ? m.knowledge_sharing_visibility_public()
@@ -123,12 +130,12 @@ export function StepConfirm({
           </Button>
         </div>
       )}
-      {errorKey === 'org_not_allowed' && (
+      {orgDenied && (
         <p className="text-sm text-[var(--color-destructive)]">
           {m.knowledge_new_error_org_not_allowed()}
         </p>
       )}
-      {errorKey === 'personal_quota' && (
+      {personalDenied && (
         <p className="text-sm text-[var(--color-destructive)]">
           {m.kb_limit_tooltip_kb_count()}
         </p>


### PR DESCRIPTION
Follow-up to #1120. Two findings from a Codex review of that merge.

## Fixed

**Deadlock after a quota 403.** After an `org_not_allowed` 403 the user could
go back, pick a personal KB, and find the create button permanently disabled.
`errorKey` is only cleared inside `onSubmit`, so a denial that outlived its
scope disabled the very button that clears it. The wizard stayed dead until a
page reload.

Same class of defect #1120 was meant to remove — an action offered but
permanently blocked — and introduced by that fix. Both denials are now tied to
the scope they apply to, for the disabled state and for the message, so
switching scope re-enables submit and drops the stale error. No extra state, no
effect.

**Stray blank line at EOF** in `useKBQuota.test.ts`, which made
`git diff --check` exit 2.

## Verification

- `tsc -b` 0 · eslint 0 · 529 frontend tests · `git diff --check` 0
- The three new regression tests were mutation-checked: reverting the scope
  condition fails all three.

## Deliberately not fixed

The review also flagged that a mid-wizard entitlement flip (false -> true)
can revert the derived scope to org and land on step 4 without the user
having seen the access and permissions steps. Confirmed, and narrowed by the
`canAdvance` entitlement gate — the reachable slow-connection race is closed;
what remains needs an actual entitlement change while the wizard is open.

The fix for it (committing the forced scope into form state via an effect) was
deliberately removed when #1120 was trimmed back. Restoring it belongs in its
own change with its own trade-off discussion, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)