### PR TITLE
fix(rag): stop the graph backfill from dropping two thirds of every document

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -33,7 +33,30 @@ from knowledge_ingest.graph import ingest_episode
 # Config
 # ---------------------------------------------------------------------------
 EPISODE_TIMEOUT = 600  # seconds per episode (large articles need more time)
-MAX_TEXT_CHARS = 4000  # limit text per episode to reduce LLM calls
+
+# Cap on the text handed to one episode. 4000 was chosen in the original
+# one-shot (2026-03-31) to "reduce LLM calls", and it cost far more than it
+# saved: on the Voys Dutch corpus 488 of 726 documents exceed it, so only 36%
+# of the text ever reached extraction. Everything past the cap was dropped
+# silently — a document simply had no facts about its second half.
+#
+# 30000 retains 91% of that corpus and leaves 24 documents truncated. It is a
+# cap rather than "no limit" because one artifact there is 464k characters:
+# unbounded, a single document would blow the context window and the per-tenant
+# rate budget in one go.
+#
+# The remaining 9% needs a document split across SEVERAL episodes, which is a
+# different change: artifacts.extra records ONE graphiti_episode_id and eight
+# call sites read it, including the connector- and KB-deletion paths that use
+# it to remove episodes from FalkorDB. One-to-many there without updating those
+# first would orphan episodes on delete. Tracked in GetKlai/klai#1176.
+MAX_TEXT_CHARS = 30000
+
+# The normal ingest path does NOT truncate — routes/ingest.py hands
+# ``indexable_content`` to the procrastinate task in full. This cap applies to
+# this operator one-shot only, which is why the graph has two populations:
+# episodes written by this script (2026-05, ~8.1k edges, truncated at 4000) and
+# episodes from live ingest (2026-08, ~9.6k edges, complete).
 
 logging.basicConfig(
     level=logging.INFO,
@@ -152,6 +175,18 @@ async def main(limit: int | None = None) -> None:
 
             full_text = "\n\n".join(chunks)
             if len(full_text) > MAX_TEXT_CHARS:
+                # Loud, not silent: a truncated document yields no facts about
+                # its tail, and the old code left no trace that it happened.
+                log.warning(
+                    "[%d/%d] %s — TRUNCATED %d of %d chars (%.0f%% dropped); "
+                    "needs a multi-episode split",
+                    idx,
+                    total_to_process,
+                    title,
+                    len(full_text) - MAX_TEXT_CHARS,
+                    len(full_text),
+                    100 * (len(full_text) - MAX_TEXT_CHARS) / len(full_text),
+                )
                 full_text = full_text[:MAX_TEXT_CHARS]
 
             try:

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -52,6 +52,13 @@ EPISODE_TIMEOUT = 600  # seconds per episode (large articles need more time)
 # first would orphan episodes on delete. Tracked in GetKlai/klai#1176.
 MAX_TEXT_CHARS = 30000
 
+# This raises the ceiling for FUTURE runs; it repairs nothing already stored.
+# The resume filter below skips every artifact that already has a
+# graphiti_episode_id, which is exactly the truncated 2026-05 population, so
+# re-running this script will not revisit them. Healing those means deleting
+# their episodes and re-extracting — the rebuild discussed in #1148, not a
+# side effect of a larger constant.
+#
 # The normal ingest path does NOT truncate — routes/ingest.py hands
 # ``indexable_content`` to the procrastinate task in full. This cap applies to
 # this operator one-shot only, which is why the graph has two populations:

--- a/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
@@ -1,0 +1,44 @@
+"""A graph backfill must not silently drop most of the corpus.
+
+The original one-shot capped episode text at 4000 characters to "reduce LLM
+calls". Measured on the Voys Dutch corpus on 2026-08-22: 488 of 726 documents
+exceed that, and only 36% of 6.59M characters ever reached extraction. The
+graph therefore had no facts about the second half of two documents in three,
+and nothing recorded that it had happened.
+"""
+
+from __future__ import annotations
+
+from knowledge_ingest import backfill
+
+
+def test_cap_retains_the_bulk_of_a_real_corpus():
+    """4000 retained 36% of the measured corpus; 30000 retains 91%."""
+    assert backfill.MAX_TEXT_CHARS >= 30000, (
+        "a cap this low drops most of every average document -- measured, "
+        "488 of 726 Voys documents exceed 4000 characters"
+    )
+
+
+def test_cap_still_exists():
+    """Not unbounded: one Voys artifact is 464k characters.
+
+    Removing the limit entirely would let a single document exhaust the context
+    window and a meaningful slice of the shared per-tenant rate budget.
+    """
+    assert backfill.MAX_TEXT_CHARS is not None
+    assert backfill.MAX_TEXT_CHARS <= 60000
+
+
+def test_truncation_is_reported(caplog):
+    """Silent truncation is what made this invisible for five months."""
+    import inspect
+
+    source = inspect.getsource(backfill)
+    truncation_block = source[source.index("MAX_TEXT_CHARS:") :]
+    truncation_block = truncation_block[: truncation_block.index("try:")]
+
+    assert "log.warning" in truncation_block, (
+        "truncation leaves no trace -- a document loses its tail and nothing says so"
+    )
+    assert "TRUNCATED" in truncation_block


### PR DESCRIPTION
`MAX_TEXT_CHARS = 4000`, set in the original one-shot on 2026-03-31 to "reduce LLM calls". It cost far more than it saved.

Measured on the Voys Dutch corpus today:

| | |
|---|---|
| documents | 726 |
| **exceeding 4,000 chars** | **488 (67%)** |
| characters total | 6,593,861 |
| **reaching extraction at cap 4,000** | **2,401,238 — 36%** |
| reaching extraction at cap 30,000 | 5,975,853 — **91%** |
| still truncated at 30,000 | 24 documents |

Two documents in three had no facts extracted about their second half, and nothing anywhere recorded that it had happened.

## Why 30,000 and not unlimited

One Voys artifact is 464,569 characters. Unbounded, a single document would exhaust the context window and a large slice of the shared per-tenant rate budget in one call.

Truncation now logs a warning naming the document and the percentage lost.

## Why the last 9% is a separate change

It needs one document to span several episodes. `knowledge.artifacts.extra` records exactly one `graphiti_episode_id` and **eight call sites read it** — including four deletion paths that use it to remove episodes from FalkorDB. Going one-to-many before updating those would orphan episodes when a page is deleted: a retention problem, not a quality one. Tracked in #1176.

## Worth knowing: the graph has two populations

The normal ingest path does **not** truncate — `routes/ingest.py` hands `indexable_content` to the procrastinate task in full. So this cap only ever applied to the operator one-shot, which explains the split by age:

| when | edges | how |
|---|---|---|
| 2026-05 | 8,141 | this script — truncated at 4,000 |
| 2026-06/07 | 273 | live ingest — complete |
| 2026-08 | 9,617 | live ingest — complete |

Roughly 45% of the graph was built from truncated text.

Tests: 1575 passed, 6 skipped. Three new.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)