### PR TITLE
fix(renovate): remove the concurrent PR limit that deadlocked the queue

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -49,8 +49,14 @@
   // config reason nobody had diagnosed yet; one eslint PR could never go green.
   // Ten unmergeable PRs, ten of ten slots, and a debug run saying it plainly:
   //
-  //   Open PR Count: 10, Existing Branch Count: 10
+  //   Open PR Count: 10, Existing Branch Count: 10, Hourly PR Count: 0
+  //   Calculated lowest branchConcurrentLimit among the upgrades present in
+  //     this branch is 10.
   //   Reached branch limit - skipping branch creation
+  //
+  // Note the middle line: what blocks creation is branchConcurrentLimit, which
+  // is null by default and inherits prConcurrentLimit. Setting the latter to 0
+  // is therefore what lifts the former; there is no second knob to turn.
   //
   // Nothing new could be opened at all. Lock file maintenance — the thing added
   // specifically because transitive pins had rotted for 28 weeks — was among

--- a/renovate.json5
+++ b/renovate.json5
@@ -43,6 +43,32 @@
   // weekly.
   platformAutomerge: false,
 
+  // Renovate's default prConcurrentLimit is 10, and on 2026-08-22 that default
+  // deadlocked the whole queue. Majors are automerge: false by policy, so six
+  // of them sat open waiting for review; three BlockNote PRs were failing for a
+  // config reason nobody had diagnosed yet; one eslint PR could never go green.
+  // Ten unmergeable PRs, ten of ten slots, and a debug run saying it plainly:
+  //
+  //   Open PR Count: 10, Existing Branch Count: 10
+  //   Reached branch limit - skipping branch creation
+  //
+  // Nothing new could be opened at all. Lock file maintenance — the thing added
+  // specifically because transitive pins had rotted for 28 weeks — was among
+  // the updates that could not get a branch. The failure mode is the same one
+  // this file keeps rediscovering: Renovate runs, reports success, and silently
+  // does nothing.
+  //
+  // The limit is the wrong tool here. It exists to stop a first run on a stale
+  // repo from opening fifty PRs at once, but prHourlyLimit (default 2) already
+  // paces that — at two per hour a backlog drains gradually no matter how large
+  // it is. What prConcurrentLimit adds on top is a hard ceiling that anything
+  // needing human review can permanently occupy, and reviewable-but-unreviewed
+  // is the normal state of a major upgrade, not an exception.
+  //
+  // 0 means unlimited. Keep prHourlyLimit at its default; it is what actually
+  // protects against a flood, and removing both at once WOULD be reckless.
+  prConcurrentLimit: 0,
+
   // Mirrors min-release-age=7 in klai-portal/frontend/.npmrc. Without it
   // Renovate would propose a version the npm CLI then refuses to install while
   // generating the lockfile, producing a PR that cannot build. Keep the two

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -70,6 +70,16 @@ if [ "$rebase_when_conflicted_count" -ne 2 ]; then
   exit 1
 fi
 
+# Renovate defaults prConcurrentLimit to 10. On 2026-08-22 ten unmergeable PRs
+# filled every slot and Renovate stopped opening branches entirely — including
+# the lock file refresh that exists precisely because silence had gone unnoticed
+# for 28 weeks before. Deleting this line restores that default, and the symptom
+# is a Renovate run that succeeds while doing nothing. prHourlyLimit stays at its
+# default and is what actually paces a large backlog.
+assert_line "$config" \
+  '  prConcurrentLimit: 0,' \
+  'the concurrent PR limit must stay unlimited, or PRs awaiting review can starve the queue'
+
 # Main requires a GitHub Actions check named `quality`. Since #1113 that context
 # comes from ONE unfiltered workflow: quality.yml runs on every PR, selects the
 # affected reusable workflows, and aggregates their results. It replaced the


### PR DESCRIPTION
## What happened

Renovate's default `prConcurrentLimit` is 10. Yesterday that default stopped the dependency queue dead.

Ten PRs were open and none of them could merge:

- six majors awaiting review — `automerge: false` for majors is deliberate policy, so this is their *normal* state
- three BlockNote PRs failing on a config bug (fixed in #1185)
- one eslint PR that could never go green (ceilinged in #1185, tracked in #1184)

Ten unmergeable PRs, ten of ten slots. A `LOG_LEVEL=debug` run said it in one line:

```
Open PR Count: 10, Existing Branch Count: 10, Hourly PR Count: 0
Calculated lowest branchConcurrentLimit among the upgrades present in this branch is 10.
Reached branch limit - skipping branch creation
```

Nothing new could be opened at all. Among the updates that could not get a branch was `lock-file-maintenance` — the one added specifically because transitive pins had rotted unnoticed for 28 weeks. Same failure mode as that outage, one layer up: Renovate runs, reports success, does nothing.

## Why removing it rather than raising it

`prConcurrentLimit` guards against a first run on a stale repo opening fifty PRs at once. But `prHourlyLimit` (default 2, untouched here) already paces that — two per hour drains any backlog gradually, however large.

What `prConcurrentLimit` adds on top is a hard ceiling that anything awaiting human review can occupy indefinitely. Since awaiting-review is the normal state of a major upgrade rather than an exception, the ceiling is guaranteed to be reachable through ordinary use. Raising it to 20 buys time; it does not change that.

So the ceiling goes and the pacing stays. Removing both would be reckless, and the comment in the file says so.

## Guard

`scripts/test-renovate-config.sh` gains an assertion pinning `prConcurrentLimit: 0`. Deleting the setting restores a default whose only symptom is a green Renovate run that did nothing — exactly the kind of silence this repo has now been bitten by twice.

The guard is verified to actually fail, not merely to pass while the line is present:

```
$ grep -v "^  prConcurrentLimit: 0,$" renovate.json5 > r && mv r renovate.json5
$ sh scripts/test-renovate-config.sh
FAIL: the concurrent PR limit must stay unlimited, or PRs awaiting review can starve the queue
exit=1
```

That matters here specifically: this file already carries a comment about an assertion that "silently kept passing after the job was renamed — the check survived the very rename it existed to catch".

## Verification

- `sh scripts/test-renovate-config.sh` -> PASS (and FAIL with the line removed, shown above)
- `npx --package renovate@44.39.2 renovate-config-validator` -> `Config validated successfully against 1 file(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)