### PR TITLE
docs: point agents at the website publishing runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,12 +178,25 @@ Confidence: [0-100] — <one-line evidence summary>   (evidence only; "looks rig
 
 ## Customer-facing publishing (private runbooks)
 
-The "What's new" product-updates feed (megaphone in the portal) and the
-customer help centre (Klai Docs KB `klai-help`) are maintained through
-operator workflows in the private `klai-infra` repo: `PRODUCT_UPDATES.md`
-and `HELP_SYSTEM.md`. Neither workflow is documented in this public repo.
+Three separate publishing paths, all operated from the private `klai-infra`
+repo. None of these workflows is documented in this public repo.
+
+| Surface | Runbook |
+|---|---|
+| "What's new" product-updates feed (megaphone in the portal) | `PRODUCT_UPDATES.md` |
+| Customer help centre (Klai Docs KB `klai-help`) | `HELP_SYSTEM.md` |
+| getklai.com website and blog | `WEBSITE_PUBLISHING.md` |
+
 When publishing a product-updates batch, check whether the help centre
 needs matching page updates.
+
+For website content, two things are worth knowing before you start, because
+both have already cost time. `klai-website` is a submodule that is usually
+NOT checked out in a Conductor worktree, so edit it in its own checkout, not
+from here. And a push to its `main` is the deploy — it is Coolify-hosted and
+rebuilds automatically, with no staging branch and no approval gate. Build
+locally first, and verify the deployed commit and the live URL afterwards.
+`WEBSITE_PUBLISHING.md` has the exact commands.
 
 <!-- codeindex:start -->
 # CodeIndex MCP


### PR DESCRIPTION
Publishing today's blog post required reverse-engineering the whole path. `SERVERS.md` documented the host. Nothing documented the workflow.

The **Customer-facing publishing** section listed two of the three paths and omitted the website entirely, so an agent reading `AGENTS.md` would reasonably conclude the website has no operator workflow.

## What changed here

The section is now a table of all three surfaces, with the website pointing at a new `WEBSITE_PUBLISHING.md` in `klai-infra`. Plus the two facts that actually cost time today:

- **`klai-website` is a submodule that is usually not checked out** in a Conductor worktree. Editing website content from a monorepo worktree silently does nothing.
- **A push to its `main` IS the deploy.** Coolify rebuilds on push, roughly two minutes, no staging branch and no approval gate.

## What went in the private repo

`klai-infra/WEBSITE_PUBLISHING.md` carries the operational detail, per the existing split. Everything in it was verified against the running system today rather than assumed:

- The Coolify image tag **is** the deployed git SHA (`sc8wk8c84woc4wo00goccwsg:5ba0c74…` matched `git rev-parse HEAD` after the push), which is what makes deploy verification exact rather than hopeful.
- Deploy took ~2 minutes, observed by polling.
- Filenames prefixed with `_` are excluded by Astro's content collections. Confirmed: the two such files in `blog-en` return 404 in production. That is the draft convention.
- Internal post links use `/blog/<slug>`, not `/en/blog/<slug>`.
- `npm run build` emits two pre-existing warnings about an empty `pages` collection. Confirmed present without any content change, so they are not a signal.

## Verification

`scripts/check-agent-knowledge.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)