### PR TITLE
feat(privacy): close the activation gaps — bounded analyzer, per-org scoping, policy endpoint

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -460,6 +460,15 @@ services:
       # Flipping this to "true" is the entire activation decision; it is
       # NOT part of this PR's scope to turn on.
       KLAI_PII_ENFORCE: ${KLAI_PII_ENFORCE:-false}
+      # Activation hardening (see klai_pii_enforce.py's `_org_is_enforced`):
+      # comma-separated org_id allowlist. KLAI_PII_ENFORCE alone applies to
+      # every tenant identically the moment it flips; this lets the FIRST
+      # activation be exactly one org. Empty/unset means enforce for NO org
+      # even if KLAI_PII_ENFORCE is "true" — the safe reading, not "every
+      # org" — so turning enforcement on for anyone is a deliberate
+      # two-variable action, never a single flag flip. NOT part of this
+      # PR's scope to populate.
+      KLAI_PII_ENFORCE_ORG_IDS: ${KLAI_PII_ENFORCE_ORG_IDS:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/litellm/klai_pii_enforce.py
+++ b/deploy/litellm/klai_pii_enforce.py
@@ -8,6 +8,14 @@ so this module changes nothing about production traffic until the flag is
 deliberately flipped. That is a requirement with its own test class in
 ``tests/test_pii_enforce.py``, not an incidental property.
 
+Activation hardening, added after Phase 3 shipped inert: ``KLAI_PII_ENFORCE``
+alone applies to every org identically the moment it flips, and this stack
+has never run end to end against a real Mistral stream. ``async_pre_call_hook``
+now also checks ``KLAI_PII_ENFORCE_ORG_IDS`` (see ``_org_is_enforced``) so the
+first activation can be scoped to one org rather than the whole tenant base.
+Both variables must be set for enforcement to do anything for any request —
+an empty or unset allowlist is "enforce nobody", not "enforce everybody".
+
 Why Klai owns mask/map/restore instead of ``output_parse_pii`` (REQ-0a):
 Phase 0 measured the native LiteLLM Presidio guardrail returning an EMPTY
 token map on the streaming path (the second failure shape in
@@ -67,6 +75,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -90,6 +99,72 @@ def _truthy_env(name: str, default: str = "false") -> bool:
 # tests reload the module after monkeypatching the env var.
 KLAI_PII_ENFORCE = _truthy_env("KLAI_PII_ENFORCE", "false")
 
+
+def _parse_org_allowlist(value: str) -> frozenset[str]:
+    return frozenset(v.strip() for v in value.split(",") if v.strip())
+
+
+# ---------------------------------------------------------------------------
+# Activation hardening — per-org enforcement scoping
+# ---------------------------------------------------------------------------
+# KLAI_PII_ENFORCE alone is read once at import time and applies identically
+# to every tenant behind one process-wide boolean: the first activation
+# would hit every customer at once, and this stack has never run end to end
+# against a real Mistral stream (all 820 tests mock the analyzer and the
+# stream). KLAI_PII_ENFORCE_ORG_IDS is a comma-separated allowlist of
+# org_ids that enforcement actually applies to, so the first activation can
+# be exactly one org while the rest of the tenant base is provably
+# untouched -- wired into deploy/docker-compose.yml next to
+# KLAI_PII_ENFORCE.
+KLAI_PII_ENFORCE_ORG_IDS = _parse_org_allowlist(os.getenv("KLAI_PII_ENFORCE_ORG_IDS", ""))
+
+
+def _org_is_enforced(org_id: Any) -> bool:
+    """Whether masking/restore should run at all for THIS request's org.
+
+    Two deliberate decisions, each argued rather than assumed:
+
+    1. EMPTY allowlist + KLAI_PII_ENFORCE=true means enforcement for NO
+       org -- not "every org", which would be the reading that reproduces
+       exactly the all-or-nothing activation this mechanism exists to
+       remove. "All orgs" is the dangerous reading: a bare
+       `KLAI_PII_ENFORCE=true` with `KLAI_PII_ENFORCE_ORG_IDS` merely
+       unset (easy to do by accident -- a new env var nobody set yet, not
+       a deliberate empty override) would silently enforce for every
+       tenant with no pilot phase at all, which is precisely the failure
+       mode named in the SPEC's own Risks table ("Fail-closed turns a
+       Presidio outage into a chat outage" -- the activation-blast-radius
+       twin of that risk). "No orgs" instead fails toward inert, which is
+       the direction every other default in this stack already fails:
+       KLAI_PII_ENFORCE itself defaults off, REQ-7's optional per-entity
+       policy defaults off per org, and REQ-10 only fails closed once the
+       control is already known to be active. Turning enforcement on for
+       the first org is therefore a deliberate TWO-variable action --
+       flip KLAI_PII_ENFORCE AND name that org -- never a one-flag flip
+       that silently waits on a second variable nobody remembered.
+    2. A request with NO org_id (the widget/partner master-key path --
+       `klai_knowledge.py:481-483` skips it for the identical reason) is
+       NEVER enforced, regardless of the flag or the allowlist's
+       contents. The allowlist matches org IDENTITIES; a request that
+       carries none has nothing to match, and treating "no identity" as
+       "matches everything" would be the same all-or-nothing mistake as
+       (1) applied to a path this module cannot attribute to a specific
+       tenant for audit in the first place. This mirrors
+       `klai_pii_org_policy.py`'s own fail-closed-to-`EMPTY_POLICY`
+       handling of a missing org_id: masking fails closed here the same
+       way per-entity policy resolution already does. Concretely, this
+       means REQ-7's "SECRET and NL_BSN are MASK for every org,
+       unconditionally" is scoped BY this allowlist during a rollout, the
+       same as every other entity -- there is no path left that masks
+       unconditionally across the whole tenant base while the allowlist
+       is not yet "every org", which is what makes the rollout actually
+       gradual rather than gradual-except-for-credentials-and-BSN.
+    """
+    if not org_id:
+        return False
+    return org_id in KLAI_PII_ENFORCE_ORG_IDS
+
+
 # Same internal service name the Phase 0/1/2 code already uses.
 PRESIDIO_ANALYZER_API_BASE = os.getenv(
     "PRESIDIO_ANALYZER_API_BASE", "http://presidio-analyzer:3000"
@@ -104,6 +179,73 @@ _HTTPX_CLIENT_TIMEOUT_SECONDS = float(os.getenv("KLAI_PII_HTTPX_TIMEOUT_SECONDS"
 # entity, and PERSON is never in `enabled_entities`; see
 # klai_pii_entities.py). "en" mirrors the Phase 0/2 default.
 _ANALYZER_LANGUAGE = os.getenv("KLAI_PII_ANALYZER_LANGUAGE", "en")
+
+# ---------------------------------------------------------------------------
+# Length cap on analysed text — system-review finding M4
+# ---------------------------------------------------------------------------
+# presidio-analyzer runs with `cpus: '1'` (docker-compose.yml), shared by
+# every tenant. Before this, no code anywhere capped how much text a single
+# `/analyze` call could carry: the PEM pattern's own quadratic-on-unmatched-
+# markers cost (fixed separately in klai_pii_recognizers.py, bounding the
+# body to 5000 chars) was one way a single oversized paste could peg that
+# shared core; a length cap is defense in depth against that class of
+# problem for every recognizer, not just the one that was measured, and
+# bounds each individual HTTP call's cost regardless.
+#
+# 20,000 chars: double the NFR's own reference payload size ("p95 under 60ms
+# added per request for a 10,000-character payload", this SPEC's Non-
+# Functional Requirements section) — generous headroom above the size the
+# latency budget is defined against, while still keeping a single `/analyze`
+# call's regex-and-checksum work bounded and cheap.
+#
+# Unlike klai_pii_observe.py (Phase 2, read-only, fail-open — truncating the
+# measured text only under-counts a telemetry signal), this module masks
+# what actually reaches Mistral. REQ-10's fail-closed contract means
+# ANALYSING less than the full outbound text and then forwarding the
+# unanalysed remainder unmasked is not an option — that is unminimised
+# content reaching the provider, exactly what REQ-10 forbids. So text longer
+# than the cap is NOT truncated: it is split into overlapping windows
+# (`_chunk_windows`), every window is analysed, and each detected span is
+# attributed to exactly the one window whose "core" region contains its
+# start offset — see `_analyze_spans_chunked` for the algorithm. 100% of the
+# outbound text is always analysed; the cap only bounds how much of it goes
+# into any single `/analyze` HTTP call.
+#
+# Klai supports genuinely large single-message payloads by design — chat
+# attachments extract up to `KLAI_CHAT_PDF_MAX_EXTRACTED_TOKENS` (120,000
+# tokens, docker-compose.yml) of PDF text directly into a message's content.
+# Refusing any request whose text exceeds this cap (the other REQ-10-
+# compatible option) would make PII enforcement incompatible with that
+# already-shipped capability the moment an org opts in — a worse regression
+# than the extra HTTP round trips chunking costs.
+_MAX_ANALYZE_CHARS = 20_000
+
+# Overlap between adjacent analysed windows must exceed the longest entity
+# this pack can ever match, or an entity straddling a window boundary could
+# be truncated in both windows and detected in neither. The longest bounded
+# entity is the PEM private-key block: `_PEM_MAX_BODY_CHARS` (5000, see
+# klai_pii_recognizers.py) plus ~40 chars of BEGIN/END marker text. 6000
+# gives comfortable margin above that ~5040 ceiling.
+#
+# Residual, explicitly not covered: the SECRET patterns for JWTs, Bearer
+# tokens and provider-key prefixes use open-ended quantifiers
+# (`{10,}`/`{16,}`) with no upper bound, so a single credential-shaped value
+# longer than this overlap could in principle straddle a boundary
+# undetected. A real-world JWT/Bearer/API key of that length (>6000 chars in
+# one token) is not a realistic shape Klai has ever observed; this is a
+# known, documented bound rather than a claim of zero risk.
+_CHUNK_OVERLAP_CHARS = 6_000
+
+# Bounds TOTAL concurrent /analyze HTTP calls in flight for one request,
+# across both `_mask_messages`'s per-text-unit gather AND
+# `_analyze_spans_chunked`'s per-window gather. Without this, one huge
+# multi-message payload (several large tool-call arguments, each itself
+# chunked into a dozen+ windows) can fan out into dozens of concurrent calls
+# against the single-core analyzer — the same shared-resource risk the
+# length cap exists to bound, just reached via concurrency instead of one
+# oversized call.
+_MAX_CONCURRENT_ANALYZER_CALLS = 8
+_analyzer_call_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_ANALYZER_CALLS)
 
 _pii_map_store = PiiMapStore()
 
@@ -175,12 +317,23 @@ def _iter_text_units(messages: list[Any]):
                 yield arguments, _set_arguments
 
 
-async def _analyze_spans(http: httpx.AsyncClient, text: str, language: str) -> list[DetectedSpan]:
+async def _analyze_spans_single(
+    http: httpx.AsyncClient, text: str, language: str
+) -> list[DetectedSpan]:
+    """One `/analyze` HTTP call over `text` as-is, no chunking.
+
+    Callers are responsible for keeping `text` at or under
+    `_MAX_ANALYZE_CHARS` — this function does not check. Bounded by
+    `_analyzer_call_semaphore` so a single request's fan-out (multiple text
+    units, each possibly chunked) cannot flood the single-core analyzer with
+    unbounded concurrent calls.
+    """
     url = PRESIDIO_ANALYZER_API_BASE.rstrip("/") + "/analyze"
-    response = await asyncio.wait_for(
-        http.post(url, json={"text": text, "language": language}),
-        timeout=_ANALYZER_CALL_TIMEOUT_SECONDS,
-    )
+    async with _analyzer_call_semaphore:
+        response = await asyncio.wait_for(
+            http.post(url, json={"text": text, "language": language}),
+            timeout=_ANALYZER_CALL_TIMEOUT_SECONDS,
+        )
     response.raise_for_status()
     results = response.json()
     if not isinstance(results, list):
@@ -207,6 +360,92 @@ async def _analyze_spans(http: httpx.AsyncClient, text: str, language: str) -> l
             )
         )
     return spans
+
+
+@dataclass(frozen=True)
+class _ChunkWindow:
+    """One analysed window over a longer text.
+
+    `core_start`/`core_end` partition the FULL text exactly, with no gap and
+    no overlap between windows — every absolute offset belongs to exactly
+    one window's core. `window_start`/`window_end` is the (padded, may
+    overlap neighbours) slice actually sent to `/analyze`: padding by
+    `_CHUNK_OVERLAP_CHARS` on each side guarantees that any entity whose
+    span STARTS inside this window's core is fully contained in the
+    analysed window, even if the entity's end reaches past the core
+    boundary — so it is both detected in this window and unambiguously
+    owned by it (see `_analyze_spans_chunked`).
+    """
+
+    core_start: int
+    core_end: int
+    window_start: int
+    window_end: int
+
+
+def _chunk_windows(text_len: int) -> list[_ChunkWindow]:
+    if text_len <= _MAX_ANALYZE_CHARS:
+        return [_ChunkWindow(0, text_len, 0, text_len)]
+    windows: list[_ChunkWindow] = []
+    core_start = 0
+    while core_start < text_len:
+        core_end = min(text_len, core_start + _MAX_ANALYZE_CHARS)
+        window_start = max(0, core_start - _CHUNK_OVERLAP_CHARS)
+        window_end = min(text_len, core_end + _CHUNK_OVERLAP_CHARS)
+        windows.append(_ChunkWindow(core_start, core_end, window_start, window_end))
+        core_start = core_end
+    return windows
+
+
+async def _analyze_spans_chunked(
+    http: httpx.AsyncClient, text: str, language: str
+) -> list[DetectedSpan]:
+    """Analyse text longer than `_MAX_ANALYZE_CHARS` with full coverage.
+
+    REQ-10's fail-closed contract forbids analysing less than the whole
+    outbound text and forwarding the rest unmasked — see the module-level
+    comment above `_MAX_ANALYZE_CHARS`. Every character of `text` is
+    covered by exactly one window's CORE region (`_chunk_windows`), and
+    each window is padded by `_CHUNK_OVERLAP_CHARS` so an entity starting
+    in that core is never truncated at the analysed-window edge. A span is
+    kept only if its absolute start falls inside the window that owns it —
+    this is what prevents the same entity from being counted twice out of
+    two overlapping windows.
+    """
+    windows = _chunk_windows(len(text))
+    per_window_spans = await asyncio.gather(
+        *(
+            _analyze_spans_single(http, text[w.window_start : w.window_end], language)
+            for w in windows
+        )
+    )
+
+    spans: list[DetectedSpan] = []
+    for window, window_spans in zip(windows, per_window_spans):
+        for span in window_spans:
+            abs_start = span.start + window.window_start
+            abs_end = span.end + window.window_start
+            if window.core_start <= abs_start < window.core_end:
+                spans.append(
+                    DetectedSpan(
+                        entity_type=span.entity_type,
+                        start=abs_start,
+                        end=abs_end,
+                        score=span.score,
+                    )
+                )
+    return spans
+
+
+async def _analyze_spans(http: httpx.AsyncClient, text: str, language: str) -> list[DetectedSpan]:
+    """Dispatch to a single `/analyze` call, or to chunked analysis above
+    `_MAX_ANALYZE_CHARS`. See the module-level comment above
+    `_MAX_ANALYZE_CHARS` for why chunking, not truncation, is the enforce-
+    path answer to an oversized payload.
+    """
+    if len(text) <= _MAX_ANALYZE_CHARS:
+        return await _analyze_spans_single(http, text, language)
+    return await _analyze_spans_chunked(http, text, language)
 
 
 async def _mask_messages(
@@ -290,6 +529,18 @@ class KlaiPiiEnforcer(CustomLogger):
     this proxy) while tests need to flip the flag per test via module
     reload; reading the module-level constant fresh in each method call
     keeps behaviour correct under that reload pattern.
+
+    Per-org scoping (`KLAI_PII_ENFORCE_ORG_IDS`, see `_org_is_enforced`)
+    is checked ONLY in `async_pre_call_hook`, the one place org_id is
+    available and the one place masking actually happens. The post-call
+    hooks below (`async_post_call_success_hook`,
+    `async_post_call_streaming_iterator_hook`,
+    `async_post_call_failure_hook`) do not re-check it: they are purely
+    map-driven — restore a placeholder if `_pii_map_store` has an entry
+    for this `litellm_call_id`, otherwise no-op — and an org excluded from
+    the allowlist never gets a map entry written for it in the first
+    place, so the post-call hooks are already a correct no-op for that
+    org without needing their own copy of the same check.
     """
 
     async def async_pre_call_hook(
@@ -307,6 +558,14 @@ class KlaiPiiEnforcer(CustomLogger):
             return data
 
         org_id = _org_id_from_key(user_api_key_dict)
+        if not _org_is_enforced(org_id):
+            # Activation hardening: KLAI_PII_ENFORCE is on globally, but
+            # this org (or a request with no org_id at all) is not in
+            # KLAI_PII_ENFORCE_ORG_IDS -- see _org_is_enforced's docstring
+            # for why empty/missing means "not enforced", not "enforced for
+            # everyone". No analyzer call, no map entry, byte-identical
+            # passthrough, same as the flag being off entirely.
+            return data
         org_policy = await resolve_org_entity_policy(org_id)
         enabled_entities = effective_enabled_entities(org_policy)
 

--- a/deploy/litellm/klai_pii_observe.py
+++ b/deploy/litellm/klai_pii_observe.py
@@ -91,6 +91,37 @@ _HTTPX_CLIENT_TIMEOUT_SECONDS = 5.0
 _ANALYZER_SUPPORTED_LANGUAGES = frozenset({"en", "nl", "de"})
 _DEFAULT_ANALYZER_LANGUAGE = "en"
 
+# ---------------------------------------------------------------------------
+# Length cap on analysed text — system-review finding M4
+# ---------------------------------------------------------------------------
+# presidio-analyzer runs with `cpus: '1'`, shared by every tenant, and this
+# observer already sends it the FULL outbound payload with no size cap at
+# all — one pasted payload shaped to be expensive for any recognizer (the
+# PEM pattern's own quadratic-on-unmatched-markers cost, fixed separately in
+# klai_pii_recognizers.py, was one concrete way to do that) pegs the shared
+# core for every tenant's request queued behind it. Even though this hook is
+# fire-and-forget and its own timeout eventually gives up client-side, the
+# analyzer process keeps chewing CPU on the call already in flight — a
+# client-side timeout does not cancel server-side work.
+#
+# 20,000 chars, same value and same basis as klai_pii_enforce.py's
+# `_MAX_ANALYZE_CHARS` (double the NFR's own 10,000-char latency reference
+# payload) — kept in sync manually since Phase 2 and Phase 3 are separate,
+# independently-owned modules per REQ-5's "no parallel old+new" boundary.
+#
+# Unlike the enforce path, truncating here is the right call, not a
+# shortcut: REQ-5 says this observer "SHALL return the payload unchanged"
+# and "SHALL NOT" affect what reaches Mistral — it exists purely to COUNT
+# detections for telemetry (REQ-6), fails open on any error already, and
+# Phase 2's own measurement is explicitly directional, not a gate (AC-14).
+# Analysing only the first `_MAX_ANALYZE_CHARS` characters of an oversized
+# payload can only under-count that one telemetry sample; it can never
+# change what the user's request does. A `truncated` flag rides along in
+# the emitted event (REQ-6 allows it — it is a boolean, not a value, an
+# offset, or a hash) so the undercount is visible in the data rather than
+# silent.
+_MAX_ANALYZE_CHARS = 20_000
+
 
 # ---------------------------------------------------------------------------
 # Language detection — local, dependency-free approximation
@@ -316,6 +347,12 @@ async def _observe(
     it SHALL NOT fail the request", the deliberate inverse of REQ-10
     (which governs Phase 3 enforcement, not this observer).
     """
+    # REQ-6 permits a boolean here (no value, no offset, no hash): it only
+    # says whether the sample below is a full or a partial count, not what
+    # was cut. See the module-level comment above `_MAX_ANALYZE_CHARS`.
+    truncated = len(combined_text) > _MAX_ANALYZE_CHARS
+    analyzed_text = combined_text[:_MAX_ANALYZE_CHARS] if truncated else combined_text
+
     try:
         analyzer_language = (
             language
@@ -323,18 +360,19 @@ async def _observe(
             else _DEFAULT_ANALYZER_LANGUAGE
         )
         async with httpx.AsyncClient(timeout=_HTTPX_CLIENT_TIMEOUT_SECONDS) as http:
-            counts = await _analyze_entity_counts(http, combined_text, analyzer_language)
+            counts = await _analyze_entity_counts(http, analyzed_text, analyzer_language)
     except Exception as exc:
         # Fail-open per REQ-5, but keep the same non-sensitive dimensions the
         # success event carries. Without them an outage cannot be filtered out
         # of the Phase 2 sample per tenant/model/language, which quietly turns
         # "Presidio was down for this org" into "this org has no PII".
         logger.warning(
-            "pii_observe_failed org_id=%s call_type=%s model=%s language=%s error=%s",
+            "pii_observe_failed org_id=%s call_type=%s model=%s language=%s truncated=%s error=%s",
             org_id,
             call_type,
             model,
             language,
+            truncated,
             exc,
         )
         return
@@ -342,11 +380,12 @@ async def _observe(
     # REQ-6: org_id, call_type, model alias, detected language, per-entity
     # counts. Nothing else — no message text, no offsets, no hashes.
     logger.warning(
-        "pii_observed org_id=%s call_type=%s model=%s language=%s entity_counts=%s",
+        "pii_observed org_id=%s call_type=%s model=%s language=%s truncated=%s entity_counts=%s",
         org_id,
         call_type,
         model,
         language,
+        truncated,
         dict(counts),
     )
 

--- a/deploy/litellm/tests/test_pii_enforce.py
+++ b/deploy/litellm/tests/test_pii_enforce.py
@@ -215,7 +215,7 @@ async def test_flag_off_failure_hook_returns_none_and_touches_nothing(monkeypatc
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_bsn_masked_and_not_restored(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())  # no optional entities
 
     text = "mijn bsn is 111222333 graag verwerken"
@@ -261,7 +261,7 @@ async def test_bsn_masked_and_not_restored(monkeypatch):
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_secret_masked_and_not_restored(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())
 
     secret = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz"
@@ -299,7 +299,7 @@ async def test_secret_masked_and_not_restored(monkeypatch):
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_iban_masked_and_restored_when_enabled_for_org(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset({"IBAN_CODE"}))
 
     iban = "NL91ABNA0417164300"
@@ -333,7 +333,7 @@ async def test_iban_masked_and_restored_when_enabled_for_org(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_iban_untouched_when_not_in_org_policy(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())  # IBAN_CODE not enabled
 
     iban = "NL91ABNA0417164300"
@@ -369,7 +369,7 @@ async def test_iban_untouched_when_not_in_org_policy(monkeypatch):
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_two_distinct_phone_numbers_get_distinct_placeholders_and_restore(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset({"PHONE_NUMBER"}))
 
     phone_a, phone_b = "06-12345678", "06-98765432"
@@ -479,7 +479,9 @@ async def test_streaming_and_non_streaming_both_restore_return_set_entities(monk
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_two_concurrent_requests_different_orgs_do_not_cross_contaminate(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(
+        monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org-a,org-b"}
+    )
     _stub_org_policy(
         mod,
         monkeypatch,
@@ -643,7 +645,7 @@ async def test_map_entry_deleted_after_success_hook_even_with_no_restore_map(mon
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_analyzer_error_with_enforcement_on_fails_the_request(monkeypatch, caplog):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())
     client = _ScriptedAnalyzerClient(raise_exc=ConnectionError("presidio-analyzer unreachable"))
     _install_analyzer(mod, monkeypatch, client)
@@ -688,7 +690,7 @@ async def test_analyzer_error_with_enforcement_off_does_nothing(monkeypatch):
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_verbatim_instruction_injected_when_masking_active(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())
 
     text = "mijn bsn is 111222333 graag verwerken"
@@ -715,7 +717,7 @@ async def test_verbatim_instruction_injected_when_masking_active(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_verbatim_instruction_absent_when_nothing_is_masked(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset())
 
     text = "hallo, hoe gaat het vandaag met je?"
@@ -743,7 +745,7 @@ async def test_verbatim_instruction_absent_when_nothing_is_masked(monkeypatch):
 # ===========================================================================
 @pytest.mark.asyncio
 async def test_tool_call_arguments_are_masked(monkeypatch):
-    mod = _load_enforcer(monkeypatch, enforce=True)
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"})
     _stub_org_policy(mod, monkeypatch, frozenset({"EMAIL_ADDRESS"}))
 
     args_text = '{"to": "jan.devries@example.nl"}'
@@ -777,3 +779,318 @@ async def test_tool_call_arguments_are_masked(monkeypatch):
     masked_args = assistant_msg["tool_calls"][0]["function"]["arguments"]
     assert email not in masked_args
     assert "<EMAIL_ADDRESS_1>" in masked_args
+
+
+# ===========================================================================
+# Activation hardening — KLAI_PII_ENFORCE_ORG_IDS per-org scoping
+# ===========================================================================
+@pytest.mark.asyncio
+async def test_org_not_in_allowlist_is_not_enforced(monkeypatch):
+    mod = _load_enforcer(
+        monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org-other"}
+    )
+    client = _ScriptedAnalyzerClient(raise_exc=AssertionError("must not call analyzer"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-allowlist-1",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    assert result is data
+    assert client.calls == []
+    assert mod._pii_map_store.get("call-allowlist-1") is None
+
+
+@pytest.mark.asyncio
+async def test_org_in_allowlist_is_enforced(monkeypatch):
+    mod = _load_enforcer(
+        monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1,org2"}
+    )
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    text = "mijn bsn is 111222333 graag verwerken"
+    start, end = text.index("111222333"), text.index("111222333") + len("111222333")
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "NL_BSN", "start": start, "end": end, "score": 0.85}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-allowlist-2",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<NL_BSN_1>" in user_message["content"]
+    assert client.calls  # analyzer WAS called for the allowlisted org
+
+
+@pytest.mark.asyncio
+async def test_empty_allowlist_means_enforcement_for_no_org_even_with_flag_on(monkeypatch):
+    """The 'empty allowlist' decision: KLAI_PII_ENFORCE=true with
+    KLAI_PII_ENFORCE_ORG_IDS unset/empty must behave exactly like the flag
+    being off -- "no orgs", not "every org". See _org_is_enforced's
+    docstring for the full argument."""
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": ""})
+    assert mod.KLAI_PII_ENFORCE_ORG_IDS == frozenset()
+    client = _ScriptedAnalyzerClient(raise_exc=AssertionError("must not call analyzer"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-allowlist-3",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    assert result is data
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_org_id_is_never_enforced_even_with_nonempty_allowlist(monkeypatch):
+    """A request with no org_id (widget/partner master-key path) can never
+    match an org allowlist -- defined, deliberate behaviour, not a gap."""
+    mod = _load_enforcer(
+        monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"}
+    )
+    client = _ScriptedAnalyzerClient(raise_exc=AssertionError("must not call analyzer"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-allowlist-4",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key(org_id=None), None, data, "completion"
+    )
+    assert result is data
+    assert client.calls == []
+
+
+def test_parse_org_allowlist_trims_whitespace_and_drops_empties():
+    from klai_pii_enforce import _parse_org_allowlist
+
+    assert _parse_org_allowlist("org1, org2 ,, org3") == frozenset({"org1", "org2", "org3"})
+    assert _parse_org_allowlist("") == frozenset()
+    assert _parse_org_allowlist("   ") == frozenset()
+
+
+# ===========================================================================
+# System-review finding M4 — length cap / chunking on the enforce path
+# ===========================================================================
+# REQ-10's fail-closed contract forbids analysing less than the whole
+# outbound text while forwarding the rest unmasked. These tests exercise
+# the chunking machinery directly (`_chunk_windows`, `_analyze_spans`,
+# `_analyze_spans_chunked`) with small monkeypatched cap/overlap constants
+# so they run fast and deterministically -- the real 20_000/6_000 values
+# are exercised implicitly by every other test staying under that size and
+# taking the single-call path.
+@pytest.mark.asyncio
+async def test_analyze_spans_makes_one_call_for_text_at_or_under_the_cap(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 20)
+
+    text = "x" * 20
+    client = _ScriptedAnalyzerClient(script={text: []})
+    spans = await mod._analyze_spans(client, text, "en")
+
+    assert spans == []
+    assert len(client.calls) == 1
+    assert client.calls[0]["json"]["text"] == text
+
+
+@pytest.mark.asyncio
+async def test_analyze_spans_dispatches_to_chunking_above_the_cap(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 10)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 3)
+
+    text = "a" * 25
+    client = _ScriptedAnalyzerClient(default=[])
+    spans = await mod._analyze_spans(client, text, "en")
+
+    assert spans == []
+    assert len(client.calls) > 1
+    # Every individual call stays within the cap.
+    assert all(len(c["json"]["text"]) <= 10 + 2 * 3 for c in client.calls)
+
+
+def test_chunk_windows_partition_the_full_text_with_no_gap_or_overlap_in_core(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 10)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 3)
+
+    windows = mod._chunk_windows(25)
+    assert windows[0].core_start == 0
+    assert windows[-1].core_end == 25
+    for prev, nxt in zip(windows, windows[1:]):
+        assert prev.core_end == nxt.core_start  # exact partition, no gap/overlap
+    for w in windows:
+        assert w.window_start == max(0, w.core_start - 3)
+        assert w.window_end == min(25, w.core_end + 3)
+        # padding guarantees any entity starting in the core is fully inside window
+        assert w.window_end - w.core_start >= (w.core_end - w.core_start)
+
+
+def test_chunk_windows_single_window_when_text_at_or_under_cap(monkeypatch):
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 100)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 20)
+
+    windows = mod._chunk_windows(100)
+    assert len(windows) == 1
+    assert windows[0] == mod._ChunkWindow(0, 100, 0, 100)
+
+
+@pytest.mark.asyncio
+async def test_chunked_analysis_detects_entity_straddling_a_window_boundary(monkeypatch):
+    """The overlap padding must be wide enough that an entity whose span
+    crosses a core boundary is still fully visible (and therefore
+    detected) inside the window that owns it -- and counted exactly ONCE,
+    not once per window that happens to see it."""
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 20)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 10)
+
+    phone = "0612345678"  # 10 chars
+    text = ("x" * 15) + phone + ("y" * 15)  # phone straddles the core boundary at 20
+    phone_start = text.index(phone)
+    phone_end = phone_start + len(phone)
+    windows = mod._chunk_windows(len(text))
+    assert len(windows) > 1  # sanity: chunking actually engaged
+
+    class _StraddleClient:
+        def __init__(self):
+            self.calls = []
+
+        async def post(self, url, json=None, **kwargs):
+            self.calls.append(json)
+            window_text = json["text"]
+            local_start = window_text.find(phone)
+            if local_start == -1:
+                return _FakeAnalyzerResponse([])
+            return _FakeAnalyzerResponse(
+                [
+                    {
+                        "entity_type": "PHONE_NUMBER",
+                        "start": local_start,
+                        "end": local_start + len(phone),
+                        "score": 0.9,
+                    }
+                ]
+            )
+
+    client = _StraddleClient()
+    spans = await mod._analyze_spans_chunked(client, text, "nl")
+
+    assert len(spans) == 1  # not double-counted across overlapping windows
+    assert spans[0].start == phone_start
+    assert spans[0].end == phone_end
+    assert spans[0].entity_type == "PHONE_NUMBER"
+
+
+@pytest.mark.asyncio
+async def test_chunked_analysis_covers_the_full_text_including_the_tail(monkeypatch):
+    """REQ-10: no silent truncation on the enforce path. An entity that
+    only appears near the very end of an oversized payload must still be
+    found -- chunking, not refusal or truncation, is the answer here."""
+    mod = _load_enforcer(monkeypatch, enforce=True)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 50)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 10)
+
+    bsn = "111222333"
+    text = ("filler tekst zonder iets gevoeligs " * 5) + f"bsn: {bsn}"
+    assert len(text) > 50
+
+    class _TailClient:
+        def __init__(self):
+            self.calls = 0
+
+        async def post(self, url, json=None, **kwargs):
+            self.calls += 1
+            window_text = json["text"]
+            local_start = window_text.find(bsn)
+            if local_start == -1:
+                return _FakeAnalyzerResponse([])
+            return _FakeAnalyzerResponse(
+                [
+                    {
+                        "entity_type": "NL_BSN",
+                        "start": local_start,
+                        "end": local_start + len(bsn),
+                        "score": 1.0,
+                    }
+                ]
+            )
+
+    client = _TailClient()
+    spans = await mod._analyze_spans_chunked(client, text, "nl")
+
+    assert len(spans) == 1
+    assert text[spans[0].start : spans[0].end] == bsn
+    assert client.calls > 1  # confirms multiple windows were actually analysed
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_through_the_real_pre_call_hook_masks_the_whole_text(
+    monkeypatch,
+):
+    """End-to-end smoke test through async_pre_call_hook (not just the
+    chunking helpers directly): a payload far above the cap still gets its
+    BSN masked, wherever it sits in the text."""
+    mod = _load_enforcer(
+        monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "org1"}
+    )
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 30)
+    monkeypatch.setattr(mod, "_CHUNK_OVERLAP_CHARS", 10)
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    bsn = "111222333"
+    text = ("veel tekst zonder iets gevoeligs " * 4) + f"mijn bsn is {bsn} graag"
+
+    class _E2EClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        async def post(self, url, json=None, **kwargs):
+            window_text = json["text"]
+            local_start = window_text.find(bsn)
+            if local_start == -1:
+                return _FakeAnalyzerResponse([])
+            return _FakeAnalyzerResponse(
+                [
+                    {
+                        "entity_type": "NL_BSN",
+                        "start": local_start,
+                        "end": local_start + len(bsn),
+                        "score": 1.0,
+                    }
+                ]
+            )
+
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: _E2EClient()))
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-oversized-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org1"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert bsn not in user_message["content"]
+    assert "<NL_BSN_1>" in user_message["content"]

--- a/deploy/litellm/tests/test_pii_observe.py
+++ b/deploy/litellm/tests/test_pii_observe.py
@@ -582,3 +582,90 @@ async def test_language_detected_from_user_turn_not_kb_context(monkeypatch, capl
     assert "language=nl" in logged, logged
     # The scan itself still saw the English block.
     assert "knowledge base" in client.last_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# System-review finding M4 — length cap on analysed text
+# ---------------------------------------------------------------------------
+# presidio-analyzer runs with cpus: '1', shared by every tenant, with no
+# upstream size cap before this fix. Phase 2 is read-only/fail-open (REQ-5),
+# so truncating the ANALYSED text can only under-count one telemetry
+# sample -- it must never change `data`, the payload Mistral receives.
+@pytest.mark.asyncio
+async def test_text_under_cap_is_analysed_in_full_and_reported_untruncated(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 100)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    text = "hallo dit is een kort berichtje zonder iets gevoeligs erin"
+    data = {"model": "klai-fast", "messages": [{"role": "user", "content": text}]}
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org1"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert client.last_text == text
+    assert any("truncated=False" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_text_over_cap_is_truncated_before_analysis_but_payload_untouched(
+    monkeypatch, caplog
+):
+    mod = _load_observer(monkeypatch)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 20)
+    client = _FakeAsyncClient(results=[])
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: client))
+
+    text = "x" * 50
+    data = {"model": "klai-fast", "messages": [{"role": "user", "content": text}]}
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        result = await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org1"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    # The ANALYSER only saw the first 20 chars.
+    assert client.last_text == "x" * 20
+    assert len(client.last_text) == 20
+    assert any("truncated=True" in r.message for r in caplog.records)
+    # REQ-5: the payload itself is untouched regardless -- truncation is a
+    # telemetry-only decision, never a mutation of what reaches Mistral.
+    assert result["messages"][0]["content"] == text
+    assert len(result["messages"][0]["content"]) == 50
+
+
+@pytest.mark.asyncio
+async def test_truncated_flag_present_in_failure_log_too(monkeypatch, caplog):
+    mod = _load_observer(monkeypatch)
+    monkeypatch.setattr(mod, "_MAX_ANALYZE_CHARS", 10)
+
+    class _FailingClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc_info):
+            return False
+
+        async def post(self, *args, **kwargs):
+            raise ConnectionError("presidio-analyzer unreachable")
+
+    monkeypatch.setattr(mod, "httpx", SimpleNamespace(AsyncClient=lambda **kw: _FailingClient()))
+
+    text = "x" * 50
+    data = {"model": "klai-fast", "messages": [{"role": "user", "content": text}]}
+
+    with caplog.at_level("WARNING", logger="klai_pii_observe"):
+        await mod.klai_pii_observer.async_pre_call_hook(
+            _user_api_key("org1"), None, data, "completion"
+        )
+        await _drain_background_tasks()
+
+    assert any(
+        "pii_observe_failed" in r.message and "truncated=True" in r.message
+        for r in caplog.records
+    )

--- a/deploy/presidio/analyzer/klai_pii_recognizers.py
+++ b/deploy/presidio/analyzer/klai_pii_recognizers.py
@@ -255,17 +255,44 @@ class NLPostcodeRecognizer(PatternRecognizer):
 # The PEM pattern deliberately makes the "<type> " token optional in BOTH the
 # BEGIN and END markers: canonical PKCS#8 keys are literally
 # "-----BEGIN PRIVATE KEY-----" with no type, and requiring one would let the
-# most common key format through unmasked. `.*?` (non-greedy) + the registry's
-# default global_regex_flags (DOTALL|MULTILINE|IGNORECASE, see conf/analyzer.yaml)
+# most common key format through unmasked. The body is base64 (`A-Za-z0-9+/=`)
+# plus whitespace between the markers, and `[A-Za-z0-9+/=\s]{0,_PEM_MAX_BODY_CHARS}?`
 # lets the span run across newlines to the matching END marker, so key material
 # is never left in the payload. A BEGIN with no following END never matches at
 # all — "bare unmatched PEM header" (AC-5) stays undetected by design, since a
 # half pattern is not sensitive key material.
+#
+# Bounded, not `.*?` (system-review finding M4). `.*?` + DOTALL is quadratic
+# on a payload containing many unmatched BEGIN markers: from every BEGIN, the
+# engine backtracks forward looking for an END that never comes, and does
+# that scan again from the next BEGIN, and the next — O(n^2) in the number of
+# markers. Measured on the unbounded pattern (deploy/presidio/tests/
+# test_klai_pii_recognizers.py::TestSecretPemPerformance fixtures): 200
+# markers ~10ms, 1000 ~257ms, 4000 (~340KB) ~4.1s on a single core — and
+# presidio-analyzer runs with `cpus: '1'`, shared by every tenant, with no
+# size cap upstream on what the Phase 2 observer or a future Phase 3
+# enforcement call sends it. Bounding the body length turns "scan to the end
+# of the payload" into "give up after `_PEM_MAX_BODY_CHARS` chars", which
+# caps the backtracking cost per BEGIN marker instead of letting it grow with
+# the remaining text length: same fixtures measured 200 markers ~0.1ms, 1000
+# ~0.7ms, 4000 ~2.7ms — no longer measurably different from linear.
+#
+# 5000 chars covers every realistic PEM private key body: a real PKCS#8 RSA
+# 4096-bit key (the largest RSA size in common use) base64-encodes to ~3.2K
+# characters (measured directly via `cryptography.hazmat` — 2048-bit is
+# ~1.6K, EC/Ed25519 keys are much shorter). 5000 leaves comfortable headroom
+# above the largest key anyone will plausibly paste while still bounding the
+# worst-case scan per BEGIN marker. A key body genuinely longer than that is
+# not a realistic PEM private key and this recognizer intentionally does not
+# chase it.
+_PEM_MAX_BODY_CHARS = 5000
 
 _SECRET_PATTERNS = [
     Pattern(
         "PEM private key block",
-        r"-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----.*?-----END(?: [A-Z0-9]+)? PRIVATE KEY-----",
+        r"-----BEGIN(?: [A-Z0-9]+)? PRIVATE KEY-----"
+        rf"[A-Za-z0-9+/=\s]{{0,{_PEM_MAX_BODY_CHARS}}}?"
+        r"-----END(?: [A-Z0-9]+)? PRIVATE KEY-----",
         0.95,
     ),
     Pattern(

--- a/deploy/presidio/tests/test_klai_pii_recognizers.py
+++ b/deploy/presidio/tests/test_klai_pii_recognizers.py
@@ -397,3 +397,139 @@ class TestIrreversibleFalsePositives:
         assert rec.analyze(
             "Zie ook 3011 AB Rotterdam.", entities=["NL_POSTCODE"], nlp_artifacts=None
         )
+
+
+# ---------------------------------------------------------------------------
+# System-review finding M4 — PEM pattern is quadratic on unmatched BEGIN
+# markers. Fixed by bounding the body to `_PEM_MAX_BODY_CHARS` instead of an
+# unbounded `.*?`. Two things must both hold: a real key still matches in
+# full, and the pathological-input cost is actually bounded now.
+# ---------------------------------------------------------------------------
+
+# A real PKCS#8 RSA-4096 private key body (the largest RSA size in common
+# use), generated once with `cryptography.hazmat` and pasted in literally so
+# this test needs no crypto library at run time. 4096-bit is the size most
+# likely to approach `_PEM_MAX_BODY_CHARS` — smaller RSA sizes and EC/Ed25519
+# keys are all shorter.
+_REAL_RSA4096_PKCS8 = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQCtu1jXyUNVMRHv\n"
+    "rrsXPZ+sFig0l8qCQSQvLXTfm6dkA5i8hY/PL54Clh9zRlEqelHek1MY+IPi7efQ\n"
+    "Rczb77UNX6IWHHh1Z5YyRDZM8pndjy0v6Nr2chITci/hx9hxZWRzoS8aGia/mPiK\n"
+    "Z7CKlIxmEnRVBVNSWfWaAEhI/OaezubtgpysmuLf75fqJuJmjf741p9mgj42cA4u\n"
+    "nD1rf2fiL3pyb9yehbC85UpvC8Zygm0pIUxb6LRPa0AdVF+wiNnXS+u1i4Ak9bu2\n"
+    "zKVsVsGTlf7zIODvAyQFMzA5XYOBSbmc5QAT8l+LJhgpjgx/yiwkBgi1n9FSXiUi\n"
+    "pn1yjC5Deeu0D9FT40LPcg9B94X43Y+YFMWolxNMpOFZQJhADmnPHDTbjRbXvW8l\n"
+    "92eyi2BIyAFb8JDL/3mFhbQh8cl2KTo6zfy+ju9tnzeQB7n2sqgtqUXoElFoZgVv\n"
+    "Wv290aNq0BqXDHuZb/K5KkvzFQC7X6XKuvhYKCoZ3nr8GKr0+BBjTwdw511Tz8g/\n"
+    "Jf9KCNJNFuUO/uMrFic2/Yp5QuDtk8xg7FasM8r4EvHAqnz5EPARDBgoFI5aBvw3\n"
+    "u5HyImUXAi88Tu+1fDa8yznN6FZuZ7Iq1nai7Bri0x+Ar/txryldWeVO++Ev0Vq/\n"
+    "LZVncgF4j+j8P1FJGvrw3fCRF8lKjQIDAQABAoICABq+hjLzweiFrQntZ1Iw05l5\n"
+    "cLeF7XAHSKN1lzIMA2T3U8Yjtmtx3FxwEUfc2YZVPbCqk8Z6jUz8DC1I7XwnBsNY\n"
+    "Bzrpp5aFO38h9oz6ZLrRfWaMbVa2YTd6osnaSqTMM75EIBzfzTq9+PbPdwMiUomt\n"
+    "ChkDgJvjCtap9/a6beMhHTYPXwCIOGg6OTPbyAr7DXbvjSrJ3nthXSGKPj9D5fFR\n"
+    "F0OyGi+SC47Mqlx1XteGYfkMrfVRGZ7HNx+8ux1RN923i4HPR4sJBBxkHQwUP+jx\n"
+    "FIYHd/D7Vgpx4pjWHzYiLA9txkkLzO7+DoapHh32+LwT7LfO8jmAki1nHVUqpL1P\n"
+    "kR4rOq790j2qOg5BCHwhHl/0gTKopBksy5zmT6M9WtGfKgnnoB6B0upr6saHpGMM\n"
+    "UX8kw2dTs/HkUBkJ5zVQ1Sh23/I9uUTFTmQuV8PN3oQhrD7PPnPNg0a1mzqHEvdY\n"
+    "JXglGhsJv9eFGN7qnBfIptNI21/4t9946ebBR/OFRB5prlqW8klCJiYd7Y5rvnMB\n"
+    "ZM+95puj3KeX2wSgpiYSijlW74MXrsYhNacWZs6jz6IfgHbJMB2zj6vildTHky4j\n"
+    "tj86Ho+SgUUQdKn61ax2folZ4aswvZNlKLdRt/slM8M37SjMzZvy81PeI+3pUpgI\n"
+    "L5ZjFDY+C5j1V2z5Vif5AoIBAQDtIxO5Wfdd3s4DAVH2qXpZEI4O12J3658W9+Mx\n"
+    "Irl4gdxITsjJheH2lh7gF8heJGXEKeo+76m4zqPLV+ER+WOhE7tMpQaJkhzzLuRB\n"
+    "DqVSBBjim+HfyTu+aT35W5d7hZN77tnCV/rfyg6d2HPg/pO+OQCN2OxoXq9U3P2a\n"
+    "GJdLoKi+xMHCsdEfwUmd7IZhmJRO49ZXWNU5dncTy8gKNAeFN+74oXi9t/oGrFud\n"
+    "KhV1aR+CPAXCumogOujRo19xbrkQ3tzW0rfQleYlXP617YjU44+ad6g17laC+1/T\n"
+    "U4pXf3YWPEXVDTBKPm4X7MnvhF6HK214WCe08YPAV0g48R4pAoIBAQC7jR9uat8U\n"
+    "o1+H3Yq69Dpr8i6IwmPw8OK/vAKMxYZbfeUp8MramyAqsxYNwoi4dHLfSb1RHXy1\n"
+    "iSme9LI/tEgL1wRD7nryIvJnGV/RJn8BHACfp02fEoRDGTpZFwqtMLp37B4N+bjX\n"
+    "p8fgiif/LydDRN03JeiUAgsTnwe7iSqOj3fVN1DS5x+WhYJY1w4LZVJy3UFkA/fs\n"
+    "4n+C9iFaz2cbv4p6oR9cBIVT5z8nRa4yaVOSFEF9HQnS1tCUL1u5uVqqac5uI9ZU\n"
+    "21g7NNruy3HnjxQB/ryIcR67fIQD/4ubnqbTmHkTE34AJ3EdYLOn0JuFX0G8MVV2\n"
+    "DWj0qNM2rQ3FAoIBAQCbtKSG1+Ps5xcuMfe3lqCXSp98b0BgrX3QfwPWh45w6hPS\n"
+    "BqkgaaBtYTT0v6j4571KiJseqA8xIb27DwDh5HbelS4urU0Vl7MamneVoCA9MiOE\n"
+    "6AXwAxoPdNsUmGdm29ZzUen6CfrYZrwiOLYdzgsEpDkQ6paQEVvexRxfyjXNmrgy\n"
+    "Ss9PH6LIzwmfgGbcPmtjQYbD47hd+sNFZFD9IhyuBIQNDTlSmTK6nwGouLFOXrAp\n"
+    "u2+s5Oo6L3Qf8r4ApUsvIKaxB7taYpKzhdRZcJaf8qugKWFxyAVWC+hnwjrcKP1I\n"
+    "rFrOAdLrbQKtAvW1J51J8+H1Wyz3Sn3QFX9+pBPBAoIBAGr5urTbZnS6HvI7DjdG\n"
+    "uM/7akl9P04dx+f/ECFFRTaIX58Fhl8cXkOctHaSwDMd0KvFvqM2w3w0STYuckFd\n"
+    "zj5anUc2DpBwGH1v/rQoVgbG9yAZaG/UOvaevCY2u1M/2Qwv9JCaILF5NMvBYcDv\n"
+    "H2ECNX+QMtHBPJoreligi1KXSI2oKISzadQMQOX1fEBJwbZct0CZ9t757is/wpSu\n"
+    "eixcm1sI7f8pYPcTjnUTDKIaa52FyjjXyFOnTX9IZ/ROYgWTpjgyXr02A2R56GqO\n"
+    "RmECvjHJH7Zfd10PT6mMKBBSdOt6K40S8CqcVKuiDbcpiJuRUshKB2n3iicK6LZm\n"
+    "DNUCggEAZi16ZOt5UXYrRv6YDtI0M8rVg/yAqvRYjgAKjWjo6GrZ+PdZb6maYPsE\n"
+    "fkXX+AFu+T/RzLD80hHKi6YeG+6FehvNN4RBb8dt0Wr1ENgkhDeW5onq2LNma68C\n"
+    "Pw3XYXE6wGdwSP5JcrBJjHT3VbOxoQYE5nQ+JQ6aaAFVroWoshyA+5zdd2HmEX2K\n"
+    "VV58tWYz4pinvFScroKxdtPlSzJBw+TTtJCmc5FSrLD94jJ8B/vI3qK52FbLl60h\n"
+    "obZCaz5wsG7GLfizW3Sqx754EPpHL4WakYXZbntE9NROBVNSf0JuKq6NWMftCY41\n"
+    "7Nuq0kIyHfue9xrq/FyLF/0ZZv6GSQ==\n"
+    "-----END PRIVATE KEY-----"
+)
+
+
+class TestSecretPemBounded:
+    """System-review finding M4: the PEM pattern was `.*?` + DOTALL, which is
+    quadratic on a payload containing many unmatched BEGIN markers. Bounding
+    the body to `_PEM_MAX_BODY_CHARS` must not break real-key detection.
+    """
+
+    def test_real_rsa4096_pkcs8_key_still_fully_detected(self):
+        rec = SecretRecognizer()
+        text = f"Here is the key:\n{_REAL_RSA4096_PKCS8}\ndone"
+        results = _detected(rec, text, "SECRET")
+        pem_results = [r for r in results if text[r.start : r.end].startswith("-----BEGIN")]
+        assert len(pem_results) == 1
+        matched = text[pem_results[0].start : pem_results[0].end]
+        assert matched == _REAL_RSA4096_PKCS8
+        assert "done" not in matched
+
+    def test_body_longer_than_bound_is_a_documented_non_match(self):
+        """Deliberate design boundary, not a bug: a body past
+        `_PEM_MAX_BODY_CHARS` is not chased. No real PEM private key body
+        (largest measured: RSA-4096 at ~3.2K chars) gets anywhere near this."""
+        from klai_pii_recognizers import _PEM_MAX_BODY_CHARS
+
+        oversized_body = "A" * (_PEM_MAX_BODY_CHARS + 1)
+        text = f"-----BEGIN PRIVATE KEY-----\n{oversized_body}\n-----END PRIVATE KEY-----"
+        rec = SecretRecognizer()
+        results = _detected(rec, text, "SECRET")
+        pem_results = [r for r in results if "BEGIN PRIVATE KEY" in text[r.start : r.end]]
+        assert pem_results == []
+
+
+class TestSecretPemPerformance:
+    """Regression for system-review finding M4's actual measurement.
+
+    presidio-analyzer runs with `cpus: '1'`, shared across every tenant, and
+    nothing upstream caps payload size before this recognizer runs. The old
+    `.*?` pattern took ~4.1s on a single core for 4000 unmatched BEGIN
+    markers (~340KB) — a chat request from one tenant pasting a payload
+    shaped like this would peg the shared analyzer for every other tenant at
+    once. The bounded pattern must stay comfortably sub-second at the same
+    marker counts. Generous bound (2s) to avoid CI-runner flakiness while
+    still failing hard if the quadratic behaviour ever comes back — the old
+    pattern blew well past this bound even at 1000 markers (~257ms) and
+    catastrophically at 4000 (~4.1s).
+    """
+
+    @staticmethod
+    def _payload_with_unmatched_begin_markers(n_markers: int, filler_len: int = 60) -> str:
+        filler = "A" * filler_len + "\n"
+        return "".join(f"-----BEGIN PRIVATE KEY-----\n{filler}" for _ in range(n_markers))
+
+    @pytest.mark.parametrize("n_markers", [200, 1000, 4000])
+    def test_unmatched_begin_markers_do_not_blow_up(self, n_markers):
+        import time
+
+        rec = SecretRecognizer()
+        payload = self._payload_with_unmatched_begin_markers(n_markers)
+
+        start = time.perf_counter()
+        results = _detected(rec, payload, "SECRET")
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 2.0, f"{n_markers} unmatched BEGIN markers took {elapsed:.3f}s"
+        # None of these should register as a PEM match -- no END marker
+        # anywhere in the payload.
+        pem_results = [r for r in results if "BEGIN PRIVATE KEY" in payload[r.start : r.end]]
+        assert pem_results == []

--- a/klai-portal/backend/alembic/versions/5d8cef52b18c_spec_privacy_mistral_pii_001_req_7_.py
+++ b/klai-portal/backend/alembic/versions/5d8cef52b18c_spec_privacy_mistral_pii_001_req_7_.py
@@ -1,0 +1,100 @@
+"""SPEC-PRIVACY-MISTRAL-PII-001 REQ-7: portal_orgs.pii_masked_entities
+
+Revision ID: 5d8cef52b18c
+Revises: 9bf37c021a4e
+Create Date: 2026-08-21
+
+Adds the per-org opt-in set of REQ-7 return-set entity types, read by
+``GET /internal/v1/orgs/{org_id}/pii-entities`` and consumed by
+``deploy/litellm/klai_pii_org_policy.py``.
+
+Storage shape follows ``portal_orgs.platform_unlocked_features``: a bounded set
+of opted-in string flags is a ``text[]`` column on ``portal_orgs``, not a side
+table. ``portal_orgs`` is the tenant root and carries no RLS policy of its own,
+so this adds no new RLS surface — see the endpoint docstring in
+``app/api/internal.py`` for the full reasoning.
+
+``ADD COLUMN ... NOT NULL DEFAULT '{}'`` is metadata-only on PostgreSQL >= 11
+(no table rewrite, no per-row UPDATE), so every pre-existing org gets REQ-7's
+"per-org, default off" for free. This migration contains pure DDL: no UPDATE,
+no INSERT, so it cannot trip a WITH CHECK policy during upgrade.
+
+``portal_orgs`` is portal_api-owned, so this DDL runs in ``upgrade()`` rather
+than in a post-deploy superuser script — same precedent as migration
+``45b528904319`` (``chk_portal_orgs_slug_safe``).
+
+The CHECK constraint is the server-side backstop for REQ-6/REQ-9 validation:
+``SECRET`` and ``NL_BSN`` are unconditional and therefore not per-org settable,
+``PERSON`` has no deployed detector, and anything outside REQ-7's return set is
+not a known entity type. Array-containment (``<@``) rejects all three classes in
+one expression, and rejects a NULL element too (``NULL`` is contained in
+nothing). The Python-side equivalent, which any write path must call, is
+``app.services.pii_entity_policy.validate_entity_selection`` — keep the two in
+step if REQ-7's set ever changes.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5d8cef52b18c"
+down_revision = "9bf37c021a4e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add portal_orgs.pii_masked_entities + its REQ-7 domain CHECK."""
+    op.execute(
+        """
+        ALTER TABLE public.portal_orgs
+            ADD COLUMN IF NOT EXISTS pii_masked_entities text[]
+                NOT NULL DEFAULT '{}'::text[];
+        """
+    )
+
+    # Idempotent via DO-block guard: PostgreSQL has no ADD CONSTRAINT IF NOT
+    # EXISTS, and a manual pre-deploy DDL run must not block `upgrade head`.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'chk_portal_orgs_pii_masked_entities'
+                  AND conrelid = 'public.portal_orgs'::regclass
+            ) THEN
+                ALTER TABLE public.portal_orgs
+                    ADD CONSTRAINT chk_portal_orgs_pii_masked_entities
+                    CHECK (
+                        -- Array containment checks ELEMENTS, not shape: a
+                        -- nested array whose leaves are all allowed values
+                        -- satisfies `<@` and then reads back as sub-lists the
+                        -- Python sanitizer drops, silently disabling the
+                        -- policy. Pin the shape to empty (ndims IS NULL) or
+                        -- one-dimensional first.
+                        (
+                            array_ndims(pii_masked_entities) IS NULL
+                            OR array_ndims(pii_masked_entities) = 1
+                        )
+                        AND pii_masked_entities <@ ARRAY[
+                            'IBAN_CODE',
+                            'CREDIT_CARD',
+                            'EMAIL_ADDRESS',
+                            'PHONE_NUMBER',
+                            'NL_KVK',
+                            'NL_BTW',
+                            'NL_POSTCODE'
+                        ]::text[]
+                    );
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the constraint, then the column."""
+    op.execute("ALTER TABLE public.portal_orgs DROP CONSTRAINT IF EXISTS chk_portal_orgs_pii_masked_entities;")
+    op.execute("ALTER TABLE public.portal_orgs DROP COLUMN IF EXISTS pii_masked_entities;")

--- a/klai-portal/backend/app/api/internal.py
+++ b/klai-portal/backend/app/api/internal.py
@@ -51,6 +51,7 @@ from app.services.entitlements import get_effective_products
 from app.services.events import emit_event
 from app.services.gap_rescorer import schedule_rescore
 from app.services.partner_rate_limit import check_rate_limit
+from app.services.pii_entity_policy import sanitize_stored_entities
 from app.services.provisioning.infrastructure import assert_shared_librechat_mount_sources_intact
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
@@ -960,6 +961,92 @@ async def admin_set_telemetry_level(
 
     await _audit_internal_call(request, org_id=org_id)
     return TelemetryLevelOut(org_id=org_id, old_level=old_level, new_level=new_level)
+
+
+# SPEC-PRIVACY-MISTRAL-PII-001 REQ-7: per-org PII entity policy, read side.
+class OrgPiiEntitiesResponse(BaseModel):
+    """Wire shape consumed by ``deploy/litellm/klai_pii_org_policy.py``.
+
+    That client reads exactly one key — ``payload.get("enabled_entities")``
+    (``klai_pii_org_policy.py:141``) — and drops the whole response unless it is
+    a ``list`` (line 142-143). ``enabled_entities`` is therefore load-bearing:
+    renaming it, nesting it, or returning a mapping makes the client fail closed
+    to the empty policy, which is indistinguishable from "this org opted into
+    nothing". ``org_id`` is echoed back for operator debuggability only; no
+    caller reads it.
+    """
+
+    org_id: int
+    enabled_entities: list[str]
+
+
+@router.get("/v1/orgs/{org_id}/pii-entities", response_model=OrgPiiEntitiesResponse)
+async def get_org_pii_entities(
+    org_id: int,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> OrgPiiEntitiesResponse:
+    """Return the REQ-7 return-set entity types this org has opted into.
+
+    Called by the LiteLLM PII-enforcement stack once per org per cache TTL to
+    resolve which of ``IBAN_CODE``, ``CREDIT_CARD``, ``EMAIL_ADDRESS``,
+    ``PHONE_NUMBER``, ``NL_KVK``, ``NL_BTW``, ``NL_POSTCODE`` to mask (and
+    restore) for that tenant. ``SECRET`` and ``NL_BSN`` are never in this
+    response: they are masked unconditionally for every org, so they are not
+    per-org state and the enforcement side adds them itself
+    (``klai_pii_entities.effective_enabled_entities``).
+
+    **Default.** An org that predates the column, or one that has opted into
+    nothing, returns ``[]``. That is REQ-7's stated default ("per-org, default
+    off"), not a degraded answer — the column is ``NOT NULL DEFAULT '{}'``, so
+    there is no NULL case to distinguish.
+
+    **Tenant isolation** (NFR): the row is selected by primary key from the path
+    ``org_id`` and nothing else, so there is no query shape in which org B's
+    policy can be returned for org A. ``portal_orgs`` is the tenant root — the
+    row *is* the tenant — and carries no RLS policy, which is why this endpoint
+    is not covered by the 4-category framework; ``set_tenant`` is still called
+    so the request's transaction carries the same tenant context as every other
+    org-scoped internal endpoint.
+
+    **404 on unknown org** matches the existing internal-endpoint convention
+    (``get_org_admin_email``, ``get_kb_metadata_internal``). The client treats
+    any non-2xx as the empty policy, so an unknown org degrades to default-off
+    rather than to a wrong tenant's policy.
+
+    There is deliberately **no write endpoint** in this change. The opt-in is set
+    by an operator (SQL / operator tooling) until a UI lands; the domain is
+    enforced server-side regardless by the CHECK constraint
+    ``chk_portal_orgs_pii_masked_entities`` and, on the read path below, by
+    ``sanitize_stored_entities``.
+    """
+    await _require_internal_token(request)
+    await set_tenant(db, org_id)
+
+    result = await db.execute(select(PortalOrg.pii_masked_entities).where(PortalOrg.id == org_id))
+    row = result.first()
+    if row is None:
+        await _audit_internal_call(request, org_id=org_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Org not found")
+
+    stored = row[0] or []
+    enabled = sanitize_stored_entities(stored)
+
+    # "fail loudly" (root AGENTS.md): sanitising is defence in depth, but
+    # dropping a stored value *silently* would make policy corruption look
+    # identical to "this org opted into nothing" — the exact ambiguity this
+    # endpoint exists to remove. Under the CHECK constraint this never fires,
+    # so a hit means the constraint was bypassed or the entity set drifted.
+    dropped = sorted({str(value) for value in stored} - set(enabled))
+    if dropped:
+        structlog_logger.warning(
+            "pii_org_policy_stored_value_rejected",
+            org_id=org_id,
+            dropped=dropped,
+        )
+
+    await _audit_internal_call(request, org_id=org_id)
+    return OrgPiiEntitiesResponse(org_id=org_id, enabled_entities=enabled)
 
 
 class PageSavedNotification(BaseModel):

--- a/klai-portal/backend/app/models/portal.py
+++ b/klai-portal/backend/app/models/portal.py
@@ -145,6 +145,25 @@ class PortalOrg(Base):
         default="shadow",
         server_default="shadow",
     )
+    # @MX:NOTE: SPEC-PRIVACY-MISTRAL-PII-001 REQ-7 — the REQ-7 return-set entity
+    # types this tenant has opted into having masked on the Mistral call path.
+    # Empty for every org that predates this column, which IS REQ-7's default
+    # ("per-org, default off") rather than a missing backfill.
+    #
+    # Same storage shape as ``platform_unlocked_features`` above: a bounded set
+    # of opted-in string flags is a text[] column on this table, not a side
+    # table. ``SECRET`` / ``NL_BSN`` are NOT stored here — they are masked
+    # unconditionally for every org and are therefore not per-org state; the DB
+    # CHECK constraint ``chk_portal_orgs_pii_masked_entities`` (migration
+    # 5d8cef52b18c) rejects them, along with ``PERSON`` (REQ-9: no detector is
+    # deployed) and any unknown type. Python-side equivalent:
+    # ``app.services.pii_entity_policy.validate_entity_selection``.
+    pii_masked_entities: Mapped[list[str]] = mapped_column(
+        ARRAY(Text()),
+        nullable=False,
+        default=list,
+        server_default=sa.text("'{}'::text[]"),
+    )
 
     users: Mapped[list["PortalUser"]] = relationship(back_populates="org")
 

--- a/klai-portal/backend/app/services/pii_entity_policy.py
+++ b/klai-portal/backend/app/services/pii_entity_policy.py
@@ -1,0 +1,115 @@
+"""Per-org PII entity policy — SPEC-PRIVACY-MISTRAL-PII-001 REQ-7.
+
+Single source of truth, on the portal-api side, for *which* entity types a
+tenant may opt into having masked on the Mistral call path, and for turning a
+stored ``portal_orgs.pii_masked_entities`` value into the wire shape the
+LiteLLM policy client parses.
+
+REQ-7 splits the entity set in two:
+
+- ``SECRET`` and ``NL_BSN`` are masked for **every** org, unconditionally, and
+  are never restored. They are therefore **not settable per org** — a tenant
+  cannot turn them on (they already are) and cannot turn them off (forwarding a
+  credential to a model provider is an incident regardless of tenant
+  preference; a BSN needs a statutory basis, which is a lawfulness question and
+  not a checkbox). They are rejected by ``validate_entity_selection`` for that
+  reason, not because they are unknown.
+- ``PII_RETURN_SET_ENTITIES`` are per-org, default off, and restored in the
+  response when enabled.
+
+``PERSON`` is deliberately absent from both sets. REQ-9 forbids enabling it
+before a GLiNER-era survival re-run exists, and no PERSON detector is deployed
+at all today (REQ-2 disables ``SpacyRecognizer``). It is rejected explicitly
+rather than falling through the "unknown entity" branch so the error names the
+real reason.
+
+**Why this list is duplicated.** ``deploy/litellm/klai_pii_entities.py`` holds
+the same two sets for the enforcement side. The two live in different
+containers with no shared Python package between them, so the duplication is
+structural, not an oversight — and it is deliberately defence in depth: the
+LiteLLM client intersects whatever portal-api returns against its *own* copy of
+``RETURN_SET_ENTITIES`` (``klai_pii_org_policy.py:145`), so a value that slips
+past this module still cannot reach the masker. If REQ-7's set ever changes,
+both files change together.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# REQ-7: per-org, default off, restored when enabled. Mirrors
+# ``RETURN_SET_ENTITIES`` in ``deploy/litellm/klai_pii_entities.py``.
+PII_RETURN_SET_ENTITIES: frozenset[str] = frozenset(
+    {
+        "IBAN_CODE",
+        "CREDIT_CARD",
+        "EMAIL_ADDRESS",
+        "PHONE_NUMBER",
+        "NL_KVK",
+        "NL_BTW",
+        "NL_POSTCODE",
+    }
+)
+
+# REQ-7: unconditional for every org, never restored, never per-org settable.
+# Mirrors ``NEVER_RESTORE_ENTITIES`` in ``deploy/litellm/klai_pii_entities.py``.
+PII_NEVER_RESTORE_ENTITIES: frozenset[str] = frozenset({"SECRET", "NL_BSN"})
+
+# REQ-9 gate. Named separately so the rejection message can say *why*.
+PII_FORBIDDEN_ENTITIES: frozenset[str] = frozenset({"PERSON"})
+
+
+class PiiEntityPolicyError(ValueError):
+    """A requested entity selection is not storable for a tenant."""
+
+
+def validate_entity_selection(values: Iterable[str]) -> frozenset[str]:
+    """Return the validated opt-in set, or raise ``PiiEntityPolicyError``.
+
+    Every future write path (operator tooling, an eventual admin endpoint,
+    a fixture) MUST go through this function; the DB CHECK constraint
+    ``chk_portal_orgs_pii_masked_entities`` is the backstop that makes the
+    same guarantee for a write that bypasses Python entirely.
+
+    Rejects, with a reason naming the requirement:
+    - ``PERSON`` — REQ-9, no detector deployed.
+    - ``SECRET`` / ``NL_BSN`` — REQ-7, unconditional, not per-org settable.
+    - anything not in ``PII_RETURN_SET_ENTITIES`` — unknown entity type.
+    """
+    requested: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise PiiEntityPolicyError(f"entity type must be a string, got {type(value).__name__}")
+        requested.append(value)
+
+    forbidden = sorted({v for v in requested if v in PII_FORBIDDEN_ENTITIES})
+    if forbidden:
+        raise PiiEntityPolicyError(f"{', '.join(forbidden)} cannot be enabled: no detector is deployed for it (REQ-9)")
+
+    unconditional = sorted({v for v in requested if v in PII_NEVER_RESTORE_ENTITIES})
+    if unconditional:
+        raise PiiEntityPolicyError(
+            f"{', '.join(unconditional)} is masked unconditionally for every org and is not per-org settable (REQ-7)"
+        )
+
+    unknown = sorted({v for v in requested if v not in PII_RETURN_SET_ENTITIES})
+    if unknown:
+        raise PiiEntityPolicyError(f"unknown PII entity type(s): {', '.join(unknown)}")
+
+    return frozenset(requested)
+
+
+def sanitize_stored_entities(values: Iterable[str] | None) -> list[str]:
+    """Read path: the stored value, narrowed to REQ-7's return set, sorted.
+
+    Defensive rather than trusting: the column is ``NOT NULL DEFAULT '{}'`` and
+    CHECK-constrained, so in practice this is an identity transform. It still
+    intersects, because the alternative is that one bad row — a constraint
+    dropped during an incident, a superuser backfill, a future column reuse —
+    puts ``PERSON`` or ``SECRET`` on the wire, and the enforcement side treats
+    the response as an instruction. Sorted so the response is stable and
+    diffable in logs.
+    """
+    if not values:
+        return []
+    return sorted({v for v in values if isinstance(v, str) and v in PII_RETURN_SET_ENTITIES})

--- a/klai-portal/backend/tests/services/test_pii_entity_policy.py
+++ b/klai-portal/backend/tests/services/test_pii_entity_policy.py
@@ -1,0 +1,109 @@
+"""SPEC-PRIVACY-MISTRAL-PII-001 REQ-7/REQ-9 — per-org PII entity policy domain.
+
+These pin the server-side validation contract, not documentation:
+``validate_entity_selection`` is what every write path must call, and the DB
+CHECK constraint ``chk_portal_orgs_pii_masked_entities`` (migration
+5d8cef52b18c) makes the identical guarantee for a write that bypasses Python.
+The two must agree — if a value is added to one it must be added to the other.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.services.pii_entity_policy import (
+    PII_NEVER_RESTORE_ENTITIES,
+    PII_RETURN_SET_ENTITIES,
+    PiiEntityPolicyError,
+    sanitize_stored_entities,
+    validate_entity_selection,
+)
+
+
+class TestValidateEntitySelection:
+    def test_empty_selection_is_valid(self):
+        """REQ-7's default: opting into nothing is a legal state, not an error."""
+        assert validate_entity_selection([]) == frozenset()
+
+    def test_full_return_set_is_valid(self):
+        assert validate_entity_selection(sorted(PII_RETURN_SET_ENTITIES)) == PII_RETURN_SET_ENTITIES
+
+    @pytest.mark.parametrize("entity", sorted(PII_RETURN_SET_ENTITIES))
+    def test_each_return_set_entity_is_settable(self, entity):
+        assert validate_entity_selection([entity]) == frozenset({entity})
+
+    def test_person_is_rejected(self):
+        """REQ-9: no PERSON detector is deployed, so it cannot be opted into."""
+        with pytest.raises(PiiEntityPolicyError) as exc:
+            validate_entity_selection(["PERSON"])
+        assert "PERSON" in str(exc.value)
+        assert "REQ-9" in str(exc.value)
+
+    def test_person_is_rejected_even_alongside_valid_entities(self):
+        with pytest.raises(PiiEntityPolicyError):
+            validate_entity_selection(["IBAN_CODE", "PERSON"])
+
+    @pytest.mark.parametrize("entity", sorted(PII_NEVER_RESTORE_ENTITIES))
+    def test_unconditional_entities_are_not_settable(self, entity):
+        """REQ-7: SECRET / NL_BSN are masked for every org and are not per-org state."""
+        with pytest.raises(PiiEntityPolicyError) as exc:
+            validate_entity_selection([entity])
+        assert entity in str(exc.value)
+        assert "REQ-7" in str(exc.value)
+
+    @pytest.mark.parametrize("entity", ["", "iban_code", "US_SSN", "NL_IBAN", "DROP TABLE"])
+    def test_unknown_entity_types_are_rejected(self, entity):
+        with pytest.raises(PiiEntityPolicyError) as exc:
+            validate_entity_selection([entity])
+        assert "unknown" in str(exc.value)
+
+    def test_non_string_is_rejected(self):
+        with pytest.raises(PiiEntityPolicyError):
+            validate_entity_selection([None])  # type: ignore[list-item]
+
+    def test_person_is_absent_from_both_sets(self):
+        """Structural, not conditional — PERSON is not a member of anything settable."""
+        assert "PERSON" not in PII_RETURN_SET_ENTITIES
+        assert "PERSON" not in PII_NEVER_RESTORE_ENTITIES
+
+
+class TestSanitizeStoredEntities:
+    def test_empty_and_none_are_empty(self):
+        assert sanitize_stored_entities([]) == []
+        assert sanitize_stored_entities(None) == []
+
+    def test_return_set_survives_and_is_sorted(self):
+        assert sanitize_stored_entities(["NL_KVK", "IBAN_CODE"]) == ["IBAN_CODE", "NL_KVK"]
+
+    @pytest.mark.parametrize("entity", ["PERSON", "SECRET", "NL_BSN", "US_SSN"])
+    def test_non_return_set_values_never_reach_the_wire(self, entity):
+        """One bad row must not become an instruction to the enforcement side."""
+        assert sanitize_stored_entities([entity, "IBAN_CODE"]) == ["IBAN_CODE"]
+
+    def test_duplicates_collapse(self):
+        assert sanitize_stored_entities(["IBAN_CODE", "IBAN_CODE"]) == ["IBAN_CODE"]
+
+
+class TestConstraintMatchesPython:
+    """The DB CHECK and the Python validator must allow exactly the same set.
+
+    A live-PostgreSQL assertion would need the ``postgres`` marker (excluded
+    from the default run), so this reads the migration source instead. It is a
+    weaker check than executing the DDL, but it is the one that fails in the
+    normal test suite when someone adds an entity to one side only.
+    """
+
+    def test_migration_check_lists_exactly_the_return_set(self):
+        migration = (
+            Path(__file__).resolve().parents[2]
+            / "alembic"
+            / "versions"
+            / "5d8cef52b18c_spec_privacy_mistral_pii_001_req_7_.py"
+        )
+        source = migration.read_text(encoding="utf-8")
+        block = source.split("pii_masked_entities <@ ARRAY[", 1)[1].split("]::text[]", 1)[0]
+        in_constraint = set(re.findall(r"'([A-Z_]+)'", block))
+        assert in_constraint == set(PII_RETURN_SET_ENTITIES)

--- a/klai-portal/backend/tests/test_internal_pii_entities.py
+++ b/klai-portal/backend/tests/test_internal_pii_entities.py
@@ -1,0 +1,218 @@
+"""SPEC-PRIVACY-MISTRAL-PII-001 REQ-7 — GET /internal/v1/orgs/{org_id}/pii-entities.
+
+Pinned behaviour:
+- No bearer / wrong bearer → 401 from ``_require_internal_token``, before any DB work.
+- Correct bearer → the handler proceeds (the token gate is not accidentally strict).
+- Org with no opt-in → ``enabled_entities == []`` (REQ-7 "per-org, default off").
+- Org with an opt-in → exactly that set, sorted.
+- A stored value outside REQ-7's return set (``PERSON`` / ``SECRET`` / unknown)
+  never reaches the wire.
+- Tenant isolation (NFR): org A's id returns A's policy and only A's.
+
+Layout follows ``tests/test_internal_user_permissions_endpoint.py`` — the handler
+is called directly with a mocked session, so no live database is needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+INTERNAL_SECRET = "internal-secret-under-test"
+
+
+def _make_request(*, token: str | None = INTERNAL_SECRET) -> MagicMock:
+    """FastAPI Request mock accepted by the real ``_require_internal_token``."""
+    headers: dict[str, str] = {}
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = MagicMock()
+    request.headers = MagicMock()
+    request.headers.get = lambda key, default="": next(
+        (v for k, v in headers.items() if k.lower() == key.lower()),
+        default,
+    )
+    request.client = MagicMock()
+    request.client.host = "172.18.0.5"
+    request.method = "GET"
+    request.url = MagicMock()
+    request.url.path = "/internal/v1/orgs/1/pii-entities"
+    request.scope = {"route": MagicMock(path="/internal/v1/orgs/{org_id}/pii-entities")}
+    request.state = MagicMock()
+    return request
+
+
+class _FakeOrgDb:
+    """Session stub that answers from a per-org table, keyed on the bound id.
+
+    Reads the compiled WHERE parameter rather than ignoring the statement, so a
+    handler that dropped the ``org_id`` filter would return the wrong row here
+    instead of quietly passing.
+    """
+
+    def __init__(self, rows: dict[int, list[str]]):
+        self._rows = rows
+        self.queried_org_ids: list[int] = []
+
+    async def execute(self, statement):
+        params = statement.compile().params
+        org_id = next(iter(params.values()))
+        self.queried_org_ids.append(org_id)
+
+        stored = self._rows.get(org_id)
+        result = MagicMock()
+        result.first.return_value = None if stored is None else (stored,)
+        return result
+
+
+@pytest.fixture
+def patched_internal(monkeypatch):
+    """Bypass rate limit + audit; keep the real token check and read path."""
+    from app.api import internal
+
+    monkeypatch.setattr(internal.settings, "internal_secret", INTERNAL_SECRET)
+    monkeypatch.setattr(internal, "_check_rate_limit_internal", AsyncMock())
+    monkeypatch.setattr(internal, "_audit_internal_call", AsyncMock())
+    monkeypatch.setattr(internal, "set_tenant", AsyncMock())
+    return internal
+
+
+class TestAuth:
+    @pytest.mark.asyncio
+    async def test_missing_bearer_returns_401_before_db(self, patched_internal):
+        db = _FakeOrgDb({1: []})
+
+        with pytest.raises(HTTPException) as exc:
+            await patched_internal.get_org_pii_entities(org_id=1, request=_make_request(token=None), db=db)
+
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert db.queried_org_ids == []
+
+    @pytest.mark.asyncio
+    async def test_wrong_bearer_returns_401_before_db(self, patched_internal):
+        db = _FakeOrgDb({1: []})
+
+        with pytest.raises(HTTPException) as exc:
+            await patched_internal.get_org_pii_entities(org_id=1, request=_make_request(token="wrong"), db=db)
+
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert db.queried_org_ids == []
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_secret_returns_503(self, patched_internal, monkeypatch):
+        """Fail closed rather than accepting an empty bearer."""
+        monkeypatch.setattr(patched_internal.settings, "internal_secret", "")
+        db = _FakeOrgDb({1: []})
+
+        with pytest.raises(HTTPException) as exc:
+            await patched_internal.get_org_pii_entities(org_id=1, request=_make_request(token=""), db=db)
+
+        assert exc.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert db.queried_org_ids == []
+
+    @pytest.mark.asyncio
+    async def test_correct_bearer_is_accepted(self, patched_internal):
+        db = _FakeOrgDb({1: ["IBAN_CODE"]})
+
+        response = await patched_internal.get_org_pii_entities(org_id=1, request=_make_request(), db=db)
+
+        assert response.enabled_entities == ["IBAN_CODE"]
+
+
+class TestPolicyResponse:
+    @pytest.mark.asyncio
+    async def test_org_without_opt_in_returns_empty_set(self, patched_internal):
+        """REQ-7 default-off, including for orgs that predate the column."""
+        db = _FakeOrgDb({7: []})
+
+        response = await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+
+        assert response.org_id == 7
+        assert response.enabled_entities == []
+
+    @pytest.mark.asyncio
+    async def test_populated_policy_is_returned_sorted(self, patched_internal):
+        db = _FakeOrgDb({7: ["NL_KVK", "IBAN_CODE", "EMAIL_ADDRESS"]})
+
+        response = await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+
+        assert response.enabled_entities == ["EMAIL_ADDRESS", "IBAN_CODE", "NL_KVK"]
+
+    @pytest.mark.asyncio
+    async def test_response_key_matches_the_litellm_client_contract(self, patched_internal):
+        """``klai_pii_org_policy.py:141-143`` reads ``enabled_entities`` and needs a list."""
+        db = _FakeOrgDb({7: ["IBAN_CODE"]})
+
+        response = await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+        payload = response.model_dump()
+
+        assert isinstance(payload.get("enabled_entities"), list)
+        assert all(isinstance(entity, str) for entity in payload["enabled_entities"])
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stored", ["PERSON", "SECRET", "NL_BSN", "US_SSN"])
+    async def test_non_return_set_values_are_filtered_out(self, patched_internal, stored):
+        db = _FakeOrgDb({7: [stored, "IBAN_CODE"]})
+
+        response = await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+
+        assert response.enabled_entities == ["IBAN_CODE"]
+
+    @pytest.mark.asyncio
+    async def test_filtered_value_is_logged_not_swallowed(self, patched_internal, monkeypatch):
+        """Fail loudly: a stored value outside the return set must be visible."""
+        logger = MagicMock()
+        monkeypatch.setattr(patched_internal, "structlog_logger", logger)
+        db = _FakeOrgDb({7: ["SECRET", "IBAN_CODE"]})
+
+        await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.args[0] == "pii_org_policy_stored_value_rejected"
+        assert logger.warning.call_args.kwargs["dropped"] == ["SECRET"]
+
+    @pytest.mark.asyncio
+    async def test_clean_policy_logs_nothing(self, patched_internal, monkeypatch):
+        logger = MagicMock()
+        monkeypatch.setattr(patched_internal, "structlog_logger", logger)
+        db = _FakeOrgDb({7: ["IBAN_CODE"]})
+
+        await patched_internal.get_org_pii_entities(org_id=7, request=_make_request(), db=db)
+
+        logger.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_org_returns_404(self, patched_internal):
+        db = _FakeOrgDb({})
+
+        with pytest.raises(HTTPException) as exc:
+            await patched_internal.get_org_pii_entities(org_id=999, request=_make_request(), db=db)
+
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestTenantIsolation:
+    @pytest.mark.asyncio
+    async def test_org_a_cannot_read_org_b_policy(self, patched_internal):
+        db = _FakeOrgDb({1: ["IBAN_CODE"], 2: ["NL_POSTCODE", "PHONE_NUMBER"]})
+
+        response_a = await patched_internal.get_org_pii_entities(org_id=1, request=_make_request(), db=db)
+        response_b = await patched_internal.get_org_pii_entities(org_id=2, request=_make_request(), db=db)
+
+        assert response_a.enabled_entities == ["IBAN_CODE"]
+        assert response_b.enabled_entities == ["NL_POSTCODE", "PHONE_NUMBER"]
+        assert "NL_POSTCODE" not in response_a.enabled_entities
+        assert "IBAN_CODE" not in response_b.enabled_entities
+        assert db.queried_org_ids == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_tenant_context_is_bound_to_the_path_org(self, patched_internal):
+        db = _FakeOrgDb({2: []})
+
+        await patched_internal.get_org_pii_entities(org_id=2, request=_make_request(), db=db)
+
+        assert patched_internal.set_tenant.await_args.args[1] == 2
+        assert patched_internal._audit_internal_call.await_args.kwargs["org_id"] == 2


### PR DESCRIPTION
Closes the three gaps that stood between the deployed-but-inert PII stack and being safe to activate. **`KLAI_PII_ENFORCE` stays off.**

## 1. The analyzer could be pegged by one paste (system-review M4)

The PEM pattern was quadratic on unmatched `BEGIN` markers — 4000 markers in 244 KB took ~1.9 s — on a container limited to `cpus: '1'` and shared by every tenant. Today that costs only telemetry (the observer fails open); under REQ-10's fail-closed contract the same paste becomes a chat outage for everyone.

The body is now bounded, and both PII modules cap how much text goes into any single `/analyze` call.

**The cap does not truncate on the enforce path.** Analysing less than the full outbound text and forwarding the rest unmasked is unminimised content reaching the provider — exactly what REQ-10 forbids. Text over the cap is split into **overlapping windows**, every window is analysed, and each span is attributed to the one window whose core contains its start. 100% of outbound text is always analysed. Overlap (6000) exceeds the longest bounded entity (PEM body 5000 + markers).

Truncating was the other REQ-10-compatible option and was rejected: chat attachments already extract up to 120k tokens of PDF into a message, so refusing oversized requests would break a shipped capability the moment an org opts in.

The observer keeps fail-open truncation deliberately — there it only under-counts telemetry.

Also adds a concurrency bound on analyzer calls (M6).

## 2. Activation was all-or-nothing

`KLAI_PII_ENFORCE` is read once at import and applies to every tenant, so the first flip would hit every customer at once — and this stack has **never run end to end against a real Mistral stream**; all tests mock the analyzer and the stream.

`KLAI_PII_ENFORCE_ORG_IDS` is now an allowlist, so the first activation can be one org. **Empty or unset means enforce nobody, not everybody** — the dangerous reading, tested explicitly.

## 3. The policy endpoint did not exist

Phase 3 has been calling `GET /internal/v1/orgs/{org_id}/pii-entities` since it shipped. Without it every lookup failed, the client fell back to empty, and only `SECRET` and `NL_BSN` could ever be masked — the reversible half that makes email drafting work could never activate.

Storage is a column on `portal_orgs`, following `telemetry_level`, `mfa_policy` and `platform_unlocked_features`. No RLS policy: `portal_orgs` is the tenant root and carries none; isolation is selection by primary key from the path `org_id`.

Validation is server-side twice — a DB CHECK pinning both the allowed set and `array_ndims`, plus read-path sanitising. `PERSON` is rejected outright.

`enabled_entities` is the load-bearing wire key: the client reads exactly that field and drops the response unless it is a list, so a rename fails closed and looks identical to "opted into nothing".

## Known limitation

**No test executes the migration.** The default suite runs without PostgreSQL, so the parity test pins the entity lists but proves no DDL. Closing it needs a `postgres`-marked test.

## Tests

```
deploy/litellm/tests/     → 835 passed (was 820)
deploy/presidio (image)   → 61 passed (was 56)
klai-portal/backend       → 3675 passed, single alembic head, ruff + pyright clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)