### PR TITLE
fix(renovate): the unfiltered-gate check had two ways to pass while blind

### DIFF
--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -86,8 +86,15 @@ fi
 # all, and the PR can never merge — which is the failure mode this whole file
 # exists to prevent.
 quality_on_block=$(awk '/^on:/{f=1;next} /^[a-z]/{f=0} f' "$quality_workflow")
-if printf '%s\n' "$quality_on_block" | grep -q 'paths:'; then
-  echo 'FAIL: quality.yml must stay unfiltered — a paths: filter means the required check cannot report on an unmatched PR' >&2
+if ! printf '%s\n' "$quality_on_block" | grep -q '^  pull_request:'; then
+  echo 'FAIL: quality.yml must trigger on pull_request, or the required check never reports on a PR at all' >&2
+  exit 1
+fi
+# Both spellings, deliberately. `paths-ignore:` does not contain the substring
+# `paths:`, so matching on that alone let the exclusive form through — and
+# excluding a directory is the more plausible edit of the two.
+if printf '%s\n' "$quality_on_block" | grep -qE '^[[:space:]]*paths(-ignore)?:'; then
+  echo 'FAIL: quality.yml must stay unfiltered — a paths:/paths-ignore: filter means the required check cannot report on an unmatched PR' >&2
   exit 1
 fi
 

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -90,10 +90,13 @@ if ! printf '%s\n' "$quality_on_block" | grep -q '^  pull_request:'; then
   echo 'FAIL: quality.yml must trigger on pull_request, or the required check never reports on a PR at all' >&2
   exit 1
 fi
-# Both spellings, deliberately. `paths-ignore:` does not contain the substring
-# `paths:`, so matching on that alone let the exclusive form through — and
-# excluding a directory is the more plausible edit of the two.
-if printf '%s\n' "$quality_on_block" | grep -qE '^[[:space:]]*paths(-ignore)?:'; then
+# Both spellings and both YAML styles, deliberately. `paths-ignore:` does not
+# contain the substring `paths:`, so matching on that alone let the exclusive
+# form through — and excluding a directory is the more plausible edit of the
+# two. Anchoring to the start of a line instead then missed the inline flow
+# mapping (`pull_request: { paths: [...] }`), which is valid YAML and which the
+# original substring check did catch. A word-boundary match covers all four.
+if printf '%s\n' "$quality_on_block" | grep -qE '\bpaths(-ignore)?:'; then
   echo 'FAIL: quality.yml must stay unfiltered — a paths:/paths-ignore: filter means the required check cannot report on an unmatched PR' >&2
   exit 1
 fi


### PR DESCRIPTION
Sol review of #1153 found a hole in the assertion added there, plus a second one
in the same block. Both let the contract report `PASS` while the required
`quality` context had stopped reporting on some or all PRs — the exact #1113 bug.

| gap | why it passed |
|---|---|
| `paths-ignore:` | does not contain the substring `paths:`, so `grep -q 'paths:'` missed it — and excluding a directory is the more plausible of the two edits |
| trigger swapped to `push:` | nothing asserted the trigger is `pull_request` at all; the on-block then has no paths key, so the check passed while no PR would ever get the context |

The delta review then caught a regression in the first fix: anchoring to the
start of a line closed `paths-ignore:` but opened `pull_request: { paths: [...] }`,
valid YAML that the *original* substring check did catch. A word-boundary match
covers all four shapes.

## Mutation-verified — five forms, each red on its own message

| mutation | caught |
|---|---|
| block `paths:` | ✓ |
| block `paths-ignore:` | ✓ (new) |
| inline `paths:` | ✓ (regression, re-closed) |
| inline `paths-ignore:` | ✓ (new) |
| `pull_request:` → `push:` | ✓ (new) |

## Verified and deliberately NOT fixed

Three further Sol findings, reported as prose rather than changed:

- **`assert_line` anchors are file-wide, not scoped to `jobs.quality`.** True, but
  not currently exploitable: each anchor occurs exactly once in `quality.yml`, and
  the eight mutations in #1153 show every assertion still fails when its own target
  changes. Scoping would need YAML parsing in a POSIX `sh` script.
- **The `needs:` loop covers only docs, portal-frontend and trivyignore**, while
  Renovate automerges patch+minor repo-wide.
- **Same for the path filters.**

The last two are a coverage decision the original test made explicitly ("These
paths cover the package/workflow files used by the current automerge branches");
this change did not narrow it. Backlog.

Test-only. No workflow file is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)