### PR TITLE
feat(privacy): Phase 3 mask and restore, shipped inert

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -474,7 +474,7 @@ services:
     # built FROM the same ghcr.io/data-privacy-stack digest Phase 0 pinned.
     # This is where REQ-3's Dutch recognizers (BSN/KvK/BTW/postcode) and
     # REQ-4's SECRET recognizer actually enter the request path.
-    image: ghcr.io/getklai/presidio-analyzer@sha256:fff95b8413f97708ce192ae1bf9e6418bcd14423ff4e0ec4a79f5ea172eed268
+    image: ghcr.io/getklai/presidio-analyzer@sha256:4a213d91feaf4febfa402b6fea1e8094afd37b325a96ecf7faf393e9c8a347a7
     restart: unless-stopped
     networks:
       - inference

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -353,6 +353,20 @@ services:
       # eval-harness mounts above), but never blocks or fails it — see
       # klai_pii_observe.py's module docstring.
       - ./litellm/klai_pii_observe.py:/app/klai_pii_observe.py:ro
+      # SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7 through REQ-11): mask/
+      # map/restore PII on the Mistral call path. Shipped INERT — gated
+      # behind KLAI_PII_ENFORCE (default off, see environment: below).
+      # klai_pii_enforce.py is the CustomLogger registered last in
+      # config.yaml's litellm_settings.callbacks; the other four are its
+      # pure/IO building blocks (entity classification, the bounded
+      # process-local restore map, span-selection + substitution, and
+      # per-org policy resolution) — split out so each has its own
+      # network-free unit-test surface.
+      - ./litellm/klai_pii_entities.py:/app/klai_pii_entities.py:ro
+      - ./litellm/klai_pii_map_store.py:/app/klai_pii_map_store.py:ro
+      - ./litellm/klai_pii_text_masking.py:/app/klai_pii_text_masking.py:ro
+      - ./litellm/klai_pii_org_policy.py:/app/klai_pii_org_policy.py:ro
+      - ./litellm/klai_pii_enforce.py:/app/klai_pii_enforce.py:ro
       - ./litellm/custom_router.py:/app/custom_router.py:ro
       # SPEC-CHAT-GUARDRAILS-001: vendored package copy of klai-libs/llm-safety
       # (kept byte-identical via deploy/litellm/tests/test_klai_llm_safety_drift.py).
@@ -440,6 +454,12 @@ services:
       # neither container has auth of its own.
       PRESIDIO_ANALYZER_API_BASE: http://presidio-analyzer:3000
       PRESIDIO_ANONYMIZER_API_BASE: http://presidio-anonymizer:3000
+      # SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7): the single switch that
+      # keeps klai_pii_enforce.py inert. Default OFF/unset — with it off,
+      # masking/restore never runs at all (no analyzer call, no map entry).
+      # Flipping this to "true" is the entire activation decision; it is
+      # NOT part of this PR's scope to turn on.
+      KLAI_PII_ENFORCE: ${KLAI_PII_ENFORCE:-false}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/litellm/config.yaml
+++ b/deploy/litellm/config.yaml
@@ -134,8 +134,28 @@ litellm_settings:
     # the anonymizer, and emits org_id/call_type/model/language/entity
     # counts only — no matched values, offsets, or hashes (REQ-6). Does
     # NOT honour `_klai_openai_passthrough` or missing org_id — see
-    # klai_pii_observe.py's module docstring. Deleted in the Phase 3 PR.
+    # klai_pii_observe.py's module docstring. NOT deleted by this PR despite
+    # REQ-5's own instruction to remove it in the Phase 3 PR: this PR's hard
+    # constraint is "add new modules, do not modify or delete existing
+    # ones". Flagged as a deliberate deviation from the SPEC's own text in
+    # the implementation report rather than silently actioned.
     - klai_pii_observe.klai_pii_observer
+    # SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7 through REQ-11): mask/map/
+    # restore PII on the Mistral call path. Shipped INERT — gated behind
+    # KLAI_PII_ENFORCE, default OFF (unset/false), so this PR reaches
+    # production changing nothing until the flag is deliberately flipped.
+    # Registered LAST (after klai_pii_observe) for two independent reasons,
+    # both verified against the installed litellm==1.96.2 source and
+    # documented in klai_pii_enforce.py's module docstring:
+    #   1. async_post_call_streaming_iterator_hook / async_post_call_
+    #      success_hook: last-registered is outermost / applied last, so
+    #      its output is what the client actually receives.
+    #   2. async_pre_call_hook runs callbacks in strict registration order,
+    #      each seeing the previous one's mutated `data`. Masking AFTER
+    #      klai_pii_observe keeps Phase 2's telemetry measuring the
+    #      pre-mask payload even once enforcement is enabled for individual
+    #      orgs, rather than measuring its own placeholders.
+    - klai_pii_enforce.klai_pii_enforcer
 
 # SPEC-PRIVACY-MISTRAL-PII-001 Phase 0 (REQ-0a/REQ-0b) — TEMPORARY,
 # EXPERIMENTAL, NOT the production control.

--- a/deploy/litellm/klai_pii_enforce.py
+++ b/deploy/litellm/klai_pii_enforce.py
@@ -1,0 +1,452 @@
+"""KlaiPiiEnforcer — Phase 3 PII mask/map/restore for the Mistral call path.
+
+SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7 through REQ-11). Shipped INERT:
+gated end-to-end behind ``KLAI_PII_ENFORCE`` (default OFF). With the flag
+off, ``async_pre_call_hook`` returns its input completely unchanged — same
+object, no analyzer call, no map entry, no verbatim-instruction injection —
+so this module changes nothing about production traffic until the flag is
+deliberately flipped. That is a requirement with its own test class in
+``tests/test_pii_enforce.py``, not an incidental property.
+
+Why Klai owns mask/map/restore instead of ``output_parse_pii`` (REQ-0a):
+Phase 0 measured the native LiteLLM Presidio guardrail returning an EMPTY
+token map on the streaming path (the second failure shape in
+BerriAI/litellm#6247 — the map does not survive from the pre-call hook to
+the post-call hook), and both Klai chat paths stream. So this module never
+uses the native guardrail's restore. It calls presidio-analyzer's
+``/analyze`` directly, does its own typed/numbered placeholder substitution
+(``klai_pii_text_masking.py``), and restores from its own process-local map
+(``klai_pii_map_store.py``) in ``async_post_call_success_hook`` /
+``async_post_call_streaming_iterator_hook`` — the same buffered
+chunk-rewrite family of hook already working at
+``klai_knowledge.py:1667-1703`` for the citation footer.
+
+Callback registration order (config.yaml): registered as the LAST entry in
+``litellm_settings.callbacks``, after ``klai_pii_observe.klai_pii_observer``.
+Verified directly against the installed ``litellm==1.96.2`` package
+(``litellm/proxy/utils.py``), not assumed from the SPEC's own claim:
+
+- ``async_post_call_streaming_iterator_hook``: ``ProxyLogging`` builds an
+  ordered ``iterator_overrides`` list by walking ``litellm.callbacks`` in
+  REGISTRATION order (no guardrail/non-guardrail split for this hook, unlike
+  the success hook below). It then wraps ``current_response`` through each
+  callback's iterator hook in that same order — callback 0 wraps the raw
+  upstream stream, callback 1 wraps callback 0's generator, and so on. The
+  LAST-registered callback therefore produces the outermost generator, the
+  one the proxy actually iterates and streams to the client. Last
+  registered = last to see (and last to transform) every chunk = its output
+  is what the user sees.
+- ``async_post_call_success_hook``: callbacks are split into
+  ``guardrail_callbacks`` (``CustomGuardrail`` instances) and
+  ``other_callbacks`` (plain ``CustomLogger`` instances, which is what this
+  module and ``klai_knowledge_hook`` both are); all guardrails run before
+  all other_callbacks regardless of interleaved registration position, but
+  WITHIN ``other_callbacks`` the relative registration order is preserved,
+  and each callback's non-``None`` return value replaces ``response`` for
+  the next one in line. Registering this module last among the
+  ``CustomLogger`` entries means it restores the FINAL rendered text (after
+  ``klai_knowledge_hook``'s own citation rendering), which is what the user
+  actually receives.
+
+Registering this module's pre-call masking AFTER
+``klai_pii_observe.klai_pii_observer`` (rather than before) is also
+deliberate for a second reason, independent of the ordering facts above:
+pre-call hooks run in strict registration order and each hook's return
+value becomes the next hook's input ``data``. Placing the masking hook
+after the Phase 2 observer means the observer keeps measuring the
+pre-mask payload even once enforcement is enabled for individual orgs —
+its telemetry stays meaningful instead of measuring its own masked
+placeholders. (This module's own docstring elsewhere in the SPEC assumes
+the Phase 2 observer is deleted in the Phase 3 PR; this change deliberately
+does not delete it, per this PR's explicit hard constraint not to touch
+other existing modules — see the implementation report.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+from litellm.integrations.custom_logger import CustomLogger
+
+from klai_pii_entities import NEVER_RESTORE_ENTITIES, effective_enabled_entities
+from klai_pii_map_store import PiiMapStore
+from klai_pii_org_policy import resolve_org_entity_policy
+from klai_pii_restore_eval import VERBATIM_TOKEN_SYSTEM_INSTRUCTION
+from klai_pii_text_masking import DetectedSpan, mask_text, restore_text, split_safe_tail
+
+logger = logging.getLogger(__name__)
+
+
+def _truthy_env(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+# REQ-7/REQ-10: the single switch that keeps this module inert. Read at
+# import time (same pattern as klai_pii_observe.py's own env constants) so
+# tests reload the module after monkeypatching the env var.
+KLAI_PII_ENFORCE = _truthy_env("KLAI_PII_ENFORCE", "false")
+
+# Same internal service name the Phase 0/1/2 code already uses.
+PRESIDIO_ANALYZER_API_BASE = os.getenv(
+    "PRESIDIO_ANALYZER_API_BASE", "http://presidio-analyzer:3000"
+)
+
+_ANALYZER_CALL_TIMEOUT_SECONDS = float(os.getenv("KLAI_PII_ANALYZER_TIMEOUT_SECONDS", "3.0"))
+_HTTPX_CLIENT_TIMEOUT_SECONDS = float(os.getenv("KLAI_PII_HTTPX_TIMEOUT_SECONDS", "5.0"))
+
+# REQ-2: Phase 3's own entities are all regex-plus-checksum, registered
+# across every language the analyzer serves — this call only needs a
+# language the analyzer accepts (PERSON is the only language-sensitive
+# entity, and PERSON is never in `enabled_entities`; see
+# klai_pii_entities.py). "en" mirrors the Phase 0/2 default.
+_ANALYZER_LANGUAGE = os.getenv("KLAI_PII_ANALYZER_LANGUAGE", "en")
+
+_pii_map_store = PiiMapStore()
+
+
+class PiiAnalyzerUnavailable(RuntimeError):
+    """Raised from async_pre_call_hook when enforcement is ON and the
+    analyzer errored or timed out. REQ-10: the request SHALL fail rather
+    than proceed unminimised. Deliberately a plain RuntimeError subclass —
+    fastapi is a `proxy` extra of litellm, not a base dependency, and this
+    module must import cleanly under the bare `litellm==1.96.2` package the
+    CI test job installs (`.github/workflows/litellm-tests.yml`). LiteLLM's
+    own pre-call hook contract ("raise exception if invalid") only requires
+    SOME exception to propagate for the request to fail; it does not
+    require a particular exception type.
+    """
+
+
+def _org_id_from_key(user_api_key_dict: Any) -> Any:
+    metadata = getattr(user_api_key_dict, "metadata", {}) or {}
+    return metadata.get("org_id")
+
+
+# ---------------------------------------------------------------------------
+# Text-unit discovery — every place outbound PII-bearing text can live
+# ---------------------------------------------------------------------------
+def _iter_text_units(messages: list[Any]):
+    """Yield (current_text, setter) for every text-bearing location.
+
+    Covers string content, multi-part (list-of-parts) content, and
+    tool_calls[].function.arguments — the last one for the same reason
+    klai_pii_observe.py scans it (Sol delta-review finding): an assistant
+    turn in an agentic flow can carry content=None while tool_calls holds
+    an email address or a BSN, and the router forwards those turns to
+    Mistral verbatim.
+    """
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content:
+
+            def _set_content(new_text: str, _message: dict = message) -> None:
+                _message["content"] = new_text
+
+            yield content, _set_content
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "text":
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text:
+
+                    def _set_part(new_text: str, _part: dict = part) -> None:
+                        _part["text"] = new_text
+
+                    yield text, _set_part
+        for call in message.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            function = call.get("function")
+            if not isinstance(function, dict):
+                continue
+            arguments = function.get("arguments")
+            if isinstance(arguments, str) and arguments:
+
+                def _set_arguments(new_text: str, _function: dict = function) -> None:
+                    _function["arguments"] = new_text
+
+                yield arguments, _set_arguments
+
+
+async def _analyze_spans(http: httpx.AsyncClient, text: str, language: str) -> list[DetectedSpan]:
+    url = PRESIDIO_ANALYZER_API_BASE.rstrip("/") + "/analyze"
+    response = await asyncio.wait_for(
+        http.post(url, json={"text": text, "language": language}),
+        timeout=_ANALYZER_CALL_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    results = response.json()
+    if not isinstance(results, list):
+        raise TypeError("presidio-analyzer /analyze returned a non-list response")
+
+    spans: list[DetectedSpan] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        entity_type = item.get("entity_type")
+        start = item.get("start")
+        end = item.get("end")
+        score = item.get("score", 0.0)
+        if not isinstance(entity_type, str) or not isinstance(start, int) or not isinstance(end, int):
+            continue
+        if end <= start:
+            continue
+        spans.append(
+            DetectedSpan(
+                entity_type=entity_type,
+                start=start,
+                end=end,
+                score=float(score) if isinstance(score, (int, float)) else 0.0,
+            )
+        )
+    return spans
+
+
+async def _mask_messages(
+    http: httpx.AsyncClient,
+    messages: list[Any],
+    *,
+    enabled_entities: frozenset[str],
+    language: str,
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Mask every enabled entity across every text unit in ``messages``.
+
+    Analyzer calls run concurrently (asyncio.gather — never `await` inside a
+    loop for independent I/O), but masking itself — and therefore instance
+    numbering — is applied in a deterministic, single-threaded pass over
+    ``units`` afterwards, so numbering never depends on network completion
+    order.
+    """
+    units = list(_iter_text_units(messages))
+    if not units:
+        return {}, ()
+
+    spans_per_unit = await asyncio.gather(
+        *(_analyze_spans(http, text, language) for text, _ in units)
+    )
+
+    instance_counters: dict[str, int] = {}
+    combined_restore_map: dict[str, str] = {}
+    all_masked_types: list[str] = []
+    for (text, setter), spans in zip(units, spans_per_unit):
+        result = mask_text(
+            text,
+            spans,
+            enabled_entities=enabled_entities,
+            never_restore_entities=NEVER_RESTORE_ENTITIES,
+            instance_counters=instance_counters,
+        )
+        if result.masked_entity_types:
+            setter(result.masked_text)
+            combined_restore_map.update(result.restore_map)
+            all_masked_types.extend(result.masked_entity_types)
+    return combined_restore_map, tuple(all_masked_types)
+
+
+# ---------------------------------------------------------------------------
+# Response-object accessors — tolerant of both dict and attribute style
+# ---------------------------------------------------------------------------
+def _get_choices(obj: Any) -> list[Any]:
+    if obj is None:
+        return []
+    choices = obj.get("choices") if isinstance(obj, dict) else getattr(obj, "choices", None)
+    return list(choices) if choices else []
+
+
+def _get_field(obj: Any, key: str) -> Any:
+    if obj is None:
+        return None
+    return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+
+def _get_content(obj: Any) -> str | None:
+    content = _get_field(obj, "content")
+    return content if isinstance(content, str) else None
+
+
+def _set_content(obj: Any, value: str) -> None:
+    if obj is None:
+        return
+    if isinstance(obj, dict):
+        obj["content"] = value
+    else:
+        obj.content = value
+
+
+class KlaiPiiEnforcer(CustomLogger):
+    """Mask outbound PII (pre-call), restore it in the response (post-call).
+
+    Every method starts with the same `if not KLAI_PII_ENFORCE:` early
+    return — the flag is checked independently in each hook rather than
+    once at class-construction time, because the class is instantiated once
+    at import time (module-level singleton, matching every other hook in
+    this proxy) while tests need to flip the flag per test via module
+    reload; reading the module-level constant fresh in each method call
+    keeps behaviour correct under that reload pattern.
+    """
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: Any,
+        cache: Any,
+        data: dict[str, Any],
+        call_type: str,
+    ) -> dict[str, Any]:
+        if not KLAI_PII_ENFORCE:
+            return data
+
+        messages = data.get("messages")
+        if not isinstance(messages, list) or not messages:
+            return data
+
+        org_id = _org_id_from_key(user_api_key_dict)
+        org_policy = await resolve_org_entity_policy(org_id)
+        enabled_entities = effective_enabled_entities(org_policy)
+
+        try:
+            async with httpx.AsyncClient(timeout=_HTTPX_CLIENT_TIMEOUT_SECONDS) as http:
+                restore_map, masked_types = await _mask_messages(
+                    http, messages, enabled_entities=enabled_entities, language=_ANALYZER_LANGUAGE
+                )
+        except Exception as exc:
+            # REQ-10: enforcement ON + analyzer unreachable/erroring -> the
+            # request SHALL fail rather than proceed unminimised. Logged at
+            # warning with org and call_type, then re-raised so LiteLLM's
+            # pre-call hook chain aborts the request.
+            logger.warning(
+                "pii_enforce_analyzer_failed org_id=%s call_type=%s error=%s",
+                org_id,
+                call_type,
+                exc,
+            )
+            raise PiiAnalyzerUnavailable(
+                "PII analyzer unavailable; refusing to forward an unminimised payload"
+            ) from exc
+
+        if not masked_types:
+            return data
+
+        call_id = data.get("litellm_call_id")
+        if restore_map and call_id:
+            _pii_map_store.put(call_id, restore_map)
+
+        # REQ-0b: mandatory whenever masking is active — measured to take
+        # PHONE_NUMBER survival from 58.3% to 95.8%. Reusing the EXACT
+        # instruction text Phase 0 measured, not a re-translation, so the
+        # measured effect actually applies to what gets sent.
+        data["messages"] = [
+            {"role": "system", "content": VERBATIM_TOKEN_SYSTEM_INSTRUCTION},
+            *messages,
+        ]
+        return data
+
+    async def async_post_call_success_hook(
+        self, data: dict[str, Any], user_api_key_dict: Any, response: Any
+    ) -> Any:
+        if not KLAI_PII_ENFORCE:
+            return None
+
+        call_id = data.get("litellm_call_id")
+        restore_map = _pii_map_store.get(call_id) if call_id else None
+        if call_id:
+            _pii_map_store.discard(call_id)  # REQ-11: deleted on the success path
+        if not restore_map:
+            return None
+
+        for choice in _get_choices(response):
+            message = _get_field(choice, "message")
+            content = _get_content(message)
+            if content:
+                _set_content(
+                    message,
+                    restore_text(content, restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES),
+                )
+        return response
+
+    async def async_post_call_streaming_iterator_hook(
+        self, user_api_key_dict: Any, response: Any, request_data: dict[str, Any]
+    ):
+        if not KLAI_PII_ENFORCE:
+            async for item in response:
+                yield item
+            return
+
+        call_id = request_data.get("litellm_call_id")
+        restore_map = _pii_map_store.get(call_id) if call_id else None
+        if not restore_map:
+            # Nothing was masked for this call (no PII detected, enforcement
+            # was off at mask time, or the entry already expired) -- stream
+            # through unchanged. Still clean up defensively: REQ-11 requires
+            # deletion at stream end regardless of whether there was
+            # anything to restore.
+            try:
+                async for item in response:
+                    yield item
+            finally:
+                if call_id:
+                    _pii_map_store.discard(call_id)
+            return
+
+        # Per-choice-index buffers -- REQ-8's tail holdback, sized in
+        # klai_pii_text_masking.TAIL_LEN. One-item lookahead (same shape as
+        # klai_knowledge.py:1667-1703's citation-footer pattern): every item
+        # is yielded exactly once, after we know whether a later item (or
+        # stream end) follows it, so the truly-last item can absorb
+        # whatever text is still held back at stream end.
+        buffers: dict[int, str] = {}
+        pending_item: Any = None
+        try:
+            async for item in response:
+                for idx, choice in enumerate(_get_choices(item)):
+                    delta = _get_field(choice, "delta")
+                    if delta is None:
+                        continue
+                    content = _get_content(delta) or ""
+                    buffered = buffers.get(idx, "") + content
+                    safe, buffers[idx] = split_safe_tail(
+                        buffered, restore_map, NEVER_RESTORE_ENTITIES
+                    )
+                    _set_content(delta, safe)
+                if pending_item is not None:
+                    yield pending_item
+                pending_item = item
+
+            if pending_item is not None:
+                for idx, choice in enumerate(_get_choices(pending_item)):
+                    delta = _get_field(choice, "delta")
+                    leftover = buffers.get(idx, "")
+                    if delta is not None and leftover:
+                        restored_tail = restore_text(
+                            leftover, restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+                        )
+                        existing = _get_content(delta) or ""
+                        _set_content(delta, existing + restored_tail)
+                    buffers[idx] = ""
+                yield pending_item
+        finally:
+            if call_id:
+                _pii_map_store.discard(call_id)  # REQ-11: success AND error path
+
+    async def async_post_call_failure_hook(
+        self,
+        request_data: dict[str, Any],
+        original_exception: Exception,
+        user_api_key_dict: Any,
+        traceback_str: str | None = None,
+    ) -> None:
+        if not KLAI_PII_ENFORCE:
+            return None
+        call_id = request_data.get("litellm_call_id") if isinstance(request_data, dict) else None
+        if call_id:
+            _pii_map_store.discard(call_id)  # REQ-11: deleted on the error path
+        return None
+
+
+klai_pii_enforcer = KlaiPiiEnforcer()

--- a/deploy/litellm/klai_pii_entities.py
+++ b/deploy/litellm/klai_pii_entities.py
@@ -1,0 +1,68 @@
+"""Entity classification for SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7).
+
+Pure, network-free, import-safe from anywhere in the PII-enforcement stack.
+This is the single source of truth for "which entity types exist, and what
+happens to each" — every other Phase 3 module (``klai_pii_text_masking.py``,
+``klai_pii_org_policy.py``, ``klai_pii_enforce.py``) imports its
+classification from here rather than repeating it, so there is exactly one
+place a reviewer needs to check to answer "can X ever be restored".
+
+REQ-7's two-tier policy, encoded structurally rather than by convention:
+
+- ``NEVER_RESTORE_ENTITIES`` (``SECRET``, ``NL_BSN``) are masked for every
+  org, unconditionally, and never restored. ``effective_enabled_entities()``
+  always includes them regardless of org policy content.
+- ``RETURN_SET_ENTITIES`` are per-org, default off, restored when enabled.
+- ``PERSON`` is deliberately absent from both sets. REQ-0b's PERSON half is
+  unmeasurable today (REQ-2 disables SpacyRecognizer, GLiNER/REQ-9 is not
+  deployed), so REQ-9 forbids enabling it before that re-run exists.
+  ``effective_enabled_entities()`` intersects any org policy against
+  ``RETURN_SET_ENTITIES`` — a policy dict that somehow contained
+  ``"PERSON": true`` (operator typo, future portal-api bug, anything) still
+  cannot produce PERSON in the enabled set, because PERSON is not a member
+  of the set being intersected against. This is what "structurally
+  impossible" means in practice: the exclusion does not depend on every
+  caller remembering to check a flag, it depends on PERSON not existing in
+  the data this function reads from.
+"""
+
+from __future__ import annotations
+
+# REQ-7: unconditional, every org, never restored. A credential in a draft
+# is an incident; a BSN is not Klai's to hold without a statutory basis.
+NEVER_RESTORE_ENTITIES: frozenset[str] = frozenset({"SECRET", "NL_BSN"})
+
+# REQ-7: per-org, default off, restored when enabled. PERSON is NOT a member
+# of this set — see module docstring. Do not add it here before REQ-9's
+# gate (a GLiNER-era survival re-run showing PERSON >= 95%) is satisfied.
+RETURN_SET_ENTITIES: frozenset[str] = frozenset(
+    {
+        "IBAN_CODE",
+        "CREDIT_CARD",
+        "EMAIL_ADDRESS",
+        "PHONE_NUMBER",
+        "NL_KVK",
+        "NL_BTW",
+        "NL_POSTCODE",
+    }
+)
+
+# Every entity type this pack can ever mask, in either tier. Used by
+# klai_pii_text_masking.py to size the streaming chunk-boundary tail
+# holdback (REQ-8) — it must cover the longest placeholder from EITHER
+# tier, because a never-restore placeholder can still be split across a
+# chunk boundary even though it is never substituted back.
+ALL_MASKABLE_ENTITIES: frozenset[str] = NEVER_RESTORE_ENTITIES | RETURN_SET_ENTITIES
+
+
+def effective_enabled_entities(org_policy: frozenset[str] | set[str]) -> frozenset[str]:
+    """The entity types that should be masked for one request.
+
+    ``org_policy`` is the set of RETURN_SET entities this org has opted
+    into (REQ-7's "per-org, default off"). The result always contains the
+    two unconditional entities regardless of what ``org_policy`` says, and
+    can never contain PERSON regardless of what ``org_policy`` says — both
+    guarantees fall out of set intersection against ``RETURN_SET_ENTITIES``
+    rather than needing a separate check.
+    """
+    return NEVER_RESTORE_ENTITIES | (RETURN_SET_ENTITIES & frozenset(org_policy))

--- a/deploy/litellm/klai_pii_map_store.py
+++ b/deploy/litellm/klai_pii_map_store.py
@@ -1,0 +1,150 @@
+"""Process-local placeholder->original-value map store (REQ-11).
+
+SPEC-PRIVACY-MISTRAL-PII-001 REQ-11: the map from placeholder to original
+value lives only for the lifetime of the request that created it, is keyed
+such that it cannot be reached by another request, and is never written to
+Redis, Postgres, disk, or any log.
+
+This class is that store. It is deliberately the ONLY place in the Phase 3
+stack that holds a placeholder->original-value mapping in memory, and it has
+no serialization method at all — not a missing feature, the absence is the
+control. Adding a ``to_json`` / ``to_dict`` here would be the one change that
+could turn this into the "shared map... reachable across requests" REQ-11
+calls the failure mode worse than masking itself.
+
+Keying: callers key entries by ``litellm_call_id`` (REQ-11's own words) — a
+per-request UUID LiteLLM puts on ``data``/``request_data`` before any hook
+runs (verified against ``litellm/proxy/common_request_processing.py`` and
+``litellm/proxy/utils.py`` in the installed v1.96.2 package: both set
+``data["litellm_call_id"]`` before the pre-call hook chain executes), and
+which the ``aim`` and ``cato_networks`` guardrails already read via
+``data.get("litellm_call_id")`` / ``request_data.get("litellm_call_id")`` in
+their own streaming iterator hooks — this store follows the same contract.
+
+Three failure modes REQ-11 names explicitly, all covered here:
+
+1. A client disconnects mid-stream, reaching neither the success nor the
+   error path -> entry would leak forever. ``_sweep_expired()`` (TTL,
+   REQ-11's own words: "a TTL sweep SHALL additionally drop entries older
+   than a bounded age") runs on every ``put``/``get`` call, so a leaked
+   entry is bounded in lifetime even if nobody ever calls ``discard()``.
+2. Unbounded growth under sustained traffic -> ``put()`` evicts the oldest
+   entry (REQ-11: "bounded... drop oldest-first when full") before
+   inserting once the store is at capacity.
+3. Cross-request reachability -> there is no lookup by anything other than
+   the exact ``litellm_call_id`` string a caller supplies; there is no
+   iteration, no "get most recent", no wildcard. A caller with the wrong
+   call_id gets ``None``, never another request's map.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable
+
+# Conservative defaults for a per-request placeholder map: entries are tiny
+# (a handful of short strings) and short-lived (one request's worth of
+# in-flight chat/stream), so neither bound needs to be generous to be safe.
+DEFAULT_MAX_ENTRIES = 512
+DEFAULT_TTL_SECONDS = 300.0  # 5 minutes: comfortably longer than any Klai
+# chat request_timeout (120s, config.yaml litellm_settings), short enough
+# that a leaked entry from a disconnected client does not linger.
+
+
+@dataclass
+class _Entry:
+    mapping: dict[str, str]
+    created_at: float
+
+
+class PiiMapStore:
+    """Bounded, TTL-swept, process-local dict keyed by ``litellm_call_id``.
+
+    Not thread-safe by design — LiteLLM's proxy hooks run on a single
+    asyncio event loop per worker process, and this store is process-local
+    (REQ-11: never shared, never persisted), so there is exactly one
+    coroutine touching any given entry's lifecycle at a time in practice.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be >= 1")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be > 0")
+        self._max_entries = max_entries
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._entries: OrderedDict[str, _Entry] = OrderedDict()
+
+    def _sweep_expired(self) -> None:
+        if not self._entries:
+            return
+        now = self._clock()
+        expired = [
+            call_id
+            for call_id, entry in self._entries.items()
+            if now - entry.created_at > self._ttl_seconds
+        ]
+        for call_id in expired:
+            del self._entries[call_id]
+
+    def put(self, call_id: str, mapping: dict[str, str]) -> None:
+        """Store (or replace) the restore map for one request.
+
+        Sweeps expired entries first (so a burst of expired garbage never
+        counts against the size bound), then evicts the single oldest
+        surviving entry, repeatedly, until there is room — "drop
+        oldest-first when full rather than grow without limit" (REQ-11).
+        """
+        if not call_id:
+            raise ValueError("call_id must be non-empty")
+        self._sweep_expired()
+        if call_id in self._entries:
+            # Replacing an existing call's map should not itself count as
+            # "growth" for the eviction check below — drop it first.
+            del self._entries[call_id]
+        while len(self._entries) >= self._max_entries:
+            self._entries.popitem(last=False)  # oldest-first (insertion order)
+        self._entries[call_id] = _Entry(mapping=dict(mapping), created_at=self._clock())
+
+    def get(self, call_id: str) -> dict[str, str] | None:
+        """Non-destructive lookup. Used mid-stream; entry survives until
+        an explicit ``discard()`` (REQ-11 requires deletion only at stream
+        end / success / error, not on every intermediate read).
+        """
+        if not call_id:
+            return None
+        self._sweep_expired()
+        entry = self._entries.get(call_id)
+        return dict(entry.mapping) if entry is not None else None
+
+    def discard(self, call_id: str) -> None:
+        """Remove the entry unconditionally. Safe to call when absent."""
+        if call_id:
+            self._entries.pop(call_id, None)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __contains__(self, call_id: str) -> bool:
+        return call_id in self._entries
+
+    def sweep(self) -> int:
+        """Force a TTL sweep now; return the number of entries removed.
+
+        ``put``/``get`` already sweep internally on every call — this is
+        for tests and any future explicit maintenance hook that wants to
+        observe sweep effects without also mutating the store via
+        ``put``/``get``.
+        """
+        before = len(self._entries)
+        self._sweep_expired()
+        return before - len(self._entries)

--- a/deploy/litellm/klai_pii_org_policy.py
+++ b/deploy/litellm/klai_pii_org_policy.py
@@ -107,6 +107,13 @@ async def resolve_org_entity_policy(org_id: Any) -> frozenset[str]:
         return cached
 
     if not PORTAL_INTERNAL_SECRET:
+        # The rule below matches the word "SECRET" in the FORMAT STRING, not a
+        # logged value — only org_id is interpolated, and the message says the
+        # secret is ABSENT. Documented false-positive class in
+        # .claude/rules/klai/infra/deploy.md ("Semgrep false positives on
+        # OAuth log messages"), whose prescribed fix is this annotation.
+        # The nosemgrep comment must be the line IMMEDIATELY before the match.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning(
             "pii_org_policy_no_secret org_id=%s — PORTAL_INTERNAL_SECRET not set, "
             "fail-closed to no optional entities",

--- a/deploy/litellm/klai_pii_org_policy.py
+++ b/deploy/litellm/klai_pii_org_policy.py
@@ -1,0 +1,140 @@
+"""Per-org entity policy resolution (REQ-7, NFR "Tenant isolation").
+
+REQ-7's optional set (``IBAN_CODE``, ``CREDIT_CARD``, ``EMAIL_ADDRESS``,
+``PHONE_NUMBER``, ``NL_KVK``, ``NL_BTW``, ``NL_POSTCODE``) is "per-org,
+default off". The NFR says that policy "is resolved through the existing
+settings path and cached per org" — this module is that path, following the
+same shape as ``klai_kb_portal_client.py``'s ``get_kb_feature`` (a portal-api
+GET, Bearer-authenticated with ``PORTAL_INTERNAL_SECRET``, short-TTL cache,
+fail CLOSED on any error) without importing or modifying that file.
+
+Honest limitation, stated rather than hidden: portal-api does not yet expose
+the endpoint this module calls (``/internal/v1/orgs/{org_id}/pii-entities``).
+Standing it up is portal-api backend work — a DB column/table plus an
+endpoint plus a migration, explicitly named as PR3 scope in the SPEC's own
+Implementation Handoff table — and is out of scope for this change, which
+only adds/wires ``deploy/litellm`` modules. Until that endpoint exists, every
+call here fails (connection refused / 404) and therefore returns the empty
+policy — which is *exactly* REQ-7's own stated default ("per-org, default
+off"). So the absence of the real endpoint does not create a gap between
+what this code does and what the SPEC asks for by default: an org with no
+resolvable policy gets no optional entities enabled, same as an org that
+explicitly has none configured. Only the "an operator turns IBAN_CODE on for
+one org" path needs the real endpoint to exist, and `KLAI_PII_ENFORCE` is off
+by default regardless (this whole module is unreachable in production until
+that flag flips for at least one deployment).
+
+Caching here is a small in-process TTL dict, not Redis. ``get_kb_feature``
+uses Redis so a shared cache survives across LiteLLM worker processes and
+portal-api can push invalidations; neither concern applies yet to a policy
+this module is the only caller of and portal-api cannot yet write. A
+Redis-backed cache mirroring ``get_kb_feature`` is a reasonable follow-up
+once the real endpoint exists — this is a deliberate scope decision, not an
+oversight.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from klai_pii_entities import RETURN_SET_ENTITIES
+
+logger = logging.getLogger(__name__)
+
+PORTAL_API_URL = os.getenv("PORTAL_API_URL", "http://portal-api:8000")
+PORTAL_INTERNAL_SECRET = os.getenv("PORTAL_INTERNAL_SECRET", "")
+
+_POLICY_TIMEOUT_SECONDS = float(os.getenv("KLAI_PII_POLICY_TIMEOUT_SECONDS", "2.0"))
+_POLICY_CACHE_TTL_SECONDS = float(os.getenv("KLAI_PII_POLICY_CACHE_TTL_SECONDS", "30"))
+
+# {org_id: (fetched_at_monotonic, frozenset[str])}
+_policy_cache: dict[Any, tuple[float, frozenset[str]]] = {}
+
+EMPTY_POLICY: frozenset[str] = frozenset()
+
+
+def _cache_get(org_id: Any) -> frozenset[str] | None:
+    cached = _policy_cache.get(org_id)
+    if cached is None:
+        return None
+    fetched_at, policy = cached
+    if time.monotonic() - fetched_at > _POLICY_CACHE_TTL_SECONDS:
+        return None
+    return policy
+
+
+def _cache_set(org_id: Any, policy: frozenset[str]) -> None:
+    _policy_cache[org_id] = (time.monotonic(), policy)
+
+
+def clear_policy_cache() -> None:
+    """Test hook — no production caller. See tests/klai_module_reset.py."""
+    _policy_cache.clear()
+
+
+async def resolve_org_entity_policy(org_id: Any) -> frozenset[str]:
+    """Return the RETURN_SET entities this org has opted into.
+
+    Fails CLOSED (empty set) on: missing ``org_id`` (master-key / widget
+    calls, same shape ``klai_pii_observe.py`` names as a KlaiKnowledgeHook
+    blind spot — here there is simply no org to look a policy up for, so
+    none of the optional entities can be enabled), no
+    ``PORTAL_INTERNAL_SECRET`` configured, a network error, a timeout, or a
+    non-2xx response. None of these raise — an unresolvable policy is not
+    the same failure class as REQ-10's analyzer-unreachable case (that one
+    fails the request); this one just means "no optional entities for this
+    request", which is REQ-7's own default.
+
+    Only entity types that are actual members of ``RETURN_SET_ENTITIES``
+    survive the response parse — an unrecognised key (typo, future entity
+    the deployed pack does not implement yet, or literally ``"PERSON"``) is
+    silently dropped rather than trusted. This is the second half of
+    PERSON's structural exclusion (the first half is
+    ``klai_pii_entities.effective_enabled_entities``'s set intersection):
+    even a directly-crafted portal-api response claiming PERSON is enabled
+    cannot make it out of this function.
+    """
+    if not org_id:
+        return EMPTY_POLICY
+
+    cached = _cache_get(org_id)
+    if cached is not None:
+        return cached
+
+    if not PORTAL_INTERNAL_SECRET:
+        logger.warning(
+            "pii_org_policy_no_secret org_id=%s — PORTAL_INTERNAL_SECRET not set, "
+            "fail-closed to no optional entities",
+            org_id,
+        )
+        return EMPTY_POLICY
+
+    try:
+        async with httpx.AsyncClient(timeout=_POLICY_TIMEOUT_SECONDS) as http:
+            response = await http.get(
+                f"{PORTAL_API_URL}/internal/v1/orgs/{org_id}/pii-entities",
+                headers={"Authorization": f"Bearer {PORTAL_INTERNAL_SECRET}"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+    except Exception as exc:
+        logger.warning(
+            "pii_org_policy_fetch_failed org_id=%s error=%s — fail-closed to no "
+            "optional entities",
+            org_id,
+            exc,
+        )
+        return EMPTY_POLICY
+
+    enabled = payload.get("enabled_entities") if isinstance(payload, dict) else None
+    if not isinstance(enabled, list):
+        return EMPTY_POLICY
+
+    policy = frozenset(e for e in enabled if isinstance(e, str)) & RETURN_SET_ENTITIES
+    _cache_set(org_id, policy)
+    return policy

--- a/deploy/litellm/klai_pii_text_masking.py
+++ b/deploy/litellm/klai_pii_text_masking.py
@@ -1,0 +1,224 @@
+"""Pure span-selection, masking, and restore logic (REQ-8).
+
+Network-free. Consumes already-fetched presidio-analyzer ``/analyze``
+results (``DetectedSpan``) and produces/consumes plain text. Kept separate
+from ``klai_pii_enforce.py`` (the CustomLogger orchestrator, which owns the
+HTTP calls) so the substitution algorithm — the part most worth testing
+exhaustively — has no async/mocking overhead to get right first.
+
+Overlap-safe substitution
+--------------------------
+presidio-analyzer runs each registered recognizer independently and returns
+every match, including matches that overlap across different entity types —
+e.g. a lower-scoring ``PHONE_NUMBER`` match fully inside a higher-scoring
+``IBAN_CODE`` match (an IBAN's check-digit-plus-account-number tail can
+parse as a phone-shaped digit run). Naive substitution corrupts the text
+either way round: replacing the IBAN first invalidates the phone's stored
+offsets, and replacing the phone first leaves the IBAN's own span pointing
+at text that no longer matches what it was scored against.
+
+``_select_non_overlapping`` resolves this before any substitution happens:
+sort candidates by score (desc), then span length (desc), then start offset
+(asc) so the strongest, most specific match wins each contested region;
+accept a candidate only if it does not overlap any span already accepted.
+This handles a fully-contained span (the case above) and a partial overlap
+identically — both are "cannot both survive substitution", so both are
+resolved by the same one rule rather than two.
+
+Substitution itself then runs in two passes: placeholders are numbered in
+left-to-right (start-ascending) order first — REQ-8's own requirement, and
+what keeps "two different people in one email" from collapsing into one
+token — and only then substituted back-to-front (highest start offset
+first), so every earlier, not-yet-processed span's offset stays valid
+against the shrinking-or-growing string.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from klai_pii_entities import ALL_MASKABLE_ENTITIES
+
+__all__ = [
+    "DetectedSpan",
+    "MaskResult",
+    "mask_text",
+    "restore_text",
+    "TAIL_LEN",
+    "split_safe_tail",
+]
+
+
+@dataclass(frozen=True)
+class DetectedSpan:
+    """One presidio-analyzer ``/analyze`` result, trimmed to what masking
+    needs. ``score`` and ``end - start`` (span length) are the two
+    tie-breakers ``_select_non_overlapping`` uses.
+    """
+
+    entity_type: str
+    start: int
+    end: int
+    score: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.start < 0 or self.end <= self.start:
+            raise ValueError(
+                f"invalid span for {self.entity_type!r}: start={self.start} end={self.end}"
+            )
+
+
+@dataclass(frozen=True)
+class MaskResult:
+    masked_text: str
+    # placeholder -> original substring. RETURN-SET entities only — see
+    # module docstring on klai_pii_entities.py: a never-restore entity's
+    # placeholder is never written here, which is what makes restoring it
+    # structurally impossible rather than merely unconfigured.
+    restore_map: dict[str, str]
+    # Every entity type actually masked, start-ascending order, including
+    # never-restore types. Callers use this to decide whether the
+    # verbatim-token system instruction is needed at all (REQ-0b: mandatory
+    # whenever masking is active).
+    masked_entity_types: tuple[str, ...]
+
+
+def _select_non_overlapping(spans: list[DetectedSpan]) -> list[DetectedSpan]:
+    """Greedy interval selection: highest score wins each contested region.
+
+    Returns the accepted spans sorted by ``start`` ascending — the order
+    both instance-numbering and substitution need.
+    """
+    ordered = sorted(spans, key=lambda s: (-s.score, -(s.end - s.start), s.start))
+    accepted: list[DetectedSpan] = []
+    for span in ordered:
+        overlaps = any(span.start < a.end and a.start < span.end for a in accepted)
+        if overlaps:
+            continue
+        accepted.append(span)
+    return sorted(accepted, key=lambda s: s.start)
+
+
+def mask_text(
+    text: str,
+    spans: list[DetectedSpan],
+    *,
+    enabled_entities: frozenset[str],
+    never_restore_entities: frozenset[str],
+    instance_counters: dict[str, int],
+) -> MaskResult:
+    """Mask every enabled, non-overlapping span in ``text``.
+
+    ``instance_counters`` is a plain ``{entity_type: count}`` dict the
+    caller owns and mutates in place across every text unit (message
+    content, a multi-part content block, a tool-call argument string)
+    processed within ONE request — so numbering is shared across the whole
+    outbound payload, not reset per message. That is what REQ-8's "two
+    different people in one email must not collapse into one token"
+    actually depends on when a name appears in more than one message of the
+    same call: each occurrence still gets its own instance number and its
+    own entry in the restore map, keyed by that number, regardless of
+    whether the two occurrences happen to be the same text.
+    """
+    candidates = [s for s in spans if s.entity_type in enabled_entities]
+    selected = _select_non_overlapping(candidates)
+    if not selected:
+        return MaskResult(text, {}, ())
+
+    # Pass 1 — assign placeholders left-to-right (REQ-8 numbering order).
+    assignments: list[tuple[DetectedSpan, str, str]] = []
+    for span in selected:
+        instance_counters[span.entity_type] = instance_counters.get(span.entity_type, 0) + 1
+        n = instance_counters[span.entity_type]
+        placeholder = f"<{span.entity_type}_{n}>"
+        original = text[span.start : span.end]
+        assignments.append((span, placeholder, original))
+
+    # Pass 2 — substitute back-to-front so earlier offsets stay valid.
+    result = text
+    restore_map: dict[str, str] = {}
+    for span, placeholder, original in reversed(assignments):
+        result = result[: span.start] + placeholder + result[span.end :]
+        if span.entity_type not in never_restore_entities:
+            restore_map[placeholder] = original
+
+    masked_types = tuple(span.entity_type for span, _, _ in assignments)
+    return MaskResult(result, restore_map, masked_types)
+
+
+# ---------------------------------------------------------------------------
+# Restore (REQ-8) — literal, case-sensitive placeholder substitution
+# ---------------------------------------------------------------------------
+# Entity type names never contain digits, so greedy backtracking on
+# `[A-Z0-9_]*` correctly finds the LAST `_<digits>>` suffix as the instance
+# number regardless of how many underscores the type name itself has
+# (NL_BSN, IBAN_CODE, PHONE_NUMBER, ...).
+_PLACEHOLDER_RE = re.compile(r"<([A-Z][A-Z0-9_]*)_(\d+)>")
+
+
+def restore_text(
+    text: str, restore_map: dict[str, str], *, never_restore_entities: frozenset[str]
+) -> str:
+    """Replace every placeholder in ``text`` with its original value.
+
+    Defense in depth for REQ-8's "never-return set SHALL NOT be restored
+    under any configuration": even though a never-restore entity's
+    placeholder is never written into ``restore_map`` in the first place
+    (see ``mask_text``), this function ALSO refuses to substitute any
+    placeholder whose entity-type prefix names a never-restore entity, even
+    if one somehow ended up in ``restore_map`` (a future bug in a caller,
+    a hand-built test fixture, anything). Two independent reasons a
+    credential or a BSN cannot come back, not one.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        placeholder = match.group(0)
+        entity_type = match.group(1)
+        if entity_type in never_restore_entities:
+            return placeholder
+        return restore_map.get(placeholder, placeholder)
+
+    return _PLACEHOLDER_RE.sub(_sub, text)
+
+
+# ---------------------------------------------------------------------------
+# Streaming chunk-boundary safety (REQ-8's own addendum to REQ-8)
+# ---------------------------------------------------------------------------
+# "<" + longest possible entity type name + "_" + a generous instance-count
+# digit allowance + ">". Computed from klai_pii_entities.ALL_MASKABLE_ENTITIES
+# rather than hardcoded so a future entity addition cannot silently shrink
+# the safety margin below what it needs to be.
+_MAX_ENTITY_NAME_LEN = max(len(e) for e in ALL_MASKABLE_ENTITIES)
+_MAX_INSTANCE_DIGITS = 4  # up to 9999 instances of one entity type per request
+TAIL_LEN = 1 + _MAX_ENTITY_NAME_LEN + 1 + _MAX_INSTANCE_DIGITS + 1
+
+
+def split_safe_tail(
+    buffer: str, restore_map: dict[str, str], never_restore_entities: frozenset[str]
+) -> tuple[str, str]:
+    """Split a growing stream buffer into (safe-to-emit, still-held-back).
+
+    Any COMPLETE placeholder anywhere in ``buffer`` is restored immediately
+    (``restore_text`` is a single regex pass over the whole buffer, not
+    just the tail). What remains held back is always at least ``TAIL_LEN``
+    characters — REQ-8: "hold back a tail of at least the longest possible
+    placeholder length when matching across streamed chunks" — so a
+    placeholder split as ``<PERS`` + ``ON_1>`` across a chunk boundary is
+    never emitted as a visible, unrestored fragment: the first chunk's
+    ``<PERS`` never leaves the held-back tail, and once ``ON_1>`` arrives
+    the combined buffer contains the complete placeholder, which the next
+    ``restore_text`` call resolves before any of it is released.
+
+    At true stream end, callers do NOT call this function — they call
+    ``restore_text`` directly on the full remaining buffer and flush
+    everything, because there is no more input that could complete a
+    still-forming placeholder.
+    """
+    if not buffer:
+        return "", buffer
+    restored = restore_text(buffer, restore_map, never_restore_entities=never_restore_entities)
+    if len(restored) <= TAIL_LEN:
+        return "", restored
+    cut = len(restored) - TAIL_LEN
+    return restored[:cut], restored[cut:]

--- a/deploy/litellm/klai_pii_text_masking.py
+++ b/deploy/litellm/klai_pii_text_masking.py
@@ -84,13 +84,38 @@ class MaskResult:
     masked_entity_types: tuple[str, ...]
 
 
-def _select_non_overlapping(spans: list[DetectedSpan]) -> list[DetectedSpan]:
+def _select_non_overlapping(
+    spans: list[DetectedSpan],
+    never_restore_entities: frozenset[str] = frozenset(),
+) -> list[DetectedSpan]:
     """Greedy interval selection: highest score wins each contested region.
+
+    Drops any span that OVERLAPS one already accepted, not merely one
+    contained in it. Containment alone is not enough: NL_BSN [20:29] score
+    1.00 sits inside NL_BTW [18:32] score 0.70, and a JWT span sits inside
+    a Bearer span with a HIGHER score, so a containment-only rule would
+    accept both and back-to-front substitution would corrupt the text.
+
+    Never-restore entities win exact ties. NL_BSN and NL_KVK can produce a
+    byte-identical span with an identical score — an 8-digit KvK number
+    that also passes the padded elfproef — and without this the winner
+    depends on the analyzer's result ordering. Ties must not decide whether
+    a value lands in the restore map, so the entity that is never restored
+    takes precedence.
 
     Returns the accepted spans sorted by ``start`` ascending — the order
     both instance-numbering and substitution need.
     """
-    ordered = sorted(spans, key=lambda s: (-s.score, -(s.end - s.start), s.start))
+    ordered = sorted(
+        spans,
+        key=lambda s: (
+            -s.score,
+            -(s.end - s.start),
+            s.entity_type not in never_restore_entities,
+            s.start,
+            s.entity_type,
+        ),
+    )
     accepted: list[DetectedSpan] = []
     for span in ordered:
         overlaps = any(span.start < a.end and a.start < span.end for a in accepted)
@@ -122,7 +147,7 @@ def mask_text(
     whether the two occurrences happen to be the same text.
     """
     candidates = [s for s in spans if s.entity_type in enabled_entities]
-    selected = _select_non_overlapping(candidates)
+    selected = _select_non_overlapping(candidates, never_restore_entities)
     if not selected:
         return MaskResult(text, {}, ())
 

--- a/deploy/litellm/tests/klai_module_reset.py
+++ b/deploy/litellm/tests/klai_module_reset.py
@@ -25,6 +25,12 @@ KLAI_KB_MODULES = (
     "klai_litellm_response",
     "klai_pasted_correspondence",
     "klai_pii_observe",
+    "klai_pii_entities",
+    "klai_pii_map_store",
+    "klai_pii_text_masking",
+    "klai_pii_org_policy",
+    "klai_pii_enforce",
+    "klai_pii_restore_eval",
 )
 
 

--- a/deploy/litellm/tests/test_pii_enforce.py
+++ b/deploy/litellm/tests/test_pii_enforce.py
@@ -1,0 +1,779 @@
+"""Tests for klai_pii_enforce.py (SPEC-PRIVACY-MISTRAL-PII-001 Phase 3,
+REQ-7 through REQ-11).
+
+litellm is not installed as the real proxy package for these tests (see
+test_klai_knowledge_hook.py / test_pii_observe.py's same rationale) — the
+import is mocked so KlaiPiiEnforcer's CustomLogger base class resolves.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.klai_module_reset import reset_klai_kb_modules
+
+
+@pytest.fixture(autouse=True)
+def _mock_litellm():
+    litellm_mod = types.ModuleType("litellm")
+    integrations_mod = types.ModuleType("litellm.integrations")
+    custom_logger_mod = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        async def async_pre_call_hook(self, *args, **kwargs):
+            pass
+
+    custom_logger_mod.CustomLogger = CustomLogger
+    litellm_mod.integrations = integrations_mod
+    integrations_mod.custom_logger = custom_logger_mod
+
+    sys.modules["litellm"] = litellm_mod
+    sys.modules["litellm.integrations"] = integrations_mod
+    sys.modules["litellm.integrations.custom_logger"] = custom_logger_mod
+
+    yield
+
+    for mod_name in ["litellm", "litellm.integrations", "litellm.integrations.custom_logger"]:
+        sys.modules.pop(mod_name, None)
+    reset_klai_kb_modules()
+
+
+def _load_enforcer(monkeypatch, *, enforce=True, extra_env=None):
+    env = {
+        "KLAI_PII_ENFORCE": "true" if enforce else "false",
+        "PRESIDIO_ANALYZER_API_BASE": "http://presidio-analyzer:3000",
+        "PORTAL_INTERNAL_SECRET": "test-secret",
+    }
+    if extra_env:
+        env.update(extra_env)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    reset_klai_kb_modules()
+    import klai_pii_enforce
+
+    return klai_pii_enforce
+
+
+def _user_api_key(org_id=None):
+    uak = MagicMock()
+    uak.metadata = {"org_id": org_id} if org_id is not None else {}
+    return uak
+
+
+def _stub_org_policy(mod, monkeypatch, policy: frozenset[str] | dict[str, frozenset[str]]):
+    """Replace resolve_org_entity_policy with a deterministic stub.
+
+    ``policy`` may be a single frozenset (same answer for every org) or a
+    dict keyed by org_id for multi-org (cross-tenant) tests.
+    """
+
+    async def _resolve(org_id):
+        if isinstance(policy, dict):
+            return policy.get(org_id, frozenset())
+        return policy
+
+    monkeypatch.setattr(mod, "resolve_org_entity_policy", _resolve)
+
+
+# ---------------------------------------------------------------------------
+# Analyzer fakes
+# ---------------------------------------------------------------------------
+class _FakeAnalyzerResponse:
+    def __init__(self, results):
+        self._results = results
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._results
+
+
+class _ScriptedAnalyzerClient:
+    """Maps exact input text -> a canned /analyze results list."""
+
+    def __init__(self, script=None, default=None, raise_exc=None):
+        self.script = script or {}
+        self.default = default if default is not None else []
+        self.raise_exc = raise_exc
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def post(self, url, json=None, **kwargs):
+        self.calls.append({"url": url, "json": json})
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        text = json["text"]
+        return _FakeAnalyzerResponse(self.script.get(text, self.default))
+
+
+def _install_analyzer(mod, monkeypatch, client):
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+
+# ---------------------------------------------------------------------------
+# Streaming/response object helpers (litellm response shapes, dict-free)
+# ---------------------------------------------------------------------------
+def _chunk(content):
+    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=content))])
+
+
+async def _achunks(*contents):
+    for c in contents:
+        yield _chunk(c)
+
+
+def _response(content):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+async def _drain(agen):
+    return [item async for item in agen]
+
+
+def _all_content(chunks):
+    return "".join(
+        c.choices[0].delta.content or "" for c in chunks if c.choices and c.choices[0].delta.content
+    )
+
+
+# ===========================================================================
+# 1. Flag OFF: byte-identical passthrough
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_flag_off_pre_call_returns_identical_object_no_analyzer_call(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=False)
+    client = _ScriptedAnalyzerClient(raise_exc=AssertionError("must not call analyzer when off"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-off-1",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    original_identity = data
+
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+
+    assert result is original_identity
+    assert result == {
+        "model": "klai-primary",
+        "litellm_call_id": "call-off-1",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    assert client.calls == []
+    assert mod._pii_map_store.get("call-off-1") is None
+
+
+@pytest.mark.asyncio
+async def test_flag_off_post_call_success_hook_returns_none(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=False)
+    result = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": "call-off-2"}, _user_api_key("org1"), _response("hello")
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_flag_off_streaming_hook_passes_chunks_through_unchanged(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=False)
+    chunks = await _drain(
+        mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+            _user_api_key("org1"), _achunks("hello ", "world"), {"litellm_call_id": "call-off-3"}
+        )
+    )
+    assert _all_content(chunks) == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_flag_off_failure_hook_returns_none_and_touches_nothing(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=False)
+    mod._pii_map_store.put("call-off-4", {"<PERSON_1>": "Jan de Vries"})
+    result = await mod.klai_pii_enforcer.async_post_call_failure_hook(
+        {"litellm_call_id": "call-off-4"}, RuntimeError("boom"), _user_api_key("org1")
+    )
+    assert result is None
+    # Flag is off -> the failure hook must not even touch the store.
+    assert mod._pii_map_store.get("call-off-4") == {"<PERSON_1>": "Jan de Vries"}
+
+
+# ===========================================================================
+# 2. Flag ON: BSN masked, never restored
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_bsn_masked_and_not_restored(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())  # no optional entities
+
+    text = "mijn bsn is 111222333 graag verwerken"
+    start, end = text.index("111222333"), text.index("111222333") + len("111222333")
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "NL_BSN", "start": start, "end": end, "score": 0.85}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-bsn-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<NL_BSN_1>" in user_message["content"]
+    assert "111222333" not in user_message["content"]
+    # Nothing restorable was masked (NL_BSN is never-restore), so no map
+    # entry is created at all -- there is nothing to restore, structurally.
+    assert mod._pii_map_store.get("call-bsn-1") is None
+
+    # Even if the model somehow echoes the placeholder, restore must not
+    # bring the real BSN back. No restore map entry exists at all for a
+    # call that only masked never-restore entities, so the hook returns
+    # None (CustomLogger's "no change" contract) -- the ORIGINAL response
+    # object is what the proxy keeps, and it still carries the literal,
+    # unrestored placeholder.
+    response = _response("Genoteerd: <NL_BSN_1>")
+    hook_return = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": "call-bsn-1"}, _user_api_key("org1"), response
+    )
+    assert hook_return is None
+    assert "111222333" not in response.choices[0].message.content
+    assert "<NL_BSN_1>" in response.choices[0].message.content
+
+
+# ===========================================================================
+# 3. Flag ON: SECRET masked, never restored
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_secret_masked_and_not_restored(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
+    text = f"gebruik deze key: {secret} in de config"
+    start, end = text.index(secret), text.index(secret) + len(secret)
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "SECRET", "start": start, "end": end, "score": 0.95}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-secret-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<SECRET_1>" in user_message["content"]
+    assert secret not in user_message["content"]
+    assert mod._pii_map_store.get("call-secret-1") is None
+
+    response = _response("Ik zie dat je <SECRET_1> hebt gedeeld.")
+    hook_return = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": "call-secret-1"}, _user_api_key("org1"), response
+    )
+    assert hook_return is None
+    assert secret not in response.choices[0].message.content
+    assert "<SECRET_1>" in response.choices[0].message.content
+
+
+# ===========================================================================
+# 4/5. Per-org REQ-7 policy: enabled -> masked+restored; disabled -> untouched
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_iban_masked_and_restored_when_enabled_for_org(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset({"IBAN_CODE"}))
+
+    iban = "NL91ABNA0417164300"
+    text = f"Betaal op IBAN {iban} graag."
+    start, end = text.index(iban), text.index(iban) + len(iban)
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "IBAN_CODE", "start": start, "end": end, "score": 1.0}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-iban-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<IBAN_CODE_1>" in user_message["content"]
+    assert iban not in user_message["content"]
+    assert mod._pii_map_store.get("call-iban-1") == {"<IBAN_CODE_1>": iban}
+
+    response = _response("Bevestigd, over te maken naar <IBAN_CODE_1>.")
+    restored = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": "call-iban-1"}, _user_api_key("org1"), response
+    )
+    assert iban in restored.choices[0].message.content
+    assert "<IBAN_CODE_1>" not in restored.choices[0].message.content
+
+
+@pytest.mark.asyncio
+async def test_iban_untouched_when_not_in_org_policy(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())  # IBAN_CODE not enabled
+
+    iban = "NL91ABNA0417164300"
+    text = f"Betaal op IBAN {iban} graag."
+    start, end = text.index(iban), text.index(iban) + len(iban)
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "IBAN_CODE", "start": start, "end": end, "score": 1.0}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-iban-2",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert user_message["content"] == text  # fully untouched
+    assert len(result["messages"]) == 1  # no verbatim-instruction message injected
+    assert mod._pii_map_store.get("call-iban-2") is None
+
+
+# ===========================================================================
+# 6. REQ-8 numbering: two occurrences of the same entity type in one
+# request must not collapse into one token, and each restores independently.
+# (Uses PHONE_NUMBER, not PERSON: PERSON is structurally excluded from
+# effective_enabled_entities regardless of org policy — see
+# klai_pii_entities.py / REQ-9. The identical numbering mechanism is
+# exercised directly against PERSON, unconstrained by org policy, in
+# tests/test_pii_text_masking.py.)
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_two_distinct_phone_numbers_get_distinct_placeholders_and_restore(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset({"PHONE_NUMBER"}))
+
+    phone_a, phone_b = "06-12345678", "06-98765432"
+    text = f"Bel {phone_a} of anders {phone_b}."
+    a_start = text.index(phone_a)
+    b_start = text.index(phone_b)
+    client = _ScriptedAnalyzerClient(
+        script={
+            text: [
+                {
+                    "entity_type": "PHONE_NUMBER",
+                    "start": a_start,
+                    "end": a_start + len(phone_a),
+                    "score": 0.9,
+                },
+                {
+                    "entity_type": "PHONE_NUMBER",
+                    "start": b_start,
+                    "end": b_start + len(phone_b),
+                    "score": 0.9,
+                },
+            ]
+        }
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-two-phones",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<PHONE_NUMBER_1>" in user_message["content"]
+    assert "<PHONE_NUMBER_2>" in user_message["content"]
+
+    restore_map = mod._pii_map_store.get("call-two-phones")
+    assert restore_map == {"<PHONE_NUMBER_1>": phone_a, "<PHONE_NUMBER_2>": phone_b}
+
+    response = _response(f"Genoteerd: <PHONE_NUMBER_1> en <PHONE_NUMBER_2>.")
+    restored = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": "call-two-phones"}, _user_api_key("org1"), response
+    )
+    restored_text = restored.choices[0].message.content
+    assert phone_a in restored_text
+    assert phone_b in restored_text
+    # Neither placeholder resolved to the wrong number.
+    assert restored_text.index(phone_a) < restored_text.index(phone_b)
+
+
+# ===========================================================================
+# 7. REQ-8 chunk-boundary safety through the real streaming hook
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_placeholder_split_across_chunk_boundary_via_streaming_hook(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    call_id = "call-stream-split"
+    mod._pii_map_store.put(call_id, {"<PERSON_1>": "Jan de Vries"})
+
+    chunks = await _drain(
+        mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+            _user_api_key("org1"),
+            _achunks("Hallo <PERS", "ON_1> vriendelijke groet"),
+            {"litellm_call_id": call_id},
+        )
+    )
+    full_text = _all_content(chunks)
+    assert full_text == "Hallo Jan de Vries vriendelijke groet"
+    # No individual chunk ever carries a bare, unrestored partial fragment.
+    for c in chunks:
+        content = c.choices[0].delta.content or ""
+        assert "<PERS" not in content or "<PERSON_1>" not in content and "PERSON_1" not in content
+    # Map entry cleaned up at stream end.
+    assert mod._pii_map_store.get(call_id) is None
+
+
+# ===========================================================================
+# 8. Streaming AND non-streaming both restore (combined smoke check)
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_streaming_and_non_streaming_both_restore_return_set_entities(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+
+    # Non-streaming
+    call_id_ns = "call-both-ns"
+    mod._pii_map_store.put(call_id_ns, {"<EMAIL_ADDRESS_1>": "jan@example.nl"})
+    restored = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": call_id_ns}, _user_api_key("org1"), _response("mail: <EMAIL_ADDRESS_1>")
+    )
+    assert "jan@example.nl" in restored.choices[0].message.content
+
+    # Streaming
+    call_id_s = "call-both-s"
+    mod._pii_map_store.put(call_id_s, {"<EMAIL_ADDRESS_1>": "jan@example.nl"})
+    chunks = await _drain(
+        mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+            _user_api_key("org1"), _achunks("mail: ", "<EMAIL_ADDRESS_1>"), {"litellm_call_id": call_id_s}
+        )
+    )
+    assert "jan@example.nl" in _all_content(chunks)
+
+
+# ===========================================================================
+# 9. Cross-tenant isolation — the most important test (REQ-11)
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_two_concurrent_requests_different_orgs_do_not_cross_contaminate(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(
+        mod,
+        monkeypatch,
+        {"org-a": frozenset({"PHONE_NUMBER"}), "org-b": frozenset({"PHONE_NUMBER"})},
+    )
+
+    phone_a = "06-11111111"
+    phone_b = "06-22222222"
+    text_a = f"Bel {phone_a} alstublieft."
+    text_b = f"Bel {phone_b} alstublieft."
+
+    client = _ScriptedAnalyzerClient(
+        script={
+            text_a: [
+                {
+                    "entity_type": "PHONE_NUMBER",
+                    "start": text_a.index(phone_a),
+                    "end": text_a.index(phone_a) + len(phone_a),
+                    "score": 0.9,
+                }
+            ],
+            text_b: [
+                {
+                    "entity_type": "PHONE_NUMBER",
+                    "start": text_b.index(phone_b),
+                    "end": text_b.index(phone_b) + len(phone_b),
+                    "score": 0.9,
+                }
+            ],
+        }
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data_a = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-org-a",
+        "messages": [{"role": "user", "content": text_a}],
+    }
+    data_b = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-org-b",
+        "messages": [{"role": "user", "content": text_b}],
+    }
+
+    # Run both pre-call masks CONCURRENTLY -- this is the scenario REQ-11
+    # exists to make safe: two in-flight requests racing on the same
+    # process-local store.
+    result_a, result_b = await asyncio.gather(
+        mod.klai_pii_enforcer.async_pre_call_hook(_user_api_key("org-a"), None, data_a, "completion"),
+        mod.klai_pii_enforcer.async_pre_call_hook(_user_api_key("org-b"), None, data_b, "completion"),
+    )
+
+    user_a = [m for m in result_a["messages"] if m.get("role") == "user"][0]["content"]
+    user_b = [m for m in result_b["messages"] if m.get("role") == "user"][0]["content"]
+    assert phone_b not in user_a
+    assert phone_a not in user_b
+
+    # Now run both restores CONCURRENTLY too.
+    response_a = _response("Genoteerd: <PHONE_NUMBER_1>")
+    response_b = _response("Genoteerd: <PHONE_NUMBER_1>")  # same placeholder text, different maps
+    restored_a, restored_b = await asyncio.gather(
+        mod.klai_pii_enforcer.async_post_call_success_hook(
+            {"litellm_call_id": "call-org-a"}, _user_api_key("org-a"), response_a
+        ),
+        mod.klai_pii_enforcer.async_post_call_success_hook(
+            {"litellm_call_id": "call-org-b"}, _user_api_key("org-b"), response_b
+        ),
+    )
+
+    text_out_a = restored_a.choices[0].message.content
+    text_out_b = restored_b.choices[0].message.content
+    assert phone_a in text_out_a
+    assert phone_b not in text_out_a
+    assert phone_b in text_out_b
+    assert phone_a not in text_out_b
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_streaming_requests_different_orgs_do_not_cross_contaminate(
+    monkeypatch,
+):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod._pii_map_store.put("call-stream-org-a", {"<PERSON_1>": "Jan de Vries"})
+    mod._pii_map_store.put("call-stream-org-b", {"<PERSON_1>": "Marieke Bakker"})
+
+    async def _run(call_id):
+        chunks = await _drain(
+            mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+                _user_api_key("org"), _achunks("Groeten aan <PERSON_1>."), {"litellm_call_id": call_id}
+            )
+        )
+        return _all_content(chunks)
+
+    text_a, text_b = await asyncio.gather(_run("call-stream-org-a"), _run("call-stream-org-b"))
+    assert "Jan de Vries" in text_a
+    assert "Marieke Bakker" not in text_a
+    assert "Marieke Bakker" in text_b
+    assert "Jan de Vries" not in text_b
+
+
+# ===========================================================================
+# 10. Map lifecycle through the hooks
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_map_entry_deleted_after_stream_end(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    call_id = "call-lifecycle-1"
+    mod._pii_map_store.put(call_id, {"<PERSON_1>": "Jan de Vries"})
+    await _drain(
+        mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+            _user_api_key("org1"), _achunks("Groeten aan <PERSON_1>."), {"litellm_call_id": call_id}
+        )
+    )
+    assert mod._pii_map_store.get(call_id) is None
+
+
+@pytest.mark.asyncio
+async def test_map_entry_deleted_after_error_mid_stream(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    call_id = "call-lifecycle-2"
+    mod._pii_map_store.put(call_id, {"<PERSON_1>": "Jan de Vries"})
+
+    async def _broken_stream():
+        yield _chunk("Groeten aan ")
+        raise ConnectionError("upstream dropped mid-stream")
+
+    with pytest.raises(ConnectionError):
+        await _drain(
+            mod.klai_pii_enforcer.async_post_call_streaming_iterator_hook(
+                _user_api_key("org1"), _broken_stream(), {"litellm_call_id": call_id}
+            )
+        )
+    assert mod._pii_map_store.get(call_id) is None
+
+
+@pytest.mark.asyncio
+async def test_map_entry_deleted_via_failure_hook(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    call_id = "call-lifecycle-3"
+    mod._pii_map_store.put(call_id, {"<PERSON_1>": "Jan de Vries"})
+    await mod.klai_pii_enforcer.async_post_call_failure_hook(
+        {"litellm_call_id": call_id}, RuntimeError("boom"), _user_api_key("org1")
+    )
+    assert mod._pii_map_store.get(call_id) is None
+
+
+@pytest.mark.asyncio
+async def test_map_entry_deleted_after_success_hook_even_with_no_restore_map(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    call_id = "call-lifecycle-4"
+    # No put() -- nothing was masked for this call.
+    result = await mod.klai_pii_enforcer.async_post_call_success_hook(
+        {"litellm_call_id": call_id}, _user_api_key("org1"), _response("hello")
+    )
+    assert result is None
+    assert mod._pii_map_store.get(call_id) is None
+
+
+# ===========================================================================
+# 11. REQ-10: analyzer failure behaviour
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_analyzer_error_with_enforcement_on_fails_the_request(monkeypatch, caplog):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())
+    client = _ScriptedAnalyzerClient(raise_exc=ConnectionError("presidio-analyzer unreachable"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-analyzer-down",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    with caplog.at_level("WARNING", logger="klai_pii_enforce"):
+        with pytest.raises(mod.PiiAnalyzerUnavailable):
+            await mod.klai_pii_enforcer.async_pre_call_hook(
+                _user_api_key("org1"), None, data, "completion"
+            )
+    assert any("pii_enforce_analyzer_failed" in r.message for r in caplog.records)
+    assert any("org1" in r.message for r in caplog.records)
+    # No unminimised payload was ever recorded as maskable.
+    assert mod._pii_map_store.get("call-analyzer-down") is None
+
+
+@pytest.mark.asyncio
+async def test_analyzer_error_with_enforcement_off_does_nothing(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=False)
+    client = _ScriptedAnalyzerClient(raise_exc=ConnectionError("presidio-analyzer unreachable"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-analyzer-down-2",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    # Must NOT raise -- enforcement is off, the analyzer is never called.
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    assert result is data
+    assert client.calls == []
+
+
+# ===========================================================================
+# 12. Verbatim-token instruction (REQ-0b) present exactly when masking fires
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_verbatim_instruction_injected_when_masking_active(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    text = "mijn bsn is 111222333 graag verwerken"
+    start, end = text.index("111222333"), text.index("111222333") + len("111222333")
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "NL_BSN", "start": start, "end": end, "score": 0.85}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-instr-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    from klai_pii_restore_eval import VERBATIM_TOKEN_SYSTEM_INSTRUCTION
+
+    assert any(
+        m.get("content") == VERBATIM_TOKEN_SYSTEM_INSTRUCTION for m in result["messages"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_verbatim_instruction_absent_when_nothing_is_masked(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    text = "hallo, hoe gaat het vandaag met je?"
+    client = _ScriptedAnalyzerClient(script={text: []})  # nothing detected
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-instr-2",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    from klai_pii_restore_eval import VERBATIM_TOKEN_SYSTEM_INSTRUCTION
+
+    assert result["messages"] == [{"role": "user", "content": text}]
+    assert not any(
+        m.get("content") == VERBATIM_TOKEN_SYSTEM_INSTRUCTION for m in result["messages"]
+    )
+
+
+# ===========================================================================
+# Agentic path: tool_calls[].function.arguments is masked too
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_tool_call_arguments_are_masked(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    _stub_org_policy(mod, monkeypatch, frozenset({"EMAIL_ADDRESS"}))
+
+    args_text = '{"to": "jan.devries@example.nl"}'
+    email = "jan.devries@example.nl"
+    start, end = args_text.index(email), args_text.index(email) + len(email)
+    client = _ScriptedAnalyzerClient(
+        script={
+            args_text: [
+                {"entity_type": "EMAIL_ADDRESS", "start": start, "end": end, "score": 0.9}
+            ]
+        }
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-large",
+        "litellm_call_id": "call-toolcall-1",
+        "messages": [
+            {"role": "user", "content": "stuur dit door"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"function": {"name": "send_mail", "arguments": args_text}}],
+            },
+        ],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    assistant_msg = [m for m in result["messages"] if m.get("role") == "assistant"][0]
+    masked_args = assistant_msg["tool_calls"][0]["function"]["arguments"]
+    assert email not in masked_args
+    assert "<EMAIL_ADDRESS_1>" in masked_args

--- a/deploy/litellm/tests/test_pii_map_store.py
+++ b/deploy/litellm/tests/test_pii_map_store.py
@@ -1,0 +1,190 @@
+"""Tests for klai_pii_map_store.py (SPEC-PRIVACY-MISTRAL-PII-001 REQ-11)."""
+
+from __future__ import annotations
+
+import pytest
+
+from klai_pii_map_store import PiiMapStore
+
+
+def test_put_then_get_round_trips():
+    store = PiiMapStore()
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    assert store.get("call-1") == {"<PERSON_1>": "Jan de Vries"}
+
+
+def test_get_missing_call_id_returns_none():
+    store = PiiMapStore()
+    assert store.get("does-not-exist") is None
+
+
+def test_get_is_non_destructive_until_discard():
+    store = PiiMapStore()
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    store.get("call-1")
+    store.get("call-1")
+    assert store.get("call-1") == {"<PERSON_1>": "Jan de Vries"}
+
+
+def test_discard_removes_entry():
+    store = PiiMapStore()
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    store.discard("call-1")
+    assert store.get("call-1") is None
+
+
+def test_discard_on_success_path():
+    """REQ-11: entry deleted when the stream ends on the success path."""
+    store = PiiMapStore()
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    # Simulate: hook restores using the map, then discards at stream end.
+    restore_map = store.get("call-1")
+    assert restore_map is not None
+    store.discard("call-1")
+    assert "call-1" not in store
+
+
+def test_discard_on_error_path_too():
+    """REQ-11: entry deleted on the error path alike."""
+    store = PiiMapStore()
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    try:
+        raise RuntimeError("upstream failure mid-stream")
+    except RuntimeError:
+        store.discard("call-1")
+    assert store.get("call-1") is None
+
+
+def test_discard_missing_call_id_is_a_no_op():
+    store = PiiMapStore()
+    store.discard("never-existed")  # must not raise
+
+
+def test_returned_mapping_is_a_copy_not_the_live_dict():
+    store = PiiMapStore()
+    original = {"<PERSON_1>": "Jan de Vries"}
+    store.put("call-1", original)
+    fetched = store.get("call-1")
+    fetched["<PERSON_1>"] = "tampered"
+    assert store.get("call-1") == {"<PERSON_1>": "Jan de Vries"}
+
+
+# ---------------------------------------------------------------------------
+# TTL sweep — a client disconnecting mid-stream must not leak forever
+# ---------------------------------------------------------------------------
+def test_ttl_sweep_drops_a_stale_entry():
+    clock = {"now": 0.0}
+    store = PiiMapStore(ttl_seconds=10.0, clock=lambda: clock["now"])
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+
+    clock["now"] = 5.0
+    assert store.get("call-1") is not None  # still fresh
+
+    clock["now"] = 20.0  # past the 10s TTL
+    assert store.get("call-1") is None  # swept lazily on access
+
+
+def test_ttl_sweep_runs_on_put_too():
+    clock = {"now": 0.0}
+    store = PiiMapStore(ttl_seconds=10.0, clock=lambda: clock["now"])
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+
+    clock["now"] = 20.0
+    store.put("call-2", {"<PERSON_1>": "Marieke Bakker"})  # triggers a sweep
+
+    assert len(store) == 1
+    assert "call-1" not in store
+    assert store.get("call-2") == {"<PERSON_1>": "Marieke Bakker"}
+
+
+def test_explicit_sweep_reports_count_removed():
+    clock = {"now": 0.0}
+    store = PiiMapStore(ttl_seconds=10.0, clock=lambda: clock["now"])
+    store.put("call-1", {})
+    store.put("call-2", {})
+    clock["now"] = 20.0
+    removed = store.sweep()
+    assert removed == 2
+    assert len(store) == 0
+
+
+def test_fresh_entries_survive_a_sweep_that_finds_nothing_stale():
+    clock = {"now": 0.0}
+    store = PiiMapStore(ttl_seconds=10.0, clock=lambda: clock["now"])
+    store.put("call-1", {"<PERSON_1>": "Jan de Vries"})
+    clock["now"] = 1.0
+    assert store.sweep() == 0
+    assert store.get("call-1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Bounded size — oldest-first eviction (REQ-11)
+# ---------------------------------------------------------------------------
+def test_store_is_bounded_and_evicts_oldest_first():
+    store = PiiMapStore(max_entries=2, ttl_seconds=10_000.0)
+    store.put("call-1", {"a": "1"})
+    store.put("call-2", {"b": "2"})
+    store.put("call-3", {"c": "3"})  # over capacity -> evict call-1 (oldest)
+
+    assert len(store) == 2
+    assert store.get("call-1") is None
+    assert store.get("call-2") == {"b": "2"}
+    assert store.get("call-3") == {"c": "3"}
+
+
+def test_eviction_keeps_evicting_until_room_exists():
+    store = PiiMapStore(max_entries=1, ttl_seconds=10_000.0)
+    store.put("call-1", {"a": "1"})
+    store.put("call-2", {"b": "2"})
+    store.put("call-3", {"c": "3"})
+
+    assert len(store) == 1
+    assert store.get("call-3") == {"c": "3"}
+    assert store.get("call-1") is None
+    assert store.get("call-2") is None
+
+
+def test_replacing_an_existing_call_id_does_not_count_as_growth():
+    store = PiiMapStore(max_entries=2, ttl_seconds=10_000.0)
+    store.put("call-1", {"a": "1"})
+    store.put("call-2", {"b": "2"})
+    store.put("call-1", {"a": "1-updated"})  # replace, not a 3rd entry
+
+    assert len(store) == 2
+    assert store.get("call-1") == {"a": "1-updated"}
+    assert store.get("call-2") == {"b": "2"}
+
+
+def test_never_grows_without_limit_under_sustained_traffic():
+    store = PiiMapStore(max_entries=50, ttl_seconds=10_000.0)
+    for i in range(1000):
+        store.put(f"call-{i}", {"x": str(i)})
+    assert len(store) <= 50
+
+
+# ---------------------------------------------------------------------------
+# Construction guards
+# ---------------------------------------------------------------------------
+def test_max_entries_must_be_positive():
+    with pytest.raises(ValueError):
+        PiiMapStore(max_entries=0)
+
+
+def test_ttl_seconds_must_be_positive():
+    with pytest.raises(ValueError):
+        PiiMapStore(ttl_seconds=0)
+
+
+def test_put_requires_non_empty_call_id():
+    store = PiiMapStore()
+    with pytest.raises(ValueError):
+        store.put("", {"a": "1"})
+
+
+# ---------------------------------------------------------------------------
+# No serialization surface at all (REQ-11: never written to Redis/PG/disk/log)
+# ---------------------------------------------------------------------------
+def test_store_exposes_no_serialization_method():
+    store = PiiMapStore()
+    for forbidden in ("to_json", "to_dict", "serialize", "dump", "save"):
+        assert not hasattr(store, forbidden)

--- a/deploy/litellm/tests/test_pii_org_policy.py
+++ b/deploy/litellm/tests/test_pii_org_policy.py
@@ -1,0 +1,180 @@
+"""Tests for klai_pii_org_policy.py (SPEC-PRIVACY-MISTRAL-PII-001 REQ-7 /
+NFR "Tenant isolation")."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.klai_module_reset import reset_klai_kb_modules
+
+
+def _load_policy_module(monkeypatch, extra_env=None):
+    env = {"PORTAL_INTERNAL_SECRET": "test-secret", "PORTAL_API_URL": "http://portal-api:8000"}
+    if extra_env:
+        env.update(extra_env)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    reset_klai_kb_modules()
+    import klai_pii_org_policy
+
+    return klai_pii_org_policy
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_ok=True):
+        self._payload = payload
+        self._status_ok = status_ok
+
+    def raise_for_status(self):
+        if not self._status_ok:
+            raise RuntimeError("simulated non-2xx")
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, response=None, raise_exc=None):
+        self._response = response
+        self._raise_exc = raise_exc
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    async def get(self, url, headers=None, **kwargs):
+        self.calls.append({"url": url, "headers": headers})
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_missing_org_id_fails_closed_no_call(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(response=_FakeResponse({"enabled_entities": ["IBAN_CODE"]}))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy(None)
+    assert policy == frozenset()
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_enabled_entities_returned_and_filtered_to_return_set(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(
+        response=_FakeResponse({"enabled_entities": ["IBAN_CODE", "PHONE_NUMBER"]})
+    )
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset({"IBAN_CODE", "PHONE_NUMBER"})
+
+
+@pytest.mark.asyncio
+async def test_person_in_response_is_dropped_structurally(monkeypatch):
+    """Even a crafted/buggy portal-api response claiming PERSON is enabled
+    cannot make PERSON survive this function -- it is intersected against
+    RETURN_SET_ENTITIES, which never contains PERSON."""
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(
+        response=_FakeResponse({"enabled_entities": ["PERSON", "IBAN_CODE"]})
+    )
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert "PERSON" not in policy
+    assert policy == frozenset({"IBAN_CODE"})
+
+
+@pytest.mark.asyncio
+async def test_unknown_entity_strings_are_dropped(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(
+        response=_FakeResponse({"enabled_entities": ["IBAN_CODE", "NOT_A_REAL_ENTITY"]})
+    )
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset({"IBAN_CODE"})
+
+
+@pytest.mark.asyncio
+async def test_network_error_fails_closed(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(raise_exc=ConnectionError("portal-api unreachable"))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_non_2xx_response_fails_closed(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(response=_FakeResponse({}, status_ok=False))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_fails_closed(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(response=_FakeResponse({"unexpected": "shape"}))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_fails_closed_without_a_network_call(monkeypatch):
+    mod = _load_policy_module(monkeypatch, extra_env={"PORTAL_INTERNAL_SECRET": ""})
+    client = _FakeAsyncClient(response=_FakeResponse({"enabled_entities": ["IBAN_CODE"]}))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy = await mod.resolve_org_entity_policy("org-123")
+    assert policy == frozenset()
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_result_is_cached_per_org(monkeypatch):
+    mod = _load_policy_module(monkeypatch)
+    client = _FakeAsyncClient(response=_FakeResponse({"enabled_entities": ["IBAN_CODE"]}))
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    await mod.resolve_org_entity_policy("org-123")
+    await mod.resolve_org_entity_policy("org-123")
+    assert len(client.calls) == 1  # second call served from cache
+
+
+@pytest.mark.asyncio
+async def test_cache_is_scoped_per_org_not_shared(monkeypatch):
+    """Tenant-isolation guard: org A's cached policy must never answer for
+    org B."""
+    mod = _load_policy_module(monkeypatch)
+
+    class _MultiOrgClient(_FakeAsyncClient):
+        async def get(self, url, headers=None, **kwargs):
+            self.calls.append({"url": url, "headers": headers})
+            if "/orgs/org-a/" in url:
+                return _FakeResponse({"enabled_entities": ["IBAN_CODE"]})
+            return _FakeResponse({"enabled_entities": ["PHONE_NUMBER"]})
+
+    client = _MultiOrgClient()
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    policy_a = await mod.resolve_org_entity_policy("org-a")
+    policy_b = await mod.resolve_org_entity_policy("org-b")
+    assert policy_a == frozenset({"IBAN_CODE"})
+    assert policy_b == frozenset({"PHONE_NUMBER"})
+    assert policy_a != policy_b

--- a/deploy/litellm/tests/test_pii_text_masking.py
+++ b/deploy/litellm/tests/test_pii_text_masking.py
@@ -408,3 +408,76 @@ def test_detected_span_rejects_invalid_bounds():
         DetectedSpan(entity_type="PERSON", start=5, end=5, score=0.9)
     with pytest.raises(ValueError):
         DetectedSpan(entity_type="PERSON", start=-1, end=5, score=0.9)
+
+
+# ---------------------------------------------------------------------------
+# System-review H1/H2 (2026-08-20) — overlap is not only containment
+# ---------------------------------------------------------------------------
+def test_overlap_not_merely_containment_higher_score_inside_lower():
+    """NL_BSN [20:29] score 1.00 sits INSIDE NL_BTW [18:32] score 0.70.
+
+    A containment-only rule takes the BSN first (higher score), then finds
+    the BTW span is not contained in it and takes that too — two overlapping
+    substitutions, corrupted output. The selection must drop any OVERLAP.
+    """
+    from klai_pii_text_masking import DetectedSpan, mask_text
+
+    text = "Ons BTW-nummer is NL123456782B01."
+    spans = [
+        DetectedSpan(entity_type="NL_BSN", start=20, end=29, score=1.00),
+        DetectedSpan(entity_type="NL_BTW", start=18, end=32, score=0.70),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"NL_BSN", "NL_BTW"}),
+        never_restore_entities=frozenset({"NL_BSN"}),
+        instance_counters={},
+    )
+    assert result.masked_text.count("<") == 1, result.masked_text
+    assert "<NL_BSN_1>" in result.masked_text
+    assert "NL_BTW" not in result.masked_text
+    assert result.masked_text.startswith("Ons BTW-nummer is ")
+
+
+def test_nested_same_entity_higher_score_inside_lower():
+    """A JWT span sits inside a Bearer span with a HIGHER score."""
+    from klai_pii_text_masking import DetectedSpan, mask_text
+
+    text = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CV"
+    spans = [
+        DetectedSpan(entity_type="SECRET", start=15, end=len(text), score=0.85),
+        DetectedSpan(entity_type="SECRET", start=22, end=len(text), score=0.90),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"SECRET"}),
+        never_restore_entities=frozenset({"SECRET"}),
+        instance_counters={},
+    )
+    assert result.masked_text.count("<SECRET_") == 1, result.masked_text
+    assert "eyJhbGci" not in result.masked_text
+
+
+def test_identical_span_and_score_never_restore_entity_wins():
+    """An 8-digit KvK that also passes the padded elfproef yields NL_BSN and
+    NL_KVK at the same span with the same score. Ties must not decide whether
+    a value lands in the restore map, so the never-restore entity wins."""
+    from klai_pii_text_masking import DetectedSpan, mask_text
+
+    text = "Ons KvK-nummer is 10000008 en dat klopt."
+    spans = [
+        DetectedSpan(entity_type="NL_KVK", start=18, end=26, score=1.00),
+        DetectedSpan(entity_type="NL_BSN", start=18, end=26, score=1.00),
+    ]
+    for ordering in (spans, list(reversed(spans))):
+        result = mask_text(
+            text,
+            list(ordering),
+            enabled_entities=frozenset({"NL_BSN", "NL_KVK"}),
+            never_restore_entities=frozenset({"NL_BSN"}),
+            instance_counters={},
+        )
+        assert "<NL_BSN_1>" in result.masked_text, result.masked_text
+        assert result.restore_map == {}, "a never-restore value must not be restorable"

--- a/deploy/litellm/tests/test_pii_text_masking.py
+++ b/deploy/litellm/tests/test_pii_text_masking.py
@@ -1,0 +1,410 @@
+"""Tests for klai_pii_text_masking.py (SPEC-PRIVACY-MISTRAL-PII-001 REQ-8)."""
+
+from __future__ import annotations
+
+from klai_pii_entities import NEVER_RESTORE_ENTITIES, RETURN_SET_ENTITIES
+from klai_pii_text_masking import (
+    TAIL_LEN,
+    DetectedSpan,
+    mask_text,
+    restore_text,
+    split_safe_tail,
+)
+
+ALL_ENTITIES = NEVER_RESTORE_ENTITIES | RETURN_SET_ENTITIES
+
+
+# ---------------------------------------------------------------------------
+# Basic masking + restore round trip
+# ---------------------------------------------------------------------------
+def test_single_entity_masked_and_restored():
+    text = "Bel mij op 06-12345678 alstublieft."
+    phone = "06-12345678"
+    span = DetectedSpan(
+        entity_type="PHONE_NUMBER",
+        start=text.index(phone),
+        end=text.index(phone) + len(phone),
+        score=0.9,
+    )
+    result = mask_text(
+        text,
+        [span],
+        enabled_entities=ALL_ENTITIES,
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_text == "Bel mij op <PHONE_NUMBER_1> alstublieft."
+    assert result.restore_map == {"<PHONE_NUMBER_1>": "06-12345678"}
+    restored = restore_text(
+        result.masked_text, result.restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+    )
+    assert restored == text
+
+
+def test_disabled_entity_type_is_left_untouched():
+    text = "IBAN NL91ABNA0417164300 hier."
+    span = DetectedSpan(entity_type="IBAN_CODE", start=5, end=23, score=1.0)
+    result = mask_text(
+        text,
+        [span],
+        enabled_entities=frozenset(),  # nothing enabled
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_text == text
+    assert result.restore_map == {}
+    assert result.masked_entity_types == ()
+
+
+# ---------------------------------------------------------------------------
+# Never-restore set: structurally impossible to restore
+# ---------------------------------------------------------------------------
+def test_secret_is_masked_but_never_enters_restore_map():
+    text = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz gebruiken"
+    span = DetectedSpan(entity_type="SECRET", start=0, end=40, score=0.95)
+    result = mask_text(
+        text,
+        [span],
+        enabled_entities=ALL_ENTITIES,
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert "<SECRET_1>" in result.masked_text
+    assert result.restore_map == {}  # structurally nothing to restore
+
+
+def test_bsn_is_masked_but_never_enters_restore_map():
+    text = "mijn bsn is 111222333 graag verwerken"
+    span = DetectedSpan(entity_type="NL_BSN", start=12, end=21, score=0.85)
+    result = mask_text(
+        text,
+        [span],
+        enabled_entities=ALL_ENTITIES,
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_text == "mijn bsn is <NL_BSN_1> graag verwerken"
+    assert result.restore_map == {}
+
+
+def test_restore_text_refuses_a_never_restore_placeholder_even_if_in_the_map():
+    """Defense in depth: even a hand-built restore_map containing a
+    never-restore placeholder (a bug elsewhere, a crafted fixture) must not
+    be honoured by restore_text itself. Two independent guarantees, not one.
+    """
+    masked = "mijn bsn is <NL_BSN_1> graag verwerken"
+    tampered_map = {"<NL_BSN_1>": "111222333"}  # should never happen, but...
+    restored = restore_text(masked, tampered_map, never_restore_entities=NEVER_RESTORE_ENTITIES)
+    assert "111222333" not in restored
+    assert "<NL_BSN_1>" in restored
+
+
+def test_mixed_masking_only_return_set_restores():
+    text = "sk-ant-api03-zzzzzzzzzzzzzzzzzzzz en bel 06-12345678"
+    spans = [
+        DetectedSpan(entity_type="SECRET", start=0, end=32, score=0.95),
+        DetectedSpan(entity_type="PHONE_NUMBER", start=41, end=53, score=0.9),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=ALL_ENTITIES,
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert list(result.restore_map.keys()) == ["<PHONE_NUMBER_1>"]
+    restored = restore_text(
+        result.masked_text, result.restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+    )
+    assert "06-12345678" in restored
+    assert "sk-ant-api03" not in restored
+    assert "<SECRET_1>" in restored
+
+
+# ---------------------------------------------------------------------------
+# REQ-8 numbering: two different people must not collapse into one token
+# ---------------------------------------------------------------------------
+def test_two_different_people_get_distinct_placeholders_and_restore_correctly():
+    text = "Van Jan de Vries naar Marieke Bakker doorsturen."
+    name_a, name_b = "Jan de Vries", "Marieke Bakker"
+    spans = [
+        DetectedSpan(
+            entity_type="PERSON",
+            start=text.index(name_a),
+            end=text.index(name_a) + len(name_a),
+            score=0.9,
+        ),
+        DetectedSpan(
+            entity_type="PERSON",
+            start=text.index(name_b),
+            end=text.index(name_b) + len(name_b),
+            score=0.9,
+        ),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"PERSON"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_text == "Van <PERSON_1> naar <PERSON_2> doorsturen."
+    assert result.restore_map == {
+        "<PERSON_1>": "Jan de Vries",
+        "<PERSON_2>": "Marieke Bakker",
+    }
+    restored = restore_text(
+        result.masked_text, result.restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+    )
+    assert restored == text
+    # Neither placeholder restores to the other's value.
+    assert result.restore_map["<PERSON_1>"] != result.restore_map["<PERSON_2>"]
+
+
+def test_instance_counters_shared_across_multiple_mask_text_calls():
+    """Same counters dict passed across two "messages" in one request keeps
+    numbering unique across the whole outbound payload, not just one text
+    unit."""
+    counters: dict[str, int] = {}
+    text_a = "Stuur naar Jan de Vries."
+    name_a = "Jan de Vries"
+    text_b = "Ook Marieke Bakker toevoegen."
+    name_b = "Marieke Bakker"
+    first = mask_text(
+        text_a,
+        [
+            DetectedSpan(
+                entity_type="PERSON",
+                start=text_a.index(name_a),
+                end=text_a.index(name_a) + len(name_a),
+                score=0.9,
+            )
+        ],
+        enabled_entities=frozenset({"PERSON"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters=counters,
+    )
+    second = mask_text(
+        text_b,
+        [
+            DetectedSpan(
+                entity_type="PERSON",
+                start=text_b.index(name_b),
+                end=text_b.index(name_b) + len(name_b),
+                score=0.9,
+            )
+        ],
+        enabled_entities=frozenset({"PERSON"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters=counters,
+    )
+    assert "<PERSON_1>" in first.masked_text
+    assert "<PERSON_2>" in second.masked_text
+    combined = {**first.restore_map, **second.restore_map}
+    assert combined == {"<PERSON_1>": "Jan de Vries", "<PERSON_2>": "Marieke Bakker"}
+
+
+# ---------------------------------------------------------------------------
+# Overlapping spans across entity types (REQ-8's own regression case):
+# an IBAN span fully containing a lower-scoring PHONE_NUMBER span. Exact
+# text and offsets from spec.md REQ-8's measured example:
+#
+#   Betaal op IBAN NL91 ABNA 0417 1643 00 graag.
+#   IBAN_CODE    [15:37] score=1.00
+#   PHONE_NUMBER [25:37] score=0.40   <- fully inside the IBAN span
+# ---------------------------------------------------------------------------
+def test_overlapping_spans_iban_contains_phone_number():
+    text = "Betaal op IBAN NL91 ABNA 0417 1643 00 graag."
+    assert text[15:37] == "NL91 ABNA 0417 1643 00"
+    assert text[25:37] == "0417 1643 00"
+
+    spans = [
+        DetectedSpan(entity_type="IBAN_CODE", start=15, end=37, score=1.00),
+        DetectedSpan(entity_type="PHONE_NUMBER", start=25, end=37, score=0.40),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"IBAN_CODE", "PHONE_NUMBER"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_text.count("<IBAN_CODE_1>") == 1
+    assert "<PHONE_NUMBER_1>" not in result.masked_text
+    assert "PHONE_NUMBER" not in "".join(result.masked_entity_types)
+    # Surrounding text intact.
+    assert result.masked_text.startswith("Betaal op IBAN ")
+    assert result.masked_text.endswith(" graag.")
+    # Restores cleanly to the original.
+    restored = restore_text(
+        result.masked_text, result.restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+    )
+    assert restored == text
+
+
+def test_overlap_resolution_prefers_higher_score():
+    text = "AAAAAAAAAA"
+    spans = [
+        DetectedSpan(entity_type="EMAIL_ADDRESS", start=0, end=10, score=0.5),
+        DetectedSpan(entity_type="PHONE_NUMBER", start=2, end=8, score=0.9),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"EMAIL_ADDRESS", "PHONE_NUMBER"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_entity_types == ("PHONE_NUMBER",)
+
+
+def test_overlap_resolution_prefers_longer_span_on_score_tie():
+    text = "AAAAAAAAAA"
+    spans = [
+        DetectedSpan(entity_type="EMAIL_ADDRESS", start=0, end=10, score=0.8),
+        DetectedSpan(entity_type="PHONE_NUMBER", start=2, end=8, score=0.8),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"EMAIL_ADDRESS", "PHONE_NUMBER"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_entity_types == ("EMAIL_ADDRESS",)  # the longer span (10 > 6)
+
+
+def test_partial_overlap_not_just_full_containment_is_resolved():
+    text = "0123456789"
+    spans = [
+        DetectedSpan(entity_type="EMAIL_ADDRESS", start=0, end=6, score=0.9),
+        DetectedSpan(entity_type="PHONE_NUMBER", start=4, end=10, score=0.5),  # partial overlap
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"EMAIL_ADDRESS", "PHONE_NUMBER"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_entity_types == ("EMAIL_ADDRESS",)
+    assert "<PHONE_NUMBER_1>" not in result.masked_text
+
+
+def test_non_overlapping_spans_are_both_kept():
+    text = "bel 06-12345678 of mail jan@example.nl"
+    spans = [
+        DetectedSpan(entity_type="PHONE_NUMBER", start=4, end=15, score=0.9),
+        DetectedSpan(entity_type="EMAIL_ADDRESS", start=25, end=39, score=0.9),
+    ]
+    result = mask_text(
+        text,
+        spans,
+        enabled_entities=frozenset({"PHONE_NUMBER", "EMAIL_ADDRESS"}),
+        never_restore_entities=NEVER_RESTORE_ENTITIES,
+        instance_counters={},
+    )
+    assert result.masked_entity_types == ("PHONE_NUMBER", "EMAIL_ADDRESS")
+    restored = restore_text(
+        result.masked_text, result.restore_map, never_restore_entities=NEVER_RESTORE_ENTITIES
+    )
+    assert restored == text
+
+
+# ---------------------------------------------------------------------------
+# REQ-8 chunk-boundary safety: a placeholder split across a streamed chunk
+# ---------------------------------------------------------------------------
+def test_placeholder_split_across_chunk_boundary_restored_correctly():
+    restore_map = {"<PERSON_1>": "Jan de Vries"}
+    never_restore = NEVER_RESTORE_ENTITIES
+
+    # Chunk 1 ends mid-placeholder.
+    buffer = ""
+    safe1, buffer = split_safe_tail("Hallo <PERS", restore_map, never_restore)
+    # No complete placeholder yet -- nothing unsafe should have leaked.
+    assert "<PERS" not in safe1 or safe1 == ""  # never emit a bare partial fragment
+    assert "PERS" not in safe1
+
+    # Chunk 2 completes the placeholder.
+    safe2, buffer = split_safe_tail(buffer + "ON_1> vriendelijke groet", restore_map, never_restore)
+
+    combined_safe = safe1 + safe2
+    # The complete restored value must appear once combined + buffer flushed.
+    final = combined_safe + restore_text(buffer, restore_map, never_restore_entities=never_restore)
+    assert final == "Hallo Jan de Vries vriendelijke groet"
+    # No raw, unrestored placeholder fragment ever appears in the safe output.
+    assert "<PERS" not in combined_safe
+    assert "PERSON_1" not in combined_safe
+
+
+def test_split_safe_tail_never_emits_a_partial_placeholder_across_many_boundaries():
+    """Feed the placeholder one character at a time and assert the safe
+    output never contains a partial '<...' fragment at any point."""
+    restore_map = {"<PHONE_NUMBER_1>": "06-12345678"}
+    never_restore = NEVER_RESTORE_ENTITIES
+    full_text = "Bel op <PHONE_NUMBER_1> alstublieft."
+
+    buffer = ""
+    emitted = ""
+    for ch in full_text:
+        buffer += ch
+        safe, buffer = split_safe_tail(buffer, restore_map, never_restore)
+        emitted += safe
+        # Never emit a lone "<" without its closing ">" already resolved.
+        if "<" in emitted:
+            assert ">" in emitted[emitted.index("<") :] or emitted.count("<") == emitted.count(">")
+    # Flush whatever remains at "stream end".
+    emitted += restore_text(buffer, restore_map, never_restore_entities=never_restore)
+    assert emitted == "Bel op 06-12345678 alstublieft."
+
+
+def test_split_safe_tail_holds_back_at_least_tail_len_when_no_placeholder_present():
+    restore_map: dict[str, str] = {}
+    text = "x" * (TAIL_LEN + 5)
+    safe, remaining = split_safe_tail(text, restore_map, NEVER_RESTORE_ENTITIES)
+    assert len(remaining) >= TAIL_LEN
+    assert safe + remaining == text
+
+
+def test_split_safe_tail_holds_everything_when_buffer_shorter_than_tail_len():
+    restore_map: dict[str, str] = {}
+    text = "short"
+    safe, remaining = split_safe_tail(text, restore_map, NEVER_RESTORE_ENTITIES)
+    assert safe == ""
+    assert remaining == text
+
+
+def test_split_safe_tail_restores_complete_placeholder_immediately_even_mid_buffer():
+    restore_map = {"<PERSON_1>": "Jan de Vries"}
+    text = "<PERSON_1>" + ("y" * (TAIL_LEN + 2))
+    safe, remaining = split_safe_tail(text, restore_map, NEVER_RESTORE_ENTITIES)
+    assert "Jan de Vries" in safe
+    assert "<PERSON_1>" not in safe
+    assert "<PERSON_1>" not in remaining
+
+
+def test_secret_placeholder_split_across_boundary_still_never_restored():
+    """Never-restore placeholders also need chunk-boundary safety even
+    though they are never substituted back -- a naive implementation could
+    otherwise emit a bare '<SECRET_1' fragment."""
+    restore_map: dict[str, str] = {}  # SECRET never enters restore_map
+    never_restore = NEVER_RESTORE_ENTITIES
+
+    buffer = ""
+    safe1, buffer = split_safe_tail("Sleutel <SECR", restore_map, never_restore)
+    assert "SECR" not in safe1
+    safe2, buffer = split_safe_tail(buffer + "ET_1> hier", restore_map, never_restore)
+    combined = safe1 + safe2 + restore_text(buffer, restore_map, never_restore_entities=never_restore)
+    assert combined == "Sleutel <SECRET_1> hier"
+
+
+# ---------------------------------------------------------------------------
+# DetectedSpan validation
+# ---------------------------------------------------------------------------
+def test_detected_span_rejects_invalid_bounds():
+    import pytest
+
+    with pytest.raises(ValueError):
+        DetectedSpan(entity_type="PERSON", start=5, end=5, score=0.9)
+    with pytest.raises(ValueError):
+        DetectedSpan(entity_type="PERSON", start=-1, end=5, score=0.9)

--- a/deploy/presidio/analyzer/klai_pii_recognizers.py
+++ b/deploy/presidio/analyzer/klai_pii_recognizers.py
@@ -63,7 +63,17 @@ class NLBSNRecognizer(PatternRecognizer):
     """
 
     PATTERNS = [
-        Pattern("NL BSN (candidate)", r"(?<!\d)\d{8,9}(?!\d)", 0.3),
+        # 9 digits is the canonical BSN and stands on the elfproef alone.
+        Pattern("NL BSN (candidate, 9 digits)", r"(?<!\d)\d{9}(?!\d)", 0.3),
+        # 8 digits is the legacy form with the leading zero omitted. It is
+        # ALSO the shape of a YYYYMMDD date, an order number and a customer
+        # reference — and ~9% of them pass the padded elfproef (measured over
+        # every date 2020-2030: 365 of 4018). On the Mistral path NL_BSN is
+        # masked for every org and NEVER restored, so a false positive here
+        # silently destroys "Factuurdatum 20200201" with no way back. That is
+        # a worse outcome than missing a legacy 8-digit BSN, so this form now
+        # requires a BSN context word nearby (see analyze()).
+        Pattern("NL BSN (candidate, 8 digits, needs context)", r"(?<!\d)\d{8}(?!\d)", 0.3),
     ]
 
     def __init__(
@@ -85,6 +95,33 @@ class NLBSNRecognizer(PatternRecognizer):
     def validate_result(self, pattern_text: str) -> Optional[bool]:
         return _valid_bsn(pattern_text)
 
+    def analyze(self, text, entities, nlp_artifacts=None, regex_flags=None):
+        """Drop 8-digit matches that have no BSN context word nearby.
+
+        The elfproef alone is not enough for the 8-digit form: it is the
+        same shape as a YYYYMMDD date, and ~9% of dates pass it. Since
+        NL_BSN is masked for every org and never restored, an unqualified
+        8-digit match irreversibly destroys ordinary business text. Nine
+        digits is the canonical form and keeps standing on the checksum
+        alone, so real BSNs written in full are unaffected.
+        """
+        results = super().analyze(text, entities, nlp_artifacts, regex_flags)
+        if not results:
+            return results
+        kept = []
+        for result in results:
+            digits = text[result.start : result.end]
+            if len(digits.strip()) > 8:
+                kept.append(result)
+                continue
+            window = text[
+                max(0, result.start - _BSN_CONTEXT_WINDOW) : result.end
+                + _BSN_CONTEXT_WINDOW
+            ].lower()
+            if any(word in window for word in _BSN_CONTEXT_WORDS):
+                kept.append(result)
+        return kept
+
 
 # ---------------------------------------------------------------------------
 # NL_KVK — 8 digits + nearby context words ("kvk", "handelsregister")
@@ -96,6 +133,9 @@ class NLBSNRecognizer(PatternRecognizer):
 # recognizer does its own text-window context check in `analyze()`. That keeps it
 # self-contained and NLP-engine-independent, in the same spirit as the checksum
 # recognizers: a plain regex/text check, not a model dependency.
+
+_BSN_CONTEXT_WORDS = ("bsn", "burgerservicenummer", "sofinummer", "sofi-nummer")
+_BSN_CONTEXT_WINDOW = 40
 
 _KVK_CONTEXT_WORDS = ("kvk", "handelsregister")
 _KVK_CONTEXT_WINDOW = 40
@@ -183,7 +223,13 @@ class NLPostcodeRecognizer(PatternRecognizer):
     """Dutch postcode: 4 digits (not starting with 0) + 2 letters."""
 
     PATTERNS = [
-        Pattern("NL postcode", r"\b[1-9][0-9]{3}\s?[A-Z]{2}\b", 0.4),
+        # (?-i:...) forces case-sensitivity for the letter pair only. The
+        # registry applies IGNORECASE globally, which turned [A-Z]{2} into
+        # "any two letters" and matched "2026 en" / "1500 op" in ordinary
+        # Dutch. A real postcode is uppercase; a year followed by a
+        # two-letter word is not one, and masking it hides the year from the
+        # model even though the user gets it back.
+        Pattern("NL postcode", r"\b[1-9][0-9]{3}\s?(?-i:[A-Z]{2})\b", 0.4),
     ]
 
     def __init__(
@@ -233,7 +279,15 @@ _SECRET_PATTERNS = [
         # "~" / "+" / "/", optionally "="-padded. The original char class
         # dropped "~", "+", "/" — real base64(url) bearer tokens routinely
         # contain them and would have gone through unmasked (sol-review).
-        r"\bBearer\s+[A-Za-z0-9\-_.~+/=]{10,}",
+        # Anchored to an actual Authorization header. Unanchored, and with
+        # the registry's default IGNORECASE, this matched ordinary Dutch
+        # prose: "De bearer verantwoordelijkheid ligt bij de klant" ->
+        # SECRET 'bearer verantwoordelijkheid'. SECRET is masked for every
+        # org and NEVER restored, so that silently deleted two words of a
+        # user's sentence with no way back. Bare tokens are still covered by
+        # the JWT and provider-key patterns, so anchoring loses no real
+        # credential.
+        r"Authorization\s*:\s*Bearer\s+[A-Za-z0-9\-_.~+/=]{10,}",
         0.85,
     ),
     Pattern(

--- a/deploy/presidio/tests/test_klai_pii_recognizers.py
+++ b/deploy/presidio/tests/test_klai_pii_recognizers.py
@@ -329,3 +329,71 @@ class TestNLPhoneRecognizer:
         text = f"Bel mij op {number} alsjeblieft."
         results = rec.analyze(text, entities=["PHONE_NUMBER"], nlp_artifacts=None)
         assert results, f"{number} not detected"
+
+
+# ---------------------------------------------------------------------------
+# System-review fixes (2026-08-20) — irreversible false positives
+# ---------------------------------------------------------------------------
+class TestIrreversibleFalsePositives:
+    """NL_BSN and SECRET are masked for every org and NEVER restored, so a
+    false positive here silently destroys user text with no way back. These
+    three patterns each did exactly that before the system review."""
+
+    @pytest.mark.parametrize(
+        "date_digits", ["20200109", "20200110", "20200122", "20200201", "20200213"]
+    )
+    def test_yyyymmdd_dates_are_not_bsn_without_context(self, date_digits):
+        """~9% of YYYYMMDD dates pass the padded elfproef (365 of 4018 over
+        2020-2030). Nine digits stands on the checksum; eight needs context."""
+        from klai_pii_recognizers import NLBSNRecognizer
+
+        rec = NLBSNRecognizer()
+        text = f"Factuurdatum {date_digits} op de nota."
+        assert rec.analyze(text, entities=["NL_BSN"], nlp_artifacts=None) == []
+
+    def test_eight_digit_bsn_still_detected_with_context(self):
+        from klai_pii_recognizers import NLBSNRecognizer
+
+        rec = NLBSNRecognizer()
+        text = "Mijn bsn is 10000008 graag verwerken."
+        assert rec.analyze(text, entities=["NL_BSN"], nlp_artifacts=None)
+
+    def test_nine_digit_bsn_needs_no_context(self):
+        from klai_pii_recognizers import NLBSNRecognizer
+
+        rec = NLBSNRecognizer()
+        assert rec.analyze(
+            "Het nummer 111222333 hoort erbij.", entities=["NL_BSN"], nlp_artifacts=None
+        )
+
+    def test_bearer_in_prose_is_not_a_secret(self):
+        """Unanchored + registry IGNORECASE matched two words of Dutch prose."""
+        from klai_pii_recognizers import SecretRecognizer
+
+        rec = SecretRecognizer()
+        text = "De bearer verantwoordelijkheid ligt bij de klant."
+        assert rec.analyze(text, entities=["SECRET"], nlp_artifacts=None) == []
+
+    def test_authorization_bearer_header_still_detected(self):
+        from klai_pii_recognizers import SecretRecognizer
+
+        rec = SecretRecognizer()
+        text = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9abcdefghij"
+        assert rec.analyze(text, entities=["SECRET"], nlp_artifacts=None)
+
+    def test_year_plus_dutch_word_is_not_a_postcode(self):
+        """Registry IGNORECASE turned [A-Z]{2} into 'any two letters', so
+        '2026 en' matched. Masking it hides the year from the model."""
+        from klai_pii_recognizers import NLPostcodeRecognizer
+
+        rec = NLPostcodeRecognizer()
+        text = "In 2026 en 2027 gaan we door."
+        assert rec.analyze(text, entities=["NL_POSTCODE"], nlp_artifacts=None) == []
+
+    def test_real_postcode_still_detected(self):
+        from klai_pii_recognizers import NLPostcodeRecognizer
+
+        rec = NLPostcodeRecognizer()
+        assert rec.analyze(
+            "Zie ook 3011 AB Rotterdam.", entities=["NL_POSTCODE"], nlp_artifacts=None
+        )

--- a/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
+++ b/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-PRIVACY-MISTRAL-PII-001
-version: "0.6.0"
+version: "0.7.0"
 status: draft
 created: 2026-08-20
 updated: 2026-08-20
@@ -17,6 +17,7 @@ roadmap: docs/architecture/knowledge-rag-improvement-plan.md
 
 | Version | Date       | Author       | Change |
 |---------|------------|--------------|--------|
+| 0.7.0   | 2026-08-20 | Mark Vletter | Maintenance pass — the SPEC is a working document, not a record of what we once believed. Adds a **Status** table (per-phase state with the commit that proves it) so this doubles as the progress overview, plus a short "what this SPEC got wrong, and how it was caught" table: three of four errors were found by measuring, not reading, and two had already been written down as confident conclusions. Removed three claims that are now false: that the LiteLLM integration is configuration rather than code (REQ-5 and REQ-0a each measured otherwise), that `PHONE_NUMBER` is a stock built-in enabled via a YAML region key (the loader drops it — it is `NLPhoneRecognizer` now), and assumption A6 (struck through with the real root cause and the fixing commits). Re-validated every `file:line` anchor **semantically**, not just for range: the `MISTRAL_API_KEY` anchor had drifted from 388-389 to 421-422 as compose grew, still pointing inside the file and therefore passing a naive check while being wrong. |
 | 0.6.0   | 2026-08-20 | Mark Vletter | **Measurement gates removed; build-then-observe instead.** Klai's current traffic volume is far too low to produce a statistically meaningful 30-day, three-tenant, hand-annotated sample, so requiring one was not caution — it was a stall dressed as rigour. The workflow is: build on stated assumptions, ship, watch it in practice, correct. Every assumption that replaced a measurement is written down under "Assumptions" so it can be checked against reality rather than forgotten. Phase 3's design is also settled: REQ-0a proved the native restore path unusable for streaming, so Klai owns mask, map and restore end to end, keyed by `litellm_call_id` in process memory. Everything ships behind `KLAI_PII_ENFORCE`, default **off**, so Phase 3 can land, deploy and be exercised in production while inert — activation stays a separate, deliberate flip. |
 | 0.5.0   | 2026-08-20 | Mark Vletter | **Phase 0 ran on core-01 and answered both questions.** REQ-0a is negative for streaming: `output_parse_pii` restores correctly non-streaming but returns an empty token map on the streaming path — the second failure shape in litellm#6247, still live on v1.96.2, and NOT the Anthropic-native bug 0.2.0 dismissed from reading. Both Klai chat paths stream, so REQ-8's restore moves to our own post-call hooks. REQ-0b: the verbatim-token instruction takes `PHONE_NUMBER` survival from 58.3% to 95.8%, so it is mandatory rather than advisory. Two gaps the run exposed: six of thirty Dutch phone numbers were never detected despite `supported_regions: [NL]` (a detection gap, separate from survival), and `PERSON` is **unmeasurable** today because REQ-2 disables SpacyRecognizer and GLiNER is not deployed — so REQ-0b's PERSON half must be re-run after REQ-9, and PERSON must not be enabled before that. |
 | 0.4.1   | 2026-08-20 | Mark Vletter | REQ-6 tightened after the Phase 2 delta review. The language label is now derived from the latest user turn rather than the whole payload — the KB context block is English-structured by design and dwarfs the question, so detecting on combined text would have labelled a Dutch question `en` on essentially every RAG request and quietly invalidated REQ-2's per-language comparison. Records the honest limitation that the observer uses a stopword heuristic rather than the canonical lingua detector, because `lingua-language-detector` is not in the stock litellm image, with the escalation path if Phase 2 data proves too noisy. |
@@ -32,7 +33,7 @@ roadmap: docs/architecture/knowledge-rag-improvement-plan.md
 ## Summary
 
 Every LLM call in the platform leaves through one container: `MISTRAL_API_KEY` is declared
-once, in the `litellm` service block (`deploy/docker-compose.yml:388-389`). No service holds
+once, in the `litellm` service block (`deploy/docker-compose.yml:421-422`). No service holds
 a provider key of its own and no code calls `api.mistral.ai` directly.
 
 This SPEC puts PII removal on that boundary using Presidio, deployed as two self-hosted
@@ -47,6 +48,43 @@ so drafting an email still works while Mistral never receives the real values.
 
 Nothing here touches PII at rest, and nothing here depends on that work.
 
+## Status — 2026-08-20
+
+**Maintenance rule.** Update this document whenever a phase lands, a measurement lands, or a
+claim in it turns out to be false — and *delete* what is no longer true rather than layering
+a correction on top. A SPEC that records what we used to believe is worse than no SPEC,
+because it is read as current. Re-check `file:line` anchors semantically when you touch it: a
+line number can stay inside the file and still point at the wrong thing, which is how the
+`MISTRAL_API_KEY` anchor silently drifted by 33 lines.
+
+Kept current as each phase lands. If this table disagrees with the requirement text below,
+the table is right and the text is stale — say so rather than working around it.
+
+| Phase | State | Evidence |
+|---|---|---|
+| **0** — prove the restore path | **Done, answered** | Ran on core-01. `output_parse_pii` restores non-streaming, returns an **empty map on streaming**. Verbatim-token instruction takes `PHONE_NUMBER` survival 58.3% → 95.8%. See the RESULT block under Phase 0 |
+| **1** — recognizer pack | **Live** | `d55d6adeb`, `d2aa35fd2`. Nine recognizers loaded across en/nl/de, spaCy disabled per language, verified in production logs. Rotterdam fix `4af66f4e0` + `b5b592051`, verified live |
+| **2** — read-only observer | **Live, measuring** | `c6dd946e4`. Real `pii_observed` events in VictoriaLogs, including `org_id=None` requests the existing hook skips. Changes no payload |
+| **3** — mask + restore | **In build, inert** | Behind `KLAI_PII_ENFORCE`, default off. Klai owns mask/map/restore because Phase 0 measured the native path unusable for streaming |
+| **4** — `PERSON` via GLiNER | **Blocked, deliberately** | No PERSON detector is deployed at all (REQ-2 disables SpacyRecognizer). REQ-0b's PERSON half is unmeasurable until GLiNER lands |
+
+**Nothing is being masked today.** The guardrail has no `default_on` and enforcement is off,
+so production payloads reach Mistral unchanged. Phases 1 and 2 detect and count; they do not
+alter.
+
+### What this SPEC got wrong, and how it was caught
+
+Recorded because the pattern matters more than the individual errors: **three of the four
+were caught by measuring, not by reading**, and two of them had already been written down as
+confident conclusions.
+
+| Claim | Reality | Caught by |
+|---|---|---|
+| `presidio_language: "nl"` is the right approach (0.2.0) | Wrong for a language-agnostic product; detection is jurisdiction-specific and needs no language at all | Review of the product's own multilingual contract |
+| Streaming restore is fine on our path (0.2.0) | Empty token map on streaming, still live on v1.96.2 | The Phase 0 run |
+| `logging_only` is a shadow-measurement mode (0.4.0) | It masks observability and sends the payload **unmasked** to the provider | Reading the docs before building |
+| Six undetected phone numbers are a format gap (A6) | The YAML region key was silently ignored; Dutch detection worked by accident | Introspecting the running container |
+
 ## Motivation
 
 ### Are the previously chosen tools still the right ones?
@@ -58,7 +96,7 @@ note was written now does most of the work for us.
 
 | Tool | Verdict | Evidence |
 |---|---|---|
-| **Presidio** | **Adopt** as the framework | MIT. Moved from Microsoft to the independent Data Privacy Stack org in 2026, actively maintained; images now `ghcr.io/data-privacy-stack/presidio-*`, the old `mcr.microsoft.com` tags are frozen. Decisive for us: LiteLLM ships a **native** Presidio guardrail, so the integration is configuration rather than code |
+| **Presidio** | **Adopt** as the framework | MIT. Moved from Microsoft to the independent Data Privacy Stack org in 2026, actively maintained; images now `ghcr.io/data-privacy-stack/presidio-*`, the old `mcr.microsoft.com` tags are frozen. LiteLLM ships a native Presidio guardrail, but **the integration turned out to be code, not configuration** — its `logging_only` mode is inverted for measurement (REQ-5) and its restore path returns an empty token map on streaming (REQ-0a). Presidio itself is still the right framework; the LiteLLM glue is ours |
 | **Presidio's default detection** | **Do not rely on it** | REDACT (25 languages, [arXiv:2606.19881](https://arxiv.org/abs/2606.19881), 18 Jun 2026) measures the rule-based detector at F1 0.195 overall and **recall 0.07 on the highest-sensitivity categories**. The framework is good; the stock recognizers are not a control |
 | **Dutch coverage** | **Must be built** | Presidio's `default_recognizers.yaml` ships 73 recognizers with country packs for DE, ES, IT, PL, FI, SE, UK, US, AU, IN, ZA, KR, TH, TR, CA, NG, PH — **and nothing for the Netherlands**. `nl` is not in `supported_languages`. There is no BSN, KvK or BTW recognizer to enable. A June 2026 release added a German pack and a Philippine TIN; still no Dutch |
 | **GLiNER `gliner_multi_pii-v1`** | **Adopt for names, gated** | License verified directly on the model card: **apache-2.0** — commercially usable. REDACT F1 0.320, better than Presidio's default but with a documented high-recall/low-precision profile. Presidio supports it as a pluggable NER engine |
@@ -68,7 +106,10 @@ note was written now does most of the work for us.
 
 So: **Presidio as the framework, a Klai-supplied Dutch recognizer pack as the substance,
 GLiNER behind a gate for names.** The 2026 delta versus the original note is that the
-integration is now configuration, and that the Dutch gap is explicit rather than assumed.
+Dutch gap is explicit rather than assumed. The other 2026 delta — that LiteLLM's native
+guardrail would make this pure configuration — **did not survive contact**: REQ-5 and REQ-0a
+each measured it doing something other than what its documentation implies, so Klai owns the
+observer, the mask, the map and the restore.
 
 ### Pseudonymisation or anonymisation?
 
@@ -87,7 +128,7 @@ is specific to the **Anthropic native** path — where response chunks arrive as
 rather than `ModelResponseStream` objects, so the unmasking iterator never fires — and it is
 **closed**, fixed by PR #30028. The OpenAI-compatible path was never affected. Klai routes
 `mistral/mistral-small-2603` (`deploy/litellm/config.yaml:5-8`) over that path on LiteLLM
-`v1.96.2` (`deploy/docker-compose.yml:304`).
+`v1.96.2` (`deploy/docker-compose.yml:309`).
 
 What remains genuinely uncertain is the older
 [#6247](https://github.com/BerriAI/litellm/issues/6247): corrupted token maps
@@ -340,7 +381,8 @@ indistinguishable from a successful restore. This exception ends with Phase 1.
 | `NL_POSTCODE` | `1234 AB` shape | `shield_compliance.py:38` |
 | `IBAN_CODE` | mod-97 | **built-in**, enable rather than write |
 | `CREDIT_CARD` | Luhn | **built-in**, enable rather than write |
-| `EMAIL_ADDRESS`, `PHONE_NUMBER` | built-in; phone with region `NL` | **built-in**, enable rather than write |
+| `EMAIL_ADDRESS` | shape | **built-in**, enable rather than write |
+| `PHONE_NUMBER` | libphonenumber, regions NL + BE prepended to the stock list | `NLPhoneRecognizer` — a subclass, **not** a YAML `supported_regions:` key, which the registry loader silently drops (see ~~A6~~) |
 
 **THE checksum-validated recognizers SHALL** be Python `PatternRecognizer` subclasses
 overriding `validate_result()`, not YAML entries. Presidio's YAML registry can express a
@@ -443,7 +485,7 @@ each with what would falsify it.
 | A3 | `PERSON` behaves worse than the other entities and needs its own evidence | Names are inflected in Dutch, the others are not | A GLiNER-era re-run showing `PERSON` ≥95% |
 | A4 | An in-process map keyed by `litellm_call_id` is sufficient isolation | The id is a per-request UUID generated by LiteLLM | A collision, or a restore writing one request's value into another's output. AC-0e-style concurrency test guards it |
 | A5 | Enforcement adds under 60 ms p95 | Regex plus checksums, no model, one in-cluster hop | The NFR's own measurement once enabled |
-| A6 | The six undetected Dutch phone numbers in the Phase 0 run are a format-coverage gap, not a systemic recogniser failure | `supported_regions: [NL]` is set and 24 of 30 were detected | Investigation showing the recogniser mis-handles a common Dutch format |
+| ~~A6~~ | ~~The six undetected Dutch phone numbers are a format-coverage gap~~ | — | **FALSIFIED and fixed, 2026-08-20.** Introspecting the running analyzer showed `PhoneRecognizer lang=nl regions=('US','UK','DE',…)`: the YAML `supported_regions:` key is silently dropped on a `type: predefined` entry, so Dutch detection ran on Presidio's defaults and worked only because most Dutch numbers also parse as valid German ones. Rotterdam's `010` has no German equivalent and was never detected. Fixed by `NLPhoneRecognizer` (`4af66f4e0`), digest pinned (`b5b592051`), verified live |
 
 An assumption that turns out wrong here costs one flag flip, not a redesign — which is the
 point of shipping it off by default.
@@ -708,7 +750,7 @@ Rules for the implementer:
 
 Source references:
 
-- `deploy/docker-compose.yml:303,388-389` — litellm service block, sole provider key
+- `deploy/docker-compose.yml:308,421-422` — litellm service block, sole provider key
 - `deploy/litellm/config.yaml:5-80,91-95,126-128` — Mistral model list, self-hosted embedder, callbacks
 - `deploy/litellm/klai_knowledge.py:423-427,481-483` — hook entry and the two early returns
 - `deploy/litellm/klai_kb_query_rewrite.py` — sets `_klai_openai_passthrough`

--- a/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
+++ b/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-PRIVACY-MISTRAL-PII-001
-version: "0.7.0"
+version: "0.8.0"
 status: draft
 created: 2026-08-20
 updated: 2026-08-20
@@ -17,6 +17,7 @@ roadmap: docs/architecture/knowledge-rag-improvement-plan.md
 
 | Version | Date       | Author       | Change |
 |---------|------------|--------------|--------|
+| 0.8.0   | 2026-08-20 | Mark Vletter | **System review of the merged stack** — the first review of the pieces together rather than each PR alone, and it found what per-diff review structurally cannot. REQ-8's overlap rule was wrong: it said "drop any span *contained* in one already taken", derived from the single IBAN⊃PHONE example, but the recogniser set produces pairs where the higher-scoring span sits INSIDE the lower-scoring one (`NL_BSN` 1.00 inside `NL_BTW` 0.70; a JWT span inside a Bearer span). A containment-only rule accepts both and corrupts the text. Now: drop any **overlap**, and never-restore entities win exact ties, because `NL_BSN` and `NL_KVK` can produce a byte-identical span with an identical score and a tie must not decide whether a value becomes restorable. The Phase 3 implementation already dropped overlaps — the defect was in this document, not the code. Three irreversible-false-positive fixes shipped alongside: 8-digit BSN now needs context (9.1% of `YYYYMMDD` dates passed the elfproef and were destroyed unrestorably), the `Bearer` pattern is anchored to an `Authorization:` header (it matched two words of ordinary Dutch prose), and the postcode letter pair is case-sensitive again (registry `IGNORECASE` made `2026 en` a postcode). A1 marked partly falsified. |
 | 0.7.0   | 2026-08-20 | Mark Vletter | Maintenance pass — the SPEC is a working document, not a record of what we once believed. Adds a **Status** table (per-phase state with the commit that proves it) so this doubles as the progress overview, plus a short "what this SPEC got wrong, and how it was caught" table: three of four errors were found by measuring, not reading, and two had already been written down as confident conclusions. Removed three claims that are now false: that the LiteLLM integration is configuration rather than code (REQ-5 and REQ-0a each measured otherwise), that `PHONE_NUMBER` is a stock built-in enabled via a YAML region key (the loader drops it — it is `NLPhoneRecognizer` now), and assumption A6 (struck through with the real root cause and the fixing commits). Re-validated every `file:line` anchor **semantically**, not just for range: the `MISTRAL_API_KEY` anchor had drifted from 388-389 to 421-422 as compose grew, still pointing inside the file and therefore passing a naive check while being wrong. |
 | 0.6.0   | 2026-08-20 | Mark Vletter | **Measurement gates removed; build-then-observe instead.** Klai's current traffic volume is far too low to produce a statistically meaningful 30-day, three-tenant, hand-annotated sample, so requiring one was not caution — it was a stall dressed as rigour. The workflow is: build on stated assumptions, ship, watch it in practice, correct. Every assumption that replaced a measurement is written down under "Assumptions" so it can be checked against reality rather than forgotten. Phase 3's design is also settled: REQ-0a proved the native restore path unusable for streaming, so Klai owns mask, map and restore end to end, keyed by `litellm_call_id` in process memory. Everything ships behind `KLAI_PII_ENFORCE`, default **off**, so Phase 3 can land, deploy and be exercised in production while inert — activation stays a separate, deliberate flip. |
 | 0.5.0   | 2026-08-20 | Mark Vletter | **Phase 0 ran on core-01 and answered both questions.** REQ-0a is negative for streaming: `output_parse_pii` restores correctly non-streaming but returns an empty token map on the streaming path — the second failure shape in litellm#6247, still live on v1.96.2, and NOT the Anthropic-native bug 0.2.0 dismissed from reading. Both Klai chat paths stream, so REQ-8's restore moves to our own post-call hooks. REQ-0b: the verbatim-token instruction takes `PHONE_NUMBER` survival from 58.3% to 95.8%, so it is mandatory rather than advisory. Two gaps the run exposed: six of thirty Dutch phone numbers were never detected despite `supported_regions: [NL]` (a detection gap, separate from survival), and `PERSON` is **unmeasurable** today because REQ-2 disables SpacyRecognizer and GLiNER is not deployed — so REQ-0b's PERSON half must be re-run after REQ-9, and PERSON must not be enabled before that. |
@@ -480,7 +481,7 @@ each with what would falsify it.
 
 | # | Assumption | Basis | What falsifies it |
 |---|---|---|---|
-| A1 | The elfproef reduces false BSN matches to roughly 1 in 11 of nine-digit runs | Arithmetic property of the checksum, not a measurement on our corpus | A tenant reporting order numbers being masked. Phase 2 counts show the rate |
+| A1 | The elfproef reduces false BSN matches to roughly 1 in 11 of **nine**-digit runs | Arithmetic property of the checksum | **Partly falsified 2026-08-20.** The recogniser also accepted **eight**-digit runs, which is the shape of a `YYYYMMDD` date: 365 of 4018 dates in 2020-2030 (9.1%) pass the padded elfproef. Since `NL_BSN` is masked for every org and never restored, `Factuurdatum 20200201` was destroyed with no way back. Nine digits now stands on the checksum alone; eight requires a BSN context word |
 | A2 | Typed, numbered placeholders survive the model well enough to be useful, given the verbatim instruction | Measured for `PHONE_NUMBER` (95.8%), assumed to generalise to `IBAN`, `EMAIL`, `KVK`, `BTW`, `POSTCODE` — all shorter and more literal than a phone number | Any of those entities showing survival below 95% once enabled |
 | A3 | `PERSON` behaves worse than the other entities and needs its own evidence | Names are inflected in Dutch, the others are not | A GLiNER-era re-run showing `PERSON` ≥95% |
 | A4 | An in-process map keyed by `litellm_call_id` is sufficient isolation | The id is a per-request UUID generated by LiteLLM | A collision, or a restore writing one request's value into another's output. AC-0e-style concurrency test guards it |
@@ -553,8 +554,21 @@ PHONE_NUMBER [25:37] score=0.40   <- fully inside the IBAN span
 Substituting naively corrupts the text: replace the IBAN first and the phone offsets are
 stale; replace the phone first and the IBAN no longer matches its own span. **THE
 implementation SHALL** substitute from the **end of the string backwards** so earlier offsets
-stay valid, and **SHALL** drop any span contained in a span already taken, preferring the
-higher score and, on a tie, the longer span. This overlap predates the Phase 1 deployment —
+stay valid, and **SHALL** drop any span that **overlaps** one already taken — not merely one
+*contained* in it. Containment alone is not sufficient, and the earlier wording of this
+requirement was wrong: the deployed recogniser set produces pairs where the higher-scoring
+span sits INSIDE the lower-scoring one, so a containment-only rule accepts both.
+
+```
+Ons BTW-nummer is NL123456782B01.
+NL_BSN [20:29] score 1.00   <- higher score, inside
+NL_BTW [18:32] score 0.70
+```
+
+Selection order is: higher score, then longer span, then **never-restore entity wins** — an
+8-digit KvK that also passes the padded elfproef produces `NL_BSN` and `NL_KVK` at a
+byte-identical span with an identical score, and a tie must not decide whether a value lands
+in the restore map. This overlap predates the Phase 1 deployment —
 it is a property of running several recognisers over one text, not a regression — and it
 needs a regression test using exactly the IBAN case above.
 


### PR DESCRIPTION
Phase 3 of `SPEC-PRIVACY-MISTRAL-PII-001`. Masks PII on the way out to Mistral and restores the return set on the way back — **behind `KLAI_PII_ENFORCE`, default OFF**. This reaches production inert; activation is a flag flip, not a deploy.

Klai owns mask, map and restore rather than using `output_parse_pii`, because REQ-0a **measured** that path returning an empty token map on streaming — which is every Klai chat request.

## Structural, not configurational

- A never-restore entity's placeholder is **never written into the restore map** (`klai_pii_text_masking.py:143-144`). `SECRET` and `NL_BSN` cannot be restored by any configuration, because the value is not there to restore.
- `effective_enabled_entities()` intersects org policy against `RETURN_SET_ENTITIES`, and `PERSON` is not a member. A policy containing `"PERSON": true` — operator typo, future portal-api bug — still cannot enable it. There is no PERSON detector deployed today and REQ-9 forbids it until a GLiNER-era survival re-run exists.

## Overlapping spans

Presidio returns `IBAN_CODE [15:37]` and `PHONE_NUMBER [25:37]` on the same IBAN. Greedy interval selection keeps the higher score; substitution runs back-to-front so earlier offsets stay valid. The regression test uses that exact string.

## The restore map

Process-local, keyed by `litellm_call_id`, deleted on **both** the success and error paths, swept on TTL for clients that disconnect mid-stream, size-bounded with oldest-first eviction. It holds real values, so an unbounded or leaking map is a privacy problem and not just a memory one.

Registered **last** in `callbacks:` — LiteLLM chains the streaming iterator hooks and each wraps the previous, so last registered is outermost and its output is what the user sees.

## Tests — 817 passed (was 745)

- Flag off: byte-identical passthrough on all four hooks, no analyzer call, no map entry
- BSN and SECRET masked, never restored
- Return set restored only when the org enables it
- Placeholder split across a chunk boundary (`<PERS` + `ON_1>`)
- **Two concurrent requests from different orgs do not cross-contaminate** — streaming and non-streaming
- Analyzer error with flag on → request fails (REQ-10); flag off → nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)