### PR TITLE
fix(rag): serialise the backfill's database writes across workers

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -219,6 +219,18 @@ async def main(
         # each reads its own chunks and writes its own artifact row. Progress
         # lines interleave, which is why each still carries its own index.
         sem = asyncio.Semaphore(max(1, concurrency))
+        # One asyncpg connection, shared by every worker. asyncpg forbids
+        # concurrent operations on a connection and raises "another operation
+        # is in progress" — measured at 715 such errors within two minutes the
+        # first time this loop ran concurrently without the lock. Serialising
+        # the writes costs nothing worth measuring: they are millisecond UPDATEs
+        # against the seconds each document spends in LLM calls.
+        db_lock = asyncio.Lock()
+
+        async def _db_execute(*args: object) -> str:
+            async with db_lock:
+                return await conn.execute(*args)
+
         counts = {"ok": 0, "err": 0}
         t_start = time.time()
         total_to_process = len(to_process)
@@ -238,7 +250,7 @@ async def main(
                         total_to_process,
                         title,
                     )
-                    await conn.execute(
+                    await _db_execute(
                         "UPDATE knowledge.artifacts "
                         "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                         "WHERE id = $2::uuid",
@@ -262,7 +274,7 @@ async def main(
                 skip_reason = graph_episode_skip_reason(full_text)
                 if skip_reason:
                     log.info("[%d/%d] %s — skipped (%s)", idx, total_to_process, title, skip_reason)
-                    await conn.execute(
+                    await _db_execute(
                         "UPDATE knowledge.artifacts "
                         "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                         "WHERE id = $2::uuid",
@@ -277,7 +289,7 @@ async def main(
                 episode_ids: list[str] = []
                 entity_graph_data = EntityGraphData()
                 try:
-                    await conn.execute(
+                    await _db_execute(
                         "UPDATE knowledge.artifacts "
                         "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                         "WHERE id = $2::uuid",
@@ -312,7 +324,7 @@ async def main(
                         await flush_entity_graph_data(artifact_id, org_id, entity_graph_data)
                     except Exception:
                         log.exception("%s — entity graph data update failed", title)
-                    await conn.execute(
+                    await _db_execute(
                         "UPDATE knowledge.artifacts "
                         "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                         "WHERE id = $2::uuid",

--- a/klai-knowledge-ingest/tests/test_backfill_concurrency.py
+++ b/klai-knowledge-ingest/tests/test_backfill_concurrency.py
@@ -35,3 +35,20 @@ def test_a_zero_or_negative_concurrency_cannot_deadlock():
     """asyncio.Semaphore(0) blocks forever; the guard must floor it at 1."""
     source = inspect.getsource(backfill.main)
     assert "max(1, concurrency)" in source
+
+
+def test_database_writes_are_serialised():
+    """asyncpg forbids concurrent operations on one connection.
+
+    The loop shares a single connection across every worker. Running it
+    concurrently without a lock produced 715 "another operation is in progress"
+    errors within two minutes and completed one document out of 905.
+    """
+    source = inspect.getsource(backfill.main)
+    assert "db_lock" in source, "workers share one asyncpg connection with no lock"
+    assert "async with db_lock" in source
+    # No worker may reach the connection directly.
+    process_src = source[source.index("async def _process") : source.index("await asyncio.gather")]
+    assert "conn.execute" not in process_src, (
+        "a worker still writes to the shared connection directly"
+    )


### PR DESCRIPTION
Follow-up to #1195, found by running it.

asyncpg forbids concurrent operations on a single connection, and the loop shares one across every worker. Running the rebuild at `--concurrency 8` produced **715 "another operation is in progress" errors within two minutes** and completed **one document out of 905**.

The four per-document writes now go through an `asyncio.Lock`. That costs nothing worth measuring: they are millisecond UPDATEs against the seconds each document spends in LLM calls, which is the part that actually needed to overlap.

#1195 was tested for its loop structure — `asyncio.gather`, the semaphore, the floor at 1 — but never against a live database, which is exactly where it failed. The new test asserts no worker touches the shared connection directly.

Tests: 1640 passed, 6 skipped.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)