### PR TITLE
fix(rag): cite the document behind a graph fact, not the sentence

### DIFF
--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -340,6 +340,35 @@ async def _retrieve_sub_queries(
     )
 
 
+async def _label_graph_results(graph_results: list[dict], req: RetrieveRequest) -> None:
+    """Attach the citation fields a graph edge cannot know about itself.
+
+    A graph edge carries a fact and its artifact_id, but no title or URL, so
+    ``evidence_pack._title()`` would fall through to ``text[:80]`` and render a
+    truncated fact as the source name. Resolving the artifact's own metadata
+    turns that back into the document the reader can actually open.
+
+    Setting ``source_url`` also collapses a graph fact and an ordinary chunk
+    from the same document into ONE source, because ``chunk_source_key`` keys
+    on the URL before falling back to ``artifact:<id>``.
+
+    Mutates in place. Fail-open: on any miss the edge keeps today's behaviour.
+    """
+    artifact_ids = [r.get("artifact_id") for r in graph_results if r.get("artifact_id")]
+    if not artifact_ids:
+        return
+    metadata = await search.fetch_artifact_display_metadata(artifact_ids, req)
+    if not metadata:
+        return
+    for result in graph_results:
+        meta = metadata.get(result.get("artifact_id") or "")
+        if not meta:
+            continue
+        for field in ("title", "source_url", "source_label", "original_filename"):
+            if meta.get(field):
+                result[field] = meta[field]
+
+
 @router.post("/retrieve", response_model=RetrieveResponse)
 async def retrieve(
     req: RetrieveRequest,
@@ -566,6 +595,7 @@ async def retrieve(
             step_latency_seconds.labels(step="graph").observe(graph_search_ms / 1000)
             graph_results_count = len(graph_results)
             if graph_results:
+                await _label_graph_results(graph_results, req)
                 graph_candidate_ids = {r["chunk_id"] for r in graph_results}
                 raw_results = _rrf_merge(raw_results, graph_results)
         except Exception:

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -112,9 +112,10 @@ def _temporal_validity_filter() -> Filter:
     )
 
 
-# One chunk per artifact is enough for title/source_url; a small multiplier
-# absorbs the fact that scroll returns chunks, not artifacts.
-_ARTIFACT_METADATA_CHUNKS_PER_ARTIFACT = 3
+# Graphiti returns at most 10 edges per query, so this bound is well above
+# the real fan-out; it exists so a pathological result set cannot turn
+# label resolution into an unbounded burst of Qdrant reads.
+_ARTIFACT_METADATA_MAX = 20
 _ARTIFACT_METADATA_TIMEOUT = 2.0
 
 
@@ -442,6 +443,44 @@ async def fetch_chunks_by_urls(
     ]
 
 
+async def _fetch_one_artifact_metadata(
+    artifact_id: str,
+    request: RetrieveRequest,
+) -> tuple[str, dict[str, str | None]] | None:
+    """Fetch the display fields of ONE artifact. Returns None when unresolved."""
+    client = _get_client()
+    artifact_filter = Filter(
+        must=[
+            *_scope_filter(request),
+            FieldCondition(key="artifact_id", match=MatchValue(value=artifact_id)),
+            _temporal_validity_filter(),
+        ]
+    )
+    try:
+        result, _ = await asyncio.wait_for(
+            client.scroll(
+                collection_name=settings.qdrant_collection,
+                scroll_filter=artifact_filter,
+                limit=1,
+                with_payload=True,
+                with_vectors=False,
+            ),
+            timeout=_ARTIFACT_METADATA_TIMEOUT,
+        )
+    except Exception:
+        logger.warning("artifact_display_metadata_failed", artifact_id=artifact_id, exc_info=True)
+        return None
+    if not result:
+        return None
+    payload = result[0].payload
+    return artifact_id, {
+        "title": payload.get("title"),
+        "source_url": payload.get("source_url"),
+        "source_label": payload.get("source_label"),
+        "original_filename": payload.get("original_filename"),
+    }
+
+
 async def fetch_artifact_display_metadata(
     artifact_ids: list[str],
     request: RetrieveRequest,
@@ -454,53 +493,38 @@ async def fetch_artifact_display_metadata(
     list shows a truncated fact instead of the document — which defeats the
     point of citing it at all.
 
+    One bounded lookup PER artifact rather than a single wider scroll. A
+    scroll is not grouped, so one large document can fill the whole page and
+    starve a one-chunk document of its label — the very defect this function
+    exists to fix, reappearing for any mix of document sizes. Per-artifact
+    lookups make that impossible instead of unlikely; they are limit=1 reads
+    on an indexed field and run concurrently.
+
     Scoped through ``_scope_filter`` like every other read here. That is not
     ceremony: a title alone can be sensitive, so the visibility rules that
     keep private chunks out of a scope must also keep their titles out of a
     source list.
 
-    Fail-open: an empty mapping costs labels, never the graph results.
+    Fail-open: an unresolved artifact costs a label, never the graph result.
     """
     unique_ids = sorted({aid for aid in artifact_ids if aid})
     if not unique_ids:
         return {}
 
-    client = _get_client()
-    artifact_filter = Filter(
-        must=[
-            *_scope_filter(request),
-            FieldCondition(key="artifact_id", match=MatchAny(any=unique_ids)),
-            _temporal_validity_filter(),
-        ]
-    )
-
-    try:
-        result, _ = await asyncio.wait_for(
-            client.scroll(
-                collection_name=settings.qdrant_collection,
-                scroll_filter=artifact_filter,
-                limit=len(unique_ids) * _ARTIFACT_METADATA_CHUNKS_PER_ARTIFACT,
-                with_payload=True,
-                with_vectors=False,
-            ),
-            timeout=_ARTIFACT_METADATA_TIMEOUT,
+    if len(unique_ids) > _ARTIFACT_METADATA_MAX:
+        # No silent caps: say what was dropped rather than let the tail
+        # quietly render as truncated facts.
+        logger.warning(
+            "artifact_display_metadata_truncated",
+            requested=len(unique_ids),
+            resolved=_ARTIFACT_METADATA_MAX,
         )
-    except Exception:
-        logger.warning("artifact_display_metadata_failed", exc_info=True)
-        return {}
+        unique_ids = unique_ids[:_ARTIFACT_METADATA_MAX]
 
-    metadata: dict[str, dict[str, str | None]] = {}
-    for point in result:
-        artifact_id = point.payload.get("artifact_id")
-        if not artifact_id or artifact_id in metadata:
-            continue
-        metadata[artifact_id] = {
-            "title": point.payload.get("title"),
-            "source_url": point.payload.get("source_url"),
-            "source_label": point.payload.get("source_label"),
-            "original_filename": point.payload.get("original_filename"),
-        }
-    return metadata
+    resolved = await asyncio.gather(
+        *(_fetch_one_artifact_metadata(aid, request) for aid in unique_ids)
+    )
+    return {aid: meta for entry in resolved if entry for aid, meta in [entry]}
 
 
 async def hybrid_search(

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -112,6 +112,12 @@ def _temporal_validity_filter() -> Filter:
     )
 
 
+# One chunk per artifact is enough for title/source_url; a small multiplier
+# absorbs the fact that scroll returns chunks, not artifacts.
+_ARTIFACT_METADATA_CHUNKS_PER_ARTIFACT = 3
+_ARTIFACT_METADATA_TIMEOUT = 2.0
+
+
 def _scope_filter(request: RetrieveRequest) -> list[FieldCondition | Filter]:
     """Build scope-specific Qdrant filter conditions for klai_knowledge.
 
@@ -434,6 +440,67 @@ async def fetch_chunks_by_urls(
         }
         for r in result
     ]
+
+
+async def fetch_artifact_display_metadata(
+    artifact_ids: list[str],
+    request: RetrieveRequest,
+) -> dict[str, dict[str, str | None]]:
+    """Resolve artifact_id -> the fields a citation is rendered from.
+
+    Graph edges carry a fact and (since SPEC-RAG-GRAPH-CITE-001) the
+    artifact_id they were extracted from, but no title or URL. Without those
+    ``evidence_pack._title()`` falls through to ``text[:80]`` and the source
+    list shows a truncated fact instead of the document — which defeats the
+    point of citing it at all.
+
+    Scoped through ``_scope_filter`` like every other read here. That is not
+    ceremony: a title alone can be sensitive, so the visibility rules that
+    keep private chunks out of a scope must also keep their titles out of a
+    source list.
+
+    Fail-open: an empty mapping costs labels, never the graph results.
+    """
+    unique_ids = sorted({aid for aid in artifact_ids if aid})
+    if not unique_ids:
+        return {}
+
+    client = _get_client()
+    artifact_filter = Filter(
+        must=[
+            *_scope_filter(request),
+            FieldCondition(key="artifact_id", match=MatchAny(any=unique_ids)),
+            _temporal_validity_filter(),
+        ]
+    )
+
+    try:
+        result, _ = await asyncio.wait_for(
+            client.scroll(
+                collection_name=settings.qdrant_collection,
+                scroll_filter=artifact_filter,
+                limit=len(unique_ids) * _ARTIFACT_METADATA_CHUNKS_PER_ARTIFACT,
+                with_payload=True,
+                with_vectors=False,
+            ),
+            timeout=_ARTIFACT_METADATA_TIMEOUT,
+        )
+    except Exception:
+        logger.warning("artifact_display_metadata_failed", exc_info=True)
+        return {}
+
+    metadata: dict[str, dict[str, str | None]] = {}
+    for point in result:
+        artifact_id = point.payload.get("artifact_id")
+        if not artifact_id or artifact_id in metadata:
+            continue
+        metadata[artifact_id] = {
+            "title": point.payload.get("title"),
+            "source_url": point.payload.get("source_url"),
+            "source_label": point.payload.get("source_label"),
+            "original_filename": point.payload.get("original_filename"),
+        }
+    return metadata
 
 
 async def hybrid_search(

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -649,6 +649,18 @@ class TestGraphMetadata:
                 new_callable=AsyncMock,
                 return_value=[graph_chunk],
             ),
+            patch(
+                "retrieval_api.api.retrieve.search.fetch_artifact_display_metadata",
+                new_callable=AsyncMock,
+                return_value={
+                    "artifact-abc": {
+                        "title": "Nummerbehoud aanvragen",
+                        "source_url": "https://help.voys.nl/nummerbehoud-aanvragen",
+                        "source_label": "help.voys.nl",
+                        "original_filename": None,
+                    }
+                },
+            ),
             patch("retrieval_api.api.retrieve.settings") as mock_settings,
         ):
             mock_settings.retrieval_candidates = 60
@@ -671,6 +683,11 @@ class TestGraphMetadata:
         assert pack["items"][0]["artifact_id"] == "artifact-abc"
         assert pack["items"][0]["content_type"] == "graph_edge"
         assert [source["artifact_id"] for source in pack["sources"]] == ["artifact-abc"]
+        # The citation names the document, not a truncated fact. Production
+        # showed the latter on 2026-08-21: "De paginamap identificeert de
+        # Voys-app als een applicatie die kan worden gebruik".
+        assert pack["sources"][0]["title"] == "Nummerbehoud aanvragen"
+        assert pack["sources"][0]["source_url"] == "https://help.voys.nl/nummerbehoud-aanvragen"
         # Graphiti's bi-temporal window survives to the served chunk.
         assert resp.json()["chunks"][0]["valid_at"] == "2026-03-11T00:00:00+00:00"
 

--- a/klai-retrieval-api/tests/test_graph_edge_labels.py
+++ b/klai-retrieval-api/tests/test_graph_edge_labels.py
@@ -73,6 +73,60 @@ class TestArtifactDisplayMetadata:
         assert meta["artifact-abc"]["source_url"] == "https://help.voys.nl/nummerbehoud-aanvragen"
 
     @pytest.mark.asyncio
+    async def test_a_large_document_cannot_starve_a_small_one(self):
+        """Regression (Sol review, high): every artifact must resolve.
+
+        A single wider scroll is not grouped by artifact, so a document with
+        hundreds of chunks can fill the whole page and leave a one-chunk
+        document unresolved — whose citation then falls back to the truncated
+        fact this whole function exists to replace. One limit=1 lookup per
+        artifact makes that impossible rather than unlikely.
+        """
+        mock_client = AsyncMock()
+
+        async def _scroll(*_args, **kwargs):
+            rendered = repr(kwargs["scroll_filter"])
+            assert kwargs["limit"] == 1, "one row per artifact, never a shared page"
+            if "big-doc" in rendered:
+                return [_point("big-doc", title="Groot handboek")], None
+            if "small-doc" in rendered:
+                return [_point("small-doc", title="Losse notitie")], None
+            return [], None
+
+        mock_client.scroll.side_effect = _scroll
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            meta = await search.fetch_artifact_display_metadata(["big-doc", "small-doc"], req)
+
+        assert meta["big-doc"]["title"] == "Groot handboek"
+        assert meta["small-doc"]["title"] == "Losse notitie"
+
+    @pytest.mark.asyncio
+    async def test_one_unresolved_artifact_does_not_lose_the_others(self):
+        mock_client = AsyncMock()
+
+        async def _scroll(*_args, **kwargs):
+            if "good" in repr(kwargs["scroll_filter"]):
+                return [_point("good", title="Wel gevonden")], None
+            raise RuntimeError("qdrant blip")
+
+        mock_client.scroll.side_effect = _scroll
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            meta = await search.fetch_artifact_display_metadata(["good", "bad"], req)
+
+        assert meta == {
+            "good": {
+                "title": "Wel gevonden",
+                "source_url": None,
+                "source_label": None,
+                "original_filename": None,
+            }
+        }
+
+    @pytest.mark.asyncio
     async def test_lookup_is_tenant_scoped(self):
         """TENANT ISOLATION: a title can be as sensitive as the text.
 

--- a/klai-retrieval-api/tests/test_graph_edge_labels.py
+++ b/klai-retrieval-api/tests/test_graph_edge_labels.py
@@ -1,0 +1,185 @@
+"""Graph edges must cite the document, not a truncated fact.
+
+SPEC-RAG-GRAPH-CITE-001 made graph edges citable by resolving their
+artifact_id. That alone is not enough: an edge carries no title and no URL,
+so ``evidence_pack._title()`` falls through to ``text[:80]`` and the source
+list renders a chopped-off sentence like
+
+    "De paginamap identificeert de Voys-app als een applicatie die kan gebruik"
+
+instead of the help-centre article it came from. Observed in production on
+2026-08-21 right after the citation change shipped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from retrieval_api.api.retrieve import _label_graph_results
+from retrieval_api.models import RetrieveRequest
+from retrieval_api.services import search
+from retrieval_api.services.evidence_pack import build_evidence_pack, chunk_source_key
+
+
+def _point(artifact_id: str, **payload):
+    return SimpleNamespace(id="c1", score=0.9, payload={"artifact_id": artifact_id, **payload})
+
+
+def _graph_chunk(artifact_id: str | None, text: str = "Nummerbehoud kan bij overstap"):
+    return {
+        "chunk_id": "graph:e1",
+        "text": text,
+        "score": 0.9,
+        "artifact_id": artifact_id,
+        "content_type": "graph_edge",
+        "context_prefix": None,
+        "scope": "org",
+        "valid_at": None,
+        "invalid_at": None,
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    search._client = None
+    yield
+    search._client = None
+
+
+class TestArtifactDisplayMetadata:
+    @pytest.mark.asyncio
+    async def test_returns_title_and_url_per_artifact(self):
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = (
+            [
+                _point(
+                    "artifact-abc",
+                    title="Nummerbehoud aanvragen",
+                    source_url="https://help.voys.nl/nummerbehoud-aanvragen",
+                    source_label="help.voys.nl",
+                )
+            ],
+            None,
+        )
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            meta = await search.fetch_artifact_display_metadata(["artifact-abc"], req)
+
+        assert meta["artifact-abc"]["title"] == "Nummerbehoud aanvragen"
+        assert meta["artifact-abc"]["source_url"] == "https://help.voys.nl/nummerbehoud-aanvragen"
+
+    @pytest.mark.asyncio
+    async def test_lookup_is_tenant_scoped(self):
+        """TENANT ISOLATION: a title can be as sensitive as the text.
+
+        The lookup must go through _scope_filter like every other read, so the
+        org condition and the private-visibility rules apply. Resolving labels
+        must never become a side channel that names documents the caller
+        cannot open.
+        """
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = ([], None)
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await search.fetch_artifact_display_metadata(["artifact-abc"], req)
+
+        scroll_filter = mock_client.scroll.await_args.kwargs["scroll_filter"]
+        rendered = repr(scroll_filter)
+        assert "org_id" in rendered and "org-1" in rendered
+        assert "visibility" in rendered, "private-visibility rules must apply to labels too"
+
+    @pytest.mark.asyncio
+    async def test_no_artifact_ids_skips_the_round_trip(self):
+        mock_client = AsyncMock()
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            assert await search.fetch_artifact_display_metadata([], req) == {}
+        mock_client.scroll.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_qdrant_failure_degrades_to_no_labels(self):
+        mock_client = AsyncMock()
+        mock_client.scroll.side_effect = RuntimeError("qdrant down")
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            assert await search.fetch_artifact_display_metadata(["a1"], req) == {}
+
+
+class TestGraphResultLabelling:
+    @pytest.mark.asyncio
+    async def test_graph_fact_cites_the_document_not_the_sentence(self):
+        chunks = [_graph_chunk("artifact-abc")]
+        meta = {
+            "artifact-abc": {
+                "title": "Nummerbehoud aanvragen",
+                "source_url": "https://help.voys.nl/nummerbehoud-aanvragen",
+                "source_label": "help.voys.nl",
+                "original_filename": None,
+            }
+        }
+
+        with patch.object(
+            search, "fetch_artifact_display_metadata", new=AsyncMock(return_value=meta)
+        ):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await _label_graph_results(chunks, req)
+
+        pack = build_evidence_pack(chunks)
+        assert pack.sources[0].title == "Nummerbehoud aanvragen"
+        assert pack.sources[0].source_url == "https://help.voys.nl/nummerbehoud-aanvragen"
+        assert "Nummerbehoud kan bij overstap" not in pack.sources[0].title
+
+    def test_without_labels_the_source_is_the_truncated_fact(self):
+        """Locks the defect this module exists to prevent."""
+        pack = build_evidence_pack([_graph_chunk("artifact-abc")])
+        assert pack.sources[0].title.startswith("Nummerbehoud kan bij overstap")
+
+    @pytest.mark.asyncio
+    async def test_graph_fact_and_chunk_from_one_document_collapse_to_one_source(self):
+        """source_url keying means a fact no longer duplicates its own document."""
+        graph = _graph_chunk("artifact-abc")
+        ordinary = {
+            "chunk_id": "c-1",
+            "text": "Nummerbehoud aanvragen doe je zo",
+            "score": 0.8,
+            "artifact_id": "artifact-abc",
+            "content_type": "kb_article",
+            "source_url": "https://help.voys.nl/nummerbehoud-aanvragen",
+            "title": "Nummerbehoud aanvragen",
+            "scope": "org",
+        }
+        meta = {
+            "artifact-abc": {
+                "title": "Nummerbehoud aanvragen",
+                "source_url": "https://help.voys.nl/nummerbehoud-aanvragen",
+                "source_label": "help.voys.nl",
+                "original_filename": None,
+            }
+        }
+
+        with patch.object(
+            search, "fetch_artifact_display_metadata", new=AsyncMock(return_value=meta)
+        ):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await _label_graph_results([graph], req)
+
+        assert chunk_source_key(graph) == chunk_source_key(ordinary)
+        pack = build_evidence_pack([graph, ordinary])
+        assert len(pack.sources) == 1
+        assert len(pack.items) == 2
+
+    @pytest.mark.asyncio
+    async def test_unresolved_artifact_keeps_previous_behaviour(self):
+        chunks = [_graph_chunk("artifact-abc")]
+        with patch.object(
+            search, "fetch_artifact_display_metadata", new=AsyncMock(return_value={})
+        ):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await _label_graph_results(chunks, req)
+        assert "title" not in chunks[0]


### PR DESCRIPTION
Follow-up to #1146, which made graph facts citable. Production showed within minutes that citable was not the same as useful.

## The defect

```
top_source_labels: ["De paginamap identificeert de Voys-app als een applicatie die kan worden gebruik",
                    "help.voys.nl",
                    "Voys provides plug-and-play telefoons (phones) that users can easily set up for "]
```

Those are 80-character truncations of the fact text. `evidence_pack._title()` tries `original_filename`, `filename`, `title`, `source_label`, `context_prefix`, then `source_url` — a graph edge has none of them, so it falls through to `text[:80]`.

#1146 gave the edge an **identity** (`artifact_id`) but no **presentation**. A citation exists so the reader can open the source; a chopped-off sentence does not let them do that.

## The fix

Resolve the artifact's own `title` / `source_url` from Qdrant, where `artifact_id` is an indexed payload field, and attach them before the RRF merge.

Setting `source_url` has a second effect worth naming: `chunk_source_key` keys on the URL before falling back to `artifact:<id>`, so a graph fact and an ordinary chunk from the same document now collapse into **one** source instead of two rows pointing at the same article.

**One `limit=1` lookup per artifact, concurrently** — not one wider scroll. Sol caught the reason: `scroll()` is not grouped, so a document with hundreds of chunks can fill a shared page and starve a one-chunk document of its label, which is exactly the defect being fixed, reappearing for any mix of document sizes. For a help centre that is not an edge case. Bounded by `_ARTIFACT_METADATA_MAX` with a log line when it truncates.

## Tenant isolation

The lookup goes through `_scope_filter` like every other Qdrant read here. That is not ceremony: a title alone can be sensitive, so the visibility rules that keep private chunks out of a scope must keep their titles out of a source list too. A test asserts both the org condition and the visibility rules are present in the filter.

## What this does NOT fix

The odd phrasing in the answer text itself. Graph facts have always been in the prompt — 181 of 1,704 Voys requests served 10 of them before any of this shipped. The citation change made their *quality* visible, and that quality is the real finding: the graph stores statements **about documents** ("de paginamap identificeert…") rather than facts about the world, and some are in English while the corpus is Dutch. That is an ingest/extraction concern and gets its own ticket rather than a hurried patch here.

## Tests

588 passed, 1 skipped. New regression tests cover the starvation case (red on the previous shape), a partial-failure case, the tenant scoping, and the source-collapse behaviour.

The full suite also caught a genuine mistake during development: the helper was first inserted between the `@router.post("/retrieve")` decorator and `retrieve()`, so FastAPI bound the decorator to the helper and 50 endpoint tests returned 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)