### PR TITLE
fix(renovate): point the config contract at the gate that actually runs

### DIFF
--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -5,8 +5,7 @@ repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 workflow="$repo_root/.github/workflows/renovate.yml"
 config="$repo_root/renovate.json5"
 docs_workflow="$repo_root/.github/workflows/docs.yml"
-portal_frontend_workflow="$repo_root/.github/workflows/portal-frontend.yml"
-trivyignore_workflow="$repo_root/.github/workflows/validate-trivyignore.yml"
+quality_workflow="$repo_root/.github/workflows/quality.yml"
 
 assert_contains() {
   file=$1
@@ -14,6 +13,21 @@ assert_contains() {
   message=$3
 
   if ! grep -Fq "$expected" "$file"; then
+    echo "FAIL: $message" >&2
+    exit 1
+  fi
+}
+
+# Whole-line variant. `assert_contains` matches substrings, so an assertion on
+# `    name: quality` silently kept passing after the job was renamed to
+# `quality-trivyignore` — the check survived the very rename it existed to
+# catch. Use this wherever the exact identifier is the point.
+assert_line() {
+  file=$1
+  expected=$2
+  message=$3
+
+  if ! grep -qxF "$expected" "$file"; then
     echo "FAIL: $message" >&2
     exit 1
   fi
@@ -56,28 +70,62 @@ if [ "$rebase_when_conflicted_count" -ne 2 ]; then
   exit 1
 fi
 
-# Main requires a GitHub Actions check named `quality`. Every Renovate update
-# that is eligible for automerge must therefore trigger a real validation job
-# with that exact name; otherwise the app can never merge an otherwise-green
-# PR. These paths cover the package/workflow files used by the current
-# automerge branches without adding a no-op check that could mask failing CI.
-assert_contains "$docs_workflow" \
+# Main requires a GitHub Actions check named `quality`. Since #1113 that context
+# comes from ONE unfiltered workflow: quality.yml runs on every PR, selects the
+# affected reusable workflows, and aggregates their results. It replaced the
+# older shape where each service workflow published its own `quality` job.
+#
+# The assertions below pin the current arrangement. They previously pinned the
+# old one and went stale the day it changed: one failed loudly, two passed on
+# substrings of the renamed jobs, and two checked `push:` path lists that no
+# longer decide anything at PR time. A red gate that has to be read to be
+# believed is worse than no gate, so they are re-pointed rather than deleted.
+
+# The aggregator must stay unfiltered. A `paths:` filter here is exactly the bug
+# #1113 fixed: on a PR matching no filter the required context never reports at
+# all, and the PR can never merge — which is the failure mode this whole file
+# exists to prevent.
+quality_on_block=$(awk '/^on:/{f=1;next} /^[a-z]/{f=0} f' "$quality_workflow")
+if printf '%s\n' "$quality_on_block" | grep -q 'paths:'; then
+  echo 'FAIL: quality.yml must stay unfiltered — a paths: filter means the required check cannot report on an unmatched PR' >&2
+  exit 1
+fi
+
+assert_line "$quality_workflow" \
   '  quality:' \
-  'docs dependency updates must publish the required quality check'
-assert_contains "$docs_workflow" \
-  '    needs: quality' \
-  'docs build-and-push must remain gated by the renamed quality job'
-assert_contains "$portal_frontend_workflow" \
-  "      - 'klai-widget/package-lock.json'" \
-  'widget lockfile updates must trigger portal quality checks'
-assert_contains "$portal_frontend_workflow" \
-  "      - 'klai-portal/.github/workflows/portal-frontend.yml'" \
-  'nested portal workflow updates must trigger portal quality checks'
-assert_contains "$trivyignore_workflow" \
-  '  quality:' \
-  'Trivy workflow dependency updates must publish the required quality check'
-assert_contains "$trivyignore_workflow" \
+  'quality.yml must define the job that carries the required context'
+assert_line "$quality_workflow" \
   '    name: quality' \
-  'the Trivy validator check name must match branch protection'
+  'the aggregator check name must match branch protection exactly'
+assert_line "$quality_workflow" \
+  '    if: always()' \
+  'the aggregator must report even when a selected workflow was skipped or failed'
+
+# Aggregating is what stops this from being the "no-op check that masks failing
+# CI" the previous version of this comment warned about: the automerge-eligible
+# branches must each be something the required check waits for.
+for needed in docs portal-frontend trivyignore; do
+  assert_line "$quality_workflow" \
+    "      - $needed" \
+    "the aggregator must wait for the $needed workflow, or its failures cannot block automerge"
+done
+
+# ...and the paths a Renovate automerge actually touches must select that work.
+assert_contains "$quality_workflow" \
+  "              - 'klai-docs/**'" \
+  'docs dependency updates must select the docs workflow'
+assert_contains "$quality_workflow" \
+  "              - 'klai-widget/package-lock.json'" \
+  'widget lockfile updates must select the portal-frontend workflow'
+assert_contains "$quality_workflow" \
+  "              - '.github/workflows/validate-trivyignore.yml'" \
+  'Trivy workflow updates must select the trivyignore validator'
+
+# The reusable workflows keep their own internal gating; only the check NAME
+# moved. Pinned as a whole line so a future rename fails here instead of
+# passing on the prefix.
+assert_line "$docs_workflow" \
+  '    needs: quality-docs' \
+  'docs build-and-push must remain gated by its own quality job'
 
 echo 'Renovate configuration contracts: PASS'


### PR DESCRIPTION
`scripts/test-renovate-config.sh` has been red since #1113, so the scheduled
Renovate workflow fails on every run.

It asserted that `docs.yml` contains a job named `quality`. That was true until
#1113 replaced the arrangement: since then **one unfiltered workflow**
(`quality.yml`) runs on every PR, selects the affected reusable workflows, and
aggregates their results into the required `quality` context. The per-service
jobs were renamed to `quality-<service>` accordingly.

**So the workflow is right and the test was wrong.** Verified rather than
assumed: Renovate PR #1008 merged on 2026-08-21 showing `quality pass 3s` and
`docs skipping` — the new shape working as intended.

## Five of the six assertions had quietly stopped testing anything

Only one failed loudly. The script `exit 1`s on the first failure, so the rest
had not run since #1113 and nobody could see what they were doing:

| assertion | actual state |
|---|---|
| `docs.yml` has `  quality:` | fails — job is `quality-docs` |
| `docs.yml` has `    needs: quality` | **passes as a substring** of `needs: quality-docs` |
| `validate-trivyignore.yml` has `  quality:` | fails — job is `quality-trivyignore` |
| `validate-trivyignore.yml` has `    name: quality` | **passes as a substring** of `name: quality-trivyignore` |
| two `portal-frontend.yml` path assertions | pass, but check `push:` paths, which no longer decide anything at PR time |

The two substring passes are the sharp part: each assertion survived the exact
rename it existed to catch. Adds `assert_line` (`grep -qxF`) and uses it wherever
the identifier is the point.

## Re-pointed at what would actually break automerge

- **`quality.yml` must stay unfiltered.** A `paths:` filter there is precisely the
  bug #1113 fixed — the required context would not report at all on a PR matching
  no filter, so the PR could never merge. **Nothing asserted this before**, and it
  is the property the whole arrangement rests on.
- the aggregator job must carry `name: quality` and `if: always()`, or it skips
  instead of reporting
- it must `needs:` docs, portal-frontend and trivyignore, or their failures cannot
  block automerge
- the paths a Renovate automerge touches must select that work
- `docs.yml`'s build-and-push stays gated on its own quality job

## Mutation-verified

Eight mutations, each red on its own assertion:

| mutation | caught by |
|---|---|
| add `paths:` to `quality.yml`'s `pull_request` | unfiltered check |
| rename the aggregator job | `  quality:` |
| rename the check (`name: quality` → `quality-all`) | `    name: quality` ← **used to pass** |
| drop `if: always()` | always() check |
| drop `- docs` from `needs:` | needs loop |
| drop `klai-docs/**` from the filter | docs path |
| drop `klai-widget/package-lock.json` | widget path |
| rename `docs.yml`'s `needs: quality-docs` | docs gating |

The ten `renovate.json5` assertions above this block are untouched — they were
never affected by #1113 and still pass.

No workflow file is modified. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)