### PR TITLE
chore(renovate): ceiling langchain-community and atlassian-python-api

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -202,5 +202,30 @@
       matchPackageNames: ['python'],
       allowedVersions: '<3.14',
     },
+    {
+      description:
+        'langchain-community: pinned below 0.4.2 — ragas 0.4.3 imports \
+        langchain_community.chat_models.vertexai at ragas/llms/base.py:12, \
+        and 0.4.2 removed that submodule as part of the langchain-community \
+        sunset. Widening the bound makes every `from ragas.llms import \
+        llm_factory` raise ModuleNotFoundError, taking the whole RAG-eval \
+        harness with it (proven by PR #1100, which failed exactly there). \
+        Lift only when ragas stops importing the Vertex AI integration.',
+      matchPackageNames: ['langchain-community'],
+      allowedVersions: '<0.4.2',
+    },
+    {
+      description:
+        'atlassian-python-api: pinned below 5 — v5 split Confluence into \
+        Cloud/Server clients and the Cloud client no longer exposes \
+        get_page_by_id, which is what ConfluenceAdapter.fetch_document() \
+        calls. Verified against 5.0.3: Confluence(url=..., cloud=True) \
+        .get_page_by_id raises AttributeError. The only Confluence test \
+        patches the SDK class, so CI cannot catch this — a lock refresh \
+        alone would ship a broken connector. Lift together with a v5 \
+        migration of the adapter. Tracking: GetKlai/klai#1137',
+      matchPackageNames: ['atlassian-python-api'],
+      allowedVersions: '<5',
+    },
   ],
 }


### PR DESCRIPTION
Adds two entries to the existing "blocked, not merely unreviewed" ceiling block in `renovate.json5`, following the pattern already used for typescript, victoria-logs, @tanstack/react-table and python.

## langchain-community `<0.4.2`

`ragas` 0.4.3 imports `langchain_community.chat_models.vertexai` at `ragas/llms/base.py:12`. 0.4.2 removed that submodule as part of the langchain-community sunset, so `from ragas.llms import llm_factory` raises `ModuleNotFoundError` and the whole RAG-eval harness goes with it.

This is not theory: #1100 widened the bound to `<0.4.3` and the knowledge-ingest `quality` job failed on exactly that import (`tests/eval/test_judge_client.py::test_build_ragas_llm_threads_max_tokens_kwarg`). The `pyproject.toml` bound already said `<0.4.2` with a comment naming the reason; the ceiling stops the bot proposing the widening every hour.

## atlassian-python-api `<5`

v5 turned `Confluence` into a dispatcher over separate Cloud and Server clients, and the Cloud client no longer has `get_page_by_id` — the method `ConfluenceAdapter.fetch_document()` calls. Verified against 5.0.3 in a clean venv:

```
Confluence(url=..., cloud=True).get_page_by_id
AttributeError: 'Cloud' object has no attribute 'get_page_by_id'
```

The only Confluence test patches `app.adapters.confluence.Confluence`, so CI stays green while the runtime fetch path is broken. #1091's lock refresh had already pulled 5.0.3 in; that PR now pins `<5` in `klai-connector/pyproject.toml` and re-locks to 4.0.7. Migration tracked in #1137.

## Verification

- `sh scripts/test-renovate-config.sh` → `Renovate configuration contracts: PASS`
- JSON5 parse → 13 packageRules, both new ceilings present with the right `allowedVersions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)