### PR TITLE
fix(rag): name the meta-fact shapes the prompt was still letting through

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -96,18 +96,30 @@ wiki pages, meeting notes), not chat messages. One extra rule applies.
    product, a person, an organisation, a procedure, a setting. A statement
    whose subject is the document, page, section, chapter, manual, index,
    table of contents, heading or layout is NOT a fact; skip it entirely
-   rather than rephrasing it.
+   rather than rephrasing it. This includes a document, manual or article
+   being titled, named, called or having a subject; a manual describing or
+   explaining a topic; and something falling under a section or category of
+   the documentation.
    - BAD: "De paginamap identificeert de Voys-app als een applicatie"
      (subject is the page map, not the Voys app)
    - BAD: "De Webphone is een applicatie met een handleiding voor klanten"
      (the existence of a manual is a property of the documentation)
    - BAD: "This section explains how to configure call forwarding"
+   - BAD: "Een van de documentatieartikelen voor Freedom is \
+getiteld 'Freedom: Het Dashboard'." (subject is the documentation article)
+   - BAD: "De handleiding 'Wachtrijstatistieken' beschrijft statistieken over \
+wachtrijen binnen Freedom." (subject is the manual)
+   - BAD: "Het onderwerp van de handleiding 'Statistieken' zijn statistische \
+overzichten in Freedom." (subject is the manual)
+   - BAD: "VoIP-bureautelefoons vallen onder de apparatuursectie in de \
+Voys-documentatie." (relation is to a documentation section)
    - GOOD: "De Voys-app gebruikt de internetverbinding van de smartphone
      voor gesprekken"
    - GOOD: "Call forwarding is configured from the Freedom web interface"
    Rewrite where a real fact hides inside a meta-statement: from "De
    paginamap identificeert de Voys-app als een applicatie die op mobiel
-   werkt", extract "De Voys-app werkt op mobiel".
+   werkt", extract "De Voys-app werkt op mobiel". If no world-fact remains,
+   drop the statement.
 
 Language is NOT covered here. It is set once, for every LLM call graphiti
 makes, by ``_LANGUAGE_POLICY`` below — stating it in two places invites the

--- a/klai-knowledge-ingest/scripts/probe_extraction_prompt.py
+++ b/klai-knowledge-ingest/scripts/probe_extraction_prompt.py
@@ -1,0 +1,230 @@
+"""Replay stored documents through Graphiti to measure the extraction prompt.
+
+Usage:
+    python -m scripts.probe_extraction_prompt \
+        --source-org-id <org_id> \
+        --kb-slug <kb_slug> \
+        --limit 5 \
+        --scratch-org-id zz-prompt-validation-<name>
+
+The source tenant is read-only: text comes from ``artifacts.extra.document_text``
+and is never crawled again. The scratch graph is always deleted after the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import time
+from collections import Counter
+from collections.abc import Sequence
+from typing import Any
+
+from knowledge_ingest import graph as graph_module
+from knowledge_ingest.config import settings
+from knowledge_ingest.db import cross_org_admin_connection
+from knowledge_ingest.enrichment_policy import graph_episode_skip_reason
+from knowledge_ingest.episode_text import split_episode_text
+from knowledge_ingest.graph import EntityGraphData, ingest_episode
+
+SCRATCH_PREFIX = "zz-prompt-validation-"
+META_MARKERS = (
+    "handleiding",
+    "documentatie",
+    "documentatieartikel",
+    "getiteld",
+    "paginamap",
+    "sectie",
+)
+LANGUAGE_MARKERS = (" the ", " is used ", " de ")
+
+
+def _validate_scratch_prefix(scratch_org_id: str) -> None:
+    if not scratch_org_id.startswith(SCRATCH_PREFIX):
+        raise ValueError(f"--scratch-org-id must begin with {SCRATCH_PREFIX!r}")
+
+
+def validate_probe_ids(source_org_id: str, scratch_org_id: str) -> None:
+    _validate_scratch_prefix(scratch_org_id)
+    if scratch_org_id == source_org_id:
+        raise ValueError("--scratch-org-id and --source-org-id must differ")
+
+
+def _open_graph(org_id: str):
+    from falkordb import FalkorDB as FalkorDBClient
+
+    client = FalkorDBClient(host=settings.falkordb_host, port=settings.falkordb_port)
+    return client.select_graph(org_id)
+
+
+def count_graph_nodes(org_id: str) -> int:
+    graph = _open_graph(org_id)
+    result = graph.query(
+        "MATCH (n) WHERE n.group_id = $org_id RETURN count(n) AS remaining",
+        params={"org_id": org_id},
+    )
+    if not result.result_set:
+        return 0
+    return int(result.result_set[0][0] or 0)
+
+
+def delete_scratch_graph(scratch_org_id: str) -> int:
+    # Re-check at the destructive boundary; callers cannot validate one value
+    # and accidentally pass another value to the wipe.
+    _validate_scratch_prefix(scratch_org_id)
+    deleted = graph_module.wipe_org_graph(scratch_org_id)
+    remaining = count_graph_nodes(scratch_org_id)
+    if remaining:
+        raise RuntimeError(
+            f"Scratch graph {scratch_org_id!r} still contains {remaining} node(s) after deletion"
+        )
+    return deleted
+
+
+async def load_documents(
+    source_org_id: str,
+    kb_slugs: Sequence[str],
+    limit: int,
+) -> list[dict[str, Any]]:
+    async with cross_org_admin_connection() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, kb_slug, path, content_type, created_at,
+                   extra ->> 'document_text' AS document_text
+            FROM knowledge.artifacts
+            WHERE org_id = $1
+              AND kb_slug = ANY($2::text[])
+              AND COALESCE(extra ->> 'document_text', '') <> ''
+            ORDER BY created_at, id
+            LIMIT $3
+            """,
+            source_org_id,
+            list(kb_slugs),
+            limit,
+        )
+    return [dict(row) for row in rows]
+
+
+async def replay_documents(
+    documents: Sequence[dict[str, Any]],
+    scratch_org_id: str,
+) -> tuple[int, Counter[str]]:
+    replayed = 0
+    skipped: Counter[str] = Counter()
+    for row in documents:
+        document_text = str(row["document_text"])
+        skip_reason = graph_episode_skip_reason(document_text)
+        if skip_reason:
+            skipped[skip_reason] += 1
+            continue
+
+        entity_graph_data = EntityGraphData()
+        for episode_text in split_episode_text(document_text):
+            episode_id = await ingest_episode(
+                artifact_id=str(row["id"]),
+                document_text=episode_text,
+                org_id=scratch_org_id,
+                content_type=row["content_type"] or "text",
+                belief_time_start=row["created_at"] or int(time.time()),
+                kb_slug=row["kb_slug"] or "",
+                path=row["path"] or "",
+                entity_graph_data=entity_graph_data,
+            )
+            if episode_id is None:
+                raise RuntimeError(f"Graph extraction failed for artifact {row['id']}")
+        replayed += 1
+    return replayed, skipped
+
+
+def read_graph_facts(scratch_org_id: str) -> list[str]:
+    graph = _open_graph(scratch_org_id)
+    result = graph.query(
+        "MATCH (:Entity)-[r:RELATES_TO]->(:Entity) "
+        "WHERE r.group_id = $org_id RETURN r.fact AS fact",
+        params={"org_id": scratch_org_id},
+    )
+    return [str(row[0]) for row in result.result_set if row and row[0]]
+
+
+def _marker_count(facts: Sequence[str], marker: str) -> int:
+    return sum(marker in f" {fact.lower()} " for fact in facts)
+
+
+def print_summary(
+    facts: Sequence[str],
+    selected_documents: int,
+    replayed_documents: int,
+    skipped: Counter[str],
+) -> None:
+    unique_facts = len(set(facts))
+    rows: list[tuple[str, str, int]] = [
+        ("documents", "selected", selected_documents),
+        ("documents", "replayed", replayed_documents),
+        ("documents", "skipped", sum(skipped.values())),
+        *(("skip reason", reason, count) for reason, count in sorted(skipped.items())),
+        ("facts", "total", len(facts)),
+        ("facts", "unique", unique_facts),
+        ("facts", "duplicates", len(facts) - unique_facts),
+        *(
+            ("meta facts containing marker", marker, _marker_count(facts, marker))
+            for marker in META_MARKERS
+        ),
+        *(
+            ("language facts containing marker", repr(marker), _marker_count(facts, marker))
+            for marker in LANGUAGE_MARKERS
+        ),
+    ]
+    category_width = max(len("category"), *(len(category) for category, _, _ in rows))
+    metric_width = max(len("metric"), *(len(metric) for _, metric, _ in rows))
+    print(f"{'category':<{category_width}}  {'metric':<{metric_width}}  count")
+    print(f"{'-' * category_width}  {'-' * metric_width}  -----")
+    for category, metric, count in rows:
+        print(f"{category:<{category_width}}  {metric:<{metric_width}}  {count}")
+
+
+async def run(
+    source_org_id: str,
+    kb_slugs: Sequence[str],
+    limit: int,
+    scratch_org_id: str,
+) -> int:
+    validate_probe_ids(source_org_id, scratch_org_id)
+    if limit <= 0:
+        raise ValueError("--limit must be positive")
+    if not kb_slugs:
+        raise ValueError("At least one --kb-slug is required")
+
+    try:
+        if not settings.graphiti_enabled:
+            raise RuntimeError("Graphiti is disabled; extraction cannot be measured")
+        documents = await load_documents(source_org_id, kb_slugs, limit)
+        if not documents:
+            raise RuntimeError("No stored document_text found for the requested source and KBs")
+        replayed, skipped = await replay_documents(documents, scratch_org_id)
+        facts = await asyncio.to_thread(read_graph_facts, scratch_org_id)
+        print_summary(facts, len(documents), replayed, skipped)
+        return 0
+    finally:
+        try:
+            deleted = await asyncio.to_thread(delete_scratch_graph, scratch_org_id)
+            print(
+                f"Deleted scratch graph {scratch_org_id!r} ({deleted} node(s)); verification passed"
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cleanup failed: scratch graph {scratch_org_id!r} may have been left behind"
+            ) from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-org-id", required=True)
+    parser.add_argument("--kb-slug", action="append", required=True, dest="kb_slugs")
+    parser.add_argument("--limit", type=int, default=5)
+    parser.add_argument("--scratch-org-id", required=True)
+    args = parser.parse_args()
+    return asyncio.run(run(args.source_org_id, args.kb_slugs, args.limit, args.scratch_org_id))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/klai-knowledge-ingest/tests/test_graph.py
+++ b/klai-knowledge-ingest/tests/test_graph.py
@@ -290,6 +290,10 @@ def test_extraction_instructions_ban_document_meta():
     assert "table of contents" in lowered
     # The observed production string is kept as the worked example.
     assert "De paginamap identificeert de Voys-app" in instructions
+    assert "documentatieartikelen" in lowered and "getiteld" in lowered
+    assert "handleiding 'wachtrijstatistieken'" in lowered and "beschrijft" in lowered
+    assert "onderwerp van de handleiding 'statistieken'" in lowered
+    assert "vallen onder de apparatuursectie" in lowered
     # Language must NOT be restated here; two copies drift.
     assert "language of the source text" not in lowered
     assert "_LANGUAGE_POLICY" in instructions

--- a/klai-knowledge-ingest/tests/test_probe_extraction_prompt.py
+++ b/klai-knowledge-ingest/tests/test_probe_extraction_prompt.py
@@ -1,0 +1,89 @@
+from unittest.mock import patch
+
+import pytest
+
+from scripts import probe_extraction_prompt as probe
+
+
+def test_marker_count_counts_baseline_facts_containing_each_marker():
+    facts = [
+        "Een van de documentatieartikelen voor Freedom is getiteld 'Freedom: Het Dashboard'.",
+        "De handleiding 'Wachtrijstatistieken' beschrijft statistieken over "
+        "wachtrijen binnen Freedom.",
+        "Het onderwerp van de handleiding 'Statistieken' zijn statistische overzichten in Freedom.",
+        "VoIP-bureautelefoons vallen onder de apparatuursectie in de Voys-documentatie.",
+    ]
+
+    assert probe._marker_count(facts, "documentatieartikel") == 1
+    assert probe._marker_count(facts, "sectie") == 1
+    assert probe._marker_count(facts, "documentatie") == 2
+    assert probe._marker_count(facts, "handleiding") == 2
+    assert probe._marker_count(facts, " de ") == 4
+
+
+def test_marker_count_counts_one_fact_with_marker_at_start_and_end_once():
+    assert probe._marker_count(["De instructie eindigt met de"], " de ") == 1
+
+
+def test_probe_requires_validation_scratch_prefix():
+    with pytest.raises(ValueError, match="zz-prompt-validation-"):
+        probe.validate_probe_ids("source-org", "scratch-org")
+
+
+def test_probe_refuses_to_replay_into_source_graph():
+    org_id = "zz-prompt-validation-same"
+
+    with pytest.raises(ValueError, match="must differ"):
+        probe.validate_probe_ids(org_id, org_id)
+
+
+def test_delete_rechecks_validation_scratch_prefix():
+    with (
+        patch.object(probe.graph_module, "wipe_org_graph") as wipe,
+        pytest.raises(ValueError, match="zz-prompt-validation-"),
+    ):
+        probe.delete_scratch_graph("customer-org")
+
+    wipe.assert_not_called()
+
+
+def test_delete_targets_and_verifies_only_the_scratch_graph():
+    scratch_org_id = "zz-prompt-validation-1148"
+
+    with (
+        patch.object(probe.graph_module, "wipe_org_graph", return_value=7) as wipe,
+        patch.object(probe, "count_graph_nodes", return_value=0) as count_nodes,
+    ):
+        deleted = probe.delete_scratch_graph(scratch_org_id)
+
+    assert deleted == 7
+    wipe.assert_called_once_with(scratch_org_id)
+    count_nodes.assert_called_once_with(scratch_org_id)
+
+
+@pytest.mark.asyncio
+async def test_probe_failure_still_deletes_the_scratch_graph():
+    scratch_org_id = "zz-prompt-validation-mid-run"
+
+    with (
+        patch.object(probe.settings, "graphiti_enabled", True),
+        patch.object(probe, "load_documents", side_effect=RuntimeError("probe failed")),
+        patch.object(probe, "delete_scratch_graph", return_value=0) as delete,
+        pytest.raises(RuntimeError, match="probe failed"),
+    ):
+        await probe.run("source-org", ["support"], 5, scratch_org_id)
+
+    delete.assert_called_once_with(scratch_org_id)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_names_the_scratch_graph_left_behind():
+    scratch_org_id = "zz-prompt-validation-cleanup-failure"
+
+    with (
+        patch.object(probe.settings, "graphiti_enabled", True),
+        patch.object(probe, "load_documents", side_effect=RuntimeError("probe failed")),
+        patch.object(probe, "delete_scratch_graph", side_effect=RuntimeError("delete failed")),
+        pytest.raises(RuntimeError, match=rf"{scratch_org_id!s}.*left behind"),
+    ):
+        await probe.run("source-org", ["support"], 5, scratch_org_id)


### PR DESCRIPTION
Follow-up on GetKlai/klai#1148, step 1 of the order that issue's last comment recommended: strengthen the rule, then re-measure, and only then decide anything about the ~18k edges already in the Voys graph.

## Why

Rule 1 shipped in `59f994890` and was then validated offline against five real Dutch `help.voys.nl` documents. Rule 2 (source language) came back clean — zero English facts from Dutch sources, against ~42% in the stored graph. Rule 1 did not: roughly 20–25 of 78 facts were still statements whose subject is the document.

The rule's BAD examples covered "X identifies Y" and "This section explains …". The measured failures were four different shapes it never named:

- `Een van de documentatieartikelen voor Freedom is getiteld 'Freedom: Het Dashboard'.`
- `De handleiding 'Wachtrijstatistieken' beschrijft statistieken over wachtrijen binnen Freedom.`
- `Het onderwerp van de handleiding 'Statistieken' zijn statistische overzichten in Freedom.`
- `VoIP-bureautelefoons vallen onder de apparatuursectie in de Voys-documentatie.`

## What changed

**`graph.py`** — rule 1 now names those shapes in prose (a document/manual/article being titled, named or having a subject; a manual describing or explaining a topic; something falling under a section of the documentation) and carries all four as verbatim BAD examples. The worked rewrite stays the `paginamap` one, deliberately: it lifts a clause already present in the source, where deriving "Freedom bevat statistieken over wachtrijen" from "the manual describes queue statistics" would teach the model to invent capability facts out of a table of contents.

**`scripts/probe_extraction_prompt.py`** (new) — #1148 said the probe was worth committing if we iterated on the prompt more than once. We now are. It pulls `document_text` from `knowledge.artifacts.extra` (no re-crawl), applies the same `graph_episode_skip_reason` gate the live path applies — so an index page inflating the numbers, as it did in the first probe, becomes a visible skip rather than a silent 25% — replays into a scratch tenant, prints the counts, and deletes the scratch graph.

Markers count **facts containing** the marker as a substring, matching what the #1148 baseline counted. The first draft used a word-boundary regex, which scores `documentatieartikelen` (plural) and `apparatuursectie` (compound) as zero — the next run would have reported a clean sweep of precisely the two shapes this PR adds.

Destructive by construction, so fail-closed: `--scratch-org-id` must carry the `zz-prompt-validation-` prefix, is re-checked immediately before the wipe, must differ from `--source-org-id`, and a cleanup that cannot verify the graph is empty names what it left behind instead of exiting 0. Each tenant is its own FalkorDB graph and `wipe_org_graph` filters on `group_id` as well, so the delete is scoped twice over.

## What this does NOT do

- It does not claim the meta-fact rate improved. That needs a probe run against `klai-fast`, which is the next step, not this PR.
- It does not heal the existing edges. `backfill.py` is still resume-only and skips any artifact that already carries an episode id; a re-extraction pipeline does not exist and is not built here.

## Verification

- `ruff check .` · `ruff format --check .` — clean
- `pytest` full knowledge-ingest suite — 1636 passed, 6 skipped
- New tests pin all four failure shapes in the prompt, the marker semantics against the baseline facts, and the three fail-closed guards on the delete path

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)