### PR TITLE
feat(privacy): activate the Klai recognizer pack on presidio-analyzer

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -463,17 +463,12 @@ services:
     # PLACEHOLDER DIGEST — deploy/presidio/analyzer-image-build.yml has not
     # run against this change yet (it runs on push to `main`; this PR does
     # not push or deploy). Replace with the real digest from that workflow's
-    # step summary. Bootstrap ordering: presidio-analyzer-image-build.yml
-    # only PUBLISHES on a push to `main`, so the Klai image does not exist
-    # until the PR carrying its Dockerfile has merged. This service therefore
-    # still runs the STOCK image, and a follow-up PR flips it to
-    # ghcr.io/getklai/presidio-analyzer@sha256:<real digest> together with
-    # the 512M limit below. A placeholder digest is not an acceptable interim
-    # state — check-klai-presidio-digest.sh rejects one, because nothing else
-    # in CI would (check-image-pullable.sh matches `image:tag` form only and
-    # is blind to every digest-pinned reference), and it would deploy an
-    # unpullable image to core-01.
-    image: ghcr.io/data-privacy-stack/presidio-analyzer@sha256:286e3fa7f3a7426e775e8564fe1870f1ba8f999d3ab8bbb8cc46a44355d9d6e9
+    # step summary. Bootstrap complete: presidio-analyzer-image-build.yml
+    # published this digest from d55d6adeb (tag 2.2.362-klai.1-d55d6adeb0ec),
+    # built FROM the same ghcr.io/data-privacy-stack digest Phase 0 pinned.
+    # This is where REQ-3's Dutch recognizers (BSN/KvK/BTW/postcode) and
+    # REQ-4's SECRET recognizer actually enter the request path.
+    image: ghcr.io/getklai/presidio-analyzer@sha256:fff95b8413f97708ce192ae1bf9e6418bcd14423ff4e0ec4a79f5ea172eed268
     restart: unless-stopped
     networks:
       - inference
@@ -492,15 +487,13 @@ services:
           # headroom over the measured steady-state for concurrent-request
           # growth without re-inflating toward the old provisional 2G.
           #
-          # NOT YET APPLIED: while this service still runs the STOCK image
-          # (see the image comment above), en_core_web_lg IS loaded, so 512M
-          # would OOM it. The limit drops to 512M in the same follow-up PR
-          # that flips the image — the two changes are one unit and must not
-          # be split. core-01 runs 78 services, so revise again from
-          # `docker stats presidio-analyzer --no-stream` once the Klai image
-          # runs on the server under real traffic.
+          # Applied together with the image above — the two are one unit: the
+          # stock image loads en_core_web_lg and would OOM at 512M. core-01
+          # runs 78 services, so revise again from
+          # `docker stats presidio-analyzer --no-stream` once this runs on the
+          # server under real traffic.
           cpus: '1'
-          memory: 2G
+          memory: 512M
 
   presidio-anonymizer:
     image: ghcr.io/data-privacy-stack/presidio-anonymizer@sha256:a10a12a2a613d13cf29d3ad3641e3258444dd8c90403dd644a0a114c472c2483

--- a/deploy/presidio/tests/test_deployment_constraints.py
+++ b/deploy/presidio/tests/test_deployment_constraints.py
@@ -6,8 +6,6 @@ text files already in the repo.
 from __future__ import annotations
 
 import re
-
-import pytest
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -31,19 +29,6 @@ def _service_block(compose_text: str, service: str) -> str:
     return "\n".join(lines[start:end])
 
 
-_BOOTSTRAP_PENDING = pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Bootstrap ordering: presidio-analyzer-image-build.yml only publishes on a "
-        "push to main, so ghcr.io/getklai/presidio-analyzer does not exist until the "
-        "PR carrying its Dockerfile has merged. Compose therefore still runs the "
-        "stock image at the stock 2G limit. strict=True is the point: the moment the "
-        "follow-up PR flips image and limit together, these XPASS and CI fails until "
-        "this marker is deleted — so the target state cannot be forgotten."
-    ),
-)
-
-
 class TestComposeImagePinning:
     """AC-2: both containers pinned by digest, both from
     ghcr.io/data-privacy-stack — neither from mcr.microsoft.com. Phase 1
@@ -51,7 +36,6 @@ class TestComposeImagePinning:
     FROM the ghcr.io/data-privacy-stack digest (checked via the Dockerfile,
     not the compose file, for that service)."""
 
-    @_BOOTSTRAP_PENDING
     def test_presidio_analyzer_uses_klai_image_pinned_by_digest(self):
         text = _COMPOSE_FILE.read_text()
         block = _service_block(text, "presidio-analyzer")
@@ -78,7 +62,6 @@ class TestComposeImagePinning:
         assert "ports:" not in block
         assert re.search(r"networks:\s*\n\s*- inference\b", block), block
 
-    @_BOOTSTRAP_PENDING
     def test_presidio_analyzer_has_explicit_resource_limits(self):
         text = _COMPOSE_FILE.read_text()
         block = _service_block(text, "presidio-analyzer")


### PR DESCRIPTION
Phase 1, part 2 of 2 — the bootstrap follow-up `d55d6adeb` described.

The image-build workflow published `ghcr.io/getklai/presidio-analyzer` from `d55d6adeb` (tag `2.2.362-klai.1-d55d6adeb0ec`), so the digest exists and compose can point at it. **This is where the Dutch recognizers actually enter the request path** — until now the service ran the stock image and detected none of them.

| | Before | After |
|---|---|---|
| Image | stock `data-privacy-stack` | `ghcr.io/getklai/presidio-analyzer@sha256:fff95b84…` |
| Memory | 2G | 512M |
| BSN / KvK / BTW / postcode / SECRET | not detected | detected |

Image and limit move **together, as one unit**: the stock image loads `en_core_web_lg` and would OOM at 512M; the Klai image loads no spaCy model at all (REQ-2 — every language uses `spacy.blank()`, tokenizer only) and measured ~257MiB steady state.

Drops the two `xfail(strict=True)` markers. They have done their job: they asserted this end state while it was unreachable, and would now XPASS and fail CI — which is exactly the forcing function they were added for.

**No behaviour change for production chat traffic.** The guardrail still has no `default_on`, so it applies only to requests that name it. Phase 2 turns it on in `logging_only`, and that does not run until the Phase 0 harness has produced REQ-0a/REQ-0b answers on the server.

## Tests

```
deploy/presidio/tests/test_deployment_constraints.py   → 6 passed (0 xfail)
deploy/check-klai-presidio-digest.sh                    → OK
deploy/scripts/tests/check-klai-presidio-digest.test.sh → all checks passed
deploy/scripts/check-dockerfile-security-updates.sh     → 12 checked, 3 skipped, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)