### PR TITLE
chore(renovate): group BlockNote and ceiling eslint 10 for klai-docs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -136,6 +136,23 @@
       automerge: false,
     },
     {
+      description:
+        'BlockNote must move as one unit. The three packages re-export each \
+        other\'s types, so bumping one alone makes npm nest a SECOND copy of \
+        @blocknote/core under @blocknote/react/node_modules. TypeScript then \
+        sees two structurally identical but nominally distinct BlockNoteEditor \
+        classes and `tsc -b` fails on BlockPageEditor.tsx with TS2322 \
+        ("Property \'options\' is protected but type ... is not a class \
+        derived from ..."). That is what killed PRs #1158, #1159 and #1160 at \
+        0.54.0. Verified 2026-08-22: with all three moved to ^0.54.0 together, \
+        npm creates no nested copy and `tsc -b --force` exits 0 with no code \
+        change. Renovate has no monorepo preset for BlockNote, so the group \
+        has to be declared here.',
+      matchManagers: ['npm'],
+      matchPackageNames: ['@blocknote/**'],
+      groupName: 'BlockNote',
+    },
+    {
       description: 'Major upgrades always get human eyes',
       matchUpdateTypes: ['major'],
       automerge: false,
@@ -201,6 +218,23 @@
       matchDatasources: ['docker'],
       matchPackageNames: ['python'],
       allowedVersions: '<3.14',
+    },
+    {
+      description:
+        'eslint (klai-docs only): pinned below 10 — eslint-config-next 16.3.1 \
+        pulls in eslint-plugin-react 7.37.5, whose lib/util/version.js still \
+        calls context.getFilename(). ESLint 10 removed that method, so \
+        `eslint .` throws "contextOrFilename.getFilename is not a function" \
+        while loading the very first React rule and the quality-docs job never \
+        gets as far as linting (proven by PR #1161). 7.37.5 is the latest \
+        release, so there is nothing to bump to and nothing in klai-docs to \
+        edit around it. klai-portal/frontend is already on eslint 10 and is \
+        unaffected — it does not use eslint-config-next. \
+        Tracking: GetKlai/klai#1184',
+      matchManagers: ['npm'],
+      matchPackageNames: ['eslint'],
+      matchFileNames: ['klai-docs/package.json'],
+      allowedVersions: '<10.0.0',
     },
     {
       description:


### PR DESCRIPTION
Ten Renovate PRs were open and none of them could merge on its own. Two of the causes are config bugs; this fixes both.

## BlockNote — #1158, #1159, #1160

Renovate has no monorepo preset for BlockNote, so it opened one PR per package. `@blocknote/react` re-exports types from `@blocknote/core`, so bumping `core` alone makes npm nest a second copy of `core` under `@blocknote/react/node_modules`. TypeScript then sees two nominally distinct `BlockNoteEditor` classes and `tsc -b` fails on `BlockPageEditor.tsx`:

```
error TS2322: Type 'InlineContentSpec<...>' is not assignable to type 'InlineContentSpec<InlineContentConfig>'.
  Property 'options' is protected but type 'BlockNoteEditor<...>' is not a class derived from 'BlockNoteEditor<...>'
```

All three PRs failed exactly that way, and all three would have kept failing forever — the fix is not in our source, it is that the three packages have to move together.

Verified locally in a clean worktree: with `@blocknote/{core,mantine,react}` all at `^0.54.0`, `find node_modules -path "*@blocknote*/node_modules/@blocknote*"` is empty and `npm run i18n:compile && npx tsc -b --force` exits 0 with no source change. The lockfile also shrinks, which is the nested duplicate disappearing.

## eslint 10 — #1161

`klai-docs/eslint.config.mjs` extends `eslint-config-next`, which pulls in `eslint-plugin-react@7.37.5`, whose `lib/util/version.js` still calls the `context.getFilename()` method ESLint 10 removed:

```
TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function
```

`eslint .` throws while loading the first React rule, so `quality-docs` never gets as far as linting. 7.37.5 is the latest published release — there is nothing to bump to, and nothing in `klai-docs` to edit around it.

`klai-portal/frontend` is already on `eslint@^10.6.0` and is unaffected, because it does not use `eslint-config-next`. The ceiling is therefore scoped with `matchFileNames: ['klai-docs/package.json']` rather than applied repo-wide, so the frontend keeps getting 10.x updates.

Tracking issue for lifting it: #1184.

## Verification

- `sh scripts/test-renovate-config.sh` -> `Renovate configuration contracts: PASS`
- `npx --package renovate@44.39.2 renovate-config-validator` -> `Config validated successfully against 1 file(s)`

Once this lands, Renovate autocloses #1158-#1161 on its next run and opens a single grouped `BlockNote` PR that can pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)