### PR TITLE
ci(docs): verify image builds on pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,27 @@ jobs:
         run: npm run build
         working-directory: klai-docs
 
+  verify-image:
+    needs: quality-docs
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Verify Docker image builds
+        uses: docker/build-push-action@v7
+        with:
+          context: ./klai-docs
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-and-push:
     needs: quality-docs
     if: github.event_name != 'pull_request'

--- a/rules/tests/test_docs_image_pr_gate.py
+++ b/rules/tests/test_docs_image_pr_gate.py
@@ -1,0 +1,47 @@
+"""Source contracts for the pull-request docs image build gate."""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
+
+
+def _jobs() -> dict[str, object]:
+    workflow = yaml.safe_load(DOCS_WORKFLOW.read_text())
+    return workflow["jobs"]
+
+
+def _build_step(job: dict[str, object]) -> dict[str, object]:
+    return next(
+        step
+        for step in job["steps"]
+        if step.get("uses") == "docker/build-push-action@v7"
+    )
+
+
+def test_pull_requests_build_the_docs_image_without_push_permissions() -> None:
+    verify = _jobs()["verify-image"]
+
+    assert verify["needs"] == "quality-docs"
+    assert verify["if"] == "github.event_name == 'pull_request'"
+    assert verify["permissions"] == {"contents": "read"}
+    assert not any(
+        step.get("uses") == "docker/login-action@v4" for step in verify["steps"]
+    )
+
+    build = _build_step(verify)
+    assert build["with"]["context"] == "./klai-docs"
+    assert build["with"]["push"] is False
+
+
+def test_production_docs_image_and_deploy_contract_is_unchanged() -> None:
+    jobs = _jobs()
+    publish = jobs["build-and-push"]
+
+    assert publish["if"] == "github.event_name != 'pull_request'"
+    assert _build_step(publish)["with"]["push"] is True
+    assert jobs["scan"]["needs"] == "build-and-push"
+    assert jobs["deploy"]["needs"] == ["build-and-push", "scan"]


### PR DESCRIPTION
## Summary
- build the documentation container on pull requests after docs quality checks
- keep PR verification non-publishing and permission-minimal
- enforce the workflow contract with rules tests

## Verification
- rules test: 2 passed
- full rules suite: 45 passed
- actionlint: passed
- Renovate config test: passed
- local Docker build: not run because no Docker daemon was available

Closes #1201