### PR TITLE
chore(privacy): pin the analyzer image carrying the system-review fixes

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -494,7 +494,7 @@ services:
     # built FROM the same ghcr.io/data-privacy-stack digest Phase 0 pinned.
     # This is where REQ-3's Dutch recognizers (BSN/KvK/BTW/postcode) and
     # REQ-4's SECRET recognizer actually enter the request path.
-    image: ghcr.io/getklai/presidio-analyzer@sha256:4a213d91feaf4febfa402b6fea1e8094afd37b325a96ecf7faf393e9c8a347a7
+    image: ghcr.io/getklai/presidio-analyzer@sha256:47151487c449f8762a3d9760279514f9bbfc3b312d2d731c12761465bd27e003
     restart: unless-stopped
     networks:
       - inference


### PR DESCRIPTION
Follow-up to `adde54046`. The image-build workflow published the analyzer containing the four system-review fixes; compose still pointed at the previous digest, so they are on main but **not running** — the compose digest is what actually executes.

Without this: 8-digit BSN keeps matching `YYYYMMDD` dates, the `Bearer` pattern keeps matching Dutch prose, and the postcode keeps eating "2026 en". All three are irreversible once enforcement is on.

Enforcement is still off (`KLAI_PII_ENFORCE` default `false`), so today this only changes what the Phase 2 observer counts.

```
check-klai-presidio-digest.sh    → OK
test_deployment_constraints.py   → 6 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)