### PR TITLE
fix(rag): put every use of the shared connection behind the lock, not just two

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -231,6 +231,14 @@ async def main(
             async with db_lock:
                 return await conn.execute(*args)
 
+        async def _db_append_episode(artifact_id: str, episode_id: str) -> None:
+            # Every touch of the shared connection goes through the lock, not
+            # just the ones written as conn.execute. This one reaches it via a
+            # pg_store helper and was missed the first time, leaving the very
+            # bug the lock exists to prevent.
+            async with db_lock:
+                await pg_store.append_graphiti_episode_id(conn, artifact_id, episode_id)
+
         counts = {"ok": 0, "err": 0}
         t_start = time.time()
         total_to_process = len(to_process)
@@ -318,7 +326,7 @@ async def main(
                         if episode_id is None:
                             raise RuntimeError("returned None (LLM issue?)")
                         episode_ids.append(episode_id)
-                        await pg_store.append_graphiti_episode_id(conn, artifact_id, episode_id)
+                        await _db_append_episode(artifact_id, episode_id)
 
                     try:
                         await flush_entity_graph_data(artifact_id, org_id, entity_graph_data)

--- a/klai-knowledge-ingest/tests/test_backfill_concurrency.py
+++ b/klai-knowledge-ingest/tests/test_backfill_concurrency.py
@@ -52,3 +52,8 @@ def test_database_writes_are_serialised():
     assert "conn.execute" not in process_src, (
         "a worker still writes to the shared connection directly"
     )
+    # Not only the calls spelled conn.execute: a pg_store helper handed the
+    # same connection is just as unsafe, and that one was missed first time.
+    assert "(conn," not in process_src, (
+        "a worker still hands the shared connection to a helper outside the lock"
+    )


### PR DESCRIPTION
#1197 wrapped the calls spelled `conn.execute` and stopped there. `append_graphiti_episode_id` takes the same connection through a `pg_store` helper and was left outside — so the "another operation is in progress" failure the lock exists to prevent was still reachable on the one write that records an episode, which is the write deciding whether a document counts as done.

Found by the Sol review of #1195, **which I merged without running**. That same review also named the shared-connection problem itself, before any of it ran against production. Skipping the gate cost a night: the rebuild completed 5 documents out of 894 across five attempts.

The test now asserts no worker hands the connection to a helper either, rather than only checking for the literal `conn.execute`.

## Reported, not fixed

`asyncio.gather(..., return_exceptions=True)` converts a worker raising *before* the inner `try` into a result nobody inspects, so that row increments neither counter and the run can end with a summary that under-reports. Cheap to fix, but a reporting defect rather than a correctness one — below the fix-now bar, recorded here instead.

Tests: 1641 passed, 6 skipped.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)