### PR TITLE
chore(privacy): pin the analyzer image carrying the NL phone fix

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -474,7 +474,7 @@ services:
     # built FROM the same ghcr.io/data-privacy-stack digest Phase 0 pinned.
     # This is where REQ-3's Dutch recognizers (BSN/KvK/BTW/postcode) and
     # REQ-4's SECRET recognizer actually enter the request path.
-    image: ghcr.io/getklai/presidio-analyzer@sha256:fff95b8413f97708ce192ae1bf9e6418bcd14423ff4e0ec4a79f5ea172eed268
+    image: ghcr.io/getklai/presidio-analyzer@sha256:4a213d91feaf4febfa402b6fea1e8094afd37b325a96ecf7faf393e9c8a347a7
     restart: unless-stopped
     networks:
       - inference


### PR DESCRIPTION
Follow-up to `4af66f4e0`. The image-build workflow published the image containing `NLPhoneRecognizer`; compose still pointed at the previous digest, so the fix was built but not deployed — the compose digest is what actually runs.

Without this, Rotterdam's `010` range stays undetected in production even though the code is on main.

No user-visible effect: enforcement is not enabled, so better detection only changes what the Phase 2 observer counts.

```
check-klai-presidio-digest.sh          → OK
test_deployment_constraints.py         → 6 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)