### PR TITLE
feat(portal): enforce design tokens and UI-doc completeness in lint/CI

### DIFF
--- a/.claude/rules/klai/design/styleguide.md
+++ b/.claude/rules/klai/design/styleguide.md
@@ -10,7 +10,7 @@ paths:
 
 > Shared brand DNA for all Klai products (portal, website, future apps).
 > Portal-specific UI/UX patterns: `klai-portal/frontend/docs/ui-standards.md`
-> Website-specific patterns (spacing, animations, buttons): `website-patterns.md`
+> Website-specific patterns (spacing, animations, buttons): `../projects/website.md`
 > Source of truth: `klai-website/src/styles/global.css` and `klai-portal/frontend/src/index.css`.
 
 ---
@@ -161,6 +161,6 @@ Height: `h-5` (20px) in nav. Never distort or tint.
 
 - Portal UI standards: `klai-portal/frontend/docs/ui-standards.md`
 - Portal compatibility rule entrypoint: `portal-patterns.md`
-- Website patterns (buttons, spacing, animations, shadows): `website-patterns.md`
+- Website patterns (buttons, spacing, animations, shadows): `../projects/website.md`
 - [rules/gtm/klai-brand-voice.md](../gtm/klai-brand-voice.md) - tone and writing style
-- [patterns/frontend.md](patterns/frontend.md) - technical frontend patterns (i18n, UI components)
+- [../projects/portal-frontend.md](../projects/portal-frontend.md) - technical frontend patterns (i18n, UI components)

--- a/.claude/rules/klai/projects/portal-frontend.md
+++ b/.claude/rules/klai/projects/portal-frontend.md
@@ -20,7 +20,7 @@ Shared brand DNA and tokens:
 
 - `.claude/rules/klai/design/styleguide.md` is shared brand guidance.
 - `.claude/rules/klai/design/tokens.md` is shared token/logo guidance.
-- Website-specific patterns stay in `.claude/rules/klai/design/website-patterns.md`.
+- Website-specific patterns stay in `.claude/rules/klai/projects/website.md`.
 - Portal-specific UI patterns stay in `klai-portal/frontend/docs/ui-standards.md`.
 
 Do not copy portal admin/app patterns into the website, and do not copy

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -19,6 +19,22 @@ rule, `/dev/ui` is the rendered proof. When you add or change a shared UI
 component, update both — a new tone, state, or variant must appear in the
 catalog and be described here in the same change.
 
+## What Is Enforced (and what is not)
+
+Most of this document is prose you are trusted to follow. Three parts are not:
+
+| Check | Where | Fails on |
+|---|---|---|
+| `klai/no-hardcoded-brand-color` | `eslint-rules/`, runs in `npm run lint` | A hex in `className` that equals a token in `index.css`. Use `bg-[var(--color-rl-dark)]`. Third-party brand marks (Google, HubSpot) never match, by design |
+| `klai/no-window-confirm` | `eslint-rules/`, runs in `npm run lint` | `window.confirm` / `alert` / `prompt`. Use `InlineDeleteConfirm` or `AlertDialog` |
+| Component table completeness | `tests/design/ui-standards-coverage.test.ts` | A module in `src/components/ui/` missing from the table below, or a table row whose module no longer exists |
+
+Everything else in this file is unenforced on purpose. Notably, raw
+`<button>` outside `components/ui/` is discouraged here but not linted: there
+are ~100 legitimate uses (disclosure toggles, custom rows) and a rule that
+noisy gets switched off. Do not add enforcement for a pattern you have not
+first counted.
+
 ## Component Library Reference
 
 All shared UI lives in `src/components/ui/`. The base is **shadcn/ui**
@@ -64,6 +80,7 @@ Build pages from these; never hand-roll a raw `<button>`, `<input>`,
 | `dropdown-menu` `popover` `command` | Menus, popovers, command/combobox | Yes |
 | `multi-select` | Multi-value select | Yes |
 | `tooltip` | Hover/focus tooltips (used by `row-action`) | Yes |
+| `LocaleSwitcher` | NL/EN language toggle (`LocaleSwitcher`). Navigates to the sibling locale URL on `/nl/…` and `/en/…` routes, and updates locale state only elsewhere. Used on the unauthenticated routes (login, signup, verify) | Yes |
 | `sonner` | Toasts (`toast()` feedback) | Yes |
 | `card` | Framed repeated items / stat blocks | Yes |
 | `conversation` | Message timeline + composer + panel (`ConversationTimeline`, `ConversationComposer`, `ConversationPanel`): sender-grouped bubbles, day separators, quiet system lines, Cmd/Enter send, inline edit of own messages, back-right header. Shared by account "Mijn meldingen" + "Berichten" and the platform-admin messages tab | Yes |

--- a/klai-portal/frontend/eslint-rules/__tests__/no-hardcoded-brand-color.test.js
+++ b/klai-portal/frontend/eslint-rules/__tests__/no-hardcoded-brand-color.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for `klai/no-hardcoded-brand-color`.
+ *
+ * RuleTester from `eslint` registers its own describe/it blocks against
+ * vitest's globals and MUST be called at module top-level.
+ *
+ * The rule reads the palette from `src/index.css`. These tests point it at a
+ * fixture stylesheet instead, so they assert rule behaviour rather than the
+ * current contents of the real theme.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { RuleTester } from 'eslint'
+import rule from '../no-hardcoded-brand-color.js'
+import { buildHexIndex } from '../klai-tokens.js'
+
+const FIXTURE_CSS = `
+@theme inline {
+  --color-rl-dark:        #191918;
+  --color-rl-bg:          #fffef2;
+  --color-rl-accent:      #fcaa2d;
+  --color-primary:        #fcaa2d;
+  --color-rl-dark-60:     #19191899;
+  --color-white-ish:      #ffffff;
+}
+`
+
+const cssPath = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), 'klai-tokens-')),
+  'index.css',
+)
+fs.writeFileSync(cssPath, FIXTURE_CSS)
+
+const options = [{ cssPath }]
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+})
+
+ruleTester.run('klai/no-hardcoded-brand-color', rule, {
+  valid: [
+    // The canonical portal form.
+    {
+      code: `const a = <div className="bg-[var(--color-rl-dark)]" />`,
+      options,
+    },
+    // Third-party brand mark: Google blue is not a Klai token.
+    {
+      code: `const a = <div className="bg-[#4285F4]" />`,
+      options,
+    },
+    // Third-party brand mark on an SVG fill attribute - not className at all.
+    {
+      code: `const a = <path fill="#EA4335" d="M9 3.58z" />`,
+      options,
+    },
+    // Tenant-configurable widget colour is runtime DATA, not styling.
+    {
+      code: `const config = { primary_color: '#fcaa2d' }`,
+      options,
+    },
+    // A brand hex passed as a prop value, not a class name.
+    {
+      code: `const a = <WidgetPreview primaryColor="#fcaa2d" />`,
+      options,
+    },
+    // Plain utility classes with no hex at all.
+    {
+      code: `const a = <div className={\`flex \${isDark ? 'bg-white' : 'bg-black'}\`} />`,
+      options,
+    },
+  ],
+  invalid: [
+    // Plain string literal className.
+    {
+      code: `const a = <div className="bg-[#191918]" />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Template literal inside a conditional - the WidgetChatSurface shape.
+    {
+      code: `const a = <div className={\`flex \${isDark ? 'bg-[#191918] text-[#fffef2]' : 'bg-white'}\`} />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }, { messageId: 'hardcoded' }],
+    },
+    // Opacity modifier still resolves to the base token.
+    {
+      code: `const a = <div className="text-[#fffef2]/55" />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Alpha-suffixed hex resolves to its opaque base token.
+    {
+      code: `const a = <div className="text-[#19191899]" />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Ternary directly as the className expression.
+    {
+      code: `const a = <div className={isDark ? 'bg-[#191918]' : 'bg-white'} />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Inside a cn() call.
+    {
+      code: `const a = <div className={cn('flex', 'border-[#fcaa2d]')} />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Property-prefixed arbitrary value.
+    {
+      code: `const a = <div className="[color:#191918]" />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+    // Shorthand hex expands to a token value.
+    {
+      code: `const a = <div className="bg-[#fff]" />`,
+      options,
+      errors: [{ messageId: 'hardcoded' }],
+    },
+  ],
+})
+
+describe('buildHexIndex', () => {
+  it('indexes every --color-* hex from the @theme block', () => {
+    const index = buildHexIndex(cssPath)
+    expect(index.get('#191918')).toEqual(['color-rl-dark', 'color-rl-dark-60'])
+    expect(index.get('#fffef2')).toEqual(['color-rl-bg'])
+  })
+
+  it('records every token name sharing one value', () => {
+    const index = buildHexIndex(cssPath)
+    expect(index.get('#fcaa2d')).toEqual(['color-rl-accent', 'color-primary'])
+  })
+
+  it('returns an empty index for a missing stylesheet, so lint never crashes', () => {
+    expect(buildHexIndex('/nonexistent/index.css').size).toBe(0)
+  })
+
+  it('indexes the real portal stylesheet', () => {
+    // Guards the parser against a future refactor of index.css (e.g. renaming
+    // the @theme block) silently turning the rule into a no-op.
+    const index = buildHexIndex()
+    expect(index.size).toBeGreaterThan(10)
+    expect(index.get('#191918')).toContain('color-rl-dark')
+  })
+})

--- a/klai-portal/frontend/eslint-rules/__tests__/no-window-confirm.test.js
+++ b/klai-portal/frontend/eslint-rules/__tests__/no-window-confirm.test.js
@@ -1,0 +1,54 @@
+/**
+ * Tests for `klai/no-window-confirm`.
+ *
+ * RuleTester from `eslint` registers its own describe/it blocks against
+ * vitest's globals and MUST be called at module top-level.
+ */
+import { RuleTester } from 'eslint'
+import rule from '../no-window-confirm.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+})
+
+ruleTester.run('klai/no-window-confirm', rule, {
+  valid: [
+    // The i18n message keys that make a naive grep look like a violation.
+    `const label = m.kb_sources_row_delete_confirm({ name })`,
+    `const step = m.admin_users_wizard_step_confirm()`,
+    // A locally-defined helper named `confirm` is the app's own symbol.
+    `function confirm(x) { return x }\nconfirm(1)`,
+    // An imported symbol named `confirm` likewise resolves locally.
+    `import { confirm } from './dialogs'\nconfirm({ title: 'x' })`,
+    // A method named confirm on something that is not window.
+    `dialog.confirm('are you sure')`,
+    // Shadowed by a parameter.
+    `function run(confirm) { confirm() }`,
+  ],
+  invalid: [
+    {
+      code: `window.confirm('Delete this?')`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+    {
+      code: `if (window.confirm(m.delete_prompt())) remove()`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+    {
+      code: `confirm('Delete this?')`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+    {
+      code: `window.alert('saved')`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+    {
+      code: `const name = window.prompt('Name?')`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+    {
+      code: `globalThis.confirm('x')`,
+      errors: [{ messageId: 'blockingDialog' }],
+    },
+  ],
+})

--- a/klai-portal/frontend/eslint-rules/klai-tokens.js
+++ b/klai-portal/frontend/eslint-rules/klai-tokens.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Parse the `@theme` block in `src/index.css` into a
+ * hex -> token-name index, so design lint rules never carry their own copy
+ * of the palette.
+ *
+ * Background: `.claude/rules/klai/design/tokens.md` is a hand-maintained
+ * markdown mirror of `index.css`. Any rule that hardcoded the palette would
+ * become a third copy and drift the same way. This module reads the real
+ * stylesheet at lint time instead, so adding a token to `index.css` is the
+ * only step needed to have it enforced.
+ *
+ * Only `--color-*` declarations are indexed; a hex is only interesting to a
+ * design rule when it is a colour someone should have referenced by name.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const THEME_BLOCK = /@theme[^{]*\{([\s\S]*?)\n\}/
+const COLOR_DECL = /--(color-[a-z0-9-]+)\s*:\s*([^;]+);/g
+const HEX = /^#[0-9a-fA-F]{3,8}$/
+
+function defaultCssPath() {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  return path.join(here, '..', 'src', 'index.css')
+}
+
+/**
+ * Build the index.
+ *
+ * Returns a Map keyed on the lowercased 6-digit hex, valued with the list of
+ * token names carrying that value. A value can have several names (e.g.
+ * `#fcaa2d` is both `--color-rl-accent` and `--color-primary`); the rule
+ * reports all of them and lets the author pick the semantically right one.
+ *
+ * @param {string} [cssPath] override, for tests
+ * @returns {Map<string, string[]>}
+ */
+export function buildHexIndex(cssPath = defaultCssPath()) {
+  const index = new Map()
+
+  let source
+  try {
+    source = fs.readFileSync(cssPath, 'utf8')
+  } catch {
+    // A missing stylesheet must not crash the whole lint run. An empty index
+    // makes the rule a no-op, which is the safe direction to fail.
+    return index
+  }
+
+  const themeMatch = THEME_BLOCK.exec(source)
+  if (!themeMatch) return index
+
+  for (const [, name, rawValue] of themeMatch[1].matchAll(COLOR_DECL)) {
+    const value = rawValue.trim()
+    if (!HEX.test(value)) continue
+    // Alpha-suffixed tokens (`#19191899`) are stored under their opaque base
+    // too, so `text-[#191918]/60` still resolves to a named token.
+    const base = `#${value.slice(1, 7)}`.toLowerCase()
+    const names = index.get(base) ?? []
+    if (!names.includes(name)) names.push(name)
+    index.set(base, names)
+  }
+
+  return index
+}
+
+/**
+ * Suggest the CSS-var form the portal actually uses.
+ *
+ * The portal convention is the Tailwind arbitrary value wrapping a var
+ * (`bg-[var(--color-rl-dark)]`), not a generated utility (`bg-rl-dark`):
+ * `var(--color-destructive)` alone appears 191 times in `src/`.
+ *
+ * @param {string[]} tokenNames
+ * @returns {string}
+ */
+export function suggestionFor(tokenNames) {
+  return tokenNames.map((name) => `var(--${name})`).join(' or ')
+}

--- a/klai-portal/frontend/eslint-rules/no-hardcoded-brand-color.js
+++ b/klai-portal/frontend/eslint-rules/no-hardcoded-brand-color.js
@@ -1,0 +1,146 @@
+/**
+ * @fileoverview Forbid Tailwind arbitrary-value hex colours in `className`
+ * when the hex is a Klai design token. Documented in
+ * `.claude/rules/klai/design/tokens.md` § Anti-patterns ("Hardcoded hex in
+ * any .tsx/.html/.css/.j2 - use var(--color-rl-accent) etc.").
+ *
+ * Background: the design language was prose-only. A repo scan found ~25
+ * arbitrary-value brand hexes concentrated in `WidgetChatSurface.tsx`
+ * (`bg-[#191918]`, `text-[#fffef2]/55`) - exactly the drift the anti-pattern
+ * warns about, with nothing to catch it. The `PreToolUse` hook prints a
+ * reminder but always exits 0, so it cannot fail anything.
+ *
+ * The rule deliberately fires ONLY when the hex equals a token value defined
+ * in `src/index.css` (see `klai-tokens.js`). That precision is what keeps it
+ * usable, because plenty of hardcoded hex in this codebase is legitimate:
+ *
+ *   - Third-party brand marks: Google `#4285F4`, Microsoft `#F25022`,
+ *     HubSpot `#ff7a59`. These are other companies' colours; they are not
+ *     ours to tokenize and they never match a Klai token.
+ *   - Tenant-configurable widget colours (`primary_color: '#fcaa2d'`) are
+ *     runtime DATA sent to an embedded surface, not styling. A CSS var would
+ *     not resolve there. Those live outside `className` and so never match.
+ *
+ * Scope is the `className`/`class` JSX attribute only - including template
+ * literals and conditional expressions nested inside it, which is where the
+ * real violations live.
+ */
+
+import { buildHexIndex, suggestionFor } from './klai-tokens.js'
+
+// `bg-[#191918]`, `text-[#fffef2]/55`, `border-[#e3e2d8]`, `[color:#191918]`.
+const ARBITRARY_HEX = /\[(?:[a-z-]+:)?(#[0-9a-fA-F]{3,8})\]/g
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow hardcoded Klai brand hex values in Tailwind arbitrary className values. Reference the design token instead.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: { cssPath: { type: 'string' } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      hardcoded:
+        "Hardcoded brand hex '{{hex}}' in className is the value of {{tokens}}. Use `{{suggestion}}` instead (e.g. `bg-[var(--color-rl-dark)]`), so a token change propagates. See .claude/rules/klai/design/tokens.md.",
+    },
+  },
+  create(context) {
+    const options = context.options?.[0] ?? {}
+    const hexIndex = buildHexIndex(options.cssPath)
+    if (hexIndex.size === 0) return {}
+
+    /**
+     * Report every tokenized hex inside one string of class names.
+     * @param {import('eslint').Rule.Node} node node to anchor the report on
+     * @param {string} value raw class string
+     */
+    function checkClassString(node, value) {
+      if (typeof value !== 'string' || !value.includes('#')) return
+
+      for (const [, hex] of value.matchAll(ARBITRARY_HEX)) {
+        // Normalize to the opaque 6-digit base so `#191918cc` and the
+        // shorthand `#fff` both resolve against the index.
+        const expanded =
+          hex.length === 4
+            ? `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+            : hex
+        const base = expanded.slice(0, 7).toLowerCase()
+
+        const tokens = hexIndex.get(base)
+        if (!tokens) continue
+
+        context.report({
+          node,
+          messageId: 'hardcoded',
+          data: {
+            hex,
+            tokens: tokens.map((t) => `--${t}`).join(' / '),
+            suggestion: suggestionFor(tokens),
+          },
+        })
+      }
+    }
+
+    /**
+     * Walk a className value, descending through the expression forms the
+     * portal actually uses: plain strings, template literals, `cn(...)`
+     * arguments, ternaries, and `&&` chains.
+     * @param {any} node
+     */
+    function walkClassValue(node) {
+      if (!node) return
+
+      switch (node.type) {
+        case 'Literal':
+          checkClassString(node, node.value)
+          break
+        case 'TemplateLiteral':
+          for (const quasi of node.quasis) {
+            checkClassString(quasi, quasi.value.raw)
+          }
+          for (const expr of node.expressions) walkClassValue(expr)
+          break
+        case 'JSXExpressionContainer':
+          walkClassValue(node.expression)
+          break
+        case 'ConditionalExpression':
+          walkClassValue(node.consequent)
+          walkClassValue(node.alternate)
+          break
+        case 'LogicalExpression':
+        case 'BinaryExpression':
+          walkClassValue(node.left)
+          walkClassValue(node.right)
+          break
+        case 'CallExpression':
+          for (const arg of node.arguments) walkClassValue(arg)
+          break
+        case 'ArrayExpression':
+          for (const el of node.elements) walkClassValue(el)
+          break
+        case 'ObjectExpression':
+          for (const prop of node.properties) {
+            if (prop.type === 'Property') walkClassValue(prop.key)
+          }
+          break
+        default:
+          break
+      }
+    }
+
+    return {
+      JSXAttribute(node) {
+        const name = node.name && node.name.name
+        if (name !== 'className' && name !== 'class') return
+        walkClassValue(node.value)
+      },
+    }
+  },
+}

--- a/klai-portal/frontend/eslint-rules/no-window-confirm.js
+++ b/klai-portal/frontend/eslint-rules/no-window-confirm.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Forbid `window.confirm` / bare `confirm()` / `window.alert`
+ * / `window.prompt` in portal code.
+ *
+ * Documented in `klai-portal/frontend/AGENTS.md` ("Do not use
+ * `window.confirm`") and `.claude/rules/klai/design/portal-patterns.md`
+ * § Minimum non-negotiables. The portal has owned components for this:
+ * `inline-delete-confirm` for destructive confirmation inside a row, and
+ * `alert-dialog` for destructive actions outside rows.
+ *
+ * There are currently zero violations - this rule is a regression guard, not
+ * a cleanup. It is cheap precisely because the codebase is already clean: a
+ * documented rule with no enforcement only holds until the next contributor
+ * (human or agent) does not read the doc.
+ *
+ * Bare `confirm(...)` is matched only when the name is not locally bound, so
+ * a helper or import named `confirm` is not reported.
+ */
+
+const FORBIDDEN = new Set(['confirm', 'alert', 'prompt'])
+
+const REPLACEMENT = {
+  confirm: '`InlineDeleteConfirm` for row-level destructive actions, or `AlertDialog` outside rows',
+  alert: '`toast()` from `sonner`, or an inline `Alert`',
+  prompt: 'a real form or dialog built from `components/ui/`',
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow blocking browser dialogs (confirm/alert/prompt). Use the portal UI components instead.',
+    },
+    schema: [],
+    messages: {
+      blockingDialog:
+        "`{{call}}` is forbidden in the portal - it is an unstyled, unlocalized, blocking browser dialog. Use {{replacement}}. See klai-portal/frontend/docs/ui-standards.md.",
+    },
+  },
+  create(context) {
+    /**
+     * True when the identifier resolves to a real binding in scope, i.e. it
+     * is the app's own symbol rather than the browser global.
+     * @param {any} node Identifier node
+     */
+    function isLocallyBound(node) {
+      const scope = context.sourceCode.getScope(node)
+      for (const ref of scope.references) {
+        if (ref.identifier === node) return ref.resolved !== null
+      }
+      return false
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+
+        // window.confirm(...) / globalThis.alert(...)
+        if (
+          callee.type === 'MemberExpression' &&
+          !callee.computed &&
+          callee.object.type === 'Identifier' &&
+          (callee.object.name === 'window' || callee.object.name === 'globalThis') &&
+          callee.property.type === 'Identifier' &&
+          FORBIDDEN.has(callee.property.name)
+        ) {
+          const name = callee.property.name
+          context.report({
+            node,
+            messageId: 'blockingDialog',
+            data: { call: `${callee.object.name}.${name}`, replacement: REPLACEMENT[name] },
+          })
+          return
+        }
+
+        // Bare confirm(...) - only when it is the global, not a local symbol.
+        if (
+          callee.type === 'Identifier' &&
+          FORBIDDEN.has(callee.name) &&
+          !isLocallyBound(callee)
+        ) {
+          context.report({
+            node,
+            messageId: 'blockingDialog',
+            data: { call: `${callee.name}()`, replacement: REPLACEMENT[callee.name] },
+          })
+        }
+      },
+    }
+  },
+}

--- a/klai-portal/frontend/eslint.config.js
+++ b/klai-portal/frontend/eslint.config.js
@@ -6,6 +6,8 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import noDirectKbQuerykey from './eslint-rules/no-direct-kb-querykey.js'
 import noCrossRouteImport from './eslint-rules/no-cross-route-import.js'
+import noHardcodedBrandColor from './eslint-rules/no-hardcoded-brand-color.js'
+import noWindowConfirm from './eslint-rules/no-window-confirm.js'
 
 export default defineConfig([
   globalIgnores([
@@ -23,6 +25,8 @@ export default defineConfig([
         rules: {
           'no-direct-kb-querykey': noDirectKbQuerykey,
           'no-cross-route-import': noCrossRouteImport,
+          'no-hardcoded-brand-color': noHardcodedBrandColor,
+          'no-window-confirm': noWindowConfirm,
         },
       },
     },
@@ -44,6 +48,8 @@ export default defineConfig([
       'no-console': ['error', { allow: ['warn', 'error'] }],
       'klai/no-direct-kb-querykey': 'error',
       'klai/no-cross-route-import': 'error',
+      'klai/no-hardcoded-brand-color': 'error',
+      'klai/no-window-confirm': 'error',
       // TanStack Router uses async functions in route config (beforeLoad, loader)
       '@typescript-eslint/no-misused-promises': [
         'error',

--- a/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
+++ b/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { ArrowUp, ChevronDown, MessageSquare, Pencil, Share2, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { WIDGET_DEFAULT_PRIMARY_COLOR } from '@/features/widgets/config/appearance'
 import * as m from '@/paraglide/messages'
 
 export interface WidgetChatSurfaceProps {
@@ -125,7 +126,7 @@ export function WidgetChatSurface({
   welcomeMessage = '',
   conversationStarters = [],
   hideDisclaimer = false,
-  primaryColor = '#fcaa2d',
+  primaryColor = WIDGET_DEFAULT_PRIMARY_COLOR,
   theme = 'light',
   showSources = true,
   showMeta = false,
@@ -311,10 +312,10 @@ export function WidgetChatSurface({
   return (
     <div
       data-widget-chat-surface
-      className={`fixed inset-0 z-[60] flex flex-col ${isDark ? 'bg-[#191918] text-[#fffef2]' : 'bg-white text-gray-900'}`}
+      className={`fixed inset-0 z-[60] flex flex-col ${isDark ? 'bg-[var(--color-rl-dark)] text-[var(--color-rl-bg)]' : 'bg-white text-gray-900'}`}
       style={{ height: '100vh' }}
     >
-      <div className={`flex h-14 shrink-0 items-center justify-between border-b px-4 sm:px-6 ${isDark ? 'border-white/10 bg-[#191918]' : 'border-gray-200 bg-white'}`}>
+      <div className={`flex h-14 shrink-0 items-center justify-between border-b px-4 sm:px-6 ${isDark ? 'border-white/10 bg-[var(--color-rl-dark)]' : 'border-gray-200 bg-white'}`}>
         <div className="flex min-w-0 items-center gap-3">
           <div
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
@@ -323,8 +324,8 @@ export function WidgetChatSurface({
             <MessageSquare className="h-4 w-4 text-white" strokeWidth={1.75} />
           </div>
           <div className="min-w-0">
-            <h2 className={`truncate text-sm font-display-medium leading-none ${isDark ? 'text-[#fffef2]' : 'text-gray-900'}`}>{botName}</h2>
-            <p className={`mt-0.5 flex items-center gap-1 text-[11px] leading-none ${isDark ? 'text-[#fffef2]/50' : 'text-gray-400'}`}>
+            <h2 className={`truncate text-sm font-display-medium leading-none ${isDark ? 'text-[var(--color-rl-bg)]' : 'text-gray-900'}`}>{botName}</h2>
+            <p className={`mt-0.5 flex items-center gap-1 text-[11px] leading-none ${isDark ? 'text-[var(--color-rl-bg)]/50' : 'text-gray-400'}`}>
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
               {m.widget_chat_status_online()}
             </p>
@@ -362,7 +363,7 @@ export function WidgetChatSurface({
               size="icon"
               onClick={onClose}
               aria-label={m.widget_chat_close()}
-              className={`ml-1 h-8 w-8 ${isDark ? 'text-[#fffef2]/55' : 'text-gray-400'}`}
+              className={`ml-1 h-8 w-8 ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-400'}`}
             >
               <X className="h-4 w-4" />
             </Button>
@@ -370,7 +371,7 @@ export function WidgetChatSurface({
         </div>
       </div>
 
-      <div className={`flex-1 overflow-y-auto ${isDark ? 'bg-[#191918]' : 'bg-white'}`}>
+      <div className={`flex-1 overflow-y-auto ${isDark ? 'bg-[var(--color-rl-dark)]' : 'bg-white'}`}>
         <div className={`mx-auto max-w-3xl px-4 sm:px-6 ${messages.length === 0 ? 'h-full flex flex-col' : 'py-6'}`}>
           {messages.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center px-4 pb-8 text-center">
@@ -380,8 +381,8 @@ export function WidgetChatSurface({
               >
                 <MessageSquare className="h-8 w-8" style={{ color: primaryColor }} strokeWidth={1.5} />
               </div>
-              <h3 className={`text-lg font-semibold ${isDark ? 'text-[#fffef2]' : 'text-gray-900'}`}>{botName}</h3>
-              <p className={`mt-1 max-w-md text-sm ${isDark ? 'text-[#fffef2]/65' : 'text-gray-500'}`}>
+              <h3 className={`text-lg font-semibold ${isDark ? 'text-[var(--color-rl-bg)]' : 'text-gray-900'}`}>{botName}</h3>
+              <p className={`mt-1 max-w-md text-sm ${isDark ? 'text-[var(--color-rl-bg)]/65' : 'text-gray-500'}`}>
                 {welcomeMessage || description || m.widget_chat_default_empty_state()}
               </p>
               {starters.length > 0 && (
@@ -392,7 +393,7 @@ export function WidgetChatSurface({
                       type="button"
                       variant="secondary"
                       onClick={() => void sendMessage(starter)}
-                      className={`h-auto rounded-xl px-4 py-2.5 text-[13px] ${isDark ? 'bg-white/10 text-[#fffef2] hover:bg-white/15' : 'bg-[var(--color-rl-cream)] text-gray-700 hover:bg-[var(--color-rl-cream)]/70'}`}
+                      className={`h-auto rounded-xl px-4 py-2.5 text-[13px] ${isDark ? 'bg-white/10 text-[var(--color-rl-bg)] hover:bg-white/15' : 'bg-[var(--color-rl-cream)] text-gray-700 hover:bg-[var(--color-rl-cream)]/70'}`}
                     >
                       {starter}
                     </Button>
@@ -422,11 +423,11 @@ export function WidgetChatSurface({
         </div>
       </div>
 
-      <div className={`shrink-0 ${isDark ? 'bg-[#191918]' : 'bg-white'}`}>
+      <div className={`shrink-0 ${isDark ? 'bg-[var(--color-rl-dark)]' : 'bg-white'}`}>
         <div className="mx-auto max-w-3xl px-4 pb-4 pt-2 sm:px-6">
           {collectUserInfo && (
             <div className="mb-3">
-              <p className={`mb-2 text-xs ${isDark ? 'text-[#fffef2]/55' : 'text-gray-400'}`}>
+              <p className={`mb-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-400'}`}>
                 {m.widget_chat_user_info_help()}
               </p>
               <div className="grid gap-2 sm:grid-cols-2">
@@ -436,7 +437,7 @@ export function WidgetChatSurface({
                   value={visitorName}
                   onChange={(e) => setVisitorName(e.target.value)}
                   placeholder={m.widget_chat_user_info_name()}
-                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[#fffef2] placeholder:text-[#fffef2]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
+                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
                 />
                 <input
                   type="email"
@@ -444,7 +445,7 @@ export function WidgetChatSurface({
                   value={visitorEmail}
                   onChange={(e) => setVisitorEmail(e.target.value)}
                   placeholder={m.widget_chat_user_info_email()}
-                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[#fffef2] placeholder:text-[#fffef2]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
+                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
                 />
               </div>
             </div>
@@ -467,7 +468,7 @@ export function WidgetChatSurface({
               placeholder={m.widget_chat_input_placeholder()}
               rows={1}
               disabled={isStreaming}
-              className={`max-h-40 min-h-[28px] flex-1 resize-none border-0 bg-transparent px-0 py-1.5 text-[15px] leading-6 focus:ring-0 ${isDark ? 'text-[#fffef2] placeholder:text-[#fffef2]/35' : 'text-gray-900'}`}
+              className={`max-h-40 min-h-[28px] flex-1 resize-none border-0 bg-transparent px-0 py-1.5 text-[15px] leading-6 focus:ring-0 ${isDark ? 'text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'text-gray-900'}`}
             />
             <Button
               type="submit"
@@ -485,7 +486,7 @@ export function WidgetChatSurface({
             </Button>
           </form>
           {!hideDisclaimer && (
-            <p className={`mt-2.5 text-center text-[11px] ${isDark ? 'text-[#fffef2]/45' : 'text-gray-400'}`}>
+            <p className={`mt-2.5 text-center text-[11px] ${isDark ? 'text-[var(--color-rl-bg)]/45' : 'text-gray-400'}`}>
               {m.widget_ai_disclaimer()}
             </p>
           )}
@@ -543,7 +544,7 @@ function MessageBubble({
           <MessageSquare className="h-4 w-4" style={{ color: primaryColor }} strokeWidth={2} />
         </div>
         <div className="min-w-0 flex-1">
-          <div className={`whitespace-pre-line break-words text-[14px] leading-[1.75] ${isDark ? 'text-[#fffef2]' : 'text-gray-900'}`}>
+          <div className={`whitespace-pre-line break-words text-[14px] leading-[1.75] ${isDark ? 'text-[var(--color-rl-bg)]' : 'text-gray-900'}`}>
             {message.content || (isStreaming && isLast ? '…' : '')}
           </div>
           <SourceDetails message={message} showSources={showSources} showMeta={showMeta} isDark={isDark} />
@@ -557,7 +558,7 @@ function MessageBubble({
       {message.content ? (
         <div>
           <div className={`max-w-[75%] rounded-2xl rounded-bl-md px-4 py-2.5 ${isDark ? 'bg-white/10' : 'bg-[var(--color-rl-cream)]'}`}>
-            <div className={`whitespace-pre-line break-words text-[14px] leading-[1.6] ${isDark ? 'text-[#fffef2]' : 'text-gray-900'}`}>
+            <div className={`whitespace-pre-line break-words text-[14px] leading-[1.6] ${isDark ? 'text-[var(--color-rl-bg)]' : 'text-gray-900'}`}>
               {message.content}
             </div>
           </div>
@@ -598,10 +599,10 @@ function SourceDetails({
     <div className="mt-2 max-w-xl space-y-1.5">
       {showSources && sources.length > 0 && (
         <details className={`group rounded-xl border ${isDark ? 'border-white/10 bg-white/[0.04]' : 'border-gray-200 bg-gray-50/70'}`}>
-          <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[#fffef2]/60 hover:text-[#fffef2]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
+          <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/60 hover:text-[var(--color-rl-bg)]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 -rotate-90 transition-transform group-open:rotate-0" strokeWidth={2} />
             <span className="min-w-0 flex-1 font-medium">{m.widget_chat_sources_label()}</span>
-            <span className={isDark ? 'text-[#fffef2]/40' : 'text-gray-400'}>{sourceCountLabel}</span>
+            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-400'}>{sourceCountLabel}</span>
           </summary>
           <ol className="space-y-1 px-3 pb-3">
             {sources.map((source) => (
@@ -611,7 +612,7 @@ function SourceDetails({
                     href={source.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className={`inline-flex max-w-full items-center gap-2 rounded-full border px-2.5 py-1.5 text-xs no-underline transition-colors ${isDark ? 'border-white/10 bg-white/5 text-[#fffef2] hover:bg-white/10' : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'}`}
+                    className={`inline-flex max-w-full items-center gap-2 rounded-full border px-2.5 py-1.5 text-xs no-underline transition-colors ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] hover:bg-white/10' : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'}`}
                   >
                     <span
                       className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
@@ -622,7 +623,7 @@ function SourceDetails({
                     <span className="truncate">{source.title}</span>
                   </a>
                 ) : (
-                  <span className={`inline-flex max-w-full items-center gap-2 rounded-full border px-2.5 py-1.5 text-xs ${isDark ? 'border-white/10 bg-white/5 text-[#fffef2]/70' : 'border-gray-200 bg-white text-gray-600'}`}>
+                  <span className={`inline-flex max-w-full items-center gap-2 rounded-full border px-2.5 py-1.5 text-xs ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)]/70' : 'border-gray-200 bg-white text-gray-600'}`}>
                     <span
                       className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
                       style={{ backgroundColor: 'var(--color-rl-dark)' }}
@@ -639,14 +640,14 @@ function SourceDetails({
       )}
       {showMeta && (
         <details className={`group rounded-xl border ${isDark ? 'border-white/10 bg-white/[0.03]' : 'border-gray-200 bg-gray-50/50'}`}>
-          <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[#fffef2]/55 hover:text-[#fffef2]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
+          <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/55 hover:text-[var(--color-rl-bg)]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 -rotate-90 transition-transform group-open:rotate-0" strokeWidth={2} />
             <span className="min-w-0 flex-1 font-medium">Agent activiteit</span>
-            <span className={isDark ? 'text-[#fffef2]/40' : 'text-gray-400'}>
+            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-400'}>
               {activity.length > 0 ? activityCountLabel : sourceCountLabel}
             </span>
           </summary>
-          <div className={`space-y-2 px-3 pb-3 text-[11px] leading-relaxed ${isDark ? 'text-[#fffef2]/55' : 'text-gray-500'}`}>
+          <div className={`space-y-2 px-3 pb-3 text-[11px] leading-relaxed ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-500'}`}>
             {sources.length > 0 && (
               <p>
                 {sources.length === 1
@@ -658,9 +659,9 @@ function SourceDetails({
               <ol className="space-y-1.5">
                 {activity.map((item) => (
                   <li key={item.step} className="flex gap-2">
-                    <span className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${isDark ? 'bg-[#fffef2]/35' : 'bg-gray-300'}`} />
+                    <span className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${isDark ? 'bg-[var(--color-rl-bg)]/35' : 'bg-gray-300'}`} />
                     <span className="min-w-0">
-                      <span className={isDark ? 'font-medium text-[#fffef2]/75' : 'font-medium text-gray-700'}>{item.label}</span>
+                      <span className={isDark ? 'font-medium text-[var(--color-rl-bg)]/75' : 'font-medium text-gray-700'}>{item.label}</span>
                       {item.detail && <span> {item.detail}</span>}
                     </span>
                   </li>

--- a/klai-portal/frontend/src/features/widgets/config/appearance.ts
+++ b/klai-portal/frontend/src/features/widgets/config/appearance.ts
@@ -1,0 +1,18 @@
+/**
+ * Widget appearance defaults.
+ *
+ * The widget's primary colour is tenant-configurable DATA, not portal
+ * styling: it is persisted per widget and handed to an embedded surface that
+ * does not share the portal's stylesheet, so a `var(--color-rl-accent)`
+ * reference would not resolve there. It therefore has to be a literal.
+ *
+ * It only has to be a literal ONCE. Before this module the same literal sat
+ * in four places (the chat surface default param, the create-widget form, the
+ * appearance tab's initial state, and its dirty-check), which is the shape of
+ * drift this repo has already paid for once with the `/kb-images/` path
+ * literal. Import from here instead of retyping the hex.
+ *
+ * The value intentionally matches `--color-rl-accent` in `src/index.css`;
+ * `widget-appearance.test.ts` asserts they stay in step.
+ */
+export const WIDGET_DEFAULT_PRIMARY_COLOR = '#fcaa2d'

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/AppearanceTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/AppearanceTab.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { WidgetToggleCard } from '@/features/widgets/components/WidgetToggleCard'
+import { WIDGET_DEFAULT_PRIMARY_COLOR } from '@/features/widgets/config/appearance'
 import * as m from '@/paraglide/messages'
 import type { WidgetDetailResponse, WidgetConfig } from '../../-types'
 import { useUpdateWidget } from '../../-hooks'
@@ -26,7 +27,7 @@ export function AppearanceTab({ widget }: Props) {
   const config = widget.widget_config
 
   const [welcome, setWelcome] = useState(config.welcome_message)
-  const [primaryColor, setPrimaryColor] = useState(config.primary_color || '#fcaa2d')
+  const [primaryColor, setPrimaryColor] = useState(config.primary_color || WIDGET_DEFAULT_PRIMARY_COLOR)
   const [theme, setTheme] = useState<'light' | 'dark'>(config.theme || 'light')
   const [startersRaw, setStartersRaw] = useState((config.conversation_starters ?? []).join('\n'))
   const [showSources, setShowSources] = useState(config.show_sources ?? true)
@@ -37,7 +38,7 @@ export function AppearanceTab({ widget }: Props) {
 
   useEffect(() => {
     setWelcome(config.welcome_message)
-    setPrimaryColor(config.primary_color || '#fcaa2d')
+    setPrimaryColor(config.primary_color || WIDGET_DEFAULT_PRIMARY_COLOR)
     setTheme(config.theme || 'light')
     setStartersRaw((config.conversation_starters ?? []).join('\n'))
     setShowSources(config.show_sources ?? true)
@@ -51,7 +52,7 @@ export function AppearanceTab({ widget }: Props) {
 
   const isDirty =
     welcome.trim() !== config.welcome_message ||
-    primaryColor !== (config.primary_color || '#fcaa2d') ||
+    primaryColor !== (config.primary_color || WIDGET_DEFAULT_PRIMARY_COLOR) ||
     theme !== (config.theme || 'light') ||
     JSON.stringify(starters) !== JSON.stringify(config.conversation_starters ?? []) ||
     showSources !== (config.show_sources ?? true) ||

--- a/klai-portal/frontend/src/routes/admin/widgets/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/new.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { WIDGET_DEFAULT_PRIMARY_COLOR } from '@/features/widgets/config/appearance'
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { AlertTriangle, ArrowLeft, ArrowRight, Loader2 } from 'lucide-react'
@@ -70,7 +71,7 @@ const INITIAL_FORM: FormState = {
   system_prompt: '',
   page_context_enabled: false,
   kb_ids: [],
-  primary_color: '#fcaa2d',
+  primary_color: WIDGET_DEFAULT_PRIMARY_COLOR,
   theme: 'light',
   welcome_message: '',
   starters_raw: '',

--- a/klai-portal/frontend/tests/design/ui-standards-coverage.test.ts
+++ b/klai-portal/frontend/tests/design/ui-standards-coverage.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `docs/ui-standards.md` is the canonical UI contract - it is what an agent
+ * or a new contributor reads before building a screen, and it opens by
+ * declaring that it wins over any other design document. Its Component
+ * Library Reference table is maintained by hand.
+ *
+ * A hand-maintained inventory of a directory drifts the moment someone adds a
+ * component and forgets the table. The failure is silent and asymmetric: the
+ * component exists and works, so nothing breaks, but every future reader is
+ * told the portal has no such primitive and hand-rolls a replacement. That is
+ * how a component library grows a second, undocumented half.
+ *
+ * This test makes the table's completeness a build-time fact.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const FRONTEND_ROOT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+)
+const UI_DIR = path.join(FRONTEND_ROOT, 'src', 'components', 'ui')
+const STANDARDS = path.join(FRONTEND_ROOT, 'docs', 'ui-standards.md')
+
+/** Every shared UI module, by the name a reader would look up. */
+function ownedComponents(): string[] {
+  return fs
+    .readdirSync(UI_DIR, { withFileTypes: true })
+    .filter((e) => e.isFile() && /\.tsx?$/.test(e.name))
+    .map((e) => e.name.replace(/\.tsx?$/, ''))
+    .sort()
+}
+
+/**
+ * The doc has several tables (action tones, layout containers, reference
+ * screens). Only the Component Library Reference one is an inventory of
+ * `src/components/ui/`, so the staleness check must read that section alone.
+ */
+function componentSection(doc: string): string {
+  const start = doc.indexOf('## Component Library Reference')
+  if (start < 0) throw new Error('ui-standards.md lost its Component Library Reference heading')
+  const next = doc.indexOf('\n## ', start + 1)
+  return doc.slice(start, next < 0 ? undefined : next)
+}
+
+describe('ui-standards.md Component Library Reference', () => {
+  const doc = fs.readFileSync(STANDARDS, 'utf8')
+
+  it('names every module in src/components/ui/', () => {
+    const undocumented = ownedComponents().filter(
+      (name) => !doc.includes(`\`${name}\``),
+    )
+
+    expect(
+      undocumented,
+      `Add these to the Component Library Reference table in docs/ui-standards.md ` +
+        `(and to the /dev/ui catalog if they render): ${undocumented.join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('does not describe components that no longer exist', () => {
+    // The other drift direction: a component gets deleted or renamed and the
+    // table keeps advertising it, so an agent imports something that is gone.
+    const owned = new Set(ownedComponents())
+    const tableRows = componentSection(doc).matchAll(/^\|\s*`([a-z0-9-]+)`[^|]*\|/gim)
+
+    const stale = [...tableRows]
+      .map((m) => m[1])
+      .filter((name) => !owned.has(name))
+
+    expect(
+      stale,
+      `These are documented in docs/ui-standards.md but absent from ` +
+        `src/components/ui/: ${stale.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/klai-portal/frontend/tests/design/widget-default-color.test.ts
+++ b/klai-portal/frontend/tests/design/widget-default-color.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The widget default primary colour is a literal by necessity (it ships to an
+ * embedded surface that cannot resolve portal CSS vars), so nothing in the
+ * type system ties it to the brand. This test does.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { WIDGET_DEFAULT_PRIMARY_COLOR } from '@/features/widgets/config/appearance'
+
+const SRC_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'src')
+
+describe('WIDGET_DEFAULT_PRIMARY_COLOR', () => {
+  it('matches --color-rl-accent in index.css', () => {
+    const css = fs.readFileSync(path.join(SRC_ROOT, 'index.css'), 'utf8')
+    const match = /--color-rl-accent:\s*(#[0-9a-fA-F]{6})\s*;/.exec(css)
+
+    expect(match, 'index.css must define --color-rl-accent').not.toBeNull()
+    expect(WIDGET_DEFAULT_PRIMARY_COLOR.toLowerCase()).toBe(match![1].toLowerCase())
+  })
+
+  it('is the only place the literal is defined', () => {
+    // Guards the dedupe: a re-introduced literal elsewhere in src/ means the
+    // four-copy drift is back.
+    const offenders: string[] = []
+
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+          if (entry.name === 'paraglide' || entry.name === '__tests__') continue
+          walk(full)
+          continue
+        }
+        if (!/\.tsx?$/.test(entry.name)) continue
+        if (full.endsWith(path.join('config', 'appearance.ts'))) continue
+        if (fs.readFileSync(full, 'utf8').includes(`'${WIDGET_DEFAULT_PRIMARY_COLOR}'`)) {
+          offenders.push(path.relative(SRC_ROOT, full))
+        }
+      }
+    }
+    walk(SRC_ROOT)
+
+    expect(
+      offenders,
+      'import WIDGET_DEFAULT_PRIMARY_COLOR instead of retyping the hex',
+    ).toEqual([])
+  })
+})

--- a/klai-portal/frontend/tsconfig.node.json
+++ b/klai-portal/frontend/tsconfig.node.json
@@ -20,7 +20,10 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "tests/design"]
 }


### PR DESCRIPTION
## Why

The portal's UI language was documented well and enforced not at all. The only mechanism was a `PreToolUse` hook that prints a reminder and always exits 0, so nothing could fail on a violation. A scan found **56 hardcoded hex values** in portal `.tsx`.

## Triage before fixing

Most were legitimate, and that shaped the rule design:

- Google/Microsoft sign-in marks and the HubSpot integration colour are **other companies' brands**. Not ours to tokenize.
- The widget's default primary colour is tenant **data**, shipped to a Shadow DOM that cannot resolve portal CSS vars.

The real violations were **32 occurrences of our own `--color-rl-dark` / `--color-rl-bg`**, all in `WidgetChatSurface.tsx`.

## Enforcement added

- **`klai/no-hardcoded-brand-color`** fires only when a hex in `className` equals a token defined in `index.css`. `klai-tokens.js` parses the `@theme` block at lint time, so the rule carries no second copy of the palette. That precision is the point: 32 hits, 0 false positives on third-party marks. A generic `color-no-hex` rule would have flagged all 56.
- **`klai/no-window-confirm`** guards a documented rule that currently has 0 violations.
- **`tests/design/ui-standards-coverage.test.ts`** asserts the Component Library Reference table matches `src/components/ui/` in both directions. It immediately found `LocaleSwitcher` missing.

## Cleanup

- 32 hex → `var()` in `WidgetChatSurface.tsx` (verified as pure substitution, no other edit in the diff)
- 4 copies of `'#fcaa2d'` → `WIDGET_DEFAULT_PRIMARY_COLOR`, with a drift test against `--color-rl-accent`
- 4 dangling rule references repaired: `website-patterns.md` and `patterns/frontend.md` never existed; `projects/website.md` is the real file

## Deliberately not done

Raw `<button>` outside `components/ui/` has ~100 legitimate uses (disclosure toggles, custom rows). A rule that noisy gets switched off. `ui-standards.md` now has a **What Is Enforced (and what is not)** section so the boundary is explicit rather than assumed.

Also skipped: a `tokens.md` ↔ `index.css` sync script (the lint rule already reads `index.css` directly, a third artifact adds nothing) and a test harness in `klai-widget` (that package has none, and its `--klai-*` layer is a deliberate Shadow-DOM token boundary, not drift).

## Gates

`eslint .` exit 0 · `tsc -b --force` exit 0 · `vitest run` 563/563 in 81 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)