### PR TITLE
feat(rag): source-language facts, canonical entity names across every language

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import types
 from datetime import UTC, datetime
 
 import httpx
@@ -69,14 +70,13 @@ _episode_semaphore: asyncio.Semaphore | None = None
 # prompts (extract_message / extract_json / extract_text), extract_edges, and
 # the combined extractor. It is NOT interpolated into the node-summary prompts
 # (extract_summary / extract_summaries_batch), so entity summaries are out of
-# scope for rule 2 — the rules deliberately speak only about entity names and
-# fact text. tests/test_graph.py pins that reach so a graphiti bump that moves
-# the hook fails in CI.
+# scope. tests/test_graph.py pins that reach so a graphiti bump that moves the
+# hook fails in CI.
 _EXTRACTION_INSTRUCTIONS = """
 # SOURCE-DOCUMENT RULES
 
 These episodes are whole documents from a company knowledge base (manuals,
-wiki pages, meeting notes), not chat messages. Two extra rules apply.
+wiki pages, meeting notes), not chat messages. One extra rule applies.
 
 1. **Extract facts about the world, never about the document.**
    The subject of a fact must be a thing that exists outside this text — a
@@ -96,13 +96,106 @@ wiki pages, meeting notes), not chat messages. Two extra rules apply.
    paginamap identificeert de Voys-app als een applicatie die op mobiel
    werkt", extract "De Voys-app werkt op mobiel".
 
-2. **Write in the language of the source text.**
-   Entity names and fact text must use the same language as the
-   CURRENT_MESSAGE. Do not translate to English. A Dutch document yields
-   Dutch entity names and Dutch facts; an English document yields English
-   ones. Keep product names, proper nouns and technical terms exactly as
-   they are spelled in the source, in either language.
+Language is NOT covered here. It is set once, for every LLM call graphiti
+makes, by ``_LANGUAGE_POLICY`` below — stating it in two places invites the
+two copies to drift apart.
 """
+
+
+# ---------------------------------------------------------------------------
+# Language policy (GetKlai/klai#1148)
+# ---------------------------------------------------------------------------
+#
+# The corpus is multilingual and open-ended: mostly Dutch and English today,
+# German already in use, and French/Spanish/Portuguese arriving with the
+# multi-country chat-agent rollout. Two DIFFERENT things need two different
+# answers, and conflating them is what produced the current graph.
+#
+# Fact text is what a user reads as a citation, so it stays in the language of
+# the document it came from. Translating it would make the citation disagree
+# with the page it links to.
+#
+# Entity names are the graph's join keys, so they cannot be per-language.
+# graphiti resolves entities with character 3-gram shingles + MinHash/Jaccard
+# over the normalised name (``dedup_helpers._shingles``). "Toestel" and
+# "Device" share no 3-gram, so lexical dedup can never merge them; across six
+# languages one concept becomes six unconnected nodes and the graph stops
+# being a graph. A canonical name in one pivot language is what keeps a Dutch
+# document and a Portuguese question anchored to the same node. English is the
+# pivot because the model is strongest there and because the existing graph is
+# already mostly English on entity names (Call 147 vs Gesprek 27, User 57 vs
+# Gebruiker 16), so this is the direction with the least to migrate.
+#
+# Proper nouns are exempt from the pivot in both directions: "Belplan" has no
+# English equivalent worth inventing, and inventing one would break the join
+# with every document that names it.
+#
+# graphiti's own default says the opposite of what we need — "Otherwise,
+# output English", appended AFTER any custom instruction, which is why facts
+# extracted before this override came out English from Dutch pages. The
+# docstring on ``get_extraction_language_instruction`` invites the override;
+# ``_install_language_policy`` below performs it.
+_LANGUAGE_POLICY = """
+
+# LANGUAGE POLICY
+
+The source material is multilingual (Dutch, English, German, French, Spanish,
+Portuguese and others). Apply these rules to every response.
+
+1. **Fact text follows the source.** Any sentence describing a fact,
+   relationship or summary must be written in the same language as the text it
+   was extracted from. A Dutch page yields Dutch facts; a German page yields
+   German facts. Never translate fact text, and never default to English.
+
+2. **Entity names are canonical English.** The name of an entity is an
+   identifier shared across every language in the corpus, so it must not vary
+   by source language. Use the ordinary English term: "Device", not "Toestel"
+   or "Gerät"; "Queue", not "Wachtrij" or "File d'attente".
+
+3. **Proper nouns are never translated.** Product names, brand names, feature
+   names, interface labels, error strings and technical identifiers keep their
+   exact source spelling in both fact text and entity names — "Belplan",
+   "Freedom", "Voys App", "Force Encryption", "sipproxy.voipgrid.nl". If a term
+   is a name rather than a description, copy it verbatim.
+
+The distinction that matters: rule 1 is about the prose a person reads, rule 2
+is about the key the system joins on. A Dutch fact may therefore reference an
+English entity name, and that is correct.
+"""
+
+
+def _install_language_policy() -> None:
+    """Replace graphiti's default language instruction with ``_LANGUAGE_POLICY``.
+
+    ``get_extraction_language_instruction`` is documented as the override point
+    ("Override this function to customize language extraction"), but every LLM
+    client binds it with ``from .client import ...`` at import time. Rebinding
+    only the definition in ``llm_client.client`` would leave each concrete
+    client calling the original, so every module that holds a reference has to
+    be rebound.
+
+    Discovering those modules by attribute rather than naming them means a
+    graphiti upgrade that adds a client picks the policy up automatically;
+    ``tests/test_graph_language_policy.py`` fails if any binding is missed.
+    """
+    import graphiti_core.llm_client as _llm_pkg
+
+    def _policy(group_id: str | None = None) -> str:  # noqa: ARG001 - graphiti's signature
+        # group_id is graphiti's per-partition hook. We deliberately do not
+        # branch on it: the policy is a property of the corpus, not of one
+        # tenant, and a per-tenant pivot language would fragment the graph in
+        # exactly the way rule 2 exists to prevent.
+        return _LANGUAGE_POLICY
+
+    patched = 0
+    for _name in dir(_llm_pkg):
+        module = getattr(_llm_pkg, _name, None)
+        if isinstance(module, types.ModuleType) and hasattr(
+            module, "get_extraction_language_instruction"
+        ):
+            module.get_extraction_language_instruction = _policy
+            patched += 1
+    logger.info("graph_language_policy_installed", bindings=patched)
 
 
 class _RateLimitedTransport(httpx.AsyncBaseTransport):
@@ -273,6 +366,10 @@ def _get_graphiti() -> Graphiti:
                 )
             ),
         )
+        # Before any client is constructed: graphiti appends its own language
+        # instruction to every system message, and its default ends in
+        # "Otherwise, output English".
+        _install_language_policy()
         llm_client = OpenAIGenericClient(config=llm_config, client=openai_client)
         embedder = _BatchSplittingEmbedder(
             inner=OpenAIEmbedder(

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -135,6 +135,17 @@ two copies to drift apart.
 # extracted before this override came out English from Dutch pages. The
 # docstring on ``get_extraction_language_instruction`` invites the override;
 # ``_install_language_policy`` below performs it.
+#
+# This governs EXTRACTION ONLY; edges already in the graph keep the language
+# they were written in. content_hash dedup means an unchanged page is never
+# re-extracted, so the existing mix heals only via a deliberate migration
+# (#1148). The transitional state is safe rather than merely tolerable: edges
+# are extracted against ``extracted_nodes`` — the names produced by this same
+# run, before resolution against existing nodes (graphiti.py:656-659) — so the
+# ENTITIES list an edge must reference always holds the canonical names, and no
+# relationship is dropped for naming a node the old graph spells differently.
+# What a pre-existing node costs is only that resolution keeps ITS name, so
+# canonicalisation of that concept waits for the migration.
 _LANGUAGE_POLICY = """
 
 # LANGUAGE POLICY

--- a/klai-knowledge-ingest/tests/test_graph.py
+++ b/klai-knowledge-ingest/tests/test_graph.py
@@ -190,24 +190,26 @@ async def test_ingest_episode_reference_time_matches_belief_time_start():
 # ---------------------------------------------------------------------------
 
 
-def test_extraction_instructions_ban_document_meta_and_pin_language():
-    """The prompt rules that #1148 exists for must be present, not just wired.
+def test_extraction_instructions_ban_document_meta():
+    """The prompt rule that #1148 exists for must be present, not just wired.
 
-    Both defects were measured on live Voys retrievals on 2026-08-21: edge
-    facts whose subject was the document ("De paginamap identificeert...")
-    and English facts extracted from a Dutch corpus.
+    Measured on live Voys retrievals on 2026-08-21: edge facts whose subject
+    was the document ("De paginamap identificeert...").
+
+    Language used to be rule 2 here. It now lives in ``_LANGUAGE_POLICY``,
+    which reaches every graphiti LLM call rather than only the prompts this
+    string is interpolated into — see tests/test_graph_language_policy.py.
     """
     instructions = graph_module._EXTRACTION_INSTRUCTIONS
 
     lowered = instructions.lower()
-    # Rule 1 — no statements about the document itself.
     assert "never about the document" in lowered
     assert "table of contents" in lowered
     # The observed production string is kept as the worked example.
     assert "De paginamap identificeert de Voys-app" in instructions
-    # Rule 2 — output language follows the source language.
-    assert "language of the source text" in lowered
-    assert "do not translate to english" in lowered
+    # Language must NOT be restated here; two copies drift.
+    assert "language of the source text" not in lowered
+    assert "_LANGUAGE_POLICY" in instructions
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_graph_language_policy.py
+++ b/klai-knowledge-ingest/tests/test_graph_language_policy.py
@@ -1,0 +1,100 @@
+"""Language policy: source-language facts, canonical entity names.
+
+GetKlai/klai#1148. The corpus is Dutch, English and German today, with
+French, Spanish and Portuguese arriving with the multi-country rollout, so
+neither half of this can be left to a default.
+
+graphiti ships its own instruction ending in "Otherwise, output English" and
+appends it to every system message AFTER any custom extraction instruction.
+That default is what put English facts on Dutch pages, and it is why the
+policy is installed over the function rather than written into a prompt.
+"""
+
+from __future__ import annotations
+
+import types
+
+import graphiti_core.llm_client as llm_pkg
+import pytest
+
+from knowledge_ingest import graph as graph_module
+
+
+def _bound_modules() -> list[types.ModuleType]:
+    """Every graphiti llm_client module holding a reference to the hook."""
+    return [
+        module
+        for name in dir(llm_pkg)
+        if isinstance(module := getattr(llm_pkg, name, None), types.ModuleType)
+        and hasattr(module, "get_extraction_language_instruction")
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _install():
+    graph_module._install_language_policy()
+
+
+def test_every_binding_is_patched_not_just_the_definition():
+    """Each client does `from .client import ...`, binding the name at import.
+
+    Patching only ``llm_client.client`` would leave every concrete client
+    calling the original. This is the assertion that catches a graphiti bump
+    adding a client module the installer does not reach.
+    """
+    modules = _bound_modules()
+    assert modules, "no graphiti llm_client module exposes the hook -- API moved"
+
+    for module in modules:
+        rendered = module.get_extraction_language_instruction()
+        assert "LANGUAGE POLICY" in rendered, (
+            f"{module.__name__} still calls graphiti's own instruction"
+        )
+        assert "Otherwise, output English" not in rendered, (
+            f"{module.__name__} still defaults non-English sources to English"
+        )
+
+
+def test_the_client_we_actually_use_is_covered():
+    """OpenAIGenericClient is the one pointed at LiteLLM (graph.py)."""
+    from graphiti_core.llm_client import openai_generic_client
+
+    assert "LANGUAGE POLICY" in openai_generic_client.get_extraction_language_instruction()
+
+
+def test_facts_follow_the_source_language():
+    policy = graph_module._LANGUAGE_POLICY
+    assert "same language as the text it" in policy
+    assert "Never translate fact text" in policy
+    assert "never default to English" in policy
+
+
+def test_entity_names_are_canonical_so_the_graph_joins_across_languages():
+    """The join key cannot vary by source language.
+
+    graphiti resolves entities on character 3-gram shingles of the name
+    (dedup_helpers._shingles). "Toestel" and "Device" share none, so without a
+    pivot one concept becomes one node per language.
+    """
+    policy = graph_module._LANGUAGE_POLICY
+    assert "canonical English" in policy
+    assert "Toestel" in policy and "Device" in policy
+
+
+def test_proper_nouns_survive_both_rules():
+    """Translating "Belplan" would break the join with every page naming it."""
+    policy = graph_module._LANGUAGE_POLICY
+    assert "never translated" in policy
+    assert "Belplan" in policy
+    assert "verbatim" in policy
+
+
+def test_language_is_stated_once():
+    """Rule 2 used to live in the extraction instructions as well.
+
+    Two copies of a language rule drift; the extraction instructions now say
+    where it moved instead of repeating it.
+    """
+    instructions = graph_module._EXTRACTION_INSTRUCTIONS
+    assert "language of the source text" not in instructions
+    assert "_LANGUAGE_POLICY" in instructions


### PR DESCRIPTION
Refs #1148. The requirement: Dutch content stays Dutch in the graph, English stays English, and the system as a whole is language-agnostic. The corpus is Dutch, English and German today, with French, Spanish and Portuguese arriving with the multi-country chat-agent rollout — and it is open-ended, so language pairs cannot be enumerated.

## Two things, two answers

Conflating them is what produced the current graph.

**Fact text follows the source.** It is what a user reads as a citation; translating it makes the citation disagree with the page it links to.

**Entity names are canonical English.** They are the graph's join keys and cannot vary by language. graphiti resolves entities on character 3-gram shingles + MinHash/Jaccard over the normalised name (`dedup_helpers._shingles`). `Toestel` and `Device` share no 3-gram, so lexical dedup can *never* merge them — across six languages one concept becomes six unconnected nodes and the graph stops being a graph.

Proper nouns are exempt in both directions. Translating `Belplan` would break the join with every page that names it.

A Dutch fact may therefore reference an English entity name. That is correct, and it is the whole point: rule 1 governs the prose a person reads, rule 2 governs the key the system joins on.

## This is already happening

Measured on the live Voys graph — a predominantly **Dutch** corpus, 7,831 entities:

| Dutch | | English | |
|---|---|---|---|
| Gesprek | 27 | Call | **147** |
| Gebruiker | 16 | User | **57** |
| Telefoon | 20 | Phone | **48** |
| Toestel | **0** | Device | **30** |
| Belplan | 7 | Call plan | 0 |

The entity layer is mostly English already, and the pattern is exactly what a default-to-English instruction produces: product names stay Dutch, generic nouns get translated. English as the pivot is therefore also the direction with the least to migrate.

## Why an override, not a prompt rule

graphiti's built-in instruction ends in **"Otherwise, output English"** and is appended to every system message *after* any custom extraction instruction. That is why edges extracted before today came out English from Dutch pages, and why stating language in a prompt is a tug-of-war we could lose on a version bump.

`get_extraction_language_instruction` is documented as the override point ("Override this function to customize language extraction"), and it reaches **every** LLM call graphiti makes — not only the prompts `custom_extraction_instructions` is interpolated into.

Every client binds it with `from .client import ...` at import time, so patching the definition alone leaves each client calling the original. The installer rebinds every module holding a reference, discovered by attribute so a graphiti upgrade adding a client is covered automatically. The test fails if a binding is missed — verified both ways: unpatched the module returns graphiti's default, patched it returns the policy.

Language left `_EXTRACTION_INSTRUCTIONS` entirely rather than living in two places, and the existing test now asserts it moved.

## Scope

Extraction only. Edges already in the graph keep their language; content_hash dedup means an unchanged page is never re-extracted, so the existing mix heals via a deliberate migration, tracked in #1148.

Sol review raised that new extractions could dedupe into an existing non-English node and have their edges rejected by the ENTITIES-list validation. **Refuted** against `graphiti.py:656-659`: `extract_edges` receives `extracted_nodes` — the names this run just produced, before resolution — so the list an edge must reference always holds the canonical names and no relationship is dropped. A pre-existing node costs only that resolution keeps its name, deferring that one concept's canonicalisation to the migration.

The reviewer's remedy — wipe and force a full re-ingest before activating — is declined. The policy is strictly better than the default from the moment it ships, and destroying 18,031 edges to avoid a transitional period is the more expensive mistake.

Tests: 1572 passed, 6 skipped. Six new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)