### PR TITLE
fix(rag): make the graph backfill name its tenant instead of guessing one

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -1,8 +1,14 @@
 """Graphiti backfill: ingest existing artifacts into the knowledge graph.
 
 Usage:
-    docker exec klai-core-knowledge-ingest-1 python -m knowledge_ingest.backfill
-    docker exec klai-core-knowledge-ingest-1 python -m knowledge_ingest.backfill --limit 1
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m knowledge_ingest.backfill --org-id <org_id>
+    docker exec klai-core-knowledge-ingest-1 \
+        python -m knowledge_ingest.backfill --org-id <org_id> --limit 1
+
+``--org-id`` is required. The tenant used to be read back from the artifacts
+table with a bare LIMIT 1 and no ORDER BY, which is an unordered pick from what
+is now 19 tenants.
 
 Reads artifacts from PostgreSQL, fetches chunks from Qdrant, and calls
 ingest_episode() for each text part. Resume-safe: prefers graphiti_episode_ids
@@ -63,19 +69,28 @@ def _has_graphiti_episode_record(raw_extra: str | dict | None) -> bool:
     return bool(extra.get("graphiti_episode_id"))
 
 
-async def main(limit: int | None = None) -> None:
+async def main(org_id: str, limit: int | None = None) -> None:
     qdrant = AsyncQdrantClient(
         url=settings.qdrant_url,
         api_key=settings.qdrant_api_key or None,
     )
 
     async with cross_org_admin_connection() as conn:
-        # ---- Discover org --------------------------------------------------
-        org = await conn.fetchrow("SELECT DISTINCT org_id FROM knowledge.artifacts LIMIT 1")
-        if not org:
-            log.error("No artifacts found — nothing to backfill")
+        # ---- Confirm the tenant exists -------------------------------------
+        # The org is an argument, never discovered. It used to be read back
+        # from the artifacts table with a bare LIMIT 1 and no ORDER BY — an
+        # unordered pick from what is now 19 tenants, so an operator running a
+        # rebuild for one customer could silently spend another customer's
+        # rate budget writing episodes into their graph. The script opens a
+        # cross_org_admin_connection precisely because it bypasses RLS, which
+        # is what made the wrong-tenant outcome reachable rather than blocked.
+        exists = await conn.fetchval(
+            "SELECT EXISTS (SELECT 1 FROM knowledge.artifacts WHERE org_id = $1)",
+            org_id,
+        )
+        if not exists:
+            log.error("No artifacts for org %s — nothing to backfill", org_id)
             return
-        org_id = str(org["org_id"])
         log.info("Org: %s", org_id)
 
         # ---- Get artifacts -------------------------------------------------
@@ -280,6 +295,12 @@ async def main(limit: int | None = None) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Graphiti backfill")
+    parser.add_argument(
+        "--org-id",
+        required=True,
+        help="Zitadel org id to backfill. Required: this script bypasses RLS, "
+        "so a wrong or missing tenant writes into someone else's graph.",
+    )
     parser.add_argument("--limit", type=int, default=None, help="Process at most N artifacts")
     args = parser.parse_args()
-    asyncio.run(main(limit=args.limit))
+    asyncio.run(main(org_id=args.org_id, limit=args.limit))

--- a/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
@@ -50,6 +50,7 @@ def test_incomplete_episode_list_is_retried_until_expected_part_count_lands():
 async def test_resume_prefers_episode_ids_list_without_reprocessing():
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value={"org_id": "org-1"})
+    conn.fetchval = AsyncMock(return_value=True)
     conn.fetch = AsyncMock(
         return_value=[
             {
@@ -72,7 +73,7 @@ async def test_resume_prefers_episode_ids_list_without_reprocessing():
         patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=ctx),
         patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
     ):
-        await backfill.main()
+        await backfill.main(org_id="org-1")
 
     qdrant.scroll.assert_not_awaited()
 
@@ -83,6 +84,7 @@ async def test_backfill_creates_and_records_every_episode_for_a_long_document():
     document_text = f"{paragraph}\n\n{paragraph}"
     conn = AsyncMock()
     conn.fetchrow = AsyncMock(return_value={"org_id": "org-1"})
+    conn.fetchval = AsyncMock(return_value=True)
     conn.fetch = AsyncMock(
         return_value=[
             {
@@ -112,7 +114,7 @@ async def test_backfill_creates_and_records_every_episode_for_a_long_document():
         patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
         patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
     ):
-        await backfill.main()
+        await backfill.main(org_id="org-1")
 
     parts = [call.kwargs["document_text"] for call in ingest_episode.await_args_list]
     assert len(parts) == 2

--- a/klai-knowledge-ingest/tests/test_backfill_requires_explicit_tenant.py
+++ b/klai-knowledge-ingest/tests/test_backfill_requires_explicit_tenant.py
@@ -1,0 +1,44 @@
+"""The graph backfill must never pick its own tenant.
+
+It ran as `SELECT DISTINCT org_id FROM knowledge.artifacts LIMIT 1` — an
+unordered pick from what is now 19 tenants. The script opens a
+`cross_org_admin_connection` because it deliberately bypasses RLS, so nothing
+downstream would have caught the wrong choice: an operator rebuilding one
+customer's graph could spend another customer's share of the shared klai-fast
+rate budget writing episodes into their graph.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from knowledge_ingest import backfill
+
+
+def test_org_id_is_a_required_argument():
+    signature = inspect.signature(backfill.main)
+    assert "org_id" in signature.parameters, "the tenant is discovered, not given"
+    assert signature.parameters["org_id"].default is inspect.Parameter.empty, (
+        "org_id has a default -- a missing --org-id would silently pick a tenant"
+    )
+
+
+def test_the_tenant_is_never_discovered():
+    source = inspect.getsource(backfill)
+    assert "SELECT DISTINCT org_id" not in source, (
+        "the tenant is still being discovered from the table"
+    )
+
+
+def test_the_cli_refuses_to_run_without_a_tenant():
+    """argparse must reject a bare invocation rather than defaulting."""
+    source = inspect.getsource(backfill)
+    assert '"--org-id"' in source
+    assert "required=True" in source
+
+
+def test_a_missing_tenant_stops_before_any_work():
+    """An org with no artifacts must abort, not fall through to a scan."""
+    source = inspect.getsource(backfill.main)
+    assert "EXISTS" in source, "existence is not checked before processing"
+    assert "nothing to backfill" in source


### PR DESCRIPTION
Found while preparing the #1148 graph rebuild: there is no way to target a tenant.

`backfill.py` chose its org with `SELECT DISTINCT org_id FROM knowledge.artifacts LIMIT 1` — no `ORDER BY`, so an unordered pick from what is now **19 tenants**. The script opens a `cross_org_admin_connection` precisely because it deliberately bypasses RLS, so nothing downstream would have caught the wrong choice.

An operator rebuilding one customer's graph could have spent another customer's share of the shared `klai-fast` rate budget writing episodes into their graph. Survivable while there was effectively one tenant; not survivable now — and a rebuild is exactly when someone runs this against production.

`--org-id` is now required, the tenant is confirmed to have artifacts before any work starts, and a missing one aborts rather than falling through to a scan.

Tests: 1623 passed, 6 skipped. Four new, including one that fails if the tenant is ever discovered from the table again.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)