### PR TITLE
fix(rag): follow a renamed page's graph episodes to its current document key

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -451,33 +451,57 @@ async def set_superseded_by(
     )
 
 
-async def get_graphiti_episode_ids(
+async def get_episode_ids_for_document_history(
     conn: asyncpg.Connection,
     org_id: str,
     artifact_ids: list[str],
 ) -> list[str]:
-    """Return the Graphiti episode uuids recorded on these artifact rows.
+    """Return the Graphiti episode uuids of these rows AND every version they replaced.
 
     ``ingest_graphiti_episode`` writes ``graphiti_episode_id`` into
-    ``knowledge.artifacts.extra`` when an episode lands, so this is the
+    ``knowledge.artifacts.extra`` when an episode lands, so that key is the
     mapping from an artifact VERSION to the episode extracted from it.
+
+    The walk backwards along ``superseded_by`` is the point. A caller passes
+    the rows a rename just closed, but ``soft_delete_artifact`` only closes
+    ACTIVE rows — so for a document ingested more than once before the rename,
+    the ids it hands over cover the newest version only. Every earlier version
+    holds episodes named after the same dead path, and stopping at the direct
+    predecessor would leave those stranded exactly as before.
 
     Rows contribute nothing when their episode never ran (graphiti disabled,
     job still queued, extraction failed) or when they carry the ``no-chunks``
     sentinel ``backfill.py`` writes for documents it deliberately skipped —
-    that string is not an episode uuid and renaming it would silently match
-    nothing.
+    that string is not an episode uuid and renaming it would match nothing.
+
+    depth < 100 bounds the walk. ``superseded_by`` points forward in time so a
+    cycle should be impossible, but an unbounded recursive CTE that meets one
+    hangs the ingest request. Truncating here costs completeness, never
+    correctness: a missed ancestor keeps its current name and the backfill
+    still reaches it.
     """
     if not artifact_ids:
         return []
     rows = await conn.fetch(
         """
-        SELECT extra->>'graphiti_episode_id' AS episode_id
-        FROM knowledge.artifacts
-        WHERE org_id = $1
-          AND id = ANY($2::uuid[])
-          AND extra->>'graphiti_episode_id' IS NOT NULL
-          AND extra->>'graphiti_episode_id' <> 'no-chunks'
+        WITH RECURSIVE history AS (
+            SELECT a.id, 0 AS depth
+            FROM knowledge.artifacts a
+            WHERE a.org_id = $1 AND a.id = ANY($2::uuid[])
+
+            UNION ALL
+
+            SELECT p.id, h.depth + 1
+            FROM history h
+            JOIN knowledge.artifacts p ON p.superseded_by = h.id AND p.org_id = $1
+            WHERE h.depth < 100
+        )
+        SELECT DISTINCT a.extra->>'graphiti_episode_id' AS episode_id
+        FROM knowledge.artifacts a
+        WHERE a.org_id = $1
+          AND a.id IN (SELECT id FROM history)
+          AND a.extra->>'graphiti_episode_id' IS NOT NULL
+          AND a.extra->>'graphiti_episode_id' <> 'no-chunks'
         """,
         org_id,
         artifact_ids,

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -451,6 +451,40 @@ async def set_superseded_by(
     )
 
 
+async def get_graphiti_episode_ids(
+    conn: asyncpg.Connection,
+    org_id: str,
+    artifact_ids: list[str],
+) -> list[str]:
+    """Return the Graphiti episode uuids recorded on these artifact rows.
+
+    ``ingest_graphiti_episode`` writes ``graphiti_episode_id`` into
+    ``knowledge.artifacts.extra`` when an episode lands, so this is the
+    mapping from an artifact VERSION to the episode extracted from it.
+
+    Rows contribute nothing when their episode never ran (graphiti disabled,
+    job still queued, extraction failed) or when they carry the ``no-chunks``
+    sentinel ``backfill.py`` writes for documents it deliberately skipped —
+    that string is not an episode uuid and renaming it would silently match
+    nothing.
+    """
+    if not artifact_ids:
+        return []
+    rows = await conn.fetch(
+        """
+        SELECT extra->>'graphiti_episode_id' AS episode_id
+        FROM knowledge.artifacts
+        WHERE org_id = $1
+          AND id = ANY($2::uuid[])
+          AND extra->>'graphiti_episode_id' IS NOT NULL
+          AND extra->>'graphiti_episode_id' <> 'no-chunks'
+        """,
+        org_id,
+        artifact_ids,
+    )
+    return [str(row["episode_id"]) for row in rows]
+
+
 async def list_stale_connector_artifact_paths(
     conn: asyncpg.Connection,
     org_id: str,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -24,7 +24,7 @@ import httpx
 import structlog
 import yaml
 from fastapi import APIRouter, HTTPException, Request
-from klai_kb_slugs import personal_kb_slug
+from klai_kb_slugs import episode_name, personal_kb_slug
 
 from knowledge_ingest import (
     chunker,
@@ -637,6 +637,46 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
                     new_path=req.path,
                     source_ref=req.source_ref,
                 )
+
+    # The rename strands the graph episodes too. They are named
+    # doc:<kb_slug>:<old_path> (SPEC-RAG-GRAPH-CITE-002), and the chunks that
+    # name resolves against are exactly the ones just deleted above — so every
+    # fact extracted before the rename loses its title and URL and renders as a
+    # truncated sentence again. Point them at the document's current key.
+    #
+    # Metadata only: no re-extraction, no LLM calls, nothing drawn from the
+    # shared klai-fast budget. Several versions legitimately end up sharing one
+    # name; retrieval resolves it against the CURRENT version in Qdrant.
+    renamed_ids = [row_id for row_id, stale_path in closed_rows if stale_path != req.path]
+    if renamed_ids:
+        try:
+            episode_ids = await pg_store.get_graphiti_episode_ids(conn, req.org_id, renamed_ids)
+            if episode_ids:
+                repointed = await graph_module.rename_episodes_to_document_keys(
+                    req.org_id,
+                    {episode_name(req.kb_slug, req.path): episode_ids},
+                )
+                logger.info(
+                    "renamed_path_episodes_repointed",
+                    org_id=req.org_id,
+                    kb_slug=req.kb_slug,
+                    new_path=req.path,
+                    episodes=repointed,
+                )
+        except Exception:
+            # Same reasoning as the chunk cleanup above: the supersede is
+            # already committed, so raising fails the ingest without undoing
+            # it, and a retry cannot recover because the closed row stops
+            # coming back from soft_delete_artifact. A stranded episode costs
+            # a citation, not correctness — the fact stays in the graph and
+            # still answers queries, it just renders without its link.
+            logger.exception(
+                "renamed_path_episode_repoint_failed",
+                org_id=req.org_id,
+                kb_slug=req.kb_slug,
+                new_path=req.path,
+                source_ref=req.source_ref,
+            )
 
     # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-06.2: record image-key
     # bookkeeping so per-connector cleanup can compute orphan keys via

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -647,10 +647,17 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # Metadata only: no re-extraction, no LLM calls, nothing drawn from the
     # shared klai-fast budget. Several versions legitimately end up sharing one
     # name; retrieval resolves it against the CURRENT version in Qdrant.
+    #
+    # closed_rows carries the ACTIVE version only — that is all
+    # soft_delete_artifact closes — so the lookup walks superseded_by backwards
+    # from it. A document ingested twice before being renamed keeps episodes on
+    # the older version too, and they name the same dead path.
     renamed_ids = [row_id for row_id, stale_path in closed_rows if stale_path != req.path]
     if renamed_ids:
         try:
-            episode_ids = await pg_store.get_graphiti_episode_ids(conn, req.org_id, renamed_ids)
+            episode_ids = await pg_store.get_episode_ids_for_document_history(
+                conn, req.org_id, renamed_ids
+            )
             if episode_ids:
                 repointed = await graph_module.rename_episodes_to_document_keys(
                     req.org_id,

--- a/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
@@ -67,9 +67,18 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
         # unresolvable as the artifact_id it replaced. The active version's
         # path is the one retrieval can look up.
         #
+        # Only rows with superseded_by IS NULL are real chain ends. Taking the
+        # deepest row reached would treat the depth cap as a terminus: a chain
+        # longer than the bound would silently key its episodes on an
+        # intermediate version's path, which is the same unresolvable-name
+        # defect this script exists to remove. An origin whose walk finds no
+        # terminal LEFT JOINs to NULL and lands in ``skipped`` instead, so it
+        # is reported rather than guessed at.
+        #
         # depth < 20 bounds the walk. superseded_by points forward in time so
         # a cycle should be impossible, but an unbounded recursive CTE that
-        # meets one hangs against production instead of failing.
+        # meets one hangs against production instead of failing. Production
+        # (Voys, 2026-08-22) tops out at 7.
         rows = await conn.fetch(
             """
             WITH RECURSIVE chain AS (
@@ -84,10 +93,16 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
                 JOIN knowledge.artifacts n ON n.id = c.superseded_by AND n.org_id = $1
                 WHERE c.superseded_by IS NOT NULL AND c.depth < 20
             )
-            SELECT DISTINCT ON (c.origin) c.kb_slug, c.path, a.extra
-            FROM chain c
-            JOIN knowledge.artifacts a ON a.id = c.origin
-            ORDER BY c.origin, c.depth DESC
+            terminal AS (
+                SELECT DISTINCT ON (c.origin) c.origin, c.kb_slug, c.path
+                FROM chain c
+                WHERE c.superseded_by IS NULL
+                ORDER BY c.origin
+            )
+            SELECT t.kb_slug, t.path, a.extra
+            FROM knowledge.artifacts a
+            LEFT JOIN terminal t ON t.origin = a.id
+            WHERE a.org_id = $1 AND a.extra IS NOT NULL
             """,
             org_id,
         )

--- a/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
@@ -92,7 +92,7 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
                 FROM chain c
                 JOIN knowledge.artifacts n ON n.id = c.superseded_by AND n.org_id = $1
                 WHERE c.superseded_by IS NOT NULL AND c.depth < 20
-            )
+            ),
             terminal AS (
                 SELECT DISTINCT ON (c.origin) c.origin, c.kb_slug, c.path
                 FROM chain c

--- a/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
@@ -13,9 +13,11 @@ draws nothing from the shared klai-fast rate limit that enrichment and
 taxonomy compete over. Postgres already holds the mapping: every successful
 episode writes ``graphiti_episode_id`` into ``knowledge.artifacts.extra``.
 
-Superseded artifacts are included on purpose. Their episodes carry exactly the
-stale edges this is meant to heal, and their ``kb_slug``/``path`` still name
-the document correctly.
+Superseded artifacts are included on purpose: their episodes carry exactly the
+stale edges this is meant to heal. They are keyed on the path of the ACTIVE
+version at the end of their ``superseded_by`` chain, not their own — a renamed
+connector page (see #1172) leaves old rows under a path Qdrant no longer holds,
+and naming an episode after that is no better than the artifact_id it replaced.
 
 Usage (in a knowledge-ingest container):
 
@@ -49,17 +51,43 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
 
     ``renames`` maps the stable document name to the episode uuids that should
     carry it; ``skipped`` counts artifacts with no usable episode pointer.
+
+    The name comes from the CURRENT version of each document, reached by
+    following ``superseded_by``, so episodes extracted from a page that was
+    later renamed land on the key retrieval can actually resolve.
     """
     renames: dict[str, list[str]] = defaultdict(list)
     skipped = 0
 
     async with tenant_scoped_connection(org_id) as conn:
+        # Walk superseded_by to the END of each supersession chain and take
+        # THAT row's kb_slug/path. A row's own path is the wrong answer when
+        # the document was renamed: the old path names a document that no
+        # longer exists in Qdrant, so an episode keyed on it stays exactly as
+        # unresolvable as the artifact_id it replaced. The active version's
+        # path is the one retrieval can look up.
+        #
+        # depth < 20 bounds the walk. superseded_by points forward in time so
+        # a cycle should be impossible, but an unbounded recursive CTE that
+        # meets one hangs against production instead of failing.
         rows = await conn.fetch(
             """
-            SELECT kb_slug, path, extra
-            FROM knowledge.artifacts
-            WHERE org_id = $1 AND extra IS NOT NULL
-            ORDER BY created_at
+            WITH RECURSIVE chain AS (
+                SELECT a.id AS origin, a.superseded_by, a.kb_slug, a.path, 0 AS depth
+                FROM knowledge.artifacts a
+                WHERE a.org_id = $1 AND a.extra IS NOT NULL
+
+                UNION ALL
+
+                SELECT c.origin, n.superseded_by, n.kb_slug, n.path, c.depth + 1
+                FROM chain c
+                JOIN knowledge.artifacts n ON n.id = c.superseded_by AND n.org_id = $1
+                WHERE c.superseded_by IS NOT NULL AND c.depth < 20
+            )
+            SELECT DISTINCT ON (c.origin) c.kb_slug, c.path, a.extra
+            FROM chain c
+            JOIN knowledge.artifacts a ON a.id = c.origin
+            ORDER BY c.origin, c.depth DESC
             """,
             org_id,
         )

--- a/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
@@ -133,3 +133,67 @@ class TestRenameEpisodes:
         assert "SET e.name" in cypher
         for forbidden in ("DELETE", "CREATE", "MERGE", "Entity"):
             assert forbidden not in cypher
+
+
+class TestRenamedDocumentsResolveToTheActivePath:
+    """A renamed page's old rows must be keyed on the path that still exists.
+
+    #1172: for connector documents ``path`` mirrors a user-editable title.
+    When a page is renamed, its pre-rename artifact rows keep the old path
+    while Qdrant only holds the new one. Keying an episode on the row's own
+    path therefore reproduces the exact defect SPEC-RAG-GRAPH-CITE-002 set out
+    to remove — an episode name nothing can resolve.
+    """
+
+    @pytest.mark.asyncio
+    async def test_query_walks_the_supersession_chain(self):
+        from scripts.backfill_episode_document_names import collect_renames
+
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=[])
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=conn)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "scripts.backfill_episode_document_names.tenant_scoped_connection", return_value=ctx
+        ):
+            await collect_renames("org-1")
+
+        sql = conn.fetch.call_args[0][0]
+        assert "superseded_by" in sql, (
+            "the backfill reads each row's own path -- renamed pages keep an "
+            "episode name that resolves to nothing"
+        )
+        assert "RECURSIVE" in sql, "a rename can be superseded again; one hop is not enough"
+        assert "depth < 20" in sql, "an unbounded recursive CTE hangs on a cycle"
+
+    @pytest.mark.asyncio
+    async def test_old_version_is_keyed_on_the_renamed_documents_new_path(self):
+        """The May row under the old title must land on the August key.
+
+        Mirrors the Voys ``support`` incident of 2026-08-14: "App troubleshoot
+        & transfers" was renamed to "App troubleshooting". Both versions'
+        episodes have to answer to the surviving name.
+        """
+        from scripts.backfill_episode_document_names import collect_renames
+
+        # What the chain-walking query returns: the ORIGIN row's extra, paired
+        # with the kb_slug/path of the ACTIVE row at the end of its chain.
+        rows = [
+            _row("support", "App troubleshooting", {"graphiti_episode_id": "ep-may"}),
+            _row("support", "App troubleshooting", {"graphiti_episode_id": "ep-august"}),
+        ]
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=rows)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=conn)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "scripts.backfill_episode_document_names.tenant_scoped_connection", return_value=ctx
+        ):
+            renames, skipped = await collect_renames("org-1")
+
+        assert renames == {"doc:support:App troubleshooting": ["ep-may", "ep-august"]}
+        assert skipped == 0

--- a/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
@@ -167,6 +167,14 @@ class TestRenamedDocumentsResolveToTheActivePath:
         )
         assert "RECURSIVE" in sql, "a rename can be superseded again; one hop is not enough"
         assert "depth < 20" in sql, "an unbounded recursive CTE hangs on a cycle"
+        assert "c.superseded_by IS NULL" in sql, (
+            "the deepest row reached is not a chain end -- a chain longer than "
+            "the depth cap would key its episodes on an intermediate path"
+        )
+        assert "LEFT JOIN terminal" in sql, (
+            "an origin with no reachable terminal must be reported as skipped, "
+            "not silently given some intermediate version's path"
+        )
 
     @pytest.mark.asyncio
     async def test_old_version_is_keyed_on_the_renamed_documents_new_path(self):

--- a/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
+++ b/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
@@ -118,7 +118,7 @@ def _ingest_patches(
         settings.enrichment_enabled = False
 
         get_episode_ids = _p(
-            "knowledge_ingest.pg_store.get_graphiti_episode_ids",
+            "knowledge_ingest.pg_store.get_episode_ids_for_document_history",
             new_callable=AsyncMock,
             return_value=list(episode_ids or []),
         )
@@ -399,3 +399,33 @@ async def test_episode_rename_failure_does_not_fail_the_ingest():
 
     assert result["status"] == "ok", "a FalkorDB hiccup must not fail a committed ingest"
     mocks["rename_episodes"].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_episode_lookup_walks_the_whole_predecessor_chain():
+    """Versions older than the one just closed hold episodes on the same dead path.
+
+    ``soft_delete_artifact`` closes ACTIVE rows only, so a document ingested
+    more than once before its rename hands over the newest version alone. Its
+    predecessors carry episodes named after the very path this ingest is about
+    to delete from Qdrant; stopping at the direct predecessor strands them
+    exactly as before the fix.
+    """
+    conn = _make_conn()
+
+    await pg_store.get_episode_ids_for_document_history(conn, "org1", ["may-artifact-id"])
+
+    sql = conn.fetch.call_args[0][0]
+    assert "RECURSIVE" in sql, "only the rows handed in are looked up -- older versions strand"
+    assert "superseded_by" in sql
+    assert "depth < 100" in sql, "an unbounded walk hangs the ingest request on a cycle"
+    assert "'no-chunks'" in sql, "the skip sentinel is not an episode uuid"
+
+
+@pytest.mark.asyncio
+async def test_episode_lookup_is_a_noop_without_artifact_ids():
+    """No closed rows means no query -- an empty ANY() would scan the tenant."""
+    conn = _make_conn()
+
+    assert await pg_store.get_episode_ids_for_document_history(conn, "org1", []) == []
+    conn.fetch.assert_not_awaited()

--- a/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
+++ b/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
@@ -20,6 +20,7 @@ from contextlib import ExitStack, asynccontextmanager, contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from klai_kb_slugs import episode_name
 
 from knowledge_ingest import pg_store
 from knowledge_ingest.models import IngestRequest
@@ -41,11 +42,18 @@ def _make_procrastinate_app() -> MagicMock:
 
 
 @contextmanager
-def _ingest_patches(req, closed_rows, delete_document_side_effect=None):
+def _ingest_patches(
+    req,
+    closed_rows,
+    delete_document_side_effect=None,
+    episode_ids=None,
+    rename_side_effect=None,
+):
     """Patch ingest_document's collaborators; yield the mocks tests assert on.
 
     ``closed_rows`` is what ``soft_delete_artifact`` returns — the
-    ``(artifact_id, path)`` pairs this ingest supersedes.
+    ``(artifact_id, path)`` pairs this ingest supersedes. ``episode_ids`` is
+    what those closed rows recorded in ``extra.graphiti_episode_id``.
     """
     with ExitStack() as stack:
 
@@ -109,10 +117,24 @@ def _ingest_patches(req, closed_rows, delete_document_side_effect=None):
         settings.chunk_overlap = 200
         settings.enrichment_enabled = False
 
+        get_episode_ids = _p(
+            "knowledge_ingest.pg_store.get_graphiti_episode_ids",
+            new_callable=AsyncMock,
+            return_value=list(episode_ids or []),
+        )
+        rename_episodes = _p(
+            "knowledge_ingest.graph.rename_episodes_to_document_keys",
+            new_callable=AsyncMock,
+            side_effect=rename_side_effect,
+            return_value=len(episode_ids or []),
+        )
+
         yield {
             "soft_delete": soft_delete,
             "delete_document": delete_document,
             "set_superseded_by": set_superseded_by,
+            "get_episode_ids": get_episode_ids,
+            "rename_episodes": rename_episodes,
         }
 
 
@@ -260,3 +282,120 @@ async def test_qdrant_cleanup_failure_does_not_fail_the_ingest():
 
     assert result["status"] == "ok", "a cleanup blip must not fail the whole ingest"
     mocks["delete_document"].assert_awaited_once_with("org1", "support", _OLD_PATH)
+
+
+@pytest.mark.asyncio
+async def test_renamed_page_repoints_its_graph_episodes_at_the_new_document_key():
+    """Facts extracted before a rename must keep citing their document.
+
+    SPEC-RAG-GRAPH-CITE-002 names episodes ``doc:<kb_slug>:<path>`` so they
+    survive re-ingest. A rename breaks that: the old artifact's episodes keep
+    the OLD path, and the block above deletes exactly the chunks that name
+    resolved against. Every fact extracted before the rename then falls back
+    to rendering as a truncated sentence — the failure the doc-key naming was
+    introduced to remove, reappearing for the one case where the document
+    identity moved.
+    """
+    req = IngestRequest(
+        org_id="org1",
+        kb_slug="support",
+        path=_NEW_PATH,
+        content="# App troubleshooting\n" + ("body content " * 40),
+        source_type="notion",
+        content_type="kb_article",
+        source_connector_id=_CONNECTOR_ID,
+        source_ref=_SOURCE_REF,
+    )
+    conn = _make_conn()
+
+    with _ingest_patches(
+        req,
+        closed_rows=[("may-artifact-id", _OLD_PATH)],
+        episode_ids=["may-episode-uuid"],
+    ) as mocks:
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        result = await ingest_document(conn, req)
+
+    assert result["status"] == "ok"
+
+    mocks["get_episode_ids"].assert_awaited_once()
+    episode_args = mocks["get_episode_ids"].await_args
+    assert "may-artifact-id" in episode_args[0][2], (
+        "the closed row under the old path was not looked up for its episode"
+    )
+
+    mocks["rename_episodes"].assert_awaited_once()
+    org_arg, renames = mocks["rename_episodes"].await_args[0]
+    assert org_arg == "org1"
+    assert renames == {episode_name("support", _NEW_PATH): ["may-episode-uuid"]}, (
+        "pre-rename episodes still carry the old path -- their citations stay unresolvable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unrenamed_reingest_does_not_touch_the_graph():
+    """A plain re-ingest supersedes under the SAME path and must rename nothing.
+
+    The episode already carries the right name, so a rename here would be
+    write traffic to FalkorDB bought with nothing.
+    """
+    req = IngestRequest(
+        org_id="org1",
+        kb_slug="support",
+        path=_NEW_PATH,
+        content="# App troubleshooting\n" + ("body content " * 40),
+        source_type="notion",
+        content_type="kb_article",
+        source_connector_id=_CONNECTOR_ID,
+        source_ref=_SOURCE_REF,
+    )
+    conn = _make_conn()
+
+    with _ingest_patches(
+        req,
+        closed_rows=[("july-artifact-id", _NEW_PATH)],
+        episode_ids=["july-episode-uuid"],
+    ) as mocks:
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        result = await ingest_document(conn, req)
+
+    assert result["status"] == "ok"
+    mocks["rename_episodes"].assert_not_awaited()
+    mocks["get_episode_ids"].assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_episode_rename_failure_does_not_fail_the_ingest():
+    """A stranded episode costs a citation, not correctness.
+
+    The supersede is already committed by this point, so raising would fail
+    the ingest without undoing it — and the retry cannot recover, because the
+    old row is closed and ``soft_delete_artifact`` stops returning it. Same
+    reasoning as the stale-chunk cleanup directly above it.
+    """
+    req = IngestRequest(
+        org_id="org1",
+        kb_slug="support",
+        path=_NEW_PATH,
+        content="# App troubleshooting\n" + ("body content " * 40),
+        source_type="notion",
+        content_type="kb_article",
+        source_connector_id=_CONNECTOR_ID,
+        source_ref=_SOURCE_REF,
+    )
+    conn = _make_conn()
+
+    with _ingest_patches(
+        req,
+        closed_rows=[("may-artifact-id", _OLD_PATH)],
+        episode_ids=["may-episode-uuid"],
+        rename_side_effect=RuntimeError("falkordb unreachable"),
+    ) as mocks:
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        result = await ingest_document(conn, req)
+
+    assert result["status"] == "ok", "a FalkorDB hiccup must not fail a committed ingest"
+    mocks["rename_episodes"].assert_awaited_once()


### PR DESCRIPTION
Closes #1172.

## The gap

SPEC-RAG-GRAPH-CITE-002 (#1152) names graph episodes `doc:<kb_slug>:<path>` so they survive re-ingest, because `artifact_id` is minted fresh every time. That holds for crawl and web sources, where `path` is a URL.

It does not hold for connector pages. There `path` mirrors a user-editable title, and the stable identity is `(source_connector_id, source_ref)` — which `soft_delete_artifact` already supersedes on. So a rename closes a row under the OLD path, ingest deletes that path's Qdrant chunks, and the episodes extracted from it keep a name nothing can resolve. Every fact from before the rename renders as a truncated sentence again: the exact defect the doc-key naming was introduced to remove, reappearing for the one case where the document's identity moved.

## Two places, failing independently

**Ingest** repoints the closed rows' episodes at the new key, in the same block that already deletes their orphaned chunks. The lookup walks `superseded_by` backwards, because `soft_delete_artifact` closes ACTIVE rows only — a document ingested more than once before its rename keeps episodes on the older versions too, all naming the same dead path.

Failure is swallowed and logged, for the reason spelled out on the chunk cleanup directly above it: the supersede is committed, so raising fails the ingest without undoing it, and the retry cannot recover because the closed row stops coming back.

**The backfill** keyed every row on its OWN path — so it reproduced the broken name for precisely the documents that needed healing. It now walks `superseded_by` to a real terminus (`superseded_by IS NULL`, not the deepest row reached) and takes the active version's path. An origin whose walk finds no terminal is counted as skipped rather than guessed at.

## Verified against production

Read-only on Voys (org 368884765035593759):

| | |
|---|---|
| artifacts carrying an episode pointer | 2160 |
| sitting under a stale path | **4** |
| deepest supersession chain | **7 hops** |
| terminals reachable | 2160 / 2160 |
| backward walk cost, largest tenant | 1.98 ms |

The 4 are the 2026-08-14 incident pages, including `App troubleshoot & transfers` → `App troubleshooting` — the pair already named in the existing test's docstring. Its chain holds 2 versions with 2 distinct episodes, so stopping at the direct predecessor would have missed one. 7 hops also means a single-hop lookup would not have been enough.

## Review

Sol `review-deep`, two rounds, 5 findings, all verified against source, 3 fixed:

- **fixed** — the repoint reached one version too few (predecessor chain)
- **fixed** — the backfill treated the depth cap as a chain end, silently keying episodes on an intermediate path
- **fixed** — missing comma between the two CTEs, which made the backfill unrunnable. Caught only because the delta review read the module; my earlier production check had validated a hand-typed copy that happened to have the comma. The query is now extracted from source with `ast` and sent to Postgres verbatim.
- **not fixed** — a Graphiti task mid-extraction has not written `graphiti_episode_id` yet, so this one-shot lookup cannot see it. Real, bounded by the extraction window, healed by the next backfill.
- **not fixed** — `superseded_by` is unindexed. True, and measured at 1.98 ms on the largest tenant, on a path that ran 4 times in that tenant's entire history. The 100-step worst case needs a 100-version document; dedup keeps chains at 7.

Tests: 1566 passed, 6 skipped. Five new regression tests, verified red first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)