### PR TITLE
fix(renovate): silence the presidio-analyzer digest warning

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -123,6 +123,23 @@
     },
     {
       description:
+        'Klai presidio-analyzer is digest-only, exactly like Klai LibreChat: \
+        the image is Klai\'s own analyzer (Dutch/credential recognizer pack \
+        layered on the digest-pinned data-privacy-stack base), built and \
+        pushed by presidio-analyzer-image-build.yml, and the pin is enforced \
+        by deploy/check-klai-presidio-digest.sh. There is no tag for Renovate \
+        to discover, which is why every run logged "Could not determine new \
+        digest for update (docker package ghcr.io/getklai/presidio-analyzer)" \
+        against deploy/docker-compose.yml — a permanent WARN that trains \
+        people to skim past Renovate warnings, which is how a real one gets \
+        missed.',
+      matchManagers: ['docker-compose'],
+      matchDatasources: ['docker'],
+      matchPackageNames: ['ghcr.io/getklai/presidio-analyzer'],
+      enabled: false,
+    },
+    {
+      description:
         'Klai crawl4ai is built and tagged directly on the deployment host; \
         there is no published GHCR package for Renovate to query.',
       matchManagers: ['docker-compose'],

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -44,6 +44,9 @@ assert_contains "$config" \
   "matchPackageNames: ['ghcr.io/getklai/crawl4ai']" \
   'the host-built crawl4ai image must not be queried as a published GHCR package'
 assert_contains "$config" \
+  "matchPackageNames: ['ghcr.io/getklai/presidio-analyzer']" \
+  'the digest-only Klai presidio-analyzer image must have an explicit Renovate policy'
+assert_contains "$config" \
   "matchPackageNames: ['aquasecurity/setup-trivy']" \
   'setup-trivy must have an IP-allowlist-safe lookup policy'
 assert_contains "$config" \


### PR DESCRIPTION
Every Renovate run has been logging this, and surfacing it on the dependency dashboard as a standing **Repository Problems → Package lookup failures** banner:

```
WARN: Package lookup failures
  "warnings": ["Could not determine new digest for update (docker package ghcr.io/getklai/presidio-analyzer)"]
  "files": ["deploy/docker-compose.yml"]
```

Nothing is broken. `ghcr.io/getklai/presidio-analyzer` is Klai's own image — the Dutch and credential recognizer pack layered onto a digest-pinned `data-privacy-stack` base — built and pushed by `.github/workflows/presidio-analyzer-image-build.yml`, with the pin enforced by `deploy/check-klai-presidio-digest.sh`. It is digest-only by design; there is no tag for Renovate to discover.

That is exactly the situation `ghcr.io/getklai/librechat` already has a rule for, with the same build-workflow shape and the same digest guard sitting next to it in `deploy/`. This gives `presidio-analyzer` the same policy.

## Why bother with a warning that breaks nothing

The cost was never the warning. It is that a warning which is *always* present teaches everyone to skim the warnings section — and the next lookup failure, a real one, then arrives into a channel nobody reads. This repo has already been bitten twice by Renovate failing quietly (the 28-week schedule no-op, and the concurrent-PR deadlock in #1194). Keeping the warning channel empty is what makes it useful.

## Scope check

`grep -ohE "ghcr\.io/getklai/[a-z0-9._-]+" deploy/docker-compose*.yml` lists fourteen own-built images, but only `librechat` and `presidio-analyzer` are digest-pinned, and only those two can produce this warning. The rest are tag-pinned and resolve normally. So this is one rule, not a category.

## Verification

- `sh scripts/test-renovate-config.sh` -> PASS, and FAIL with the rule removed:
  ```
  FAIL: the digest-only Klai presidio-analyzer image must have an explicit Renovate policy
  exit=1
  ```
- `npx --package renovate@44.39.2 renovate-config-validator` -> `Config validated successfully against 1 file(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)