### PR TITLE
feat(privacy): Phase 2 read-only PII observer

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -347,6 +347,12 @@ services:
       # requires every top-level module to be mounted so it can run inside
       # the actual container (docker exec ... python scripts/eval_pii_restore_live.py).
       - ./litellm/klai_pii_restore_eval.py:/app/klai_pii_restore_eval.py:ro
+      # SPEC-PRIVACY-MISTRAL-PII-001 Phase 2 (REQ-5, REQ-6): read-only PII
+      # observer, registered as the last entry in config.yaml's
+      # litellm_settings.callbacks. On the request path (unlike the two
+      # eval-harness mounts above), but never blocks or fails it — see
+      # klai_pii_observe.py's module docstring.
+      - ./litellm/klai_pii_observe.py:/app/klai_pii_observe.py:ro
       - ./litellm/custom_router.py:/app/custom_router.py:ro
       # SPEC-CHAT-GUARDRAILS-001: vendored package copy of klai-libs/llm-safety
       # (kept byte-identical via deploy/litellm/tests/test_klai_llm_safety_drift.py).

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -126,6 +126,16 @@ litellm_settings:
   callbacks:
     - klai_knowledge.klai_knowledge_hook
     - custom_router.token_router
+    # SPEC-PRIVACY-MISTRAL-PII-001 Phase 2 (REQ-5, REQ-6): read-only PII
+    # observer. Registered LAST so it sees the outbound payload after KB
+    # context injection and router upgrade/downgrade, not the original
+    # request. Calls presidio-analyzer's /analyze out of band (never
+    # awaited by any hook), returns the payload unchanged, never calls
+    # the anonymizer, and emits org_id/call_type/model/language/entity
+    # counts only — no matched values, offsets, or hashes (REQ-6). Does
+    # NOT honour `_klai_openai_passthrough` or missing org_id — see
+    # klai_pii_observe.py's module docstring. Deleted in the Phase 3 PR.
+    - klai_pii_observe.klai_pii_observer
 
 # SPEC-PRIVACY-MISTRAL-PII-001 Phase 0 (REQ-0a/REQ-0b) — TEMPORARY,
 # EXPERIMENTAL, NOT the production control.

--- a/deploy/litellm/klai_pii_observe.py
+++ b/deploy/litellm/klai_pii_observe.py
@@ -1,0 +1,405 @@
+"""KlaiPiiObserver — Phase 2 read-only PII observer for the Mistral call path.
+
+SPEC-PRIVACY-MISTRAL-PII-001 REQ-5/REQ-6. Registered as the LAST entry in
+``config.yaml``'s ``litellm_settings.callbacks`` list, so it runs after
+``klai_knowledge.klai_knowledge_hook`` (KB context / attachment injection)
+and ``custom_router.token_router`` (model upgrade/downgrade) — it observes
+the actual outbound payload, not the original request.
+
+Correction (SPEC 0.4.0): an earlier draft of REQ-5 specified the native
+LiteLLM Presidio guardrail in ``mode: "logging_only"``. That mode masks
+what reaches observability platforms (Langfuse etc.) and sends the
+payload to the provider UNMASKED — inverted for measurement purposes.
+LiteLLM's Presidio guardrail has no detect-only mode at all. This module
+is the read-only observer that replaces that plan: it calls the
+analyzer directly, counts detections, and NEVER touches the payload.
+
+Contract (REQ-5):
+  - Calls presidio-analyzer's ``/analyze`` with the outbound message text.
+  - Returns ``data`` completely unchanged. Never calls the anonymizer.
+  - Does NOT honour ``_klai_openai_passthrough`` or missing ``org_id`` —
+    the two blind spots in ``KlaiKnowledgeHook`` (``klai_knowledge.py``
+    :426-427, :481-483) that this phase exists to see (AC-7, AC-8).
+  - Inspects every ``content`` field of every message, not just the last
+    user turn.
+  - Runs OUT OF BAND: the analyzer call is scheduled via
+    ``asyncio.create_task`` and never awaited by the hook itself, so it
+    cannot add latency to the user's request. A timeout or error inside
+    the scheduled task is caught, logged at ``warning``, and swallowed —
+    it can never fail or delay the request. This mirrors the existing
+    fire-and-forget pattern in ``klai_retrieval_telemetry.py``
+    (``fire_retrieval_log`` / ``fire_gap_event``): build the coroutine
+    only as the argument to ``create_task`` so a missing running loop
+    (test/sync context) raises before any coroutine object is created —
+    no "coroutine was never awaited" warning at GC.
+
+Contract (REQ-6): the emitted event carries ``org_id``, ``call_type``,
+model alias, detected language, and a COUNT per entity type. It never
+carries a matched value, surrounding text, a character offset, or a hash
+of a matched value — REQ-6's own reasoning is that a hash of a BSN is a
+BSN (nine digits is a trivially brute-forceable search space). The log
+call below passes only: an opaque ``org_id``, the ``call_type`` string
+LiteLLM itself supplies, the routed model alias, a two/three-letter
+language code, and ``{entity_type: count}`` — no code path in this
+module ever puts a message string, a slice of one, an offset, or a
+digest into a log argument.
+
+Deleted in the Phase 3 PR (REQ-5's own instruction): once the native
+guardrail enforces, a second path evaluating the same payload is
+duplicate machinery ("clean over clever, no parallel old+new").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from collections import Counter
+from typing import Any
+
+import httpx
+from litellm.integrations.custom_logger import CustomLogger
+
+from klai_kb_request_context import message_text as _message_text
+
+logger = logging.getLogger(__name__)
+
+# Same internal service name the Phase 0/1 guardrail and harness already use
+# (config.yaml's `presidio-pii-phase0` guardrail, docker-compose.yml, and
+# scripts/eval_pii_restore_live.py). No secret: neither Presidio container
+# has auth of its own.
+PRESIDIO_ANALYZER_API_BASE = os.getenv(
+    "PRESIDIO_ANALYZER_API_BASE", "http://presidio-analyzer:3000"
+)
+
+# Out-of-band call: kept short on purpose. This is a background task the
+# user's request never waits on, but an unbounded call here would still
+# pile up concurrent tasks under load and eventually starve the analyzer
+# for its OTHER caller (the Phase 0 harness / a future Phase 3 guardrail).
+# `asyncio.wait_for` is the real deadline; the httpx client timeout is the
+# safety net underneath it (see .claude/rules/klai/lang/python.md).
+_ANALYZER_CALL_TIMEOUT_SECONDS = 3.0
+_HTTPX_CLIENT_TIMEOUT_SECONDS = 5.0
+
+# deploy/presidio/analyzer/conf/analyzer.yaml `supported_languages` (REQ-2,
+# Phase 1). None of the entities this pack detects are language-scoped —
+# every one is regex-plus-checksum — so this only selects which /analyze
+# call the analyzer accepts vs. rejects with a language error; it is NOT a
+# detection-quality knob for anything except a future PERSON/GLiNER
+# recognizer this phase does not have yet.
+_ANALYZER_SUPPORTED_LANGUAGES = frozenset({"en", "nl", "de"})
+_DEFAULT_ANALYZER_LANGUAGE = "en"
+
+
+# ---------------------------------------------------------------------------
+# Language detection — local, dependency-free approximation
+# ---------------------------------------------------------------------------
+# REQ-2 asks Phase 2 telemetry to "reuse the existing detector rather than
+# adding one" — klai-retrieval-api's `util/language_detect.py`, a
+# lingua-backed detector with preloaded per-language models.
+#
+# That module cannot be imported here as-is. deploy/litellm runs the STOCK
+# ghcr.io/berriai/litellm image: individual .py files are bind-mounted onto
+# PYTHONPATH (see docker-compose.yml's `litellm:` service), there is no
+# Dockerfile and no pip-install step for this container. The `lingua`
+# package (and its preloaded language models) is not, and cannot become,
+# part of that image without introducing a custom build — the same
+# constraint already recorded against klai_chat_prompts.py and
+# klai_llm_safety's vendoring ("Phase D plan: pip install in custom
+# image"). Mounting the canonical module unmodified would crash the
+# container at import time with ModuleNotFoundError, the exact failure
+# class documented on klai_retrieval_telemetry.py's own compose mount.
+#
+# REQ-6 only needs this signal for TELEMETRY — "so per-language recall can
+# be compared instead of assumed" — never to change detection or routing
+# behaviour. A coarse, stdlib-only function-word heuristic over the same
+# six target languages is proportionate for that purpose and adds no new
+# dependency. This is a deliberate simplification, not a hidden shortcut —
+# see the implementation report's "could not fully satisfy" note.
+TARGET_LANGUAGES = ("nl", "en", "de", "fr", "pt", "es")
+UNKNOWN_LANGUAGE = "und"
+
+# Lingua needs ~30 chars before it trusts its own result; mirrored here so
+# short/greeting-only turns consistently report "und" rather than a guess.
+_MIN_CHARS_FOR_DETECTION = 30
+_MIN_STOPWORD_HITS = 2
+
+_STOPWORDS: dict[str, frozenset[str]] = {
+    "nl": frozenset(
+        {
+            "de", "het", "een", "en", "van", "ik", "je", "is", "dat", "niet",
+            "met", "voor", "op", "aan", "te", "dit", "ook", "zijn", "wij",
+            "hebben", "kunt", "graag", "alstublieft",
+        }
+    ),
+    "en": frozenset(
+        {
+            "the", "and", "is", "of", "to", "in", "that", "it", "for",
+            "with", "on", "as", "are", "was", "this", "have", "you", "not",
+            "please", "could", "would",
+        }
+    ),
+    "de": frozenset(
+        {
+            "der", "die", "das", "und", "ist", "nicht", "mit", "für", "auf",
+            "den", "dem", "des", "ein", "eine", "sie", "wir", "haben",
+            "bitte", "können",
+        }
+    ),
+    "fr": frozenset(
+        {
+            "le", "la", "les", "et", "est", "un", "une", "pour", "avec",
+            "sur", "dans", "ne", "pas", "je", "vous", "nous", "des",
+            "merci", "pouvez",
+        }
+    ),
+    "pt": frozenset(
+        {
+            "o", "a", "os", "as", "de", "e", "um", "uma", "para", "com",
+            "não", "em", "que", "você", "nós", "é", "por", "favor",
+        }
+    ),
+    "es": frozenset(
+        {
+            "el", "la", "los", "las", "de", "y", "un", "una", "para",
+            "con", "no", "en", "que", "usted", "nosotros", "es", "por",
+            "favor",
+        }
+    ),
+}
+
+_WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+
+def _detect_language(text: str) -> str:
+    """Return a best-effort ISO-639-1-ish code, or ``UNKNOWN_LANGUAGE``.
+
+    Telemetry-only (REQ-6) — never used to gate or change detection
+    behaviour. See the module-level note above for why this is a local
+    heuristic rather than an import of the canonical lingua-based
+    detector.
+    """
+    if not text or len(text.strip()) < _MIN_CHARS_FOR_DETECTION:
+        return UNKNOWN_LANGUAGE
+
+    tokens = [tok.lower() for tok in _WORD_RE.findall(text)]
+    if not tokens:
+        return UNKNOWN_LANGUAGE
+
+    scores = {
+        lang: sum(1 for tok in tokens if tok in words)
+        for lang, words in _STOPWORDS.items()
+    }
+    best_score = max(scores.values())
+    if best_score < _MIN_STOPWORD_HITS:
+        return UNKNOWN_LANGUAGE
+
+    # A single ambiguous overlap word ("de" is a stopword in nl/fr/pt/es)
+    # must not silently pick a winner — report unknown rather than guess.
+    tied = [lang for lang, score in scores.items() if score == best_score]
+    if len(tied) > 1:
+        return UNKNOWN_LANGUAGE
+    return tied[0]
+
+
+# ---------------------------------------------------------------------------
+# Analyzer call
+# ---------------------------------------------------------------------------
+def _payload_texts(messages: list[Any]) -> list[str]:
+    """Every non-empty ``content`` field across every message.
+
+    Uses the same ``message_text`` helper klai_knowledge.py's own
+    request-context parsing already relies on, so both string content and
+    multi-part (list-of-parts) content are handled identically — no
+    reimplementation of that shape-handling here.
+    """
+    texts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        text = _message_text(message)
+        if text:
+            texts.append(text)
+        # An assistant turn in an agentic flow can carry content=None while
+        # tool_calls[].function.arguments holds an email address, a BSN, or
+        # anything else the model decided to pass along. The router keeps
+        # those turns and they go to Mistral verbatim, so a measurement that
+        # reads only `content` under-reports exactly the agentic paths
+        # (klai-large, MCP) where PII is most likely to be moving around.
+        for call in message.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            arguments = (call.get("function") or {}).get("arguments")
+            if isinstance(arguments, str) and arguments.strip():
+                texts.append(arguments)
+    return texts
+
+
+def _user_text(messages: list[Any]) -> str:
+    """Text of the latest user turn, for language detection only.
+
+    Detecting on the whole payload would classify almost everything as
+    English: the KB context block is deliberately English-structured
+    (SPEC-RAG-MULTILINGUAL-CHAT-001) and usually dwarfs the question. The
+    language dimension exists so REQ-2's per-language recall can be
+    compared, and a field that says "en" for a Dutch question is worse
+    than no field at all. The PII scan itself still covers the full
+    payload — only the language label is narrowed.
+    """
+    for message in reversed(messages):
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        text = _message_text(message)
+        if text:
+            return text
+    return ""
+
+
+async def _analyze_entity_counts(
+    http: httpx.AsyncClient, text: str, language: str
+) -> Counter[str]:
+    """Call presidio-analyzer's ``/analyze`` and count hits per entity type.
+
+    Deliberately discards everything /analyze returns except
+    ``entity_type`` — REQ-6 forbids emitting the matched value, its
+    offset, or any surrounding text, and this is the one place in the
+    module that ever sees the analyzer's raw (potentially
+    value-adjacent) response, so it is also the one place that must never
+    forward more of it than a bare count.
+    """
+    url = PRESIDIO_ANALYZER_API_BASE.rstrip("/") + "/analyze"
+    response = await asyncio.wait_for(
+        http.post(url, json={"text": text, "language": language}),
+        timeout=_ANALYZER_CALL_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    results = response.json()
+    if not isinstance(results, list):
+        raise TypeError("presidio-analyzer /analyze returned a non-list response")
+
+    counts: Counter[str] = Counter()
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        entity_type = item.get("entity_type")
+        if isinstance(entity_type, str) and entity_type:
+            counts[entity_type] += 1
+    return counts
+
+
+def _org_id_from_key(user_api_key_dict: Any) -> Any:
+    """Best-effort org_id, WITHOUT the KlaiKnowledgeHook early-return.
+
+    ``klai_knowledge.py`` treats a missing org_id as "master key usage,
+    skip silently" (:481-483) — every widget and partner request, since
+    ``partner_chat.py`` calls with the master key and no ``user`` field.
+    That is exactly the blind spot AC-8 tests: this observer reports
+    ``None`` for org_id rather than skipping the request.
+    """
+    metadata = getattr(user_api_key_dict, "metadata", {}) or {}
+    return metadata.get("org_id")
+
+
+async def _observe(
+    combined_text: str,
+    *,
+    language: str,
+    org_id: Any,
+    call_type: str,
+    model: Any,
+) -> None:
+    """Do the analyzer call + emit telemetry. Runs as a background task.
+
+    Every exception, including a timeout, is caught here and logged at
+    ``warning`` rather than re-raised — REQ-5's "a failure or timeout in
+    it SHALL NOT fail the request", the deliberate inverse of REQ-10
+    (which governs Phase 3 enforcement, not this observer).
+    """
+    try:
+        analyzer_language = (
+            language
+            if language in _ANALYZER_SUPPORTED_LANGUAGES
+            else _DEFAULT_ANALYZER_LANGUAGE
+        )
+        async with httpx.AsyncClient(timeout=_HTTPX_CLIENT_TIMEOUT_SECONDS) as http:
+            counts = await _analyze_entity_counts(http, combined_text, analyzer_language)
+    except Exception as exc:
+        # Fail-open per REQ-5, but keep the same non-sensitive dimensions the
+        # success event carries. Without them an outage cannot be filtered out
+        # of the Phase 2 sample per tenant/model/language, which quietly turns
+        # "Presidio was down for this org" into "this org has no PII".
+        logger.warning(
+            "pii_observe_failed org_id=%s call_type=%s model=%s language=%s error=%s",
+            org_id,
+            call_type,
+            model,
+            language,
+            exc,
+        )
+        return
+
+    # REQ-6: org_id, call_type, model alias, detected language, per-entity
+    # counts. Nothing else — no message text, no offsets, no hashes.
+    logger.warning(
+        "pii_observed org_id=%s call_type=%s model=%s language=%s entity_counts=%s",
+        org_id,
+        call_type,
+        model,
+        language,
+        dict(counts),
+    )
+
+
+class KlaiPiiObserver(CustomLogger):
+    """Read-only PII observer. Never mutates or blocks the request."""
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: Any,
+        cache: Any,
+        data: dict[str, Any],
+        call_type: str,
+    ) -> dict[str, Any]:
+        messages = data.get("messages")
+        try:
+            if isinstance(messages, list) and messages:
+                org_id = _org_id_from_key(user_api_key_dict)
+                model = data.get("model")
+                # Build the coroutine only as create_task's argument: if
+                # get_running_loop() raises (no running loop — sync/test
+                # context), the coroutine is never constructed and no
+                # "never awaited" warning fires at GC. Mirrors
+                # klai_retrieval_telemetry.py's fire_retrieval_log /
+                # fire_gap_event.
+                # Snapshot the text SYNCHRONOUSLY, before scheduling. The
+                # background task must not read `messages` by reference:
+                # klai_knowledge.py mutates data["messages"] (history
+                # sanitisation, system prefixes, KB context injection), so a
+                # deferred read would measure whatever the list happens to
+                # hold when the loop gets round to the task. Same list,
+                # different content, no error — the measurement would just
+                # quietly drift. An immutable string fixes the measurement
+                # point at this callback's position, which is deliberately
+                # last in `callbacks:` so it is the post-injection payload.
+                texts = _payload_texts(messages)
+                if texts:
+                    language = _detect_language(_user_text(messages))
+                    asyncio.get_running_loop().create_task(
+                        _observe(
+                            "\n\n".join(texts),
+                            language=language,
+                            org_id=org_id,
+                            call_type=call_type,
+                            model=model,
+                        )
+                    )
+        except Exception as exc:
+            # Scheduling itself must never fail the request either — this
+            # is the observer's own version of REQ-5's fail-open contract,
+            # one layer up from _observe's internal try/except.
+            logger.warning("pii_observe_schedule_failed error=%s", exc)
+        return data
+
+
+klai_pii_observer = KlaiPiiObserver()

--- a/deploy/litellm/tests/klai_module_reset.py
+++ b/deploy/litellm/tests/klai_module_reset.py
@@ -24,6 +24,7 @@ KLAI_KB_MODULES = (
     "klai_kb_urls",
     "klai_litellm_response",
     "klai_pasted_correspondence",
+    "klai_pii_observe",
 )
 
 

--- a/deploy/litellm/tests/test_pii_observe.py
+++ b/deploy/litellm/tests/test_pii_observe.py
@@ -1,0 +1,584 @@
+"""Tests for klai_pii_observe.py (SPEC-PRIVACY-MISTRAL-PII-001 Phase 2).
+
+litellm is not installed as the real proxy package for these tests (see
+test_klai_knowledge_hook.py's same rationale) — we mock the import so
+KlaiPiiObserver's CustomLogger base class resolves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.klai_module_reset import reset_klai_kb_modules
+
+
+@pytest.fixture(autouse=True)
+def _mock_litellm():
+    """Mock litellm module so klai_pii_observe can be imported."""
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        async def async_pre_call_hook(self, *args, **kwargs):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+    litellm_mod.integrations = integrations_mod
+    integrations_mod.custom_logger = custom_logger_mod
+
+    sys.modules["litellm"] = litellm_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+    yield
+
+    for mod_name in ["litellm", "litellm.integrations", "litellm.integrations.custom_logger"]:
+        sys.modules.pop(mod_name, None)
+    reset_klai_kb_modules()
+
+
+def _load_observer(monkeypatch, extra_env=None):
+    env = {"PRESIDIO_ANALYZER_API_BASE": "http://presidio-analyzer:3000"}
+    if extra_env:
+        env.update(extra_env)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+    reset_klai_kb_modules()
+    import klai_pii_observe
+
+    return klai_pii_observe
+
+
+def _user_api_key(org_id=None):
+    uak = MagicMock()
+    uak.metadata = {"org_id": org_id} if org_id is not None else {}
+    return uak
+
+
+class _FakeAnalyzerResponse:
+    def __init__(self, results):
+        self._results = results
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._results
+
+
+class _FakeAsyncClient:
+    """Records every POST and returns a scripted result list."""
+
+    def __init__(self, results=None, hang_event=None):
+        self._results = results if results is not None else []
+        self.calls = []
+        self._hang_event = hang_event
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    @property
+    def last_text(self):
+        """Text of the most recent /analyze POST — what the analyzer saw."""
+        return self.calls[-1]["json"]["text"] if self.calls else ""
+
+    async def post(self, url, json=None, **kwargs):
+        self.calls.append({"url": url, "json": json})
+        if self._hang_event is not None:
+            await self._hang_event.wait()
+        return _FakeAnalyzerResponse(self._results)
+
+
+async def _drain_background_tasks():
+    """Let any create_task()-scheduled coroutines finish before a test ends."""
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current]
+    if pending:
+        await asyncio.wait(pending, timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Payload is returned unchanged
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_payload_returned_byte_identical(monkeypatch):
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "hello there, how are you today?"}],
+    }
+    original_identity = data
+
+    result = await mod.klai_pii_observer.async_pre_call_hook(
+        _user_api_key("org123"), None, data, "completion"
+    )
+
+    # Not just equal — the exact same object. REQ-5: "return the payload
+    # completely unchanged."
+    assert result is original_identity
+    assert result == {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "hello there, how are you today?"}],
+    }
+    await _drain_background_tasks()
+
+
+# ---------------------------------------------------------------------------
+# AC-7 / AC-8 — the two KlaiKnowledgeHook blind spots do NOT suppress this
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_openai_passthrough_flag_does_not_suppress_observation(monkeypatch):
+    """AC-7: a request carrying `_klai_openai_passthrough` and a BSN is
+    still evaluated and counted — the regression test for the hook's
+    blind spot named in REQ-5.
+    """
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[{"entity_type": "NL_BSN"}])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "metadata": {"_klai_openai_passthrough": True},
+        "messages": [
+            {"role": "user", "content": "mijn bsn is 111222333, kun je dit verwerken alsjeblieft?"}
+        ],
+    }
+
+    await mod.klai_pii_observer.async_pre_call_hook(
+        _user_api_key("org123"), None, data, "completion"
+    )
+    await _drain_background_tasks()
+
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_org_id_is_still_observed(monkeypatch, caplog):
+    """AC-8: a request with no org_id (widget/partner shape, master-key
+    calls) is still evaluated and counted.
+    """
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[{"entity_type": "EMAIL_ADDRESS"}])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-fast",
+        "messages": [{"role": "user", "content": "contact me at jan@example.com please, thanks"}],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key(org_id=None), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert len(client.calls) == 1
+    assert any("pii_observed" in r.message for r in caplog.records)
+    assert any("org_id=None" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — no matched value, offset, or hash ever leaves the module
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_emitted_event_contains_no_value_offset_or_hash(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    bsn_digits = "111222333"
+    # Analyzer response shaped the way real Presidio /analyze responds:
+    # entity_type + start/end/score. The observer must discard everything
+    # except entity_type.
+    client = _FakeAsyncClient(
+        results=[{"entity_type": "NL_BSN", "start": 12, "end": 21, "score": 0.85}]
+    )
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": f"mijn burgerservicenummer is {bsn_digits} graag verwerken"}],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    all_logged_text = "\n".join(r.message for r in caplog.records)
+    assert bsn_digits not in all_logged_text
+    assert "start" not in all_logged_text
+    assert "end=" not in all_logged_text
+    assert "0.85" not in all_logged_text
+    # A hash of a BSN is a BSN (REQ-6) — no hex digest of any length either.
+    import hashlib
+    import re
+
+    assert hashlib.sha256(bsn_digits.encode()).hexdigest() not in all_logged_text
+    assert not re.search(r"\b[0-9a-f]{32,64}\b", all_logged_text)
+    # Only the count survives.
+    assert "NL_BSN" in all_logged_text
+    assert "entity_counts={'NL_BSN': 1}" in all_logged_text
+
+
+# ---------------------------------------------------------------------------
+# Entity in a non-last message is counted
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_entity_in_non_last_message_is_counted(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[{"entity_type": "NL_BSN"}])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [
+            {"role": "user", "content": "mijn bsn is 111222333, kun je dit onthouden?"},
+            {"role": "assistant", "content": "Genoteerd, dank u wel."},
+            {"role": "user", "content": "kun je nu een samenvatting maken?"},
+        ],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    # The combined text sent to the analyzer must include the FIRST
+    # message's content, not just the last user turn.
+    assert len(client.calls) == 1
+    assert "111222333" in client.calls[0]["json"]["text"]
+    assert any("entity_counts={'NL_BSN': 1}" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Analyzer failure/timeout is swallowed — request unaffected
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_analyzer_error_is_swallowed_and_logged(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+
+    class _RaisingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        async def post(self, *args, **kwargs):
+            raise ConnectionError("presidio-analyzer unreachable")
+
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: _RaisingClient()))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "just a normal chat message, nothing special here"}],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        result = await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert result is data
+    assert any("pii_observe_failed" in r.message for r in caplog.records)
+    assert not any("pii_observed " in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_analyzer_500_is_swallowed_and_logged(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+
+    class _HttpErrorResponse:
+        def raise_for_status(self):
+            raise RuntimeError("500 Internal Server Error")
+
+        def json(self):
+            return []
+
+    class _ErrorClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _HttpErrorResponse()
+
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: _ErrorClient()))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "just a normal chat message, nothing special here"}],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        result = await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert result is data
+    assert any("pii_observe_failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Out-of-band: the hook returns without waiting for a slow analyzer
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_hook_does_not_await_the_analyzer_call(monkeypatch):
+    """Concrete proof of REQ-5's "out of band" requirement: even when the
+    analyzer never responds, the hook itself returns almost immediately.
+    If the hook awaited the analyzer call directly, this would hang until
+    the outer `asyncio.wait_for` below raised `TimeoutError`.
+    """
+    mod = _load_observer(monkeypatch)
+    hang_event = asyncio.Event()  # never set during the timed section
+    client = _FakeAsyncClient(results=[], hang_event=hang_event)
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "hello there, how are you doing today?"}],
+    }
+
+    started = time.monotonic()
+    result = await asyncio.wait_for(
+        mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        ),
+        timeout=1.0,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result is data
+    # The analyzer call is gated on an Event that is never set in this
+    # section — a blocking implementation would need the full 1.0s
+    # `wait_for` timeout (or hang forever without it). An out-of-band
+    # implementation returns near-instantly regardless.
+    assert elapsed < 0.1, f"hook took {elapsed:.3f}s — looks like it awaited the analyzer call"
+
+    # Let the background task make progress and finish so nothing leaks
+    # past the test.
+    hang_event.set()
+    await _drain_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_no_running_loop_does_not_raise(monkeypatch):
+    """When called outside a running loop (defensive path — LiteLLM always
+    calls hooks from inside its own event loop, but the observer must not
+    assume that), scheduling failure is swallowed too.
+
+    Patches ``get_running_loop`` itself to raise (the real no-loop
+    behaviour), rather than returning a loop whose ``create_task`` raises —
+    the latter would still construct the ``_observe(...)`` coroutine as
+    the call argument before the raise, leaking an unawaited coroutine.
+    """
+    mod = _load_observer(monkeypatch)
+
+    def _raise_no_running_loop():
+        raise RuntimeError("no running event loop")
+
+    monkeypatch.setattr(mod.asyncio, "get_running_loop", _raise_no_running_loop)
+
+    data = {
+        "model": "klai-primary",
+        "messages": [{"role": "user", "content": "hello there, how are you doing today?"}],
+    }
+
+    result = await mod.klai_pii_observer.async_pre_call_hook(
+        _user_api_key("org123"), None, data, "completion"
+    )
+    assert result is data
+
+
+# ---------------------------------------------------------------------------
+# Detected language rides along in the event
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_event_carries_detected_dutch_language(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Kunt u dit voor mij regelen? Ik heb het niet zelf gedaan en wil het graag weten.",
+            }
+        ],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert any("language=nl" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_event_carries_detected_english_language(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-primary",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Could you please help me with this and let me know what you think of it?",
+            }
+        ],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert any("language=en" in r.message for r in caplog.records)
+
+
+def test_short_text_detects_as_unknown_language(monkeypatch):
+    mod = _load_observer(monkeypatch)
+    assert mod._detect_language("hoi") == mod.UNKNOWN_LANGUAGE
+    assert mod._detect_language("") == mod.UNKNOWN_LANGUAGE
+
+
+def test_analyzer_language_falls_back_to_supported_set(monkeypatch):
+    mod = _load_observer(monkeypatch)
+    assert "fr" not in mod._ANALYZER_SUPPORTED_LANGUAGES
+    assert "nl" in mod._ANALYZER_SUPPORTED_LANGUAGES
+
+
+# ---------------------------------------------------------------------------
+# No messages -> nothing to observe, no analyzer call
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_no_messages_skips_analyzer_call(monkeypatch):
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {"model": "klai-bge-m3", "input": ["some embedding text"]}
+
+    result = await mod.klai_pii_observer.async_pre_call_hook(
+        _user_api_key("org123"), None, data, "embeddings"
+    )
+    await _drain_background_tasks()
+
+    assert result is data
+    assert client.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Sol delta-review: tool_call arguments are provider-visible text
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_tool_call_arguments_are_scanned(monkeypatch, caplog):
+    """An assistant turn can carry content=None while tool_calls hold PII.
+
+    The router keeps those turns and they reach Mistral verbatim, so a
+    measurement reading only `content` under-reports exactly the agentic
+    paths (klai-large, MCP) where PII moves around most.
+    """
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[{"entity_type": "EMAIL_ADDRESS"}])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    data = {
+        "model": "klai-large",
+        "messages": [
+            {"role": "user", "content": "stuur dit door"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "send_mail",
+                            "arguments": '{"to": "jan.devries@example.nl"}',
+                        }
+                    }
+                ],
+            },
+        ],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    # The arguments string must have reached the analyzer payload.
+    assert "jan.devries@example.nl" in client.last_text
+    assert "entity_counts={'EMAIL_ADDRESS': 1}" in "\n".join(
+        r.message for r in caplog.records
+    )
+    # And the address itself must still not appear in the emitted event.
+    assert "jan.devries@example.nl" not in "\n".join(r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Sol delta-review: language comes from the user turn, not the KB context
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_language_detected_from_user_turn_not_kb_context(monkeypatch, caplog):
+    """The KB context block is deliberately English-structured.
+
+    Detecting on the whole payload would label a Dutch question "en" on
+    essentially every RAG request, making REQ-2's per-language recall
+    comparison meaningless. The PII scan still covers the full payload.
+    """
+    mod = _load_observer(monkeypatch)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    english_kb_block = (
+        "[Klai Knowledge Base - use this as supplementary context for your answer. "
+        "You may complement it with your general knowledge.] "
+        "The following documents were retrieved from the knowledge base and are "
+        "provided so that the assistant can ground its answer in them."
+    )
+    data = {
+        "model": "klai-primary",
+        "messages": [
+            {"role": "system", "content": english_kb_block},
+            {"role": "user", "content": "Kun je mij vertellen hoe ik dit moet doen met de nieuwe instellingen?"},
+        ],
+    }
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org123"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "language=nl" in logged, logged
+    # The scan itself still saw the English block.
+    assert "knowledge base" in client.last_text.lower()

--- a/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
+++ b/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-PRIVACY-MISTRAL-PII-001
-version: "0.3.0"
+version: "0.4.1"
 status: draft
 created: 2026-08-20
 updated: 2026-08-20
@@ -17,6 +17,8 @@ roadmap: docs/architecture/knowledge-rag-improvement-plan.md
 
 | Version | Date       | Author       | Change |
 |---------|------------|--------------|--------|
+| 0.4.1   | 2026-08-20 | Mark Vletter | REQ-6 tightened after the Phase 2 delta review. The language label is now derived from the latest user turn rather than the whole payload — the KB context block is English-structured by design and dwarfs the question, so detecting on combined text would have labelled a Dutch question `en` on essentially every RAG request and quietly invalidated REQ-2's per-language comparison. Records the honest limitation that the observer uses a stopword heuristic rather than the canonical lingua detector, because `lingua-language-detector` is not in the stock litellm image, with the escalation path if Phase 2 data proves too noisy. |
+| 0.4.0   | 2026-08-20 | Mark Vletter | REQ-5 corrected before it was built. It specified the native guardrail in `mode: "logging_only"` as the shadow-measurement mechanism; that mode masks what goes to **observability** and sends the payload to the provider **unmasked** — inverted for our purpose, and LiteLLM's Presidio guardrail has no detect-only mode at all. Phase 2 is now a read-only observer callback (`klai_pii_observe.py`) that calls the analyzer, emits REQ-6's counts, returns the payload unchanged, never calls the anonymizer, runs out of band so it cannot add latency or fail a request, and is deleted by the Phase 3 PR. The Phase 0 experiment guardrail stays registered so the REQ-0a/REQ-0b harness remains runnable. Also records what Phase 0 and Phase 1 actually shipped: both merged (`d55d6adeb`, `d2aa35fd2`), nine recognizers verified loaded across en/nl/de on core-01 with spaCy disabled per language, and the Phase 0 harness still **unrun**. |
 | 0.3.0   | 2026-08-20 | Mark Vletter | Language-agnosticism corrected. 0.2.0's REQ-2 pinned `presidio_language: "nl"` and dismissed mixed traffic as a known limitation — wrong for a product that ships a language detector, language-neutral KB context, and per-language correctness monitoring (SPEC-RAG-MULTILINGUAL-CHAT-001). REQ-2 now makes detection language-agnostic **by construction**: every REQ-3 entity is regex-plus-checksum and therefore jurisdiction-specific rather than language-specific, registered across all languages; `PERSON` is the only language-sensitive entity and uses multilingual GLiNER instead of a per-language spaCy pipeline. Net effect is a simplification — no spaCy model is loaded at all, which also removes the per-language model matrix and the memory it would cost. Phase 2 telemetry now carries detected language so per-language recall is measured, not assumed. Phase 0 keeps the stock English engine as an explicit, bounded exception because it measures the restore mechanism, not detection quality. |
 | 0.2.0   | 2026-08-20 | Mark Vletter | Reversibility reinstated after correcting a misread. 0.1.0 excluded reversible pseudonymisation because `output_parse_pii` "does not un-mask streaming" — that bug (#22821) is **Anthropic-native-specific and closed**, and we route Mistral over the OpenAI-compatible path, so it never applied to us. Decision is now hybrid: irreversible for the never-return set (`SECRET`, `NL_BSN`), reversible for the set the drafting use case needs back (names, phone, email, IBAN, KvK, BTW, postcode). Adds Phase 0 (REQ-0a, REQ-0b) — prove the restore path on `v1.96.2` and measure Dutch token-survival rate **before** building the recognizer pack, since the remaining uncertainty (#6247, closed as stale) is not answerable by reading. Adds REQ-11: the placeholder map is request-scoped and never persisted, because a shared map is the one failure mode that is worse than masking. GLiNER moves from shadow-only to viable, on the reasoning that restore makes precision non-binding. Adds a Deployment section: two CPU services on core-01, no secrets, no GPU. |
 | 0.1.0   | 2026-08-20 | Mark Vletter | Initial draft. Answers two questions: are Presidio + GLiNER still the right tools in August 2026, and how do we wire them into the calls that go to Mistral. Research re-run 2026-08-20; the earlier architecture note (`klai-knowledge-architecture.md:1661`) named the right framework but predates three facts that change the implementation: Presidio ships **no Dutch recognizers at all**, LiteLLM has since gained a **native Presidio guardrail** that removes the need for custom hook code, and its reversible `output_parse_pii` path is **broken on streaming**, which decides pseudonymisation versus anonymisation for us. |
@@ -32,8 +34,10 @@ once, in the `litellm` service block (`deploy/docker-compose.yml:388-389`). No s
 a provider key of its own and no code calls `api.mistral.ai` directly.
 
 This SPEC puts PII removal on that boundary using Presidio, deployed as two self-hosted
-containers and wired in through **LiteLLM's native Presidio guardrail** rather than custom
-hook code. It adds the Dutch recognizer pack that Presidio does not ship, and it splits
+containers. Enforcement (Phase 3) rides on **LiteLLM's native Presidio guardrail** rather
+than custom hook code; measurement (Phase 2) needs a small read-only observer, because the
+native guardrail has no detect-only mode — see REQ-5. It adds the Dutch recognizer pack that
+Presidio does not ship, and it splits
 handling by intent: credentials and BSN are removed and never restored, while names, phone
 numbers and account identifiers are tokenised on the way out and restored on the way back —
 so drafting an email still works while Mistral never receives the real values.
@@ -148,6 +152,7 @@ supported path, it covers the two cases our own hook misses, and it is less code
 - A Klai Dutch recognizer pack: BSN, KvK, BTW, postcode — plus credentials.
 - LiteLLM guardrail configuration with `default_on: true`.
 - A round-trip harness proving the restore path and measuring Dutch token survival (Phase 0).
+- A read-only observer for Phase 2 measurement, removed again by Phase 3.
 - Shadow-then-enforce rollout, per-entity and per-org policy.
 - Reversible restore for the return set; irreversible for the never-return set.
 - GLiNER as the NER engine for `PERSON`, gated on REQ-0b's survival rate.
@@ -302,25 +307,67 @@ through. Matching only the header leaves the key material in the payload.
 
 ### Phase 2 — measure before changing anything
 
-#### REQ-5 — the guardrail runs on every request, in logging-only mode (ubiquitous)
+#### REQ-5 — measurement runs on every request through a read-only observer (ubiquitous)
 
-**THE LiteLLM configuration SHALL** register the Presidio guardrail with
-`mode: "logging_only"` and **`default_on: true`**, so it evaluates every request without the
-caller opting in.
+**Correction (0.4.0).** Earlier versions of this requirement specified the native guardrail
+with `mode: "logging_only"` and `default_on: true`. That does not do what it sounds like.
+LiteLLM's `logging_only` means *"only apply PII masking before logging to Langfuse, etc. Not
+on the actual llm api request / response"* — it masks what reaches **observability** and
+sends the payload to the provider **unmasked**. For our purpose that is exactly inverted: it
+would leave provider egress untouched (the status quo) while blinding the one place we want
+counts. LiteLLM's Presidio guardrail has **no** detect-only mode; all four modes either mask
+or block.
 
-`default_on` is the coverage mechanism and the reason no custom callback is needed. It also
-covers the two paths Klai's own hook skips — see the Motivation.
+**THE Phase 2 implementation SHALL** therefore be a read-only observer:
+`deploy/litellm/klai_pii_observe.py`, a `CustomLogger` registered in `callbacks:` alongside
+the existing hooks.
 
-**WHILE** in `logging_only`, **THE guardrail SHALL NOT** modify any payload.
+**IT SHALL** call the analyzer's `/analyze` endpoint with the outbound payload and emit the
+telemetry in REQ-6. **IT SHALL** return the payload **unchanged**, and **SHALL NOT** call the
+anonymizer at all.
+
+**IT SHALL NOT** honour `_klai_openai_passthrough`, `org_id` absence, or any other early
+return — the two blind spots in `KlaiKnowledgeHook` named in the Motivation are precisely
+what Phase 2 needs to see.
+
+**IT SHALL** run **out of band** of the response path: the measurement call **SHALL NOT**
+add latency to the user's request, and a failure or timeout in it **SHALL NOT** fail the
+request. Phase 2 changes nothing, so it must not be able to break anything either. This is
+the deliberate inverse of REQ-10, which applies to enforcement.
+
+**THE observer SHALL** be deleted in the Phase 3 PR. It exists to answer REQ-8's activation
+question; once the native guardrail enforces, a second path evaluating the same payload is
+duplicate machinery, and `clean over clever, no parallel old+new` applies.
+
+The Phase 0 experiment guardrail (`presidio-pii-phase0`, opt-in, no `default_on`) stays
+registered and unchanged so the REQ-0a/REQ-0b harness remains runnable.
 
 #### REQ-6 — detections are recorded without recording the values (ubiquitous)
 
-**THE Phase 2 telemetry SHALL** emit, per request: `org_id`, `call_type`, model alias, and a
-count per entity type.
+**THE Phase 2 telemetry SHALL** emit, per request: `org_id`, `call_type`, model alias, the
+detected language (REQ-2), and a count per entity type.
 
 **IT SHALL NOT** emit matched values, surrounding text, character offsets, or a hash of a
 matched value. A hash of a BSN is a BSN: the search space is nine digits and brute-forcing it
 is trivial.
+
+**THE language label SHALL** be derived from the latest **user turn**, not the whole payload.
+The KB context block is deliberately English-structured (SPEC-RAG-MULTILINGUAL-CHAT-001) and
+usually dwarfs the question, so detecting on the combined text would label a Dutch question
+`en` on essentially every RAG request. A language field that is wrong is worse than absent,
+because REQ-2's per-language recall comparison would silently rest on it. The PII scan itself
+still covers the full payload — only the label is narrowed.
+
+**Known limitation, recorded rather than hidden.** The observer uses a local stopword
+heuristic, not the canonical lingua detector in
+`klai-retrieval-api/retrieval_api/util/language_detect.py`. `lingua-language-detector` is a
+dependency of retrieval-api and knowledge-ingest but **not** of the litellm container, which
+runs the stock `ghcr.io/berriai/litellm` image with bind-mounted modules — importing it would
+mean building and maintaining a custom litellm image, which is disproportionate for a
+telemetry label in a phase that is deleted again by Phase 3. The heuristic returns an explicit
+unknown rather than guessing on a tie. **IF** Phase 2 data shows the language dimension is too
+noisy to support REQ-9's gating decision, **THEN** the correct response is a custom litellm
+image with the canonical detector — not tuning the word lists.
 
 Recording that a BSN was found, without recording which, is what accountability needs.
 Storing the value to prove it was removed moves the exposure into the log store — and that
@@ -526,7 +573,7 @@ Three PRs, in order.
 |----|-------|-------|-------------------|
 | 0 | 0 | `deploy/docker-compose.yml` (stock Presidio only), `deploy/litellm/config.yaml` (guardrail, temporary), harness script | AC-0a through AC-0f. **Merges first and its result is written into this SPEC before PR 1 starts** |
 | 1 | 1 | `deploy/presidio/` (recognizer pack image + registry config), compose update | AC-1 through AC-6 |
-| 2 | 2 | `deploy/litellm/config.yaml` (guardrail, `logging_only`, `default_on`), telemetry | AC-7, AC-8, AC-9, AC-10, AC-13 (Phase 2 half) |
+| 2 | 2 | `deploy/litellm/klai_pii_observe.py` (new, read-only observer), `deploy/litellm/config.yaml` (callback registration), compose bind-mount | AC-7, AC-8, AC-9, AC-10, AC-13 (Phase 2 half) |
 | 3 | 3 | `deploy/litellm/config.yaml` (`pre_call`, `pii_entities_config`), org policy column, migration, `docs/privacy/` update | AC-11, AC-12, AC-13, AC-15 + `/klai:tenant-review` |
 
 Rules for the implementer:


### PR DESCRIPTION
Phase 2 of `SPEC-PRIVACY-MISTRAL-PII-001`. **Measures what PII actually reaches Mistral, and changes nothing.**

## REQ-5 was wrong and was corrected before this was built

The spec originally said to use the native guardrail in `mode: "logging_only"`. That does the opposite of what it sounds like — it masks what goes to *observability* and sends the payload to the provider **unmasked**. LiteLLM's Presidio guardrail has no detect-only mode at all, so measurement needs a read-only observer. Registered last in `callbacks:` so it sees the post-injection payload; the Phase 3 PR deletes it again.

## Three properties that matter

**No early returns.** It deliberately does not honour `_klai_openai_passthrough` (`klai_knowledge.py:426-427`) or missing `org_id` (`:481-483`). Those two blind spots cover the query-rewrite call that forwards pasted customer correspondence, and every widget/partner request — precisely what Phase 2 needs to see.

**Out of band.** The analyzer call is a background task and cannot add latency or fail a request; the scheduling itself is wrapped too. The deliberate inverse of REQ-10, which governs enforcement.

**No values.** The event carries `org_id`, `call_type`, `model`, `language` and a per-entity count. The test asserts the BSN digits, the offsets, the score, the SHA-256 of the BSN, and any 32–64 char hex digest are all absent — a hash of a BSN is a BSN.

## Delta review (Sol): five findings, four fixed, one refuted

| Finding | Outcome |
|---|---|
| Background task read `messages` by reference | **Fixed** — text snapshotted synchronously. `klai_knowledge.py` mutates that list, so the measurement point depended on scheduling: same list, different content, no error, silent drift |
| `tool_calls[].function.arguments` not scanned | **Fixed** — an assistant turn can have `content: null` while the arguments hold an address or BSN. The router keeps those and they reach Mistral verbatim, so reading only `content` under-reported exactly the agentic paths |
| Language detected from the whole payload | **Fixed** — now the user turn only. The KB block is English by design and dwarfs the question, so this would have labelled Dutch questions `en` on nearly every RAG request |
| Failure event lost `org_id`/model/language | **Fixed** — a Presidio outage must be filterable out of the sample, not read as "this org has no PII" |
| "Log success at info, not warning" | **Refuted** — in this repo `info` from litellm does not reach VictoriaLogs. SPEC-RAG-SOURCE-SELECTION-001 REQ-1 codifies promoting exactly these events to `warning` for that reason. Following it would have silently disabled the measurement |

## Known limitation, recorded in the SPEC

The language label uses a local stopword heuristic, not the canonical lingua detector — `lingua-language-detector` is not in the stock litellm image, and a custom image is disproportionate for a telemetry label in a phase that Phase 3 deletes. If Phase 2 data proves too noisy for REQ-9's gating decision, the escalation path is a custom image, not tuning word lists.

## Tests

```
pytest deploy/litellm/tests/ -q  → 745 passed (16 in the new observer suite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)