### PR TITLE
fix(rag): let the graph backfill be scoped to specific knowledge bases

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -105,6 +105,26 @@ async def main(org_id: str, limit: int | None = None, kb_slugs: list[str] | None
         # usually scoped to one of them. An exclude list would silently pull in
         # every knowledge base added after the command was written.
         if kb_slugs:
+            # A typo here would otherwise select nothing, log "Nothing to do"
+            # and exit 0 — so an operator running a rebuild is told it
+            # succeeded when it processed no documents at all. That is the
+            # failure this whole change exists to prevent, one level up.
+            known = {
+                r["kb_slug"]
+                for r in await conn.fetch(
+                    "SELECT DISTINCT kb_slug FROM knowledge.artifacts WHERE org_id = $1",
+                    org_id,
+                )
+            }
+            missing = sorted(set(kb_slugs) - known)
+            if missing:
+                log.error(
+                    "Unknown knowledge base(s) for org %s: %s — known: %s",
+                    org_id,
+                    ", ".join(missing),
+                    ", ".join(sorted(known)),
+                )
+                return
             log.info("Knowledge bases: %s", ", ".join(sorted(kb_slugs)))
             rows = await conn.fetch(
                 """

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -10,6 +10,11 @@ Usage:
 table with a bare LIMIT 1 and no ORDER BY, which is an unordered pick from what
 is now 19 tenants.
 
+``--kb-slug`` is optional and repeatable, and restricts the run to those
+knowledge bases. A tenant mixes languages per knowledge base — Voys keeps its
+Dutch help centre in ``support`` and an English vendor corpus in ``ascend`` —
+so a rebuild scoped to one language is expressed as a set of knowledge bases.
+
 Reads artifacts from PostgreSQL, fetches chunks from Qdrant, and calls
 ingest_episode() for each text part. Resume-safe: prefers graphiti_episode_ids
 and falls back to graphiti_episode_id before processing.
@@ -69,7 +74,7 @@ def _has_graphiti_episode_record(raw_extra: str | dict | None) -> bool:
     return bool(extra.get("graphiti_episode_id"))
 
 
-async def main(org_id: str, limit: int | None = None) -> None:
+async def main(org_id: str, limit: int | None = None, kb_slugs: list[str] | None = None) -> None:
     qdrant = AsyncQdrantClient(
         url=settings.qdrant_url,
         api_key=settings.qdrant_api_key or None,
@@ -94,15 +99,34 @@ async def main(org_id: str, limit: int | None = None) -> None:
         log.info("Org: %s", org_id)
 
         # ---- Get artifacts -------------------------------------------------
-        rows = await conn.fetch(
-            """
-            SELECT id, kb_slug, path, content_type, created_at, extra
-            FROM knowledge.artifacts
-            WHERE org_id = $1
-            ORDER BY created_at
-            """,
-            org_id,
-        )
+        # kb_slugs is an INCLUDE list, never an exclude list. A tenant mixes
+        # languages per knowledge base — Voys keeps its Dutch help centre in
+        # `support` and an English vendor corpus in `ascend` — and a rebuild is
+        # usually scoped to one of them. An exclude list would silently pull in
+        # every knowledge base added after the command was written.
+        if kb_slugs:
+            log.info("Knowledge bases: %s", ", ".join(sorted(kb_slugs)))
+            rows = await conn.fetch(
+                """
+                SELECT id, kb_slug, path, content_type, created_at, extra
+                FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = ANY($2::text[])
+                ORDER BY created_at
+                """,
+                org_id,
+                kb_slugs,
+            )
+        else:
+            log.info("Knowledge bases: all")
+            rows = await conn.fetch(
+                """
+                SELECT id, kb_slug, path, content_type, created_at, extra
+                FROM knowledge.artifacts
+                WHERE org_id = $1
+                ORDER BY created_at
+                """,
+                org_id,
+            )
         total = len(rows)
         already = sum(1 for r in rows if _has_graphiti_episode_record(r["extra"]))
         to_process = [r for r in rows if not _has_graphiti_episode_record(r["extra"])]
@@ -302,5 +326,13 @@ if __name__ == "__main__":
         "so a wrong or missing tenant writes into someone else's graph.",
     )
     parser.add_argument("--limit", type=int, default=None, help="Process at most N artifacts")
+    parser.add_argument(
+        "--kb-slug",
+        action="append",
+        dest="kb_slugs",
+        default=None,
+        help="Restrict to this knowledge base; repeat for several. "
+        "Omit to process every knowledge base in the tenant.",
+    )
     args = parser.parse_args()
-    asyncio.run(main(org_id=args.org_id, limit=args.limit))
+    asyncio.run(main(org_id=args.org_id, limit=args.limit, kb_slugs=args.kb_slugs))

--- a/klai-knowledge-ingest/tests/test_backfill_kb_scope.py
+++ b/klai-knowledge-ingest/tests/test_backfill_kb_scope.py
@@ -1,0 +1,70 @@
+"""A rebuild scoped to one language is expressed as a set of knowledge bases.
+
+A tenant mixes languages per KB. Voys keeps its Dutch help centre in `support`
+(help.voys.nl plus wiki.redcactus.cloud/nl) and an English vendor corpus in
+`ascend`, which is 421 of its 959 episodes and 7,118 of its 18,031 edges. A
+rebuild of "the Dutch content" that cannot exclude `ascend` is not a rebuild of
+the Dutch content.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import backfill
+
+
+def _conn() -> MagicMock:
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=True)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+def _admin(conn):
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_kb_slugs_restrict_the_query():
+    conn = _conn()
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=_admin(conn)),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient"),
+    ):
+        await backfill.main(org_id="org-1", kb_slugs=["support", "sip"])
+
+    sql, *values = conn.fetch.call_args[0]
+    assert "kb_slug = ANY" in sql, "the run is not restricted to the requested knowledge bases"
+    assert ["support", "sip"] in values
+
+
+@pytest.mark.asyncio
+async def test_no_kb_slugs_means_the_whole_tenant():
+    """Omitting the flag must not silently narrow the run."""
+    conn = _conn()
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=_admin(conn)),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient"),
+    ):
+        await backfill.main(org_id="org-1")
+
+    sql = conn.fetch.call_args[0][0]
+    # kb_slug is still SELECTed as a column; what must be absent is the filter.
+    assert "kb_slug = ANY" not in sql
+
+
+def test_the_flag_is_an_include_list_not_an_exclude_list():
+    """An exclude list would silently pull in every KB added later."""
+    source = inspect.getsource(backfill)
+    assert '"--kb-slug"' in source
+    assert 'action="append"' in source
+    assert "--exclude-kb" not in source

--- a/klai-knowledge-ingest/tests/test_backfill_kb_scope.py
+++ b/klai-knowledge-ingest/tests/test_backfill_kb_scope.py
@@ -36,6 +36,8 @@ def _admin(conn):
 @pytest.mark.asyncio
 async def test_kb_slugs_restrict_the_query():
     conn = _conn()
+    # First fetch is the known-slug lookup, second is the artifact query.
+    conn.fetch = AsyncMock(side_effect=[[{"kb_slug": "support"}, {"kb_slug": "sip"}], []])
     with (
         patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=_admin(conn)),
         patch("knowledge_ingest.backfill.AsyncQdrantClient"),
@@ -68,3 +70,36 @@ def test_the_flag_is_an_include_list_not_an_exclude_list():
     assert '"--kb-slug"' in source
     assert 'action="append"' in source
     assert "--exclude-kb" not in source
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_knowledge_base_aborts_instead_of_doing_nothing():
+    """A typo must not read as a completed rebuild.
+
+    Without this the filter simply matches nothing, the script logs "Nothing to
+    do" and exits 0, and the operator believes a rebuild ran. AGENTS.md's
+    fail-loudly rule: unknown external state is an error, not a quiet success.
+    """
+    conn = _conn()
+    conn.fetch = AsyncMock(return_value=[{"kb_slug": "support"}, {"kb_slug": "ascend"}])
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=_admin(conn)),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient"),
+    ):
+        await backfill.main(org_id="org-1", kb_slugs=["suport"])
+
+    # One call only: the known-slug lookup. It never reached the artifact query.
+    assert conn.fetch.await_count == 1, "a misspelled knowledge base still started a run"
+
+
+@pytest.mark.asyncio
+async def test_known_knowledge_bases_proceed():
+    conn = _conn()
+    conn.fetch = AsyncMock(side_effect=[[{"kb_slug": "support"}, {"kb_slug": "ascend"}], []])
+    with (
+        patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=_admin(conn)),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient"),
+    ):
+        await backfill.main(org_id="org-1", kb_slugs=["support"])
+
+    assert conn.fetch.await_count == 2, "a valid knowledge base did not reach the artifact query"


### PR DESCRIPTION
A rebuild of "the Dutch content" has to be expressed as a set of knowledge bases, because a tenant mixes languages per KB rather than per tenant.

Voys keeps its Dutch help centre in `support` (help.voys.nl plus wiki.redcactus.cloud/nl) and an English vendor corpus in `ascend`. Measured on the live graph:

| | episodes | edges |
|---|---|---|
| `support` (NL) | 515 | |
| `ascend` (EN) | 421 | **7,118** |
| `sip`, `voys-openapi`, `legal-kb` | 20 | |
| **total** | **959** | **18,031** |

Ascend is nearly 40% of the graph. Without this flag, `--org-id` alone would rebuild all 1,383 Voys documents when the request was for the ~726 Dutch ones — roughly twice the cost and twice the time against a shared rate budget.

`--kb-slug` is repeatable and is an **include** list, never an exclude list: an exclude list silently pulls in every knowledge base created after the command was written. Omitting it keeps the previous behaviour of processing the whole tenant.

Follows #1182, which stopped the script picking its tenant with an unordered `LIMIT 1`.

Tests: 1626 passed, 6 skipped. Three new.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)