### PR TITLE
fix(design): resolve --font-display contradiction, lock doc token values

### DIFF
--- a/.claude/rules/klai/design/styleguide.md
+++ b/.claude/rules/klai/design/styleguide.md
@@ -79,7 +79,18 @@ Klai should feel calm, confident, and warm. Not a startup shouting for attention
 
 One font family (Parabole) in multiple weights, plus Decima Mono for labels.
 
-### Font stack
+> [HARD] **The table below is the WEBSITE font stack only.** The portal binds
+> the same token names to different faces and weights. `--font-display` is
+> `"Parabole Trial Regular Text"` at 400 here and `"Parabole Medium"` at 500
+> in the portal, and `--font-display-medium` does not exist in the portal at
+> all. When you are editing `klai-portal/**`, the font tokens in
+> `tokens.md` win over this section. Colors, radii, logo and anti-patterns in
+> this file ARE shared and apply to both.
+>
+> Source of truth: `klai-website/src/styles/global.css` for the values below,
+> `klai-portal/frontend/src/index.css` for the portal.
+
+### Font stack (website)
 
 | Variable | Font | Tailwind class | Weight | Usage |
 |---|---|---|---|---|

--- a/klai-portal/frontend/tests/design/rule-doc-token-values.test.ts
+++ b/klai-portal/frontend/tests/design/rule-doc-token-values.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `.claude/rules/klai/design/tokens.md` quotes hex values from `index.css` in
+ * a markdown table. It carries `paths: "**"`, so it loads into EVERY agent
+ * session in this monorepo, for every file. It is the single most-read design
+ * document we have, and nothing connects it to the stylesheet it mirrors.
+ *
+ * A wrong value there is worse than a missing one. An agent that reads
+ * `--color-rl-accent` is `#fcaa2d` when the stylesheet says otherwise will
+ * confidently hardcode the stale value, and the brand-colour lint rule will
+ * not catch it: that rule compares against `index.css`, so a hex matching a
+ * stale doc is simply an unknown colour to it.
+ *
+ * There is no drift today. This is a lock, not a clean-up.
+ *
+ * Values documented but absent from the portal stylesheet are skipped rather
+ * than failed: `styleguide.md` covers the website too, and website-only
+ * tokens (`--color-rl-dark-30`, `--color-rl-muted`, ...) live in
+ * `klai-website/src/styles/global.css`, which is a separate repo.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.join(HERE, '..', '..', '..', '..')
+const CSS = path.join(HERE, '..', '..', 'src', 'index.css')
+
+const RULE_DOCS = [
+  '.claude/rules/klai/design/tokens.md',
+  '.claude/rules/klai/design/styleguide.md',
+]
+
+/** Every `--color-*: #hex;` declaration in the portal stylesheet. */
+function stylesheetColors(): Map<string, string> {
+  const css = fs.readFileSync(CSS, 'utf8')
+  const out = new Map<string, string>()
+  for (const m of css.matchAll(/(--color-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{3,8})\s*;/g)) {
+    out.set(m[1], m[2].toLowerCase())
+  }
+  return out
+}
+
+/**
+ * Table rows that name at least one token AND at least one hex.
+ * A row may carry several of each (`--color-rl-cream` / `--color-secondary`
+ * with two values), so a row passes when the stylesheet value appears
+ * anywhere in that row.
+ */
+function documentedPairs(docPath: string): Array<{ token: string; hexes: string[]; line: number }> {
+  const lines = fs.readFileSync(path.join(REPO_ROOT, docPath), 'utf8').split('\n')
+  const pairs: Array<{ token: string; hexes: string[]; line: number }> = []
+
+  lines.forEach((line, i) => {
+    if (!line.startsWith('|')) return
+    const tokens = [...line.matchAll(/`(--color-[a-z0-9-]+)`/g)].map((m) => m[1])
+    const hexes = [...line.matchAll(/`(#[0-9a-fA-F]{3,8})`/g)].map((m) => m[1].toLowerCase())
+    if (!tokens.length || !hexes.length) return
+    for (const token of tokens) pairs.push({ token, hexes, line: i + 1 })
+  })
+
+  return pairs
+}
+
+describe('design rule docs quote real token values', () => {
+  const css = stylesheetColors()
+
+  it('finds the portal stylesheet tokens', () => {
+    // If index.css is restructured and this parser stops matching, every
+    // assertion below would vacuously pass. Fail loudly instead.
+    expect(css.size).toBeGreaterThan(20)
+    expect(css.get('--color-rl-accent')).toBeDefined()
+  })
+
+  for (const doc of RULE_DOCS) {
+    it(`${doc} matches index.css`, () => {
+      const drift = documentedPairs(doc)
+        .filter((p) => css.has(p.token))
+        .filter((p) => !p.hexes.includes(css.get(p.token)!))
+        .map((p) => `${doc}:${p.line} ${p.token} documented as ${p.hexes.join('/')}, index.css says ${css.get(p.token)}`)
+
+      expect(drift, drift.join('\n')).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
Follow-up to #1139. Two findings from the same investigation, both verified against source rather than assumed.

## 1. `--font-display` meant two different things in one context

Two design rules load simultaneously when editing portal frontend: `tokens.md` (`paths: "**"`) and `styleguide.md` (which globs `klai-portal/frontend/**`).

| | `--font-display` |
|---|---|
| portal `index.css` | `"Parabole Medium"`, weight 500, headings and buttons |
| website `global.css` | `"Parabole Trial Regular Text"`, weight 400, "default for everything" |

Both docs were individually correct. `styleguide.md` documents the **website** font stack, but its `paths` glob pulls it into portal work. An agent building a portal component received both definitions of the same token name, plus `--font-display-medium`, which does not exist in the portal at all.

Colors are genuinely shared (verified identical in both stylesheets). The fonts are not. The typography section is now marked website-only and points at `tokens.md` for the portal. The shared parts of `styleguide.md` (colors, radii, logo, anti-patterns) keep applying to both.

## 2. Documented token values were tied to nothing

#1139 deferred this with a bad argument: "the lint rule already reads `index.css`". That rule compares *code* against the stylesheet. It does nothing for the hex values quoted in the rule docs themselves, and it cannot: a hex matching a stale doc is simply an unknown colour to it, so it stays silent.

`tokens.md` loads into every agent session for every file. It is the most-read design document in the repo, and a wrong value there is worse than a missing one.

`rule-doc-token-values.test.ts` ties documented values back to `index.css`. Website-only tokens (`--color-rl-dark-30`, `--color-rl-muted`) are skipped rather than failed, since they live in `klai-website/src/styles/global.css` in a separate repo.

**Verified it fails on drift, not just passes clean.** Injecting `#ff0000` for `--color-rl-accent` produces:

```
tokens.md:32 --color-rl-accent documented as #ff0000, index.css says #fcaa2d
```

There is no drift today. This is a lock, not a clean-up.

## Gates

`eslint .` 0 · `tsc -b --force` 0 · `vitest run` 566/566 in 82 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)