### PR TITLE
feat(rag): let one document own several graph episodes, safely

### DIFF
--- a/klai-knowledge-ingest/.venv
+++ b/klai-knowledge-ingest/.venv
@@ -1,0 +1,1 @@
+/Users/mvletter/conductor/workspaces/Klai/belmopan/klai-knowledge-ingest/.venv

--- a/klai-knowledge-ingest/.venv
+++ b/klai-knowledge-ingest/.venv
@@ -1,1 +1,0 @@
-/Users/mvletter/conductor/workspaces/Klai/belmopan/klai-knowledge-ingest/.venv

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -5,8 +5,8 @@ Usage:
     docker exec klai-core-knowledge-ingest-1 python -m knowledge_ingest.backfill --limit 1
 
 Reads artifacts from PostgreSQL, fetches chunks from Qdrant, and calls
-ingest_episode() for each. Resume-safe: checks for graphiti_episode_id
-in artifact.extra before processing.
+ingest_episode() for each text part. Resume-safe: prefers graphiti_episode_ids
+and falls back to graphiti_episode_id before processing.
 
 SPEC-TI-003-FOLLOWUP-001 AC-2: this is an operator one-shot that does
 cross-org admin work (it picks the org via DISTINCT on first run, then
@@ -25,52 +25,42 @@ import time
 
 from qdrant_client import AsyncQdrantClient
 
+from knowledge_ingest import pg_store
 from knowledge_ingest.config import settings
 from knowledge_ingest.db import cross_org_admin_connection
 from knowledge_ingest.enrichment_policy import graph_episode_skip_reason
-from knowledge_ingest.graph import ingest_episode
+from knowledge_ingest.episode_text import MAX_TEXT_CHARS, split_episode_text
+from knowledge_ingest.graph import EntityGraphData, flush_entity_graph_data, ingest_episode
+
+__all__ = ["MAX_TEXT_CHARS"]
 
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 EPISODE_TIMEOUT = 600  # seconds per episode (large articles need more time)
 
-# Cap on the text handed to one episode. 4000 was chosen in the original
-# one-shot (2026-03-31) to "reduce LLM calls", and it cost far more than it
-# saved: on the Voys Dutch corpus 488 of 726 documents exceed it, so only 36%
-# of the text ever reached extraction. Everything past the cap was dropped
-# silently — a document simply had no facts about its second half.
-#
-# 30000 retains 91% of that corpus and leaves 24 documents truncated. It is a
-# cap rather than "no limit" because one artifact there is 464k characters:
-# unbounded, a single document would blow the context window and the per-tenant
-# rate budget in one go.
-#
-# The remaining 9% needs a document split across SEVERAL episodes, which is a
-# different change: artifacts.extra records ONE graphiti_episode_id and eight
-# call sites read it, including the connector- and KB-deletion paths that use
-# it to remove episodes from FalkorDB. One-to-many there without updating those
-# first would orphan episodes on delete. Tracked in GetKlai/klai#1176.
-MAX_TEXT_CHARS = 30000
-
-# This raises the ceiling for FUTURE runs; it repairs nothing already stored.
-# The resume filter below skips every artifact that already has a
-# graphiti_episode_id, which is exactly the truncated 2026-05 population, so
-# re-running this script will not revisit them. Healing those means deleting
-# their episodes and re-extracting — the rebuild discussed in #1148, not a
-# side effect of a larger constant.
-#
-# The normal ingest path does NOT truncate — routes/ingest.py hands
-# ``indexable_content`` to the procrastinate task in full. This cap applies to
-# this operator one-shot only, which is why the graph has two populations:
-# episodes written by this script (2026-05, ~8.1k edges, truncated at 4000) and
-# episodes from live ingest (2026-08, ~9.6k edges, complete).
-
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
 )
 log = logging.getLogger("backfill")
+
+
+def _has_graphiti_episode_record(raw_extra: str | dict | None) -> bool:
+    if not raw_extra:
+        return False
+    extra = json.loads(raw_extra) if isinstance(raw_extra, str) else raw_extra
+    if "graphiti_episode_ids" in extra:
+        if not isinstance(extra["graphiti_episode_ids"], list):
+            raise TypeError("graphiti_episode_ids must be a JSON list")
+        expected_parts = extra.get("graphiti_episode_part_count")
+        if expected_parts is not None:
+            return (
+                extra.get("graphiti_episode_complete") is True
+                and len(extra["graphiti_episode_ids"]) >= expected_parts
+            )
+        return True
+    return bool(extra.get("graphiti_episode_id"))
 
 
 async def main(limit: int | None = None) -> None:
@@ -99,14 +89,8 @@ async def main(limit: int | None = None) -> None:
             org_id,
         )
         total = len(rows)
-        already = sum(
-            1 for r in rows if r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id")
-        )
-        to_process = [
-            r
-            for r in rows
-            if not (r["extra"] and json.loads(r["extra"]).get("graphiti_episode_id"))
-        ]
+        already = sum(1 for r in rows if _has_graphiti_episode_record(r["extra"]))
+        to_process = [r for r in rows if not _has_graphiti_episode_record(r["extra"])]
         log.info(
             "Found %d artifacts, %d already processed, %d to backfill",
             total,
@@ -176,7 +160,12 @@ async def main(limit: int | None = None) -> None:
                     "UPDATE knowledge.artifacts "
                     "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                     "WHERE id = $2::uuid",
-                    json.dumps({"graphiti_episode_id": "no-chunks"}),
+                    json.dumps(
+                        {
+                            "graphiti_episode_id": "no-chunks",
+                            "graphiti_episode_ids": [],
+                        }
+                    ),
                     artifact_id,
                 )
                 continue
@@ -200,33 +189,58 @@ async def main(limit: int | None = None) -> None:
                 )
                 continue
 
-            if len(full_text) > MAX_TEXT_CHARS:
-                # Loud, not silent: a truncated document yields no facts about
-                # its tail, and the old code left no trace that it happened.
-                log.warning(
-                    "[%d/%d] %s — TRUNCATED %d of %d chars (%.0f%% dropped); "
-                    "needs a multi-episode split",
-                    idx,
-                    total_to_process,
-                    title,
-                    len(full_text) - MAX_TEXT_CHARS,
-                    len(full_text),
-                    100 * (len(full_text) - MAX_TEXT_CHARS) / len(full_text),
-                )
-                full_text = full_text[:MAX_TEXT_CHARS]
-
+            # No truncation branch any more: split_episode_text spreads a long
+            # document across several episodes instead of dropping its tail.
+            episode_parts = split_episode_text(full_text)
+            episode_ids: list[str] = []
+            entity_graph_data = EntityGraphData()
             try:
-                episode_id = await asyncio.wait_for(
-                    ingest_episode(
-                        artifact_id=artifact_id,
-                        document_text=full_text,
-                        org_id=org_id,
-                        content_type=content_type,
-                        belief_time_start=created_epoch,
-                        kb_slug=row["kb_slug"] or "",
-                        path=row["path"] or "",
+                await conn.execute(
+                    "UPDATE knowledge.artifacts "
+                    "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
+                    "WHERE id = $2::uuid",
+                    json.dumps(
+                        {
+                            "graphiti_episode_part_count": len(episode_parts),
+                            "graphiti_episode_complete": False,
+                        }
                     ),
-                    timeout=EPISODE_TIMEOUT,
+                    artifact_id,
+                )
+                for episode_text in episode_parts:
+                    episode_id = await asyncio.wait_for(
+                        ingest_episode(
+                            artifact_id=artifact_id,
+                            document_text=episode_text,
+                            org_id=org_id,
+                            content_type=content_type,
+                            belief_time_start=created_epoch,
+                            kb_slug=row["kb_slug"] or "",
+                            path=row["path"] or "",
+                            entity_graph_data=entity_graph_data,
+                        ),
+                        timeout=EPISODE_TIMEOUT,
+                    )
+                    if episode_id is None:
+                        raise RuntimeError("returned None (LLM issue?)")
+                    episode_ids.append(episode_id)
+                    await pg_store.append_graphiti_episode_id(conn, artifact_id, episode_id)
+
+                try:
+                    await flush_entity_graph_data(artifact_id, org_id, entity_graph_data)
+                except Exception:
+                    log.exception("%s — entity graph data update failed", title)
+                await conn.execute(
+                    "UPDATE knowledge.artifacts "
+                    "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
+                    "WHERE id = $2::uuid",
+                    json.dumps(
+                        {
+                            "graphiti_episode_complete": True,
+                            "graphiti_model": settings.graphiti_llm_model,
+                        }
+                    ),
+                    artifact_id,
                 )
             except TimeoutError:
                 err_count += 1
@@ -243,39 +257,15 @@ async def main(limit: int | None = None) -> None:
                 log.error("[%d/%d] %s — %s", idx, total_to_process, title, exc)
                 continue
 
-            if episode_id is None:
-                err_count += 1
-                log.error(
-                    "[%d/%d] %s — returned None (LLM issue?)",
-                    idx,
-                    total_to_process,
-                    title,
-                )
-                continue
-
-            # Success — persist for resume
             ok_count += 1
-            await conn.execute(
-                "UPDATE knowledge.artifacts "
-                "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
-                "WHERE id = $2::uuid",
-                json.dumps(
-                    {
-                        "graphiti_episode_id": episode_id,
-                        "graphiti_model": settings.graphiti_llm_model,
-                    }
-                ),
-                artifact_id,
-            )
-
             elapsed = time.time() - t_start
             rate = ok_count / (elapsed / 3600) if elapsed > 0 else 0
             log.info(
-                "[%d/%d] %s — OK episode=%s (%d/hr, %ds elapsed)",
+                "[%d/%d] %s — OK episodes=%s (%d/hr, %ds elapsed)",
                 idx,
                 total_to_process,
                 title,
-                episode_id,
+                episode_ids,
                 int(rate),
                 int(elapsed),
             )

--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -313,9 +313,8 @@ async def purge_connector(
         # because their inputs depend on rows that no longer exist.
         # Org-wide sweep: catches both this connector's late-arrivers AND
         # historical orphans from previous failed purges. Computes alive
-        # episode-uuid set from postgres
-        # (``artifacts.extra->>'graphiti_episode_id'`` — the FalkorDB
-        # ``Episodic.uuid`` value the ingest pipeline persists) and
+        # episode-uuid set from both the list and legacy scalar in
+        # ``artifacts.extra`` and
         # intersects against the org's FalkorDB graph.
         alive_episode_uuids = await pg_store.get_alive_episode_uuids_for_org(conn, org_id)
         falkor_orphans_deleted = await graph_module.sweep_orphan_episodes_org_wide(

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -44,6 +44,7 @@ from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import cross_org_admin_connection, tenant_scoped_connection
 from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 from knowledge_ingest.enrichment_policy import enrichment_skip_reason
+from knowledge_ingest.episode_text import split_episode_text
 
 logger = structlog.get_logger()
 
@@ -401,19 +402,93 @@ def _register_tasks(procrastinate_app: Any) -> None:
             )
             from knowledge_ingest import graph as graph_module
 
-            episode_id = await graph_module.ingest_episode(
-                artifact_id=artifact_id,
-                document_text=document_text,
-                org_id=org_id,
-                content_type=content_type,
-                belief_time_start=belief_time_start,
-                kb_slug=kb_slug,
-                path=path,
+            episode_parts = split_episode_text(document_text)
+            await pg_store.update_artifact_extra(
+                conn,
+                artifact_id,
+                {
+                    "graphiti_episode_part_count": len(episode_parts),
+                    "graphiti_episode_complete": False,
+                },
             )
-            if episode_id:
-                await pg_store.update_artifact_extra(
-                    conn, artifact_id, {"graphiti_episode_id": episode_id}
+            episode_ids: list[str] = []
+            entity_graph_data = graph_module.EntityGraphData()
+            for part_index, episode_text in enumerate(episode_parts):
+                if part_index > 0:
+                    # Page deletion can land while an earlier part is spending
+                    # minutes in Graphiti; never regrow later parts afterward.
+                    if not await pg_store.artifact_exists(conn, artifact_id):
+                        logger.info(
+                            "graphiti_aborted_artifact_missing",
+                            artifact_id=artifact_id,
+                            org_id=org_id,
+                        )
+                        return
+                    if not await pg_store.artifact_is_active(conn, artifact_id):
+                        logger.info(
+                            "graphiti_aborted_artifact_superseded",
+                            artifact_id=artifact_id,
+                            org_id=org_id,
+                        )
+                        return
+                episode_id = await graph_module.ingest_episode(
+                    artifact_id=artifact_id,
+                    document_text=episode_text,
+                    org_id=org_id,
+                    content_type=content_type,
+                    belief_time_start=belief_time_start,
+                    kb_slug=kb_slug,
+                    path=path,
+                    entity_graph_data=entity_graph_data,
                 )
+                if episode_id is None:
+                    logger.error(
+                        "graphiti_episode_partial",
+                        artifact_id=artifact_id,
+                        org_id=org_id,
+                        completed_parts=len(episode_ids),
+                        expected_parts=len(episode_parts),
+                    )
+                    raise RuntimeError(
+                        f"Graphiti returned no episode id for part "
+                        f"{part_index + 1} of {len(episode_parts)}"
+                    )
+                episode_ids.append(episode_id)
+                # A worker retry starts with a fresh Python list, so the SQL
+                # append must retain IDs written before a mid-loop worker kill.
+                await pg_store.append_graphiti_episode_id(conn, artifact_id, episode_id)
+                if not await pg_store.artifact_exists(conn, artifact_id):
+                    # Deletion may finish while Graphiti is extracting this
+                    # part; the delete path could not have seen its new UUID.
+                    await graph_module.delete_kb_episodes(org_id, [episode_id])
+                    logger.info(
+                        "graphiti_aborted_artifact_missing",
+                        artifact_id=artifact_id,
+                        org_id=org_id,
+                    )
+                    return
+                if not await pg_store.artifact_is_active(conn, artifact_id):
+                    await graph_module.delete_kb_episodes(org_id, [episode_id])
+                    logger.info(
+                        "graphiti_aborted_artifact_superseded",
+                        artifact_id=artifact_id,
+                        org_id=org_id,
+                    )
+                    return
+
+            try:
+                await graph_module.flush_entity_graph_data(
+                    artifact_id,
+                    org_id,
+                    entity_graph_data,
+                )
+            except Exception:
+                logger.exception("entity_graph_data_failed", artifact_id=artifact_id)
+            await pg_store.update_artifact_extra(
+                conn,
+                artifact_id,
+                {"graphiti_episode_complete": True},
+            )
 
     procrastinate_app.ingest_graphiti_episode = ingest_graphiti_episode  # type: ignore[attr-defined]
 

--- a/klai-knowledge-ingest/knowledge_ingest/episode_text.py
+++ b/klai-knowledge-ingest/knowledge_ingest/episode_text.py
@@ -1,0 +1,67 @@
+import structlog
+
+MAX_TEXT_CHARS = 30000
+
+logger = structlog.get_logger()
+
+
+def _split_with_fallback_boundaries(document_text: str, max_chars: int) -> list[str]:
+    parts: list[str] = []
+    remaining = document_text
+    while remaining:
+        if len(remaining) <= max_chars:
+            parts.append(remaining)
+            break
+
+        split_at = remaining.rfind("\n\n", 1, max_chars + 1)
+        if split_at < 1:
+            split_at = remaining.rfind("\n", 1, max_chars + 1)
+        if split_at < 1:
+            split_at = next(
+                (index + 1 for index in range(max_chars - 1, 0, -1) if remaining[index].isspace()),
+                max_chars,
+            )
+
+        # A leading delimiter alone would recreate the empty-episode bug for
+        # API input beginning with a blank line; keep it with following text.
+        if not remaining[:split_at].strip():
+            split_at = max_chars
+        parts.append(remaining[:split_at])
+        remaining = remaining[split_at:]
+    return parts
+
+
+def split_episode_text(document_text: str, *, max_chars: int = MAX_TEXT_CHARS) -> list[str]:
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    if not document_text:
+        return []
+    if len(document_text) <= max_chars:
+        return [document_text]
+
+    paragraphs = document_text.split("\n\n")
+    oversized = next((paragraph for paragraph in paragraphs if len(paragraph) > max_chars), None)
+    if oversized is not None or any(not paragraph for paragraph in paragraphs):
+        # Markdown tables and transcripts can arrive from skip_chunking as one
+        # 40k paragraph; failing here would exhaust all three task attempts and
+        # leave the document with zero episodes.
+        parts = _split_with_fallback_boundaries(document_text, max_chars)
+        logger.warning(
+            "episode_text_fallback_split",
+            document_chars=len(document_text),
+            max_chars=max_chars,
+            part_count=len(parts),
+        )
+        return parts
+
+    parts: list[str] = []
+    current = paragraphs[0]
+    for paragraph in paragraphs[1:]:
+        candidate = f"{current}\n\n{paragraph}"
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            parts.append(current)
+            current = paragraph
+    parts.append(current)
+    return parts

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import time
 import types
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import httpx
@@ -43,6 +44,18 @@ logger = structlog.get_logger()
 # Rate-limit Graphiti episodes: each add_episode() makes ~5 LLM calls internally.
 # Concurrency controlled by GRAPHITI_MAX_CONCURRENT env var (default: 1).
 _episode_semaphore: asyncio.Semaphore | None = None
+
+
+@dataclass
+class EntityGraphData:
+    """Entity data collected across every episode part of one document."""
+
+    entity_uuids: list[str] = field(default_factory=list)
+    entity_names: list[str] = field(default_factory=list)
+
+    def extend(self, entity_uuids: list[str], entity_names: list[str]) -> None:
+        self.entity_uuids.extend(uid for uid in entity_uuids if uid not in self.entity_uuids)
+        self.entity_names.extend(name for name in entity_names if name not in self.entity_names)
 
 
 # Extra rules appended to Graphiti's entity- AND edge-extraction prompts
@@ -508,8 +521,9 @@ async def sweep_orphan_episodes_org_wide(org_id: str, alive_episode_uuids: set[s
     Graphiti's Episodic node-schema has ``uuid``, ``name``, ``group_id``,
     ``source``, ``source_description``, ``valid_at``, ``created_at`` —
     but NO ``artifact_id`` property. The ingest pipeline links postgres
-    -> FalkorDB by writing the FalkorDB ``Episodic.uuid`` into
-    ``knowledge.artifacts.extra->>'graphiti_episode_id'``.
+    -> FalkorDB by writing FalkorDB ``Episodic.uuid`` values into
+    ``knowledge.artifacts.extra->'graphiti_episode_ids'`` while retaining the
+    first value in the legacy scalar.
 
     Implementation uses the direct ``falkordb`` Python client (the same
     pattern as ``routes/stats.py::get_graph_stats``). The earlier
@@ -582,8 +596,8 @@ async def delete_orphan_episodes_for_artifact_ids(org_id: str, artifact_ids: lis
     do synchronous LLM calls that don't honour ``asyncio.CancelledError``
     — they keep running after the procrastinate cancel and write a fresh
     episode for an already-deleted artifact. Those episodes never made
-    it into ``knowledge.artifacts.extra->>graphiti_episode_id`` (the row
-    was already gone), so ``delete_kb_episodes`` cannot find them via
+    them into ``knowledge.artifacts.extra`` (the row was already gone), so
+    ``delete_kb_episodes`` cannot find them via
     the normal path.
 
     The orchestrator runs this AFTER ``delete_connector_artifacts`` with
@@ -718,6 +732,24 @@ def _episode_name(artifact_id: str, kb_slug: str, path: str) -> str:
     return artifact_id
 
 
+async def flush_entity_graph_data(
+    artifact_id: str,
+    org_id: str,
+    entity_graph_data: EntityGraphData,
+) -> None:
+    """Write the complete document entity payload and refresh PageRank once."""
+    if not entity_graph_data.entity_uuids and not entity_graph_data.entity_names:
+        return
+    pagerank_scores = await compute_entity_pagerank(org_id)
+    await qdrant_store.set_entity_graph_data(
+        artifact_id=artifact_id,
+        org_id=org_id,
+        entity_uuids=entity_graph_data.entity_uuids,
+        pagerank_scores=pagerank_scores,
+        entity_names=entity_graph_data.entity_names,
+    )
+
+
 async def ingest_episode(
     artifact_id: str,
     document_text: str,
@@ -726,6 +758,7 @@ async def ingest_episode(
     belief_time_start: int,
     kb_slug: str = "",
     path: str = "",
+    entity_graph_data: EntityGraphData | None = None,
 ) -> str | None:
     """Ingest a document as a Graphiti episode.
 
@@ -833,20 +866,20 @@ async def ingest_episode(
                     if getattr(n, "name", None) and str(getattr(n, "name", "")).strip()
                 ]
                 if entity_uuids_list or entity_names_list:
-                    try:
-                        pagerank_scores = await compute_entity_pagerank(org_id)
-                        await qdrant_store.set_entity_graph_data(
-                            artifact_id=artifact_id,
-                            org_id=org_id,
-                            entity_uuids=entity_uuids_list,
-                            pagerank_scores=pagerank_scores,
-                            entity_names=entity_names_list,
-                        )
-                    except Exception:
-                        logger.exception(
-                            "entity_graph_data_failed",
-                            artifact_id=artifact_id,
-                        )
+                    if entity_graph_data is not None:
+                        entity_graph_data.extend(entity_uuids_list, entity_names_list)
+                    else:
+                        try:
+                            await flush_entity_graph_data(
+                                artifact_id,
+                                org_id,
+                                EntityGraphData(entity_uuids_list, entity_names_list),
+                            )
+                        except Exception:
+                            logger.exception(
+                                "entity_graph_data_failed",
+                                artifact_id=artifact_id,
+                            )
 
                 break
 

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -458,9 +458,9 @@ async def get_episode_ids_for_document_history(
 ) -> list[str]:
     """Return the Graphiti episode uuids of these rows AND every version they replaced.
 
-    ``ingest_graphiti_episode`` writes ``graphiti_episode_id`` into
-    ``knowledge.artifacts.extra`` when an episode lands, so that key is the
-    mapping from an artifact VERSION to the episode extracted from it.
+    ``ingest_graphiti_episode`` writes ``graphiti_episode_ids`` plus the first
+    id in ``graphiti_episode_id`` when episodes land. The list is authoritative;
+    the scalar keeps rows written before GetKlai/klai#1176 readable.
 
     The walk backwards along ``superseded_by`` is the point. A caller passes
     the rows a rename just closed, but ``soft_delete_artifact`` only closes
@@ -498,13 +498,21 @@ async def get_episode_ids_for_document_history(
             JOIN knowledge.artifacts p ON p.superseded_by = h.id AND p.org_id = $1
             WHERE h.depth < 100
         )
-        SELECT DISTINCT a.extra->>'graphiti_episode_id' AS episode_id
+        SELECT DISTINCT stored_episode.episode_id
         FROM knowledge.artifacts a
+        CROSS JOIN LATERAL jsonb_array_elements_text(
+            CASE
+                WHEN a.extra::jsonb ? 'graphiti_episode_ids'
+                    THEN a.extra::jsonb->'graphiti_episode_ids'
+                WHEN a.extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                    THEN jsonb_build_array(a.extra::jsonb->>'graphiti_episode_id')
+                ELSE '[]'::jsonb
+            END
+        ) AS stored_episode(episode_id)
         WHERE a.org_id = $1
           AND a.id IN (SELECT id FROM history)
-          AND a.extra->>'graphiti_episode_id' IS NOT NULL
-          AND a.extra->>'graphiti_episode_id' <> 'no-chunks'
-          AND a.extra->>'graphiti_episode_id' NOT LIKE 'skipped:%'
+          AND stored_episode.episode_id <> 'no-chunks'
+          AND stored_episode.episode_id NOT LIKE 'skipped:%'
         """,
         org_id,
         artifact_ids,
@@ -667,15 +675,23 @@ async def soft_delete_stale_connector_artifacts(
 async def get_episode_ids(conn: asyncpg.Connection, org_id: str, kb_slug: str) -> list[str]:
     """Return Graphiti episode UUIDs for all artifacts in a KB.
 
-    Reads the graphiti_episode_id from the extra JSON field before deletion.
+    Reads graphiti_episode_ids, falling back to the legacy scalar, before deletion.
     Excludes the 'no-chunks' sentinel (artifacts with no text content).
     """
     rows = await conn.fetch(
-        """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
-           FROM knowledge.artifacts
-           WHERE org_id = $1 AND kb_slug = $2
-             AND extra IS NOT NULL
-             AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+        """SELECT DISTINCT stored_episode.episode_id
+           FROM knowledge.artifacts AS a
+           CROSS JOIN LATERAL jsonb_array_elements_text(
+               CASE
+                   WHEN a.extra::jsonb ? 'graphiti_episode_ids'
+                       THEN a.extra::jsonb->'graphiti_episode_ids'
+                   WHEN a.extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                       THEN jsonb_build_array(a.extra::jsonb->>'graphiti_episode_id')
+                   ELSE '[]'::jsonb
+               END
+           ) AS stored_episode(episode_id)
+           WHERE a.org_id = $1 AND a.kb_slug = $2
+             AND stored_episode.episode_id <> 'no-chunks'""",
         org_id,
         kb_slug,
     )
@@ -754,12 +770,20 @@ async def get_connector_episode_ids(
 ) -> list[str]:
     """Return Graphiti episode UUIDs for artifacts ingested by a specific connector."""
     rows = await conn.fetch(
-        """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
-           FROM knowledge.artifacts
-           WHERE org_id = $1 AND kb_slug = $2
-             AND extra IS NOT NULL
-             AND extra::jsonb->>'source_connector_id' = $3
-             AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+        """SELECT DISTINCT stored_episode.episode_id
+           FROM knowledge.artifacts AS a
+           CROSS JOIN LATERAL jsonb_array_elements_text(
+               CASE
+                   WHEN a.extra::jsonb ? 'graphiti_episode_ids'
+                       THEN a.extra::jsonb->'graphiti_episode_ids'
+                   WHEN a.extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                       THEN jsonb_build_array(a.extra::jsonb->>'graphiti_episode_id')
+                   ELSE '[]'::jsonb
+               END
+           ) AS stored_episode(episode_id)
+           WHERE a.org_id = $1 AND a.kb_slug = $2
+             AND a.extra::jsonb->>'source_connector_id' = $3
+             AND stored_episode.episode_id <> 'no-chunks'""",
         org_id,
         kb_slug,
         connector_id,
@@ -962,22 +986,27 @@ async def get_orphan_image_keys_for_connector(
 async def get_alive_episode_uuids_for_org(conn: asyncpg.Connection, org_id: str) -> set[str]:
     """Return every Graphiti episode UUID still referenced by an artifact for this org.
 
-    Read from ``knowledge.artifacts.extra->>'graphiti_episode_id'`` —
-    this is where the ingest pipeline stores the FalkorDB ``Episodic.uuid``
-    after a successful ``graph_module.ingest_episode``. The org-wide
-    janitor uses the result to compute which FalkorDB episodes are no
-    longer referenced and therefore orphan.
+    The list key is authoritative when present; the scalar fallback keeps rows
+    written before GetKlai/klai#1176 visible to the org-wide janitor.
 
     Excludes the ``no-chunks`` sentinel that artifacts use when an
     article had no extractable text.
     """
     rows = await conn.fetch(
         """
-        SELECT extra::jsonb->>'graphiti_episode_id' AS episode_uuid
-          FROM knowledge.artifacts
-         WHERE org_id = $1
-           AND extra IS NOT NULL
-           AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+        SELECT DISTINCT stored_episode.episode_id AS episode_uuid
+          FROM knowledge.artifacts AS a
+          CROSS JOIN LATERAL jsonb_array_elements_text(
+              CASE
+                  WHEN a.extra::jsonb ? 'graphiti_episode_ids'
+                      THEN a.extra::jsonb->'graphiti_episode_ids'
+                  WHEN a.extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                      THEN jsonb_build_array(a.extra::jsonb->>'graphiti_episode_id')
+                  ELSE '[]'::jsonb
+              END
+          ) AS stored_episode(episode_id)
+         WHERE a.org_id = $1
+           AND stored_episode.episode_id <> 'no-chunks'
         """,
         org_id,
     )
@@ -1354,11 +1383,19 @@ async def get_page_episode_ids(
     to clean up Graphiti graph nodes before soft-deleting the artifact.
     """
     rows = await conn.fetch(
-        """SELECT extra::jsonb->>'graphiti_episode_id' AS episode_id
-           FROM knowledge.artifacts
-           WHERE org_id = $1 AND kb_slug = $2 AND path = $3
-             AND extra IS NOT NULL
-             AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL""",
+        """SELECT DISTINCT stored_episode.episode_id
+           FROM knowledge.artifacts AS a
+           CROSS JOIN LATERAL jsonb_array_elements_text(
+               CASE
+                   WHEN a.extra::jsonb ? 'graphiti_episode_ids'
+                       THEN a.extra::jsonb->'graphiti_episode_ids'
+                   WHEN a.extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                       THEN jsonb_build_array(a.extra::jsonb->>'graphiti_episode_id')
+                   ELSE '[]'::jsonb
+               END
+           ) AS stored_episode(episode_id)
+           WHERE a.org_id = $1 AND a.kb_slug = $2 AND a.path = $3
+             AND stored_episode.episode_id <> 'no-chunks'""",
         org_id,
         kb_slug,
         path,
@@ -1431,6 +1468,50 @@ async def update_artifact_extra(
         """,
         json.dumps(extra_patch),
         artifact_id,
+    )
+
+
+async def append_graphiti_episode_id(
+    conn: asyncpg.Connection,
+    artifact_id: str,
+    episode_id: str,
+) -> None:
+    """Atomically retain every Graphiti episode created across task attempts."""
+    await conn.execute(
+        """
+        WITH current AS (
+            SELECT id,
+                   COALESCE(
+                       CASE
+                           WHEN jsonb_typeof(extra::jsonb->'graphiti_episode_ids') = 'array'
+                               THEN extra::jsonb->'graphiti_episode_ids'
+                           WHEN extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                            AND extra::jsonb->>'graphiti_episode_id' <> 'no-chunks'
+                               THEN jsonb_build_array(extra::jsonb->>'graphiti_episode_id')
+                           ELSE '[]'::jsonb
+                       END,
+                       '[]'::jsonb
+                   ) AS episode_ids,
+                   NULLIF(extra::jsonb->>'graphiti_episode_id', 'no-chunks') AS first_id
+            FROM knowledge.artifacts
+            WHERE id = $1
+        )
+        UPDATE knowledge.artifacts AS artifact
+        SET extra = COALESCE(artifact.extra::jsonb, '{}'::jsonb)
+                    || jsonb_build_object(
+                        'graphiti_episode_id', COALESCE(current.first_id, $2::text),
+                        'graphiti_episode_ids',
+                        CASE
+                            WHEN current.episode_ids @> jsonb_build_array($2::text)
+                                THEN current.episode_ids
+                            ELSE current.episode_ids || jsonb_build_array($2::text)
+                        END
+                    )
+        FROM current
+        WHERE artifact.id = current.id
+        """,
+        artifact_id,
+        episode_id,
     )
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -346,7 +346,14 @@ async def _graphiti_background(
         path=path,
     )
     if episode_id:
-        await pg_store.update_artifact_extra(conn, artifact_id, {"graphiti_episode_id": episode_id})
+        await pg_store.update_artifact_extra(
+            conn,
+            artifact_id,
+            {
+                "graphiti_episode_id": episode_id,
+                "graphiti_episode_ids": [episode_id],
+            },
+        )
 
 
 async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:

--- a/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/scripts/backfill_episode_document_names.py
@@ -10,8 +10,8 @@ renders as a truncated sentence instead of a link.
 
 The rename is metadata only. It does NOT re-extract, makes no LLM calls, and
 draws nothing from the shared klai-fast rate limit that enrichment and
-taxonomy compete over. Postgres already holds the mapping: every successful
-episode writes ``graphiti_episode_id`` into ``knowledge.artifacts.extra``.
+taxonomy compete over. Postgres already holds the mapping in
+``graphiti_episode_ids``, with ``graphiti_episode_id`` as the legacy fallback.
 
 Superseded artifacts are included on purpose: their episodes carry exactly the
 stale edges this is meant to heal. They are keyed on the path of the ACTIVE
@@ -112,11 +112,24 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
             extra = json.loads(row["extra"]) if isinstance(row["extra"], str) else row["extra"]
         except (TypeError, ValueError):
             continue
-        episode_id = (extra or {}).get("graphiti_episode_id")
-        # Sentinels, not uuids: "no-chunks" from backfill.py, and
-        # "skipped:<reason>" from the ingest route for a page that must not
-        # become an episode at all (a navigation page, #1148).
-        if not episode_id or episode_id == "no-chunks" or episode_id.startswith("skipped:"):
+        extra = extra or {}
+        if "graphiti_episode_ids" in extra:
+            episode_ids = extra["graphiti_episode_ids"]
+            if not isinstance(episode_ids, list):
+                raise TypeError("graphiti_episode_ids must be a JSON list")
+        else:
+            episode_ids = [extra.get("graphiti_episode_id")]
+        # Sentinels, not uuids: "no-chunks" from backfill.py for an artifact it
+        # deliberately skipped, and "skipped:<reason>" for a page held out of
+        # the graph entirely (a navigation page, #1148).
+        episode_ids = [
+            episode_id
+            for episode_id in episode_ids
+            if episode_id
+            and episode_id != "no-chunks"
+            and not str(episode_id).startswith("skipped:")
+        ]
+        if not episode_ids:
             skipped += 1
             continue
         kb_slug, path = row["kb_slug"], row["path"]
@@ -124,7 +137,7 @@ async def collect_renames(org_id: str) -> tuple[dict[str, list[str]], int]:
             skipped += 1
             continue
         name = episode_name(kb_slug, path)
-        renames[name].append(episode_id)
+        renames[name].extend(episode_ids)
 
     return dict(renames), skipped
 

--- a/klai-knowledge-ingest/scripts/backfill_graphiti_episode_ids.py
+++ b/klai-knowledge-ingest/scripts/backfill_graphiti_episode_ids.py
@@ -1,0 +1,76 @@
+"""Populate Graphiti episode-id lists for artifacts that only have the legacy scalar.
+
+Usage (in a knowledge-ingest container):
+
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m scripts.backfill_graphiti_episode_ids --org-id <org_id> [--dry-run]
+
+Idempotent: rows that already carry ``graphiti_episode_ids`` are left unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+import structlog
+
+from knowledge_ingest.db import tenant_scoped_connection
+
+logger = structlog.get_logger()
+
+
+async def run(org_id: str, dry_run: bool) -> int:
+    async with tenant_scoped_connection(org_id) as conn:
+        pending = await conn.fetchval(
+            """SELECT count(*)
+               FROM knowledge.artifacts
+               WHERE org_id = $1
+                 AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                 AND NOT (extra::jsonb ? 'graphiti_episode_ids')""",
+            org_id,
+        )
+        logger.info(
+            "backfill_graphiti_episode_ids_plan",
+            org_id=org_id,
+            artifacts=pending,
+            dry_run=dry_run,
+        )
+        if dry_run or not pending:
+            return 0
+
+        status = await conn.execute(
+            """UPDATE knowledge.artifacts
+               SET extra = extra::jsonb || jsonb_build_object(
+                   'graphiti_episode_ids',
+                   CASE
+                       WHEN extra::jsonb->>'graphiti_episode_id' = 'no-chunks'
+                           THEN '[]'::jsonb
+                       ELSE jsonb_build_array(extra::jsonb->>'graphiti_episode_id')
+                   END
+               )
+               WHERE org_id = $1
+                 AND extra::jsonb->>'graphiti_episode_id' IS NOT NULL
+                 AND NOT (extra::jsonb ? 'graphiti_episode_ids')""",
+            org_id,
+        )
+
+    logger.info(
+        "backfill_graphiti_episode_ids_complete",
+        org_id=org_id,
+        artifacts_updated=int(status.rsplit(" ", 1)[-1]),
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--org-id", required=True, help="Zitadel org id (one tenant per run)")
+    parser.add_argument("--dry-run", action="store_true", help="Report the plan, change nothing")
+    args = parser.parse_args()
+    return asyncio.run(run(args.org_id, args.dry_run))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_document_names.py
@@ -22,6 +22,34 @@ def _row(kb_slug, path, extra):
 
 class TestCollectRenames:
     @pytest.mark.asyncio
+    async def test_prefers_all_episode_ids_over_legacy_scalar(self):
+        from scripts.backfill_episode_document_names import collect_renames
+
+        rows = [
+            _row(
+                "support",
+                "webphone",
+                {
+                    "graphiti_episode_ids": ["ep-1", "ep-2"],
+                    "graphiti_episode_id": "ep-1",
+                },
+            )
+        ]
+        conn = AsyncMock()
+        conn.fetch = AsyncMock(return_value=rows)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=conn)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "scripts.backfill_episode_document_names.tenant_scoped_connection", return_value=ctx
+        ):
+            renames, skipped = await collect_renames("org-1")
+
+        assert renames == {"doc:support:webphone": ["ep-1", "ep-2"]}
+        assert skipped == 0
+
+    @pytest.mark.asyncio
     async def test_groups_every_version_of_a_document_under_one_name(self):
         """Several versions share a document, and all their episodes must move.
 

--- a/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
@@ -9,6 +9,12 @@ and nothing recorded that it had happened.
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from knowledge_ingest import backfill
 
 
@@ -30,15 +36,97 @@ def test_cap_still_exists():
     assert backfill.MAX_TEXT_CHARS <= 60000
 
 
-def test_truncation_is_reported(caplog):
-    """Silent truncation is what made this invisible for five months."""
-    import inspect
+def test_incomplete_episode_list_is_retried_until_expected_part_count_lands():
+    extra = {
+        "graphiti_episode_ids": ["episode-1"],
+        "graphiti_episode_part_count": 2,
+        "graphiti_episode_complete": False,
+    }
 
-    source = inspect.getsource(backfill)
-    truncation_block = source[source.index("MAX_TEXT_CHARS:") :]
-    truncation_block = truncation_block[: truncation_block.index("try:")]
+    assert backfill._has_graphiti_episode_record(extra) is False
 
-    assert "log.warning" in truncation_block, (
-        "truncation leaves no trace -- a document loses its tail and nothing says so"
+
+@pytest.mark.asyncio
+async def test_resume_prefers_episode_ids_list_without_reprocessing():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"org_id": "org-1"})
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "artifact-1",
+                "kb_slug": "support",
+                "path": "guide.md",
+                "content_type": "text/markdown",
+                "created_at": 1,
+                "extra": json.dumps({"graphiti_episode_ids": ["ep-1", "ep-2"]}),
+            }
+        ]
     )
-    assert "TRUNCATED" in truncation_block
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    qdrant = MagicMock()
+    qdrant.scroll = AsyncMock(return_value=([], None))
+
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=ctx),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+    ):
+        await backfill.main()
+
+    qdrant.scroll.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_creates_and_records_every_episode_for_a_long_document():
+    paragraph = ("A complete sentence. " * 1000).strip()
+    document_text = f"{paragraph}\n\n{paragraph}"
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"org_id": "org-1"})
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "artifact-1",
+                "kb_slug": "support",
+                "path": "guide.md",
+                "content_type": "text/markdown",
+                "created_at": 1,
+                "extra": None,
+            }
+        ]
+    )
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    qdrant = MagicMock()
+    qdrant.scroll = AsyncMock(
+        return_value=(
+            [SimpleNamespace(payload={"artifact_id": "artifact-1", "text": document_text})],
+            None,
+        )
+    )
+    ingest_episode = AsyncMock(side_effect=["episode-1", "episode-2"])
+
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=ctx),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+    ):
+        await backfill.main()
+
+    parts = [call.kwargs["document_text"] for call in ingest_episode.await_args_list]
+    assert len(parts) == 2
+    assert "\n\n".join(parts) == document_text
+    assert all(len(part) <= backfill.MAX_TEXT_CHARS for part in parts)
+    assert conn.execute.await_count == 4
+    first_patch = json.loads(conn.execute.await_args_list[0].args[1])
+    final_patch = json.loads(conn.execute.await_args_list[-1].args[1])
+    assert first_patch == {
+        "graphiti_episode_part_count": 2,
+        "graphiti_episode_complete": False,
+    }
+    assert [call.args[2] for call in conn.execute.await_args_list[1:3]] == [
+        "episode-1",
+        "episode-2",
+    ]
+    assert final_patch["graphiti_episode_complete"] is True

--- a/klai-knowledge-ingest/tests/test_backfill_graphiti_episode_ids.py
+++ b/klai-knowledge-ingest/tests/test_backfill_graphiti_episode_ids.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _connection_context(conn: AsyncMock) -> MagicMock:
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reports_rows_without_updating():
+    from scripts import backfill_graphiti_episode_ids as script
+
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=2)
+
+    with patch(
+        "scripts.backfill_graphiti_episode_ids.tenant_scoped_connection",
+        return_value=_connection_context(conn),
+    ):
+        result = await script.run("org-1", dry_run=True)
+
+    assert result == 0
+    conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_populates_list_from_scalar_idempotently_for_one_tenant():
+    from scripts import backfill_graphiti_episode_ids as script
+
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=2)
+    conn.execute = AsyncMock(return_value="UPDATE 2")
+
+    with patch(
+        "scripts.backfill_graphiti_episode_ids.tenant_scoped_connection",
+        return_value=_connection_context(conn),
+    ):
+        result = await script.run("org-1", dry_run=False)
+
+    assert result == 0
+    sql = conn.execute.await_args.args[0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_build_array" in sql
+    assert "no-chunks" in sql
+    assert "NOT (extra::jsonb ? 'graphiti_episode_ids')" in sql
+    assert conn.execute.await_args.args[1] == "org-1"

--- a/klai-knowledge-ingest/tests/test_episode_text.py
+++ b/klai-knowledge-ingest/tests/test_episode_text.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+import pytest
+
+from knowledge_ingest.episode_text import split_episode_text
+
+
+def test_split_episode_text_preserves_paragraph_and_sentence_boundaries():
+    text = "Alpha sentence.\n\nBravo sentence.\n\nCharlie sentence."
+
+    parts = split_episode_text(text, max_chars=34)
+
+    assert parts == ["Alpha sentence.\n\nBravo sentence.", "Charlie sentence."]
+    assert "\n\n".join(parts) == text
+    assert all(part.endswith(".") for part in parts)
+    assert all(len(part) <= 34 for part in parts)
+
+
+@pytest.mark.parametrize(
+    ("text", "max_chars", "expected_first_part"),
+    [
+        ("first\nsecond line", 10, "first"),
+        ("alpha beta gamma", 12, "alpha beta "),
+        ("x" * 25, 10, "x" * 10),
+    ],
+)
+def test_oversized_paragraph_uses_fallback_boundaries_without_dropping_text(
+    text, max_chars, expected_first_part
+):
+    with patch("knowledge_ingest.episode_text.logger", create=True) as logger:
+        parts = split_episode_text(text, max_chars=max_chars)
+
+    assert "".join(parts) == text
+    assert parts[0] == expected_first_part
+    assert all(0 < len(part) <= max_chars for part in parts)
+    logger.warning.assert_called_once()
+
+
+def test_over_cap_document_starting_with_blank_line_has_no_empty_episode():
+    text = "\n\n" + "x" * 25
+
+    parts = split_episode_text(text, max_chars=25)
+
+    assert parts
+    assert "".join(parts) == text
+    assert all(part.strip() for part in parts)

--- a/klai-knowledge-ingest/tests/test_graph.py
+++ b/klai-knowledge-ingest/tests/test_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,6 +37,88 @@ def _make_episode_result(uuid: str = "ep-001") -> MagicMock:
     result.nodes = []
     result.edges = []
     return result
+
+
+@pytest.mark.asyncio
+async def test_document_entity_graph_data_accumulates_entities_across_episode_parts():
+    graphiti = AsyncMock()
+    first = _make_episode_result("ep-1")
+    first.nodes = [SimpleNamespace(uuid="entity-1", name="Alpha")]
+    second = _make_episode_result("ep-2")
+    second.nodes = [SimpleNamespace(uuid="entity-2", name="Bravo")]
+    graphiti.add_episode = AsyncMock(side_effect=[first, second])
+    entity_data = graph_module.EntityGraphData()
+
+    with (
+        patch("knowledge_ingest.graph.settings") as mock_settings,
+        patch("knowledge_ingest.graph._get_graphiti", return_value=graphiti),
+        patch(
+            "knowledge_ingest.graph.compute_entity_pagerank",
+            new=AsyncMock(return_value={"entity-1": 0.2, "entity-2": 0.7}),
+        ),
+        patch(
+            "knowledge_ingest.graph.qdrant_store.set_entity_graph_data",
+            new=AsyncMock(return_value=None),
+        ) as set_entity_graph_data,
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graphiti_max_concurrent = 1
+        mock_settings.graphiti_episode_delay = 0
+        for body in ("Part one", "Part two"):
+            await graph_module.ingest_episode(
+                artifact_id="art-1",
+                document_text=body,
+                org_id="org-1",
+                content_type="markdown",
+                belief_time_start=1700000000,
+                entity_graph_data=entity_data,
+            )
+        await graph_module.flush_entity_graph_data("art-1", "org-1", entity_data)
+
+    assert set_entity_graph_data.await_args.kwargs["entity_uuids"] == [
+        "entity-1",
+        "entity-2",
+    ]
+    assert set_entity_graph_data.await_args.kwargs["entity_names"] == ["Alpha", "Bravo"]
+
+
+@pytest.mark.asyncio
+async def test_document_entity_graph_data_computes_pagerank_once_after_all_parts():
+    graphiti = AsyncMock()
+    first = _make_episode_result("ep-1")
+    first.nodes = [SimpleNamespace(uuid="entity-1", name="Alpha")]
+    second = _make_episode_result("ep-2")
+    second.nodes = [SimpleNamespace(uuid="entity-2", name="Bravo")]
+    graphiti.add_episode = AsyncMock(side_effect=[first, second])
+    entity_data = graph_module.EntityGraphData()
+
+    with (
+        patch("knowledge_ingest.graph.settings") as mock_settings,
+        patch("knowledge_ingest.graph._get_graphiti", return_value=graphiti),
+        patch(
+            "knowledge_ingest.graph.compute_entity_pagerank",
+            new=AsyncMock(return_value={}),
+        ) as compute_entity_pagerank,
+        patch(
+            "knowledge_ingest.graph.qdrant_store.set_entity_graph_data",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        mock_settings.graphiti_enabled = True
+        mock_settings.graphiti_max_concurrent = 1
+        mock_settings.graphiti_episode_delay = 0
+        for body in ("Part one", "Part two"):
+            await graph_module.ingest_episode(
+                artifact_id="art-1",
+                document_text=body,
+                org_id="org-1",
+                content_type="markdown",
+                belief_time_start=1700000000,
+                entity_graph_data=entity_data,
+            )
+        await graph_module.flush_entity_graph_data("art-1", "org-1", entity_data)
+
+    compute_entity_pagerank.assert_awaited_once_with("org-1")
 
 
 def test_graphiti_retry_delay_rate_limit_waits_for_minute_window():

--- a/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
 import knowledge_ingest
 from knowledge_ingest import enrichment_tasks, queues
+from knowledge_ingest.episode_text import MAX_TEXT_CHARS
+from knowledge_ingest.routes import ingest as ingest_route
 
 _ARTIFACT_ID = "0f9c1a2b-3d4e-4f50-9a61-72b83c94d5e6"
 _ORG_ID = "368884765035593759"
@@ -73,11 +75,14 @@ async def _run(graphiti_task, *, exists: bool, active: bool):
     ingest_episode = AsyncMock(return_value="episode-uuid")
     graph_module = MagicMock()
     graph_module.ingest_episode = ingest_episode
+    graph_module.EntityGraphData.return_value = SimpleNamespace()
+    graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
 
     pg_store = MagicMock()
     pg_store.artifact_exists = AsyncMock(return_value=exists)
     pg_store.artifact_is_active = AsyncMock(return_value=active)
     pg_store.update_artifact_extra = AsyncMock(return_value=None)
+    pg_store.append_graphiti_episode_id = AsyncMock(return_value=None)
 
     # The task body does `from knowledge_ingest import pg_store` / `import graph
     # as graph_module`, which reads the PACKAGE attribute -- patching
@@ -95,6 +100,46 @@ async def _run(graphiti_task, *, exists: bool, active: bool):
             belief_time_start=0,
         )
     return ingest_episode
+
+
+async def _run_active_document(
+    graphiti_task,
+    document_text: str,
+    episode_results: list[str | Exception | None],
+    expected_error: type[Exception] | None = None,
+):
+    ingest_episode = AsyncMock(side_effect=episode_results)
+    graph_module = MagicMock()
+    graph_module.ingest_episode = ingest_episode
+    graph_module.EntityGraphData.return_value = SimpleNamespace()
+    graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
+
+    pg_store = MagicMock()
+    pg_store.artifact_exists = AsyncMock(return_value=True)
+    pg_store.artifact_is_active = AsyncMock(return_value=True)
+    pg_store.update_artifact_extra = AsyncMock(return_value=None)
+    pg_store.append_graphiti_episode_id = AsyncMock(return_value=None)
+
+    with (
+        patch.object(knowledge_ingest, "pg_store", pg_store),
+        patch.object(knowledge_ingest, "graph", graph_module),
+        patch.object(enrichment_tasks, "tenant_scoped_connection", _fake_conn),
+    ):
+        kwargs = {
+            "artifact_id": _ARTIFACT_ID,
+            "document_text": document_text,
+            "org_id": _ORG_ID,
+            "content_type": "text/markdown",
+            "belief_time_start": 0,
+            "kb_slug": "support",
+            "path": "guide.md",
+        }
+        if expected_error is None:
+            await graphiti_task(**kwargs)
+        else:
+            with pytest.raises(expected_error):
+                await graphiti_task(**kwargs)
+    return ingest_episode, pg_store, graph_module
 
 
 @pytest.mark.asyncio
@@ -116,3 +161,151 @@ async def test_deleted_artifact_still_aborts(graphiti_task):
     """SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-07 must keep holding."""
     ingest_episode = await _run(graphiti_task, exists=False, active=False)
     ingest_episode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_short_document_creates_one_episode_and_records_both_id_keys(graphiti_task):
+    ingest_episode, pg_store, graph_module = await _run_active_document(
+        graphiti_task, "One short sentence.", ["episode-1"]
+    )
+
+    ingest_episode.assert_awaited_once()
+    assert ingest_episode.call_args.kwargs["document_text"] == "One short sentence."
+    pg_store.append_graphiti_episode_id.assert_awaited_once_with(ANY, _ARTIFACT_ID, "episode-1")
+    assert pg_store.update_artifact_extra.await_args_list[0].args[2] == {
+        "graphiti_episode_part_count": 1,
+        "graphiti_episode_complete": False,
+    }
+    assert pg_store.update_artifact_extra.await_args_list[-1].args[2] == {
+        "graphiti_episode_complete": True
+    }
+    graph_module.flush_entity_graph_data.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_long_document_creates_every_episode_and_records_all_ids(graphiti_task):
+    paragraph = ("A complete sentence. " * 1000).strip()
+    document_text = f"{paragraph}\n\n{paragraph}"
+    assert len(document_text) > MAX_TEXT_CHARS
+
+    ingest_episode, pg_store, graph_module = await _run_active_document(
+        graphiti_task, document_text, ["episode-1", "episode-2"]
+    )
+
+    parts = [call.kwargs["document_text"] for call in ingest_episode.await_args_list]
+    assert len(parts) == 2
+    assert "\n\n".join(parts) == document_text
+    assert all(len(part) <= MAX_TEXT_CHARS for part in parts)
+    assert all(call.kwargs["kb_slug"] == "support" for call in ingest_episode.await_args_list)
+    assert all(call.kwargs["path"] == "guide.md" for call in ingest_episode.await_args_list)
+    assert [call.args[2] for call in pg_store.append_graphiti_episode_id.await_args_list] == [
+        "episode-1",
+        "episode-2",
+    ]
+    graph_module.flush_entity_graph_data.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_records_episodes_created_before_the_error(graphiti_task):
+    paragraph = ("A complete sentence. " * 1000).strip()
+    document_text = f"{paragraph}\n\n{paragraph}"
+
+    ingest_episode, pg_store, graph_module = await _run_active_document(
+        graphiti_task,
+        document_text,
+        ["episode-1", RuntimeError("second episode failed")],
+        expected_error=RuntimeError,
+    )
+
+    assert ingest_episode.await_count == 2
+    pg_store.append_graphiti_episode_id.assert_awaited_once_with(ANY, _ARTIFACT_ID, "episode-1")
+    assert pg_store.update_artifact_extra.await_count == 1
+    graph_module.flush_entity_graph_data.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_episode_id_raises_and_reports_partial_coverage(graphiti_task):
+    paragraph = ("A complete sentence. " * 1000).strip()
+
+    with patch.object(enrichment_tasks.logger, "error") as log_error:
+        ingest_episode, _, _ = await _run_active_document(
+            graphiti_task,
+            f"{paragraph}\n\n{paragraph}",
+            ["episode-1", None],
+            expected_error=RuntimeError,
+        )
+
+    assert ingest_episode.await_count == 2
+    log_error.assert_called_once_with(
+        "graphiti_episode_partial",
+        artifact_id=_ARTIFACT_ID,
+        org_id=_ORG_ID,
+        completed_parts=1,
+        expected_parts=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deletion_between_episode_parts_aborts_before_the_next_write(graphiti_task):
+    paragraph = ("A complete sentence. " * 1000).strip()
+    ingest_episode = AsyncMock(side_effect=["episode-1", "episode-2", "episode-3"])
+    graph_module = MagicMock()
+    graph_module.ingest_episode = ingest_episode
+    graph_module.EntityGraphData.return_value = SimpleNamespace()
+    graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
+    graph_module.delete_kb_episodes = AsyncMock(return_value=None)
+    pg_store = MagicMock()
+    pg_store.artifact_exists = AsyncMock(side_effect=[True, True, True, False])
+    pg_store.artifact_is_active = AsyncMock(return_value=True)
+    pg_store.update_artifact_extra = AsyncMock(return_value=None)
+    pg_store.append_graphiti_episode_id = AsyncMock(return_value=None)
+
+    with (
+        patch.object(knowledge_ingest, "pg_store", pg_store),
+        patch.object(knowledge_ingest, "graph", graph_module),
+        patch.object(enrichment_tasks, "tenant_scoped_connection", _fake_conn),
+    ):
+        await graphiti_task(
+            artifact_id=_ARTIFACT_ID,
+            document_text=f"{paragraph}\n\n{paragraph}\n\n{paragraph}",
+            org_id=_ORG_ID,
+            content_type="text/markdown",
+            belief_time_start=0,
+            kb_slug="support",
+            path="guide.md",
+        )
+
+    assert ingest_episode.await_count == 2
+    graph_module.delete_kb_episodes.assert_awaited_once_with(_ORG_ID, ["episode-2"])
+    assert pg_store.artifact_exists.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_legacy_background_writer_records_both_id_keys():
+    conn = SimpleNamespace()
+
+    with (
+        patch.object(
+            ingest_route.graph_module,
+            "ingest_episode",
+            new=AsyncMock(return_value="episode-1"),
+        ),
+        patch.object(
+            ingest_route.pg_store,
+            "update_artifact_extra",
+            new=AsyncMock(return_value=None),
+        ) as update_extra,
+    ):
+        await ingest_route._graphiti_background(
+            conn,
+            _ARTIFACT_ID,
+            "One short sentence.",
+            _ORG_ID,
+            "text/markdown",
+            0,
+        )
+
+    assert update_extra.await_args.args[2] == {
+        "graphiti_episode_id": "episode-1",
+        "graphiti_episode_ids": ["episode-1"],
+    }

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -607,3 +607,95 @@ async def test_update_artifact_extra_merges_jsonb():
     assert patch_dict["graphiti_episode_id"] == "ep-xyz"
     # Second positional arg is the artifact_id
     assert call_args[2] == "art-001"
+
+
+@pytest.mark.asyncio
+async def test_append_graphiti_episode_id_preserves_ids_from_earlier_worker_attempts():
+    conn = _make_conn()
+
+    await pg_store.append_graphiti_episode_id(conn, "art-001", "ep-new")
+
+    sql, artifact_id, episode_id = conn.execute.call_args.args
+    assert "extra::jsonb->'graphiti_episode_ids'" in sql
+    assert "|| jsonb_build_array($2::text)" in sql
+    assert artifact_id == "art-001"
+    assert episode_id == "ep-new"
+
+
+@pytest.mark.asyncio
+async def test_document_history_reader_selects_all_episode_ids():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_id": "ep-1"}, {"episode_id": "ep-2"}])
+
+    result = await pg_store.get_episode_ids_for_document_history(conn, "org1", ["artifact-1"])
+
+    assert result == ["ep-1", "ep-2"]
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_array_elements_text" in sql
+
+
+@pytest.mark.asyncio
+async def test_kb_deletion_selects_all_episode_ids():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_id": "ep-1"}, {"episode_id": "ep-2"}])
+
+    result = await pg_store.get_episode_ids(conn, "org1", "support")
+
+    assert result == ["ep-1", "ep-2"]
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_array_elements_text" in sql
+
+
+@pytest.mark.asyncio
+async def test_connector_deletion_selects_all_episode_ids():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_id": "ep-1"}, {"episode_id": "ep-2"}])
+
+    result = await pg_store.get_connector_episode_ids(conn, "org1", "support", "connector-1")
+
+    assert result == ["ep-1", "ep-2"]
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_array_elements_text" in sql
+
+
+@pytest.mark.asyncio
+async def test_page_deletion_selects_all_episode_ids():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_id": "ep-1"}, {"episode_id": "ep-2"}])
+
+    result = await pg_store.get_page_episode_ids(conn, "org1", "support", "guide.md")
+
+    assert result == ["ep-1", "ep-2"]
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_array_elements_text" in sql
+
+
+@pytest.mark.asyncio
+async def test_page_deletion_falls_back_to_legacy_scalar_episode_id():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_id": "legacy-episode"}])
+
+    result = await pg_store.get_page_episode_ids(conn, "org1", "support", "legacy.md")
+
+    assert result == ["legacy-episode"]
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_id" in sql
+    assert "jsonb_build_array" in sql
+
+
+@pytest.mark.asyncio
+async def test_org_orphan_sweep_keeps_all_referenced_episode_ids():
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[{"episode_uuid": "ep-1"}, {"episode_uuid": "ep-2"}])
+
+    result = await pg_store.get_alive_episode_uuids_for_org(conn, "org1")
+
+    assert result == {"ep-1", "ep-2"}
+    sql = conn.fetch.call_args[0][0]
+    assert "graphiti_episode_ids" in sql
+    assert "jsonb_array_elements_text" in sql
+    assert "jsonb_build_array" in sql


### PR DESCRIPTION
Closes #1176. Item 7 of the extraction-quality sweep (#1148). Reopened from #1180, which GitHub never created a workflow run for.

Episode text is capped and everything past the cap was dropped. One Voys artifact is 464k characters, so a cap alone silently loses most of the longest — and often richest — documents. Splitting them needs one artifact to own several episodes, which was blocked by `extra` recording a single `graphiti_episode_id` that **eight call sites read, four of them deletion paths** that use it to remove episodes from FalkorDB.

`graphiti_episode_ids` (a list) now sits alongside the scalar, which stays populated with `ids[0]` so any reader not yet updated — and a mid-deploy rollback — behaves exactly as before. Every reader prefers the list and falls back to `jsonb_build_array(scalar)` for pre-change rows.

## The retention case is the one that mattered

A document is now written across N sequential LLM extractions, so the window in which a page can be deleted mid-run is N times longer. Guards run **before each part and after each write**: if the artifact vanished or was superseded while a part was being extracted, the episode just created is deleted again.

The reviewer worked the orderings and could not construct a surviving episode, including the nastiest — a deleter reading `extra` in the gap between the FalkorDB write and the append, so it never sees the new uuid. The post-write check catches that one.

## Partial runs are visible, not silent

`graphiti_episode_part_count` is written up front with `complete: False`; `True` only after every part lands. A failed part raises and logs completed/expected instead of vanishing from the list. That restores the guarantee `test_truncation_is_reported` carried before this change, which round one had deleted.

## Entity data no longer overwritten per part

Writing per part replaced the artifact's whole Qdrant entity payload each time, so a 3-part document ended up carrying only part 3's entities — the same "only the last portion counts" defect this change exists to remove, relocated from FalkorDB into Qdrant. Now accumulated and flushed once. PageRank, a full-graph computation per tenant, runs once per document instead of once per part.

## Review

Written by a Codex agent, reviewed twice by a Claude agent.

**Round one was rejected.** The splitter raised `ValueError` on a paragraph over the cap, unguarded inside a task with three retries — so a transcript without blank lines got **zero** episodes where it previously got one, reachable straight from API input. Eight defects, five high, including the retention gap.

**Round two:** all eight verified fixed. The splitter falls back paragraph → line → whitespace → hard cut, and was fuzzed over 200,000 random inputs with no exception, no text loss, no oversized part, no empty part.

Two residuals below the fix-now bar, reported rather than fixed:
- a whitespace-only trailing part is still reachable for a document ending in a blank line — one wasted extraction, no data effect
- `pg_store.artifact_exists` swallows exceptions, which in its new post-write position could delete a legitimately created episode on a transient DB error

Tests: 1600 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)