### PR TITLE
fix(rag): name graph episodes after the document, not the artifact version

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -60,7 +60,7 @@ async def main(limit: int | None = None) -> None:
         # ---- Get artifacts -------------------------------------------------
         rows = await conn.fetch(
             """
-            SELECT id, path, content_type, created_at, extra
+            SELECT id, kb_slug, path, content_type, created_at, extra
             FROM knowledge.artifacts
             WHERE org_id = $1
             ORDER BY created_at
@@ -162,6 +162,8 @@ async def main(limit: int | None = None) -> None:
                         org_id=org_id,
                         content_type=content_type,
                         belief_time_start=created_epoch,
+                        kb_slug=row["kb_slug"] or "",
+                        path=row["path"] or "",
                     ),
                     timeout=EPISODE_TIMEOUT,
                 )

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -347,6 +347,8 @@ def _register_tasks(procrastinate_app: Any) -> None:
         org_id: str,
         content_type: str,
         belief_time_start: int,
+        kb_slug: str = "",
+        path: str = "",
     ) -> None:
         """Ingest a document into the Graphiti knowledge graph.
 
@@ -389,6 +391,8 @@ def _register_tasks(procrastinate_app: Any) -> None:
                 org_id=org_id,
                 content_type=content_type,
                 belief_time_start=belief_time_start,
+                kb_slug=kb_slug,
+                path=path,
             )
             if episode_id:
                 await pg_store.update_artifact_extra(

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -31,6 +31,7 @@ except ImportError:
     _GRAPHITI_AVAILABLE = False  # graphiti-core not installed yet; added in /run SPEC-KB-011
 
 import structlog
+from klai_kb_slugs import episode_name
 
 import knowledge_ingest.qdrant_store as qdrant_store
 from knowledge_ingest.config import settings
@@ -489,12 +490,33 @@ async def compute_entity_pagerank(org_id: str) -> dict[str, float]:
         return {}
 
 
+def _episode_name(artifact_id: str, kb_slug: str, path: str) -> str:
+    """Name an episode after the DOCUMENT, falling back to the artifact_id.
+
+    SPEC-RAG-GRAPH-CITE-002. ``artifact_id`` identifies a version, not a
+    document: every ingest mints a fresh uuid4 and supersedes the previous
+    row, while Qdrant keeps only the current version's chunks. An episode
+    named after it therefore stops resolving the moment its page is
+    re-ingested, which is exactly what made graph citations render as
+    truncated sentences instead of links.
+
+    The fallback keeps in-flight Procrastinate jobs working: those were
+    deferred with the old kwargs and arrive without kb_slug/path, and a task
+    that has been queued for an hour must not fail on a signature change.
+    """
+    if kb_slug and path:
+        return episode_name(kb_slug, path)
+    return artifact_id
+
+
 async def ingest_episode(
     artifact_id: str,
     document_text: str,
     org_id: str,
     content_type: str,
     belief_time_start: int,
+    kb_slug: str = "",
+    path: str = "",
 ) -> str | None:
     """Ingest a document as a Graphiti episode.
 
@@ -528,7 +550,7 @@ async def ingest_episode(
                 )
                 t0 = time.perf_counter()
                 result = await graphiti.add_episode(
-                    name=artifact_id,
+                    name=_episode_name(artifact_id, kb_slug, path),
                     episode_body=document_text,
                     source=EpisodeType.text,
                     source_description=content_type,

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -268,9 +268,7 @@ async def _update_edge_weights(
     return updated
 
 
-async def rename_episodes_to_document_keys(
-    org_id: str, renames: dict[str, list[str]]
-) -> int:
+async def rename_episodes_to_document_keys(org_id: str, renames: dict[str, list[str]]) -> int:
     """Point existing episodes at their DOCUMENT instead of an artifact version.
 
     ``renames`` maps a stable episode name (``doc:<kb_slug>:<path>``) to the

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -268,6 +268,48 @@ async def _update_edge_weights(
     return updated
 
 
+async def rename_episodes_to_document_keys(
+    org_id: str, renames: dict[str, list[str]]
+) -> int:
+    """Point existing episodes at their DOCUMENT instead of an artifact version.
+
+    ``renames`` maps a stable episode name (``doc:<kb_slug>:<path>``) to the
+    episode uuids that should carry it.
+
+    SPEC-RAG-GRAPH-CITE-002 makes ingest write this name, but that only helps
+    documents that get ingested again — and content_hash dedup means an
+    unchanged page is never re-ingested, so an existing edge would keep its
+    artifact-version name forever and its citations would stay unresolvable.
+
+    This is a metadata rename, not a re-extraction: no LLM calls, no entity
+    work, nothing drawn from the shared klai-fast budget. Idempotent, so a
+    partially completed run can simply be repeated.
+
+    Several versions of one document legitimately end up sharing a name. That
+    is fine — the name is a pointer, and retrieval resolves it against the
+    CURRENT version in Qdrant.
+    """
+    if not settings.graphiti_enabled or not renames:
+        return 0
+    graphiti = _get_graphiti()
+    driver = graphiti.driver.clone(org_id)
+    renamed = 0
+    for name, uuids in renames.items():
+        if not uuids:
+            continue
+        result = await driver.execute_query(
+            "MATCH (e:Episodic) WHERE e.uuid IN $uuids SET e.name = $name RETURN count(e) AS n",
+            uuids=uuids,
+            name=name,
+        )
+        if result is not None:
+            records, _, _ = result
+            if records:
+                renamed += records[0].get("n", 0)
+    logger.info("graph_episodes_renamed", org_id=org_id, documents=len(renames), episodes=renamed)
+    return renamed
+
+
 async def delete_kb_episodes(org_id: str, episode_ids: list[str]) -> None:
     """Delete FalkorDB nodes for a set of episodes within an org's graph.
 

--- a/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
@@ -124,6 +124,10 @@ async def ensure_collection() -> None:
 
     for field in (
         "kb_slug",
+        # SPEC-RAG-GRAPH-CITE-002: retrieval resolves a graph fact to its source
+        # document by (kb_slug, path), the identity that survives re-ingest.
+        # Without the index that filter degrades to a payload scan of the KB.
+        "path",
         "artifact_id",
         "content_type",
         "user_id",

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -286,6 +286,8 @@ async def _graphiti_background(
     org_id: str,
     content_type: str,
     belief_time_start: int,
+    kb_slug: str = "",
+    path: str = "",
 ) -> None:
     """Background task: ingest document into Graphiti, then store episode_id (AC-1, AC-2).
 
@@ -300,6 +302,8 @@ async def _graphiti_background(
         org_id=org_id,
         content_type=content_type,
         belief_time_start=belief_time_start,
+        kb_slug=kb_slug,
+        path=path,
     )
     if episode_id:
         await pg_store.update_artifact_extra(conn, artifact_id, {"graphiti_episode_id": episode_id})
@@ -831,6 +835,8 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             org_id=req.org_id,
             content_type=req.content_type,
             belief_time_start=kf["belief_time_start"],
+            kb_slug=req.kb_slug,
+            path=req.path,
         )
 
     ingest_ms = int((time.monotonic() - t_ingest) * 1000)

--- a/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
@@ -1,0 +1,135 @@
+"""Rename existing Graphiti episodes from artifact-version ids to document keys.
+
+SPEC-RAG-GRAPH-CITE-002 changed episode naming from ``artifact_id`` to
+``doc:<kb_slug>:<path>``. That fixes new ingests, but NOT the graph that is
+already there — and it cannot heal by itself: knowledge-ingest dedups on
+content_hash, so re-crawling an unchanged page never creates a new episode.
+Without this backfill every fact extracted before the change keeps a pointer
+to a superseded artifact version, its Qdrant lookup misses, and its citation
+renders as a truncated sentence instead of a link.
+
+The rename is metadata only. It does NOT re-extract, makes no LLM calls, and
+draws nothing from the shared klai-fast rate limit that enrichment and
+taxonomy compete over. Postgres already holds the mapping: every successful
+episode writes ``graphiti_episode_id`` into ``knowledge.artifacts.extra``.
+
+Superseded artifacts are included on purpose. Their episodes carry exactly the
+stale edges this is meant to heal, and their ``kb_slug``/``path`` still name
+the document correctly.
+
+Usage (in a knowledge-ingest container):
+
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m scripts.backfill_episode_document_names --org-id <org_id> [--dry-run]
+
+Idempotent: SET writes the same name on a re-run, so an interrupted pass can
+simply be repeated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import defaultdict
+
+import structlog
+from klai_kb_slugs import episode_name
+
+from knowledge_ingest import graph as graph_module
+from knowledge_ingest.config import settings
+from knowledge_ingest.db import tenant_scoped_connection
+
+logger = structlog.get_logger()
+
+
+async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
+    """Return (renames, skipped) for one org.
+
+    ``renames`` maps the stable document name to the episode uuids that should
+    carry it; ``skipped`` counts artifacts with no usable episode pointer.
+    """
+    renames: dict[str, list[str]] = defaultdict(list)
+    skipped = 0
+
+    async with tenant_scoped_connection(org_id) as conn:
+        rows = await conn.fetch(
+            """
+            SELECT kb_slug, path, extra
+            FROM knowledge.artifacts
+            WHERE org_id = $1 AND extra IS NOT NULL
+            ORDER BY created_at
+            """,
+            org_id,
+        )
+
+    for row in rows:
+        try:
+            extra = json.loads(row["extra"]) if isinstance(row["extra"], str) else row["extra"]
+        except (TypeError, ValueError):
+            continue
+        episode_id = (extra or {}).get("graphiti_episode_id")
+        # "no-chunks" is the sentinel backfill.py writes for artifacts it
+        # deliberately skipped; it is not an episode uuid.
+        if not episode_id or episode_id == "no-chunks":
+            skipped += 1
+            continue
+        kb_slug, path = row["kb_slug"], row["path"]
+        if not kb_slug or not path:
+            skipped += 1
+            continue
+        name = episode_name(kb_slug, path)
+        renames[name].append(episode_id)
+
+    return dict(renames), skipped
+
+
+async def run(org_id: str, dry_run: bool) -> int:
+    if not settings.graphiti_enabled:
+        logger.error("graphiti_disabled", org_id=org_id)
+        return 1
+
+    renames, skipped = await collect_renames(org_id)
+    episodes = sum(len(uuids) for uuids in renames.values())
+    logger.info(
+        "backfill_episode_names_plan",
+        org_id=org_id,
+        documents=len(renames),
+        episodes=episodes,
+        skipped_without_episode=skipped,
+        dry_run=dry_run,
+    )
+    if dry_run or not renames:
+        return 0
+
+    renamed = await graph_module.rename_episodes_to_document_keys(org_id, renames)
+    logger.info(
+        "backfill_episode_names_complete",
+        org_id=org_id,
+        documents=len(renames),
+        episodes_matched=renamed,
+        episodes_expected=episodes,
+    )
+    # A shortfall is normal: an episode row can be gone from FalkorDB while
+    # its artifact still records the id (deleted KB, purged connector). Say so
+    # rather than let the difference pass silently.
+    if renamed < episodes:
+        logger.warning(
+            "backfill_episode_names_shortfall",
+            org_id=org_id,
+            missing_in_graph=episodes - renamed,
+        )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org-id", required=True, help="Zitadel org id (one tenant per run)")
+    parser.add_argument("--dry-run", action="store_true", help="Report the plan, change nothing")
+    args = parser.parse_args()
+    return asyncio.run(run(args.org_id, args.dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
@@ -1,0 +1,135 @@
+"""The graph cannot heal itself, so the backfill must be correct.
+
+SPEC-RAG-GRAPH-CITE-002 renames episodes at ingest, but knowledge-ingest
+dedups on content_hash: re-crawling an unchanged page never produces a new
+episode. Every fact extracted before the change therefore keeps a pointer to
+a superseded artifact version unless this backfill runs.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import graph as graph_module
+
+
+def _row(kb_slug, path, extra):
+    return {"kb_slug": kb_slug, "path": path, "extra": json.dumps(extra) if extra else None}
+
+
+class TestCollectRenames:
+    @pytest.mark.asyncio
+    async def test_groups_every_version_of_a_document_under_one_name(self):
+        """Several versions share a document, and all their episodes must move.
+
+        Superseded artifacts are the point of the exercise: their episodes
+        carry the stale edges whose citations do not resolve.
+        """
+        from scripts.backfill_episode_document_names import collect_renames
+
+        rows = [
+            _row("support", "webphone", {"graphiti_episode_id": "ep-v1"}),
+            _row("support", "webphone", {"graphiti_episode_id": "ep-v2"}),
+            _row("support", "yealink", {"graphiti_episode_id": "ep-y"}),
+        ]
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=rows)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=conn)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "scripts.backfill_episode_document_names.tenant_scoped_connection", return_value=ctx
+        ):
+            renames, skipped = await collect_renames("org-1")
+
+        assert renames == {
+            "doc:support:webphone": ["ep-v1", "ep-v2"],
+            "doc:support:yealink": ["ep-y"],
+        }
+        assert skipped == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_artifacts_without_a_usable_episode_pointer(self):
+        """no-chunks is backfill.py's sentinel, not an episode uuid."""
+        from scripts.backfill_episode_document_names import collect_renames
+
+        rows = [
+            _row("support", "a", {"graphiti_episode_id": "no-chunks"}),
+            _row("support", "b", {}),
+            _row("support", "c", None),
+            _row("", "d", {"graphiti_episode_id": "ep-1"}),
+            _row("support", "", {"graphiti_episode_id": "ep-2"}),
+        ]
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=rows)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=conn)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "scripts.backfill_episode_document_names.tenant_scoped_connection", return_value=ctx
+        ):
+            renames, skipped = await collect_renames("org-1")
+
+        assert renames == {}
+        assert skipped == 5
+
+
+class TestRenameEpisodes:
+    @pytest.mark.asyncio
+    async def test_renames_within_the_tenant_graph(self):
+        """TENANT ISOLATION: the write goes to the org's own FalkorDB database."""
+        driver = MagicMock()
+        driver.execute_query = AsyncMock(return_value=([{"n": 2}], None, None))
+        graphiti = MagicMock()
+        graphiti.driver.clone = MagicMock(return_value=driver)
+
+        with (
+            patch.object(graph_module, "_get_graphiti", return_value=graphiti),
+            patch.object(graph_module.settings, "graphiti_enabled", True),
+        ):
+            renamed = await graph_module.rename_episodes_to_document_keys(
+                "org-1", {"doc:support:webphone": ["ep-1", "ep-2"]}
+            )
+
+        graphiti.driver.clone.assert_called_once_with("org-1")
+        assert renamed == 2
+        kwargs = driver.execute_query.await_args.kwargs
+        assert kwargs["uuids"] == ["ep-1", "ep-2"]
+        assert kwargs["name"] == "doc:support:webphone"
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_there_is_nothing_to_rename(self):
+        graphiti = MagicMock()
+        with patch.object(graph_module, "_get_graphiti", return_value=graphiti):
+            assert await graph_module.rename_episodes_to_document_keys("org-1", {}) == 0
+        graphiti.driver.clone.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_is_a_metadata_rename_not_a_reingest(self):
+        """Guard the property that makes this safe to run on a live tenant.
+
+        A re-ingest would cost ~5 LLM calls per episode out of the shared
+        klai-fast budget. This must only ever touch the episode name.
+        """
+        driver = MagicMock()
+        driver.execute_query = AsyncMock(return_value=([{"n": 1}], None, None))
+        graphiti = MagicMock()
+        graphiti.driver.clone = MagicMock(return_value=driver)
+
+        with (
+            patch.object(graph_module, "_get_graphiti", return_value=graphiti),
+            patch.object(graph_module.settings, "graphiti_enabled", True),
+        ):
+            await graph_module.rename_episodes_to_document_keys(
+                "org-1", {"doc:support:a": ["ep-1"]}
+            )
+
+        cypher = driver.execute_query.await_args.args[0]
+        assert "SET e.name" in cypher
+        for forbidden in ("DELETE", "CREATE", "MERGE", "Entity"):
+            assert forbidden not in cypher

--- a/klai-knowledge-ingest/tests/test_qdrant_link_counts.py
+++ b/klai-knowledge-ingest/tests/test_qdrant_link_counts.py
@@ -289,6 +289,9 @@ async def test_ensure_collection_skips_indexes_when_already_present():
     all_fields = {
         "org_id",
         "kb_slug",
+        # SPEC-RAG-GRAPH-CITE-002: retrieval filters on (kb_slug, path) to
+        # resolve a graph fact to its source document.
+        "path",
         "artifact_id",
         "content_type",
         "user_id",

--- a/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
+++ b/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
@@ -14,6 +14,8 @@ shared lib is the coordination point.
 
 from __future__ import annotations
 
+from urllib.parse import quote, unquote
+
 __all__ = ["episode_name", "parse_episode_name", "personal_kb_slug"]
 
 
@@ -62,8 +64,19 @@ def episode_name(kb_slug: str, path: str) -> str:
 
     Stamped by knowledge-ingest at episode creation and parsed back by
     retrieval-api when it resolves a graph fact to its source document.
+
+    ``kb_slug`` is percent-encoded so the encoding stays reversible. Nothing
+    validates the slug shape — ``IngestRequest.kb_slug`` is a bare ``str`` —
+    so a slug containing ``:`` would otherwise split in the wrong place, the
+    document lookup would silently never match, and (because a document-key
+    edge only receives its artifact_id from that lookup) the fact would drop
+    out of the evidence pack entirely. Encoding at the boundary is cheaper
+    than trusting every caller.
+
+    ``path`` needs no encoding: it is the final segment, so it may contain
+    colons freely.
     """
-    return f"{_EPISODE_NAME_PREFIX}:{kb_slug}:{path}"
+    return f"{_EPISODE_NAME_PREFIX}:{quote(kb_slug, safe='')}:{path}"
 
 
 def parse_episode_name(name: str) -> tuple[str, str] | None:
@@ -71,15 +84,14 @@ def parse_episode_name(name: str) -> tuple[str, str] | None:
 
     None means the episode predates SPEC-RAG-GRAPH-CITE-002 and is still named
     after its artifact_id; callers fall back to resolving that instead. Split
-    with maxsplit=2 because a path may legitimately contain colons while a
-    kb_slug may not.
+    with maxsplit=2 so the path keeps any colons it contains.
     """
     if not name:
         return None
     parts = name.split(":", 2)
     if len(parts) != 3 or parts[0] != _EPISODE_NAME_PREFIX:
         return None
-    kb_slug, path = parts[1], parts[2]
+    kb_slug, path = unquote(parts[1]), parts[2]
     if not kb_slug or not path:
         return None
     return kb_slug, path

--- a/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
+++ b/klai-libs/kb-slugs/klai_kb_slugs/__init__.py
@@ -14,7 +14,7 @@ shared lib is the coordination point.
 
 from __future__ import annotations
 
-__all__ = ["personal_kb_slug"]
+__all__ = ["episode_name", "parse_episode_name", "personal_kb_slug"]
 
 
 def personal_kb_slug(user_id: str) -> str:
@@ -31,3 +31,55 @@ def personal_kb_slug(user_id: str) -> str:
     already passes a verified identifier upstream.
     """
     return f"personal-{user_id}"
+
+
+# ---------------------------------------------------------------------------
+# Graphiti episode naming (SPEC-RAG-GRAPH-CITE-002)
+# ---------------------------------------------------------------------------
+#
+# An episode used to be named after the artifact_id it was ingested from.
+# That id identifies a VERSION, not a document: knowledge-ingest mints a fresh
+# uuid4 on every ingest (pg_store.create_artifact) and marks the previous row
+# superseded_by. Qdrant only holds chunks of the current version, so as soon as
+# a page was re-ingested every graph edge extracted from it pointed at an id
+# nothing could resolve any more — the fact stayed citable but its source could
+# not be looked up, and the citation rendered as a truncated sentence.
+#
+# ``(org_id, kb_slug, path)`` is the identity ingest already dedups on, and
+# ``kb_slug``/``path`` are both stamped on every Qdrant chunk. It survives
+# re-ingest, so an episode named this way stays resolvable for the life of the
+# document.
+#
+# org_id is deliberately absent: each tenant has its own FalkorDB database, so
+# the name is already tenant-scoped by construction and repeating org_id here
+# would invite a caller to trust the string instead of the database boundary.
+
+_EPISODE_NAME_PREFIX = "doc"
+
+
+def episode_name(kb_slug: str, path: str) -> str:
+    """Return the stable Graphiti episode name for a document.
+
+    Stamped by knowledge-ingest at episode creation and parsed back by
+    retrieval-api when it resolves a graph fact to its source document.
+    """
+    return f"{_EPISODE_NAME_PREFIX}:{kb_slug}:{path}"
+
+
+def parse_episode_name(name: str) -> tuple[str, str] | None:
+    """Return ``(kb_slug, path)`` for a stable episode name, else None.
+
+    None means the episode predates SPEC-RAG-GRAPH-CITE-002 and is still named
+    after its artifact_id; callers fall back to resolving that instead. Split
+    with maxsplit=2 because a path may legitimately contain colons while a
+    kb_slug may not.
+    """
+    if not name:
+        return None
+    parts = name.split(":", 2)
+    if len(parts) != 3 or parts[0] != _EPISODE_NAME_PREFIX:
+        return None
+    kb_slug, path = parts[1], parts[2]
+    if not kb_slug or not path:
+        return None
+    return kb_slug, path

--- a/klai-libs/kb-slugs/tests/test_kb_slugs.py
+++ b/klai-libs/kb-slugs/tests/test_kb_slugs.py
@@ -1,5 +1,3 @@
-
-
 def test_episode_name_round_trips():
     from klai_kb_slugs import episode_name, parse_episode_name
 
@@ -28,3 +26,23 @@ def test_legacy_artifact_id_names_are_not_parsed():
     assert parse_episode_name("") is None
     assert parse_episode_name("doc:support") is None
     assert parse_episode_name("doc::path") is None
+
+
+def test_episode_name_survives_a_colon_in_the_kb_slug():
+    """Regression (Sol review): IngestRequest.kb_slug has no shape validation.
+
+    Without encoding, episode_name("team:blue", "page") parses back as
+    ("team", "blue:page"), the document lookup never matches, and because a
+    document-key edge gets its artifact_id from that lookup the fact stops
+    being citable at all — silent and total for the affected KB.
+    """
+    from klai_kb_slugs import episode_name, parse_episode_name
+
+    assert parse_episode_name(episode_name("team:blue", "page")) == ("team:blue", "page")
+
+
+def test_episode_name_survives_other_awkward_slugs():
+    from klai_kb_slugs import episode_name, parse_episode_name
+
+    for slug in ("team/blue", "team blue", "team%3Ablue", "persoonlijk-123"):
+        assert parse_episode_name(episode_name(slug, "a/b:c.md")) == (slug, "a/b:c.md")

--- a/klai-libs/kb-slugs/tests/test_kb_slugs.py
+++ b/klai-libs/kb-slugs/tests/test_kb_slugs.py
@@ -1,0 +1,30 @@
+
+
+def test_episode_name_round_trips():
+    from klai_kb_slugs import episode_name, parse_episode_name
+
+    assert parse_episode_name(episode_name("support", "yealink-dect-configuratie")) == (
+        "support",
+        "yealink-dect-configuratie",
+    )
+
+
+def test_episode_name_keeps_colons_in_the_path():
+    from klai_kb_slugs import episode_name, parse_episode_name
+
+    name = episode_name("support", "https://help.voys.nl/a:b")
+    assert parse_episode_name(name) == ("support", "https://help.voys.nl/a:b")
+
+
+def test_legacy_artifact_id_names_are_not_parsed():
+    """Episodes created before this scheme are named after their artifact_id.
+
+    Returning None is what tells retrieval-api to fall back to the old
+    artifact_id lookup instead of inventing a kb_slug from a uuid.
+    """
+    from klai_kb_slugs import parse_episode_name
+
+    assert parse_episode_name("3f4a1c2d-8b9e-4f1a-b2c3-d4e5f6a7b8c9") is None
+    assert parse_episode_name("") is None
+    assert parse_episode_name("doc:support") is None
+    assert parse_episode_name("doc::path") is None

--- a/klai-libs/kb-slugs/tests/test_personal_kb_slug.py
+++ b/klai-libs/kb-slugs/tests/test_personal_kb_slug.py
@@ -53,12 +53,20 @@ def test_personal_kb_slug_matches_legacy_inline_pattern() -> None:
         )
 
 
-def test_personal_kb_slug_is_in_dunder_all() -> None:
-    """Public-API surface is intentionally narrow — exactly one export.
+def test_public_api_surface_is_deliberate() -> None:
+    """Public-API surface stays narrow and explicit.
 
-    Adding new exports requires updating ``__all__``; this test ensures
-    re-exports stay deliberate.
+    Adding new exports requires updating ``__all__`` AND this list, so a
+    re-export is always a decision rather than a side effect. The episode
+    helpers were added by SPEC-RAG-GRAPH-CITE-002: they belong here because
+    knowledge-ingest writes the episode name and retrieval-api parses it, so
+    the format must live in exactly one place — the same reason
+    ``personal_kb_slug`` does.
     """
     import klai_kb_slugs
 
-    assert klai_kb_slugs.__all__ == ["personal_kb_slug"]
+    assert klai_kb_slugs.__all__ == [
+        "episode_name",
+        "parse_episode_name",
+        "personal_kb_slug",
+    ]

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -343,30 +343,52 @@ async def _retrieve_sub_queries(
 async def _label_graph_results(graph_results: list[dict], req: RetrieveRequest) -> None:
     """Attach the citation fields a graph edge cannot know about itself.
 
-    A graph edge carries a fact and its artifact_id, but no title or URL, so
-    ``evidence_pack._title()`` would fall through to ``text[:80]`` and render a
-    truncated fact as the source name. Resolving the artifact's own metadata
-    turns that back into the document the reader can actually open.
+    A graph edge carries a fact and a pointer to the document it came from,
+    but no title or URL, so ``evidence_pack._title()`` would fall through to
+    ``text[:80]`` and render a truncated fact as the source name.
+
+    Two pointer schemes coexist and both are resolved here:
+
+    - ``(kb_slug, path)`` — SPEC-RAG-GRAPH-CITE-002, stable across re-ingest.
+      Also yields the CURRENT artifact_id, which is what makes the edge
+      citable at all.
+    - a legacy ``artifact_id`` — every edge written before that change. It
+      identifies a version, so it only resolves while that version is still
+      the current one; those edges heal on their document's next ingest.
 
     Setting ``source_url`` also collapses a graph fact and an ordinary chunk
     from the same document into ONE source, because ``chunk_source_key`` keys
     on the URL before falling back to ``artifact:<id>``.
 
-    Mutates in place. Fail-open: on any miss the edge keeps today's behaviour.
+    Mutates in place. Fail-open: an unresolved edge keeps whatever identity it
+    already had, so a failed lookup never costs a result.
     """
+    documents = [
+        (r["graph_kb_slug"], r["graph_path"])
+        for r in graph_results
+        if r.get("graph_kb_slug") and r.get("graph_path")
+    ]
     artifact_ids = [r.get("artifact_id") for r in graph_results if r.get("artifact_id")]
-    if not artifact_ids:
+    if not documents and not artifact_ids:
         return
-    metadata = await search.fetch_artifact_display_metadata(artifact_ids, req)
-    if not metadata:
-        return
+
+    by_document, by_artifact = await asyncio.gather(
+        search.fetch_document_display_metadata(documents, req),
+        search.fetch_artifact_display_metadata(artifact_ids, req),
+    )
+
     for result in graph_results:
-        meta = metadata.get(result.get("artifact_id") or "")
+        key = (result.get("graph_kb_slug"), result.get("graph_path"))
+        meta = (
+            by_document.get(key) if all(key) else by_artifact.get(result.get("artifact_id") or "")
+        )
         if not meta:
             continue
         for field in ("title", "source_url", "source_label", "original_filename"):
             if meta.get(field):
                 result[field] = meta[field]
+        if meta.get("artifact_id"):
+            result["artifact_id"] = meta["artifact_id"]
 
 
 @router.post("/retrieve", response_model=RetrieveResponse)

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -260,16 +260,23 @@ def _convert_results(
             score = base
 
         uid = str(getattr(r, "uuid", i))
-        source_name = None
-        for episode_uuid in _episode_uuids(r):
-            source_name = (episode_artifacts or {}).get(episode_uuid)
-            if source_name:
-                break
-        document = parse_episode_name(source_name or "")
+        # Prefer a document-key episode over a legacy artifact-id one. An edge
+        # accumulates episodes as later ingests re-confirm the same fact, and
+        # the pre-rollout episode stays FIRST in that list — taking whichever
+        # name resolves first would therefore keep picking the superseded
+        # artifact_id and no existing edge would ever heal. Choosing by scheme
+        # instead of by position removes the ordering assumption entirely.
+        names = [
+            name
+            for episode_uuid in _episode_uuids(r)
+            if (name := (episode_artifacts or {}).get(episode_uuid))
+        ]
+        document = next((parsed for name in names if (parsed := parse_episode_name(name))), None)
+        source_name = None if document else next(iter(names), None)
         # A doc-key edge gets its artifact_id from the CURRENT version at
         # label time; a legacy edge carries the (possibly superseded) id it
         # was named after, which keeps it citable exactly as it is today.
-        artifact_id = None if document else source_name
+        artifact_id = source_name
         converted.append(
             {
                 "chunk_id": f"graph:{uid}",

--- a/klai-retrieval-api/retrieval_api/services/graph_search.py
+++ b/klai-retrieval-api/retrieval_api/services/graph_search.py
@@ -23,6 +23,7 @@ from graphiti_core.llm_client.config import LLMConfig
 from graphiti_core.llm_client.openai_generic_client import OpenAIGenericClient
 from graphiti_core.nodes import EpisodicNode
 from klai_graphiti_compat import apply_falkordb_compat
+from klai_kb_slugs import parse_episode_name
 
 from retrieval_api.config import settings
 
@@ -131,8 +132,8 @@ async def _search_with_provenance(
         graphiti.search(query, group_ids=[org_id]),
         timeout=settings.graph_search_timeout,
     )
-    episode_artifacts = await _resolve_episode_artifacts(graphiti, results, org_id)
-    return _convert_results(results, top_k, episode_artifacts)
+    episode_names = await _resolve_episode_names(graphiti, results, org_id)
+    return _convert_results(results, top_k, episode_names)
 
 
 def _episode_uuids(edge: object) -> list[str]:
@@ -143,14 +144,17 @@ def _episode_uuids(edge: object) -> list[str]:
     return [uuid for uuid in episodes if isinstance(uuid, str) and uuid]
 
 
-async def _resolve_episode_artifacts(
-    graphiti: Graphiti, results: list, org_id: str
-) -> dict[str, str]:
-    """Map episode uuid -> Klai artifact_id for the edges in ``results``.
+async def _resolve_episode_names(graphiti: Graphiti, results: list, org_id: str) -> dict[str, str]:
+    """Map episode uuid -> episode name for the edges in ``results``.
 
-    knowledge-ingest calls ``add_episode(name=artifact_id, ...)``, so an
-    episode node's ``name`` IS the artifact identity. That is what turns a
-    derived graph fact into something the evidence pack can cite.
+    The name is what ties a derived fact back to a document. Two schemes are
+    in the graph at once and both must keep working:
+
+    - ``doc:<kb_slug>:<path>`` (SPEC-RAG-GRAPH-CITE-002) — the identity
+      ingest dedups on, stable across re-ingest.
+    - a bare ``artifact_id`` — every episode written before that change.
+      artifact_id identifies a VERSION, so it stops resolving once the page
+      is re-ingested; those edges heal on their next ingest.
 
     TENANT ISOLATION. ``EpisodicNode.get_by_uuids`` matches on uuid alone —
     it applies no group_id filter of its own. Scoping therefore rests on the
@@ -185,10 +189,10 @@ async def _resolve_episode_artifacts(
         if getattr(episode, "group_id", None) != org_id:
             foreign += 1
             continue
-        artifact_id = getattr(episode, "name", None)
+        name = getattr(episode, "name", None)
         uuid = getattr(episode, "uuid", None)
-        if isinstance(artifact_id, str) and artifact_id and isinstance(uuid, str):
-            resolved[uuid] = artifact_id
+        if isinstance(name, str) and name and isinstance(uuid, str):
+            resolved[uuid] = name
     if foreign:
         logger.warning("graph_episode_foreign_group_id_dropped", org_id=org_id, count=foreign)
     return resolved
@@ -256,17 +260,24 @@ def _convert_results(
             score = base
 
         uid = str(getattr(r, "uuid", i))
-        artifact_id = None
+        source_name = None
         for episode_uuid in _episode_uuids(r):
-            artifact_id = (episode_artifacts or {}).get(episode_uuid)
-            if artifact_id:
+            source_name = (episode_artifacts or {}).get(episode_uuid)
+            if source_name:
                 break
+        document = parse_episode_name(source_name or "")
+        # A doc-key edge gets its artifact_id from the CURRENT version at
+        # label time; a legacy edge carries the (possibly superseded) id it
+        # was named after, which keeps it citable exactly as it is today.
+        artifact_id = None if document else source_name
         converted.append(
             {
                 "chunk_id": f"graph:{uid}",
                 "text": text,
                 "score": score,
                 "artifact_id": artifact_id,
+                "graph_kb_slug": document[0] if document else None,
+                "graph_path": document[1] if document else None,
                 "content_type": "graph_edge",
                 "context_prefix": None,
                 "scope": "org",

--- a/klai-retrieval-api/retrieval_api/services/search.py
+++ b/klai-retrieval-api/retrieval_api/services/search.py
@@ -481,6 +481,80 @@ async def _fetch_one_artifact_metadata(
     }
 
 
+async def _fetch_one_document_metadata(
+    kb_slug: str,
+    path: str,
+    request: RetrieveRequest,
+) -> tuple[tuple[str, str], dict[str, str | None]] | None:
+    """Fetch display fields for ONE document, keyed by (kb_slug, path)."""
+    client = _get_client()
+    document_filter = Filter(
+        must=[
+            *_scope_filter(request),
+            FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)),
+            FieldCondition(key="path", match=MatchValue(value=path)),
+            _temporal_validity_filter(),
+        ]
+    )
+    try:
+        result, _ = await asyncio.wait_for(
+            client.scroll(
+                collection_name=settings.qdrant_collection,
+                scroll_filter=document_filter,
+                limit=1,
+                with_payload=True,
+                with_vectors=False,
+            ),
+            timeout=_ARTIFACT_METADATA_TIMEOUT,
+        )
+    except Exception:
+        logger.warning("document_display_metadata_failed", kb_slug=kb_slug, exc_info=True)
+        return None
+    if not result:
+        return None
+    payload = result[0].payload
+    return (kb_slug, path), {
+        "title": payload.get("title"),
+        "source_url": payload.get("source_url"),
+        "source_label": payload.get("source_label"),
+        "original_filename": payload.get("original_filename"),
+        # The CURRENT version's id. A graph edge outlives the artifact it was
+        # extracted from, so this is the only id worth putting on a citation.
+        "artifact_id": payload.get("artifact_id"),
+    }
+
+
+async def fetch_document_display_metadata(
+    documents: list[tuple[str, str]],
+    request: RetrieveRequest,
+) -> dict[tuple[str, str], dict[str, str | None]]:
+    """Resolve (kb_slug, path) -> the fields a citation is rendered from.
+
+    This is the resolution path for episodes named by SPEC-RAG-GRAPH-CITE-002.
+    Unlike artifact_id it survives re-ingest, because ingest mints a new
+    artifact uuid every time while ``(org_id, kb_slug, path)`` is the identity
+    it dedups on.
+
+    Same shape as ``fetch_artifact_display_metadata``: tenant-scoped through
+    ``_scope_filter``, one bounded lookup per document, fail-open per entry.
+    """
+    unique = sorted({(kb, p) for kb, p in documents if kb and p})
+    if not unique:
+        return {}
+    if len(unique) > _ARTIFACT_METADATA_MAX:
+        logger.warning(
+            "document_display_metadata_truncated",
+            requested=len(unique),
+            resolved=_ARTIFACT_METADATA_MAX,
+        )
+        unique = unique[:_ARTIFACT_METADATA_MAX]
+
+    resolved = await asyncio.gather(
+        *(_fetch_one_document_metadata(kb, p, request) for kb, p in unique)
+    )
+    return {key: meta for entry in resolved if entry for key, meta in [entry]}
+
+
 async def fetch_artifact_display_metadata(
     artifact_ids: list[str],
     request: RetrieveRequest,

--- a/klai-retrieval-api/tests/test_graph_edge_labels.py
+++ b/klai-retrieval-api/tests/test_graph_edge_labels.py
@@ -20,12 +20,26 @@ import pytest
 
 from retrieval_api.api.retrieve import _label_graph_results
 from retrieval_api.models import RetrieveRequest
-from retrieval_api.services import search
+from retrieval_api.services import graph_search, search
 from retrieval_api.services.evidence_pack import build_evidence_pack, chunk_source_key
 
 
 def _point(artifact_id: str, **payload):
     return SimpleNamespace(id="c1", score=0.9, payload={"artifact_id": artifact_id, **payload})
+
+
+def _edge(uuid: str, episodes: list[str]):
+    """Minimal stand-in for a Graphiti EntityEdge (see test_graph_search.py)."""
+    edge = SimpleNamespace(
+        uuid=uuid,
+        fact="fact",
+        score=0.8,
+        weight=None,
+        episodes=episodes,
+        valid_at=None,
+        invalid_at=None,
+    )
+    return edge
 
 
 def _graph_chunk(artifact_id: str | None, text: str = "Nummerbehoud kan bij overstap"):
@@ -237,3 +251,122 @@ class TestGraphResultLabelling:
             req = RetrieveRequest(query="q", org_id="org-1", scope="org")
             await _label_graph_results(chunks, req)
         assert "title" not in chunks[0]
+
+
+class TestStableDocumentResolution:
+    """SPEC-RAG-GRAPH-CITE-002: resolve a fact via (kb_slug, path), not a version id.
+
+    Observed in production on 2026-08-21: every graph citation rendered as a
+    truncated fact because the episode was named after the artifact_id it was
+    ingested from. pg_store mints a fresh uuid4 per ingest and supersedes the
+    previous row, while Qdrant keeps only the current version's chunks — so
+    the moment a page was re-ingested, the pointer went stale.
+    """
+
+    def test_doc_key_episode_yields_a_document_pointer(self):
+        converted = graph_search._convert_results(
+            [_edge("e1", ["ep-1"])], 10, {"ep-1": "doc:support:yealink-dect-configuratie"}
+        )
+        assert converted[0]["graph_kb_slug"] == "support"
+        assert converted[0]["graph_path"] == "yealink-dect-configuratie"
+        # The current artifact_id is only known after the lookup.
+        assert converted[0]["artifact_id"] is None
+
+    def test_legacy_episode_still_yields_an_artifact_id(self):
+        """Edges written before the change must not get worse."""
+        converted = graph_search._convert_results(
+            [_edge("e1", ["ep-1"])], 10, {"ep-1": "artifact-abc"}
+        )
+        assert converted[0]["artifact_id"] == "artifact-abc"
+        assert converted[0]["graph_kb_slug"] is None
+
+    @pytest.mark.asyncio
+    async def test_document_lookup_is_tenant_scoped(self):
+        """TENANT ISOLATION: same rule as the artifact path — titles are data."""
+        mock_client = AsyncMock()
+        mock_client.scroll.return_value = ([], None)
+
+        with patch.object(search, "_get_client", return_value=mock_client):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await search.fetch_document_display_metadata([("support", "a-page")], req)
+
+        rendered = repr(mock_client.scroll.await_args.kwargs["scroll_filter"])
+        assert "org_id" in rendered and "org-1" in rendered
+        assert "visibility" in rendered
+
+    @pytest.mark.asyncio
+    async def test_resolved_document_supplies_the_current_artifact_id(self):
+        """The edge becomes citable via the CURRENT version, not the dead one."""
+        chunks = [_graph_chunk(None)]
+        chunks[0]["graph_kb_slug"] = "support"
+        chunks[0]["graph_path"] = "yealink-dect-configuratie"
+        meta = {
+            ("support", "yealink-dect-configuratie"): {
+                "title": "Yealink Draadloze Telefoons (Basisstation) Instellen",
+                "source_url": "https://help.voys.nl/yealink-dect-configuratie",
+                "source_label": "help.voys.nl",
+                "original_filename": None,
+                "artifact_id": "artifact-current",
+            }
+        }
+
+        with (
+            patch.object(
+                search, "fetch_document_display_metadata", new=AsyncMock(return_value=meta)
+            ),
+            patch.object(search, "fetch_artifact_display_metadata", new=AsyncMock(return_value={})),
+        ):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await _label_graph_results(chunks, req)
+
+        assert chunks[0]["artifact_id"] == "artifact-current"
+        pack = build_evidence_pack(chunks)
+        assert pack.sources[0].title == "Yealink Draadloze Telefoons (Basisstation) Instellen"
+        assert pack.sources[0].source_url == "https://help.voys.nl/yealink-dect-configuratie"
+
+    @pytest.mark.asyncio
+    async def test_legacy_edge_keeps_working_alongside_the_new_scheme(self):
+        """Both schemes are live in the graph at once; one must not break the other."""
+        legacy = _graph_chunk("artifact-legacy", text="Oud feit")
+        modern = _graph_chunk(None, text="Nieuw feit")
+        modern["chunk_id"] = "graph:e2"
+        modern["graph_kb_slug"] = "support"
+        modern["graph_path"] = "webphone"
+
+        with (
+            patch.object(
+                search,
+                "fetch_document_display_metadata",
+                new=AsyncMock(
+                    return_value={
+                        ("support", "webphone"): {
+                            "title": "De Webphone",
+                            "source_url": "https://help.voys.nl/webphone",
+                            "source_label": "help.voys.nl",
+                            "original_filename": None,
+                            "artifact_id": "artifact-current",
+                        }
+                    }
+                ),
+            ),
+            patch.object(
+                search,
+                "fetch_artifact_display_metadata",
+                new=AsyncMock(
+                    return_value={
+                        "artifact-legacy": {
+                            "title": "Oud artikel",
+                            "source_url": "https://help.voys.nl/oud",
+                            "source_label": "help.voys.nl",
+                            "original_filename": None,
+                        }
+                    }
+                ),
+            ),
+        ):
+            req = RetrieveRequest(query="q", org_id="org-1", scope="org")
+            await _label_graph_results([legacy, modern], req)
+
+        assert legacy["title"] == "Oud artikel"
+        assert modern["title"] == "De Webphone"
+        assert modern["artifact_id"] == "artifact-current"

--- a/klai-retrieval-api/tests/test_graph_edge_labels.py
+++ b/klai-retrieval-api/tests/test_graph_edge_labels.py
@@ -370,3 +370,30 @@ class TestStableDocumentResolution:
         assert legacy["title"] == "Oud artikel"
         assert modern["title"] == "De Webphone"
         assert modern["artifact_id"] == "artifact-current"
+
+    def test_a_healed_edge_prefers_its_document_episode(self):
+        """Regression (Sol review, high): existing edges must heal on re-ingest.
+
+        An edge accumulates episodes as later ingests re-confirm the same
+        fact, and the pre-rollout artifact-id episode stays FIRST. Taking the
+        first name that resolves would keep choosing the superseded id, so no
+        existing edge would ever pick up its new document key — defeating the
+        healing this change is built on.
+        """
+        converted = graph_search._convert_results(
+            [_edge("e1", ["ep-old", "ep-new"])],
+            10,
+            {"ep-old": "artifact-superseded", "ep-new": "doc:support:webphone"},
+        )
+        assert converted[0]["graph_kb_slug"] == "support"
+        assert converted[0]["graph_path"] == "webphone"
+        assert converted[0]["artifact_id"] is None
+
+    def test_edge_with_only_legacy_episodes_is_unchanged(self):
+        converted = graph_search._convert_results(
+            [_edge("e1", ["ep-a", "ep-b"])],
+            10,
+            {"ep-a": "artifact-one", "ep-b": "artifact-two"},
+        )
+        assert converted[0]["artifact_id"] == "artifact-one"
+        assert converted[0]["graph_kb_slug"] is None

--- a/klai-retrieval-api/tests/test_graph_search.py
+++ b/klai-retrieval-api/tests/test_graph_search.py
@@ -476,7 +476,7 @@ async def test_episode_lookup_is_scoped_to_the_tenant_database():
         "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
         new=AsyncMock(return_value=[_make_episode("ep-1", "artifact-abc", "org-1")]),
     ) as mock_lookup:
-        mapping = await graph_search._resolve_episode_artifacts(mock_graphiti, [edge], "org-1")
+        mapping = await graph_search._resolve_episode_names(mock_graphiti, [edge], "org-1")
 
     mock_graphiti.clients.driver.clone.assert_called_once_with(database="org-1")
     assert mock_lookup.await_args.args[0] is cloned
@@ -500,7 +500,7 @@ async def test_episode_from_another_tenant_is_discarded():
         "retrieval_api.services.graph_search.EpisodicNode.get_by_uuids",
         new=AsyncMock(return_value=[_make_episode("ep-1", "artifact-of-other-org", "org-2")]),
     ):
-        mapping = await graph_search._resolve_episode_artifacts(mock_graphiti, [edge], "org-1")
+        mapping = await graph_search._resolve_episode_names(mock_graphiti, [edge], "org-1")
 
     assert mapping == {}
 


### PR DESCRIPTION
Root cause of the truncated graph citations, found by following the chain instead of the symptom.

```
graph edge → episode (name) → Qdrant chunk → title + URL
```

`pg_store.create_artifact` mints a fresh `uuid4()` on **every** ingest and marks the previous row `superseded_by`, while Qdrant keeps only the current version's chunks. Episodes were named after the artifact_id of the moment, so as soon as a page was re-ingested the pointer went stale. For a repeatedly crawled help centre that is the normal case — which is why *zero* graph citations resolved rather than some of them.

An artifact_id identifies a **version**. A citation needs a **document**.

## The fix

`(org_id, kb_slug, path)` is the identity ingest already dedups on, and `kb_slug`/`path` are stamped on every Qdrant chunk. Episodes are now named `doc:<kb_slug>:<path>`, which survives re-ingest.

The format lives in `klai-kb-slugs` because knowledge-ingest writes it and retrieval-api parses it — the same reason `personal_kb_slug` lives there. Its public-API guard test was updated deliberately rather than bypassed.

Both schemes are live in the graph simultaneously and both resolve:
- **doc key** → lookup by `(kb_slug, path)`, which also yields the *current* artifact_id
- **bare artifact_id** → the existing lookup, unchanged

## The backfill, which is not optional

The naming change alone would never heal the existing graph: knowledge-ingest dedups on `content_hash`, so re-crawling an unchanged page never creates a new episode. Every pre-change fact would keep its stale pointer forever.

`scripts/backfill_episode_document_names.py` renames existing episodes in place. Postgres already holds the mapping (`graphiti_episode_id` in `knowledge.artifacts.extra`), so this is **metadata only** — no re-extraction, no LLM calls, nothing drawn from the shared klai-fast budget. Per-tenant, `--dry-run`, idempotent, and it logs a shortfall rather than letting one pass silently.

A test asserts the Cypher contains `SET e.name` and none of `DELETE`/`CREATE`/`MERGE`/`Entity`, so this cannot quietly grow into a heavier operation.

## Safety properties

- **Deploy order is safe either way.** Ingest first: old retrieval treats the doc key as an artifact_id, misses, and degrades to today's behaviour. Retrieval first: no doc keys exist yet.
- **In-flight Procrastinate jobs keep working** — `kb_slug`/`path` default to `""` and the namer falls back to artifact_id. A job queued before the deploy must not fail on a signature change.
- `path` added to the Qdrant payload indexes; without it the new filter degrades to a payload scan.

## Review

Sol (review-deep) found three issues, all verified against source:

1. **[high]** Taking the first resolving episode name meant a healed edge would keep picking its superseded artifact_id, because the pre-rollout episode stays first in `edge.episodes`. Now selects by scheme, removing the ordering assumption entirely. Regression test verified red on the previous shape.
2. **[medium, authorised by Mark]** `IngestRequest.kb_slug` has no shape validation, so a slug containing `:` parsed back wrong — and because a doc-key edge gets its artifact_id *from* that lookup, the fact would drop out of the evidence pack entirely. kb_slug is now percent-encoded. Fixed despite being medium because this is a format introduced in this change, and formats are expensive to alter once written to production data.
3. **[deferred]** A fact removed from a page without explicit contradiction keeps its edge, which would then be labelled with the current document version. Real, but it is an edge-lifecycle concern that belongs with #1148, not a hurried patch here.

## Tests

kb-slugs 11 · knowledge-ingest 1552 · retrieval-api 595. Two existing guard tests failed first and were updated deliberately — the `__all__` guard and the payload-index inventory — which is exactly what they are for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)