### PR TITLE
fix(mcp): reject unsafe requests before they can consume a session

### DIFF
--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -46,7 +46,10 @@ from klai_retrieval_telemetry import (
 from log_utils import sanitize_response_body, verify_shared_secret
 from mcp.server.mcpserver import Context, MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
-from mcp.server.transport_security import TransportSecuritySettings
+from mcp.server.transport_security import (
+    TransportSecurityMiddleware,
+    TransportSecuritySettings,
+)
 
 from logging_setup import setup_logging
 from shield_compliance import check_compliance as _shield_check_compliance
@@ -824,6 +827,7 @@ _TRANSPORT_SECURITY = TransportSecuritySettings(
         "127.0.0.1:8080",
     ],
 )
+_TRANSPORT_SECURITY_VALIDATOR = TransportSecurityMiddleware(_TRANSPORT_SECURITY)
 
 mcp = MCPServer(
     "klai-knowledge",
@@ -1926,6 +1930,17 @@ class _WWWAuthenticateMiddleware(BaseHTTPMiddleware):
                         ),
                     },
                 )
+
+            # The SDK's stateful manager registers a transport before the
+            # transport applies this validator. Run the same validator at the
+            # outer boundary so rejected requests never consume a session.
+            if path.startswith("/mcp"):
+                transport_error = await _TRANSPORT_SECURITY_VALIDATOR.validate_request(
+                    request,
+                    is_post=request.method == "POST",
+                )
+                if transport_error is not None:
+                    return transport_error
 
         response: Response = await call_next(request)
         if response.status_code == 401 and "www-authenticate" not in {

--- a/klai-knowledge-mcp/tests/test_mcp_hygiene.py
+++ b/klai-knowledge-mcp/tests/test_mcp_hygiene.py
@@ -13,11 +13,24 @@ This test now enforces the new state:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
 
 MAIN_PY = Path(__file__).resolve().parents[1] / "main.py"
 DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
 CADDYFILE = Path(__file__).resolve().parents[2] / "deploy" / "caddy" / "Caddyfile"
+
+
+@pytest.fixture(scope="module")
+def mcp_client() -> Iterator[TestClient]:
+    """Start the SDK session manager once; MCP 2.0 managers cannot restart."""
+    import main
+
+    with TestClient(main.app) as client:
+        yield client
 
 
 def test_dns_rebinding_protection_is_enabled_with_anchor() -> None:
@@ -46,7 +59,9 @@ def test_dns_rebinding_protection_is_enabled_with_anchor() -> None:
     assert "spec-mcp-auth-001" in reason_text, "@MX:REASON must reference SPEC-MCP-AUTH-001"
 
 
-def test_dns_rebinding_protection_actually_rejects_a_foreign_host() -> None:
+def test_dns_rebinding_protection_actually_rejects_a_foreign_host(
+    mcp_client: TestClient,
+) -> None:
     """SPEC-MCP-AUTH-001 REQ-A6 — the settings are WIRED UP, not merely written down.
 
     The test above greps main.py for ``enable_dns_rebinding_protection=True``.
@@ -68,10 +83,6 @@ def test_dns_rebinding_protection_actually_rejects_a_foreign_host() -> None:
     for the allowed case would also accept a 404 or a 500 from an app that no
     longer serves /mcp at all.
     """
-    from starlette.testclient import TestClient
-
-    import main
-
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
@@ -79,22 +90,64 @@ def test_dns_rebinding_protection_actually_rejects_a_foreign_host() -> None:
     }
     body = {"jsonrpc": "2.0", "id": 1, "method": "ping"}
 
-    with TestClient(main.app) as client:
-        for allowed in ("mcp.getklai.com", "klai-knowledge-mcp:8080"):
-            response = client.post("/mcp", headers={**headers, "Host": allowed}, json=body)
-            assert response.status_code == 400, (
-                f"allow-listed Host {allowed!r} should reach the MCP transport and fail "
-                f"there on the missing session ID; got {response.status_code}. 421 means "
-                "the host gate rejected it and production traffic through Caddy and "
-                "LibreChat would both break."
-            )
+    for allowed in ("mcp.getklai.com", "klai-knowledge-mcp:8080"):
+        response = mcp_client.post("/mcp", headers={**headers, "Host": allowed}, json=body)
+        assert response.status_code == 400, (
+            f"allow-listed Host {allowed!r} should reach the MCP transport and fail "
+            f"there on the missing session ID; got {response.status_code}. 421 means "
+            "the host gate rejected it and production traffic through Caddy and "
+            "LibreChat would both break."
+        )
 
-        for foreign in ("evil.example.com", "attacker.test"):
-            response = client.post("/mcp", headers={**headers, "Host": foreign}, json=body)
-            assert response.status_code == 421, (
-                f"Host {foreign!r} should be refused with 421 Misdirected Request; got "
-                f"{response.status_code}. DNS-rebinding protection is not reaching the app."
-            )
+    for foreign in ("evil.example.com", "attacker.test"):
+        response = mcp_client.post("/mcp", headers={**headers, "Host": foreign}, json=body)
+        assert response.status_code == 421, (
+            f"Host {foreign!r} should be refused with 421 Misdirected Request; got "
+            f"{response.status_code}. DNS-rebinding protection is not reaching the app."
+        )
+
+
+def test_rejected_foreign_hosts_do_not_consume_mcp_sessions(mcp_client: TestClient) -> None:
+    """A transport-security rejection must not consume process-lifetime session capacity."""
+    import main
+
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer klai_mcp_test-token-never-verified",
+        "Host": "evil.example.com",
+    }
+    body = {"jsonrpc": "2.0", "id": 1, "method": "ping"}
+
+    session_manager = main.mcp.session_manager
+    sessions_before = len(session_manager._server_instances)
+
+    responses = [mcp_client.post("/mcp", headers=headers, json=body) for _ in range(50)]
+
+    assert {response.status_code for response in responses} == {421}
+    assert len(session_manager._server_instances) == sessions_before
+
+
+def test_rejected_foreign_origins_do_not_consume_mcp_sessions(mcp_client: TestClient) -> None:
+    """The adjacent Origin rejection must happen before session allocation too."""
+    import main
+
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer klai_mcp_test-token-never-verified",
+        "Host": "mcp.getklai.com",
+        "Origin": "https://evil.example.com",
+    }
+    body = {"jsonrpc": "2.0", "id": 1, "method": "ping"}
+
+    session_manager = main.mcp.session_manager
+    sessions_before = len(session_manager._server_instances)
+
+    response = mcp_client.post("/mcp", headers=headers, json=body)
+
+    assert response.status_code == 403
+    assert len(session_manager._server_instances) == sessions_before
 
 
 def test_caddyfile_routes_mcp_subdomain_to_knowledge_mcp() -> None:


### PR DESCRIPTION
**Partially addresses #1198 — deliberately does NOT close it.** An adversarial review after the fix showed the dominant leak vector is untouched; measured evidence below and in the issue.

Implemented by a Codex Sol agent, reviewed and independently re-verified here.

## What this does fix

`StreamableHTTPSessionManager` registers a transport **before** the transport applies the Host/Origin allowlist, and `session_idle_timeout` is `None`. So a request refused with 421 (foreign Host) or 403 (foreign Origin) had already allocated a session that lives for the process lifetime.

This runs the SDK's own `TransportSecurityMiddleware` at the outer boundary, before `call_next`, for `/mcp` only. The inner validation stays as defense in depth.

**Provably not a new rejection surface.** Both the legacy transport (`streamable_http.py:465`) and the modern path (`_streamable_http_modern.py:325`) call `validate_request(request, is_post=request.method == "POST")` — the same validator, the same settings object, the same expression used here. A 30-case A/B matrix across methods, Hosts, Origins, content types, both protocol eras and the internal-secret path returned byte-identical status and body for every case.

Four status codes change, all error→error, none a working request becoming a rejection: `POST /mcp/` 401→421, `POST /mcp/anything` 404→421, `POST /mcpfoo` 404→421, and `POST /mcp` with an unknown session ID plus a foreign Host 404→421.

That last one is a **security improvement** in its own right: the manager's unknown-session branch returns 404 *without* reaching transport security, so before this an attacker page could probe session-ID existence cross-origin with the Host gate not applying.

Scoped to `path.startswith("/mcp")`. `/.well-known/oauth-protected-resource/mcp` has a path starting with `/.well-known`, so it never enters the branch — verified 200 with an allow-listed Host, with `evil.example.com`, and with no Host at all, identical before and after.

## What this does NOT fix

The dominant vector is unauthenticated, internet-reachable, and untouched:

```
POST https://mcp.getklai.com/mcp
Host: mcp.getklai.com                  <- Caddy sets this on all public traffic
Authorization: Bearer klai_mcp_AAAA    <- prefix-only check, never verified here
{"jsonrpc":"2.0","id":1,"method":"ping"}
```

The outer auth gate passes on the prefix. The outer transport check passes, because the Host *is* the allow-listed one by definition. The manager then sees no `Mcp-Session-Id`, creates a transport, registers it, starts a serve loop — and only then does the transport return 400 "Missing session ID". Session and task are retained for the process lifetime.

Measured on this branch, post-fix: **200 requests → 200 retained sessions.** The reviewer measured 500 → +12.6 MiB, about 25.8 KB per session. Caddy's 600/min/IP means ~600 sessions and ~15 MiB per minute from a single IP, unbounded.

`origin/main` behaves identically on this vector, so this PR is a strict improvement rather than a regression — the classes it closes are a subset of what leaked before. But #1198 stays open, and the remaining work is tracked there with the two candidate fixes.

## Options rejected

**Verify the bearer token at the edge.** #1198 called this the "real" fix; it is the wrong one. Invalid tokens are not cacheable, so every junk token costs a portal-api round trip with a 2s timeout, making the MCP's availability depend on portal-api's.

**Construct the session manager directly** to reach `session_idle_timeout`. Needs private SDK interfaces and duplicates the route/auth/lifespan wiring.

**Reap the transport after rejection.** Mutating a private registry while racing the transport's own task.

## Tests

Two regression tests, each verified red before the fix and green after — reproduced independently during review by removing the fix (2 failed) and restoring it (6 passed). The Origin case was not in the issue; it leaked the same way.

Known limitation of the Origin test, carried as a backlog item: `allowed_origins` is empty, so *every* request carrying an `Origin` header gets 403, including our own. The test therefore cannot distinguish allow from deny. Measured: `https://mcp.getklai.com` → 403, `https://evil.example.com` → 403, no Origin → 400. Server-side clients send no Origin and are unaffected; browser-based MCP clients are hard-403'd today.

## Verification

`ruff check` 0, `ruff format --check` 0, `pyright` 0 errors, `pytest` 155 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)