### PR TITLE
feat(rag): make graph facts citable and bound the graph timeout

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1368,7 +1368,14 @@ services:
       FALKORDB_HOST: falkordb
       FALKORDB_PORT: "6379"
       GRAPHITI_ENABLED: "true"
-      GRAPH_SEARCH_TIMEOUT: "60.0"
+      # Back to the code default after measurement: over 10,151 graph
+      # searches in 30 days the mean was 252 ms and the worst case
+      # 2,679 ms, so 5s leaves ~2x headroom on the observed peak. The
+      # previous 60.0 let the graph leg hold a live chat query for a
+      # minute, which made the AC-7 fail-open path unreachable in
+      # practice: retrieval degrades gracefully without graph results,
+      # but not if it waits a minute to find that out.
+      GRAPH_SEARCH_TIMEOUT: "5.0"
       # Graphiti LLM model for knowledge-graph extraction. klai-fast
       # points at Mistral Small 4 (same model the dropped klai-pipeline
       # alias used to point at). Override via env if a different tier

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -21,6 +21,7 @@ from graphiti_core.driver.falkordb_driver import FalkorDriver
 from graphiti_core.embedder.openai import OpenAIEmbedder, OpenAIEmbedderConfig
 from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
+from graphiti_core.nodes import EpisodicNode
 from klai_graphiti_compat import apply_falkordb_compat
 
 from retrieval_api.config import settings
@@ -89,11 +90,10 @@ async def search(query: str, org_id: str, top_k: int = 20) -> list[dict]:
 
     graphiti = _get_graphiti()
     try:
-        results = await asyncio.wait_for(
-            graphiti.search(query, group_ids=[org_id]),
+        return await asyncio.wait_for(
+            _search_with_provenance(graphiti, query, org_id, top_k),
             timeout=settings.graph_search_timeout,
         )
-        return _convert_results(results, top_k)
     except TimeoutError:
         logger.warning(
             "graph_search_timeout",
@@ -111,6 +111,84 @@ async def search(query: str, org_id: str, top_k: int = 20) -> list[dict]:
         return []
 
 
+async def _search_with_provenance(
+    graphiti: Graphiti, query: str, org_id: str, top_k: int
+) -> list[dict]:
+    """Search, then resolve each edge back to the artifact it came from.
+
+    Both steps share one timeout budget: the lookup is a uuid-indexed read in
+    the same graph the search just used, so it must never become a second,
+    unbounded round trip.
+    """
+    results = await graphiti.search(query, group_ids=[org_id])
+    episode_artifacts = await _resolve_episode_artifacts(graphiti, results, org_id)
+    return _convert_results(results, top_k, episode_artifacts)
+
+
+def _episode_uuids(edge: object) -> list[str]:
+    """Episode uuids on an edge, or [] when the shape is not what we expect."""
+    episodes = getattr(edge, "episodes", None)
+    if not isinstance(episodes, list):
+        return []
+    return [uuid for uuid in episodes if isinstance(uuid, str) and uuid]
+
+
+async def _resolve_episode_artifacts(
+    graphiti: Graphiti, results: list, org_id: str
+) -> dict[str, str]:
+    """Map episode uuid -> Klai artifact_id for the edges in ``results``.
+
+    knowledge-ingest calls ``add_episode(name=artifact_id, ...)``, so an
+    episode node's ``name`` IS the artifact identity. That is what turns a
+    derived graph fact into something the evidence pack can cite.
+
+    TENANT ISOLATION. ``EpisodicNode.get_by_uuids`` matches on uuid alone —
+    it applies no group_id filter of its own. Scoping therefore rests on the
+    driver being cloned to ``database=<org_id>``, the same per-tenant graph
+    boundary ``graphiti.search()`` gets from ``handle_multiple_group_ids``.
+    The ``group_id`` assertion below is deliberate defence in depth, not
+    redundancy: it keeps the read fail-closed if a future Graphiti change
+    alters how a driver resolves its database.
+
+    Fail-open on error: returning ``{}`` costs citations, raising would cost
+    the whole graph leg.
+    """
+    uuids = sorted({uuid for edge in results for uuid in _episode_uuids(edge)})
+    if not uuids:
+        return {}
+
+    try:
+        driver = graphiti.clients.driver.clone(database=org_id)
+        episodes = await EpisodicNode.get_by_uuids(driver, uuids)
+    except Exception:
+        logger.warning("graph_episode_lookup_failed", org_id=org_id, exc_info=True)
+        return {}
+
+    resolved: dict[str, str] = {}
+    foreign = 0
+    for episode in episodes:
+        if getattr(episode, "group_id", None) != org_id:
+            foreign += 1
+            continue
+        artifact_id = getattr(episode, "name", None)
+        uuid = getattr(episode, "uuid", None)
+        if isinstance(artifact_id, str) and artifact_id and isinstance(uuid, str):
+            resolved[uuid] = artifact_id
+    if foreign:
+        logger.warning("graph_episode_foreign_group_id_dropped", org_id=org_id, count=foreign)
+    return resolved
+
+
+def _iso(value: object) -> str | None:
+    """Serialise Graphiti's datetimes to the ISO strings ChunkResult expects."""
+    if value is None:
+        return None
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value) if isinstance(value, str) else None
+
+
 def _has_searchable_text(query: str) -> bool:
     return any(ch.isalnum() for ch in query)
 
@@ -120,7 +198,9 @@ def _is_empty_fulltext_query_error(exc: Exception) -> bool:
     return "syntax" in message.lower() and _EMPTY_FULLTEXT_QUERY_RE.search(message) is not None
 
 
-def _convert_results(results: list, top_k: int) -> list[dict]:
+def _convert_results(
+    results: list, top_k: int, episode_artifacts: dict[str, str] | None = None
+) -> list[dict]:
     """Convert Graphiti search results to chunk-compatible format for RRF merge.
 
     Graphiti search returns EdgeResult / EntityEdge objects. Key fields:
@@ -128,6 +208,14 @@ def _convert_results(results: list, top_k: int) -> list[dict]:
     - .score: semantic relevance from Graphiti (cosine similarity)
     - .weight: Hebbian reinforcement count (incremented per confirming episode)
     - .uuid: unique identifier
+    - .episodes: uuids of the episodes the fact was extracted from
+    - .valid_at / .invalid_at: Graphiti's bi-temporal validity window
+
+    ``episode_artifacts`` maps episode uuid -> artifact_id (see
+    ``_resolve_episode_artifacts``). An edge can be supported by several
+    episodes; the first one that resolves is used, which is enough for a
+    citation because any supporting document lets the reader verify the
+    claim. Multi-source attribution belongs with knowledge.derivations.
 
     Scoring: base semantic score boosted by log-scaled Hebbian weight.
     Results are sorted by combined score so RRF uses the correct rank ordering.
@@ -153,17 +241,22 @@ def _convert_results(results: list, top_k: int) -> list[dict]:
             score = base
 
         uid = str(getattr(r, "uuid", i))
+        artifact_id = None
+        for episode_uuid in _episode_uuids(r):
+            artifact_id = (episode_artifacts or {}).get(episode_uuid)
+            if artifact_id:
+                break
         converted.append(
             {
                 "chunk_id": f"graph:{uid}",
                 "text": text,
                 "score": score,
-                "artifact_id": None,
+                "artifact_id": artifact_id,
                 "content_type": "graph_edge",
                 "context_prefix": None,
                 "scope": "org",
-                "valid_at": None,
-                "invalid_at": None,
+                "valid_at": _iso(getattr(r, "valid_at", None)),
+                "invalid_at": _iso(getattr(r, "invalid_at", None)),
             }
         )
 

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -32,6 +32,10 @@ apply_falkordb_compat()
 logger = structlog.get_logger()
 
 _graphiti_client: Graphiti | None = None
+# Provenance is optional garnish on the graph leg: it gets its own small
+# budget so it can never cost more than the search it annotates.
+_PROVENANCE_TIMEOUT = 1.0
+
 _EMPTY_FULLTEXT_QUERY_RE = re.compile(r"\(@group_id:[^)]*\)\s+\(\s*\)(?:\s|['\"]|$)")
 
 
@@ -90,10 +94,7 @@ async def search(query: str, org_id: str, top_k: int = 20) -> list[dict]:
 
     graphiti = _get_graphiti()
     try:
-        return await asyncio.wait_for(
-            _search_with_provenance(graphiti, query, org_id, top_k),
-            timeout=settings.graph_search_timeout,
-        )
+        return await _search_with_provenance(graphiti, query, org_id, top_k)
     except TimeoutError:
         logger.warning(
             "graph_search_timeout",
@@ -116,11 +117,20 @@ async def _search_with_provenance(
 ) -> list[dict]:
     """Search, then resolve each edge back to the artifact it came from.
 
-    Both steps share one timeout budget: the lookup is a uuid-indexed read in
-    the same graph the search just used, so it must never become a second,
-    unbounded round trip.
+    The two steps have SEPARATE budgets on purpose. Sharing one would mean a
+    slow provenance lookup gets the whole coroutine cancelled by the outer
+    ``wait_for``, and ``asyncio.CancelledError`` inherits from BaseException,
+    so ``_resolve_episode_artifacts``'s ``except Exception`` cannot turn that
+    back into "no provenance". Results already in hand would be thrown away by
+    an optional lookup — worse than the behaviour before citations existed.
+
+    Worst case is therefore ``graph_search_timeout + _PROVENANCE_TIMEOUT``,
+    both bounded and explicit.
     """
-    results = await graphiti.search(query, group_ids=[org_id])
+    results = await asyncio.wait_for(
+        graphiti.search(query, group_ids=[org_id]),
+        timeout=settings.graph_search_timeout,
+    )
     episode_artifacts = await _resolve_episode_artifacts(graphiti, results, org_id)
     return _convert_results(results, top_k, episode_artifacts)
 
@@ -159,7 +169,12 @@ async def _resolve_episode_artifacts(
 
     try:
         driver = graphiti.clients.driver.clone(database=org_id)
-        episodes = await EpisodicNode.get_by_uuids(driver, uuids)
+        episodes = await asyncio.wait_for(
+            EpisodicNode.get_by_uuids(driver, uuids), timeout=_PROVENANCE_TIMEOUT
+        )
+    except TimeoutError:
+        logger.warning("graph_episode_lookup_timeout", org_id=org_id, uuid_count=len(uuids))
+        return {}
     except Exception:
         logger.warning("graph_episode_lookup_failed", org_id=org_id, exc_info=True)
         return {}

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -593,6 +593,87 @@ class TestGraphMetadata:
         assert "graph_search_ms" in data["metadata"]
         assert data["metadata"]["graph_results_count"] == 0
 
+    def test_graph_edge_with_provenance_reaches_the_evidence_pack(
+        self, client, sample_retrieve_request
+    ):
+        """SPEC-RAG-GRAPH-CITE-001: a resolved graph fact must be citable.
+
+        Proves the whole chain end to end, because every stage between
+        graph_search and the response re-handles the chunk dict: RRF merge,
+        reranking, quality boost, source selection and evidence-pack
+        assembly. A unit test on _convert_results alone cannot show that
+        artifact_id survives all of them.
+
+        Scope note: this test injects a resolved graph chunk, so it locks the
+        DOWNSTREAM half of the contract and would also pass on the old code.
+        The conversion itself — episode uuid -> artifact_id — is locked by
+        test_graph_search.py::test_convert_results_sets_artifact_id_from_episode
+        and ::test_graph_edge_with_artifact_id_becomes_citable, which both
+        failed before this change.
+        """
+        graph_chunk = {
+            "chunk_id": "graph:edge-1",
+            "text": "Nummerbehoud is mogelijk bij overstap",
+            "score": 0.9,
+            "artifact_id": "artifact-abc",
+            "content_type": "graph_edge",
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": "2026-03-11T00:00:00+00:00",
+            "invalid_at": None,
+        }
+
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="resolved query",
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.graph_search.search",
+                new_callable=AsyncMock,
+                return_value=[graph_chunk],
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_enabled = False
+            mock_settings.graphiti_enabled = True
+            mock_settings.link_expand_enabled = False
+            mock_settings.link_expand_score_boost = 1.00
+            mock_settings.source_quota_enabled = False
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+
+            resp = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert resp.status_code == 200
+        pack = resp.json()["evidence_pack"]
+        assert pack["no_citable_reason"] is None
+        assert [item["chunk_id"] for item in pack["items"]] == ["graph:edge-1"]
+        assert pack["items"][0]["artifact_id"] == "artifact-abc"
+        assert pack["items"][0]["content_type"] == "graph_edge"
+        assert [source["artifact_id"] for source in pack["sources"]] == ["artifact-abc"]
+        # Graphiti's bi-temporal window survives to the served chunk.
+        assert resp.json()["chunks"][0]["valid_at"] == "2026-03-11T00:00:00+00:00"
+
     def test_decision_record_graph_search_tracks_top_k_contribution(
         self, client, sample_retrieve_request, caplog
     ):

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -573,3 +573,38 @@ def test_graphiti_provenance_api_contract_holds():
     assert "clients" in inspect.getsource(Graphiti.__init__)
     assert list(inspect.signature(FalkorDriver.clone).parameters) == ["self", "database"]
     assert list(inspect.signature(EpisodicNode.get_by_uuids).parameters) == ["driver", "uuids"]
+
+
+@pytest.mark.asyncio
+async def test_slow_provenance_lookup_never_costs_the_graph_results():
+    """Regression (Sol review, high): an optional lookup must not eat the results.
+
+    When search() finishes but the episode lookup hangs, a single shared
+    wait_for would cancel the whole coroutine. asyncio.CancelledError derives
+    from BaseException, so _resolve_episode_artifacts' ``except Exception``
+    cannot downgrade it to "no provenance" — search() would return [] and the
+    graph leg would be worse off than before citations existed.
+    """
+    edge = _make_graph_result("e1", "fact", episodes=["ep-1"])
+    mock_graphiti = AsyncMock()
+    mock_graphiti.search = AsyncMock(return_value=[edge])
+    mock_graphiti.clients.driver.clone = MagicMock(return_value=MagicMock())
+
+    async def _hang(*_args, **_kwargs):
+        await asyncio.sleep(30)
+
+    with (
+        patch("retrieval_api.services.graph_search.settings") as mock_settings,
+        patch("retrieval_api.services.graph_search._get_graphiti", return_value=mock_graphiti),
+        patch("retrieval_api.services.graph_search._PROVENANCE_TIMEOUT", 0.01),
+        patch(
+            "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
+            new=AsyncMock(side_effect=_hang),
+        ),
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graph_search_timeout = 5.0
+        result = await graph_search.search("query", "org-1", top_k=10)
+
+    assert len(result) == 1, "a slow provenance lookup must not drop graph results"
+    assert result[0]["artifact_id"] is None

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -546,3 +546,30 @@ async def test_search_resolves_provenance_end_to_end():
         result = await graph_search.search("query", "org-1", top_k=10)
 
     assert result[0]["artifact_id"] == "artifact-abc"
+
+
+def test_graphiti_provenance_api_contract_holds():
+    """Guard the real Graphiti API this feature depends on.
+
+    Every other test here mocks the client, so a graphiti-core upgrade that
+    renamed any of these would keep the suite green and silently disable
+    provenance in production — the exact failure mode that shipped a broken
+    Confluence connector in #1137. Assert against the real classes instead.
+    """
+    import inspect
+
+    from graphiti_core import Graphiti
+    from graphiti_core.driver.falkordb_driver import FalkorDriver
+    from graphiti_core.edges import EntityEdge
+    from graphiti_core.nodes import EpisodicNode
+
+    # The edge fields we read.
+    for field in ("episodes", "valid_at", "invalid_at"):
+        assert field in EntityEdge.model_fields, f"EntityEdge lost {field}"
+    # The episode fields provenance and the tenant assertion depend on.
+    for field in ("uuid", "name", "group_id"):
+        assert field in EpisodicNode.model_fields, f"EpisodicNode lost {field}"
+    # The tenant-scoped lookup path.
+    assert "clients" in inspect.getsource(Graphiti.__init__)
+    assert list(inspect.signature(FalkorDriver.clone).parameters) == ["self", "database"]
+    assert list(inspect.signature(EpisodicNode.get_by_uuids).parameters) == ["driver", "uuids"]

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from retrieval_api.api.retrieve import _rrf_merge
 from retrieval_api.services import graph_search
+from retrieval_api.services.evidence_pack import build_evidence_pack, chunk_source_key
 
 
 def _make_graph_result(
@@ -16,6 +18,9 @@ def _make_graph_result(
     fact: str,
     score: float = 0.8,
     weight: float | None = None,
+    episodes: list[str] | None = None,
+    valid_at: object | None = None,
+    invalid_at: object | None = None,
 ) -> MagicMock:
     """Build a fake Graphiti EdgeResult for tests.
 
@@ -33,6 +38,12 @@ def _make_graph_result(
     r.fact = fact
     r.score = score
     r.weight = weight
+    # Set explicitly for the same reason ``weight`` is: a bare MagicMock
+    # attribute is truthy and iterable-ish, so leaving these unset would let a
+    # test pass against accidental provenance instead of the real path.
+    r.episodes = episodes if episodes is not None else []
+    r.valid_at = valid_at
+    r.invalid_at = invalid_at
     return r
 
 
@@ -361,3 +372,177 @@ async def test_close_is_safe_before_client_initialization(monkeypatch):
     await graph_search.close()
 
     assert graph_search._graphiti_client is None
+
+
+# ---------------------------------------------------------------------------
+# Provenance: graph edges must be citable (SPEC-RAG-GRAPH-CITE-001)
+# ---------------------------------------------------------------------------
+
+
+def _make_episode(uuid: str, name: str, group_id: str) -> MagicMock:
+    """Stand-in for a Graphiti EpisodicNode.
+
+    ``name`` is the Klai artifact_id: knowledge-ingest calls
+    ``add_episode(name=artifact_id, ...)``, so the episode node carries the
+    artifact identity that makes a derived fact citable.
+    """
+    ep = MagicMock()
+    ep.uuid = uuid
+    ep.name = name
+    ep.group_id = group_id
+    return ep
+
+
+def test_convert_results_sets_artifact_id_from_episode():
+    """An edge's episode resolves to the artifact it was extracted from.
+
+    Without this the evidence pack drops every graph edge on
+    ``if not source_key: continue`` — the fact reaches the model but the
+    document it came from never reaches the user.
+    """
+    edge = _make_graph_result("e1", "Nummerbehoud kan bij overstap", episodes=["ep-1"])
+
+    converted = graph_search._convert_results([edge], 10, {"ep-1": "artifact-abc"})
+
+    assert converted[0]["artifact_id"] == "artifact-abc"
+
+
+def test_convert_results_keeps_artifact_id_none_when_episode_unresolved():
+    """Unresolvable provenance degrades to today's behaviour, not an error."""
+    edge = _make_graph_result("e1", "fact", episodes=["ep-missing"])
+
+    converted = graph_search._convert_results([edge], 10, {})
+
+    assert converted[0]["artifact_id"] is None
+
+
+def test_convert_results_passes_through_temporal_validity():
+    """Graphiti's bi-temporal fields are the one thing Qdrant cannot express.
+
+    They were hardcoded to None at this boundary, discarding the only
+    signal that distinguishes a superseded fact from a current one.
+    """
+    edge = _make_graph_result(
+        "e1",
+        "fact",
+        valid_at=datetime(2026, 3, 11, tzinfo=UTC),
+        invalid_at=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+
+    converted = graph_search._convert_results([edge], 10, {})
+
+    assert converted[0]["valid_at"] == "2026-03-11T00:00:00+00:00"
+    assert converted[0]["invalid_at"] == "2026-08-01T00:00:00+00:00"
+
+
+def test_graph_edge_with_artifact_id_becomes_citable():
+    """End of the chain: the evidence pack now emits the graph fact.
+
+    ``chunk_source_key`` falls back to ``artifact:<id>`` for URL-less
+    sources, so filling artifact_id is all that stands between a graph
+    fact and a citation — no evidence-pack change required.
+    """
+    edge = _make_graph_result("e1", "Nummerbehoud kan bij overstap", episodes=["ep-1"])
+    citable = graph_search._convert_results([edge], 10, {"ep-1": "artifact-abc"})
+    uncitable = graph_search._convert_results([edge], 10, {})
+
+    pack = build_evidence_pack(citable)
+    assert len(pack.items) == 1
+    assert pack.items[0].chunk_id == "graph:e1"
+    assert pack.items[0].artifact_id == "artifact-abc"
+    assert pack.items[0].content_type == "graph_edge"
+    assert [source.artifact_id for source in pack.sources] == ["artifact-abc"]
+    assert chunk_source_key(citable[0]) == "artifact:artifact-abc"
+    # Regression guard on the behaviour this change fixes.
+    assert build_evidence_pack(uncitable).no_citable_reason == "no_citable_sources"
+
+
+@pytest.mark.asyncio
+async def test_episode_lookup_is_scoped_to_the_tenant_database():
+    """TENANT ISOLATION: the lookup must run in the org's own FalkorDB graph.
+
+    ``EpisodicNode.get_by_uuids`` matches on uuid ALONE — it has no group_id
+    filter. Isolation therefore rests entirely on the driver being cloned to
+    ``database=<org_id>``, which is the same boundary graphiti.search() uses
+    via handle_multiple_group_ids. Passing the shared driver would read
+    whatever database it happens to point at.
+    """
+    edge = _make_graph_result("e1", "fact", episodes=["ep-1"])
+    cloned = MagicMock()
+    mock_graphiti = AsyncMock()
+    mock_graphiti.clients.driver.clone = MagicMock(return_value=cloned)
+
+    with patch(
+        "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
+        new=AsyncMock(return_value=[_make_episode("ep-1", "artifact-abc", "org-1")]),
+    ) as mock_lookup:
+        mapping = await graph_search._resolve_episode_artifacts(mock_graphiti, [edge], "org-1")
+
+    mock_graphiti.clients.driver.clone.assert_called_once_with(database="org-1")
+    assert mock_lookup.await_args.args[0] is cloned
+    assert mapping == {"ep-1": "artifact-abc"}
+
+
+@pytest.mark.asyncio
+async def test_episode_from_another_tenant_is_discarded():
+    """TENANT ISOLATION, defence in depth: group_id must match the caller.
+
+    The database clone above is the real boundary. This assertion is the
+    fail-closed backstop so a future Graphiti refactor that changes how the
+    driver resolves databases cannot silently turn a uuid-only MATCH into a
+    cross-tenant read.
+    """
+    edge = _make_graph_result("e1", "fact", episodes=["ep-1"])
+    mock_graphiti = AsyncMock()
+    mock_graphiti.clients.driver.clone = MagicMock(return_value=MagicMock())
+
+    with patch(
+        "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
+        new=AsyncMock(return_value=[_make_episode("ep-1", "artifact-of-other-org", "org-2")]),
+    ):
+        mapping = await graph_search._resolve_episode_artifacts(mock_graphiti, [edge], "org-1")
+
+    assert mapping == {}
+
+
+@pytest.mark.asyncio
+async def test_episode_lookup_failure_keeps_graph_results():
+    """Fail-open: losing provenance must not lose the graph leg itself."""
+    edge = _make_graph_result("e1", "fact", episodes=["ep-1"])
+    mock_graphiti = AsyncMock()
+    mock_graphiti.search = AsyncMock(return_value=[edge])
+    mock_graphiti.clients.driver.clone = MagicMock(side_effect=RuntimeError("falkor down"))
+
+    with (
+        patch("retrieval_api.services.graph_search.settings") as mock_settings,
+        patch("retrieval_api.services.graph_search._get_graphiti", return_value=mock_graphiti),
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graph_search_timeout = 5.0
+        result = await graph_search.search("query", "org-1", top_k=10)
+
+    assert len(result) == 1
+    assert result[0]["artifact_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_resolves_provenance_end_to_end():
+    """search() wires the lookup in without changing its contract."""
+    edge = _make_graph_result("e1", "fact", episodes=["ep-1"])
+    mock_graphiti = AsyncMock()
+    mock_graphiti.search = AsyncMock(return_value=[edge])
+    mock_graphiti.clients.driver.clone = MagicMock(return_value=MagicMock())
+
+    with (
+        patch("retrieval_api.services.graph_search.settings") as mock_settings,
+        patch("retrieval_api.services.graph_search._get_graphiti", return_value=mock_graphiti),
+        patch(
+            "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
+            new=AsyncMock(return_value=[_make_episode("ep-1", "artifact-abc", "org-1")]),
+        ),
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graph_search_timeout = 5.0
+        result = await graph_search.search("query", "org-1", top_k=10)
+
+    assert result[0]["artifact_id"] == "artifact-abc"


### PR DESCRIPTION
Graphiti contributes to roughly a third of Voys' retrievals and none of it was ever citable.

## What the data said

Over 30 days, 1,704 Voys retrievals (`retrieval_decision_record`):

| | count |
|---|---|
| graph returned nothing | 1,208 (71%) |
| graph returned 10 candidates | 496 (29%) |

Whenever the graph fires, at least one result reaches the served list — and in 181 requests all 10 do, with `served_top_k: 20`. So half the model's context was graph facts. A real request from this morning:

```
served_top_k: 20   graph_in_top_k: 10
evidence item_count: 8   source_count: 3
top_source_labels: ["help.voys.nl", "help.voys.nl", "help.voys.nl"]
```

Not one of those 3 sources is a graph fact. `_convert_results()` hardcoded `artifact_id` to `None`, so `chunk_source_key()` returned `""` and `build_evidence_pack` dropped every edge on `if not source_key: continue`. The model used the fact; the user got no way to check it.

## The fix is a field, not a feature

The link already existed and was unused:

- knowledge-ingest calls `add_episode(name=artifact_id, ...)`, so an episode node's `name` **is** the artifact identity
- `EntityEdge.episodes` carries the episode uuids (our own FalkorDB patch returns them via `get_entity_edge_return_query`)
- `chunk_source_key()` already falls back to `artifact:<id>` for URL-less sources

Resolving `edge.episodes -> artifact_id` is therefore all that stood between a derived fact and a citation. **The evidence pack is unchanged.**

Also stops discarding Graphiti's bi-temporal window: `valid_at`/`invalid_at` were hardcoded to `None` on the same lines. Passthrough only — the temporal filter is Qdrant-side and never sees graph edges, so no filtering behaviour changes.

## Tenant isolation

`EpisodicNode.get_by_uuids()` matches on uuid **alone** — no group_id filter of its own. Isolation therefore rests entirely on cloning the driver to `database=<org_id>`, the same per-tenant graph boundary `graphiti.search()` gets from `handle_multiple_group_ids`. Two layers:

1. the database clone — the real boundary
2. an explicit `group_id != org_id -> drop` assertion, as defence in depth against a future Graphiti change to database resolution

Both are covered by tests (`test_episode_lookup_is_scoped_to_the_tenant_database`, `test_episode_from_another_tenant_is_discarded`). Verified that `EPISODIC_NODE_RETURN` really returns `group_id` and `name`, so the backstop cannot silently disable the feature.

## GRAPH_SEARCH_TIMEOUT 60.0 -> 5.0

Back to the code default, not an invented number. Over 10,151 graph searches in 30 days: mean 252 ms, worst case 2,679 ms — 5s leaves ~2x headroom. At 60s the AC-7 fail-open path was unreachable in practice: retrieval degrades gracefully without graph results, but not if it waits a minute to find that out.

## Review

Sol (review-deep) found one real issue: sharing a single `wait_for` between the search and the lookup meant a slow lookup got the whole coroutine cancelled, and `asyncio.CancelledError` inherits from `BaseException` so `except Exception` could not downgrade it to "no provenance". Results already in hand would be thrown away by an optional lookup — a regression against pre-branch behaviour. Fixed with separate budgets; the regression test was verified red on the flagged shape. Delta review clean.

## Tests

578 passed, 1 skipped. Nine new tests, six of which failed before this change. Includes `test_graphiti_provenance_api_contract_holds`, which asserts against the real Graphiti classes rather than mocks — the failure mode from #1137, where the Confluence adapter's only test patched the SDK class and a major bump passed CI while the runtime path was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)