### PR TITLE
ci(widget): enforce portal distribution contract

### DIFF
--- a/.github/workflows/portal-frontend.yml
+++ b/.github/workflows/portal-frontend.yml
@@ -6,10 +6,7 @@ on:
     branches: [main]
     paths:
       - 'klai-portal/frontend/**'
-      - 'klai-widget/src/**'
-      - 'klai-widget/package.json'
-      - 'klai-widget/package-lock.json'
-      - 'klai-widget/vite.config.ts'
+      - 'klai-widget/**'
       - '.github/workflows/portal-frontend.yml'
 jobs:
   # Split out of build-deploy on 2026-08-14 for two reasons:
@@ -79,6 +76,7 @@ jobs:
           cd klai-widget
           npm ci
           npm run build
+          npm run check-size
           mkdir -p ../klai-portal/frontend/public/widget
           cp dist/klai-chat.js ../klai-portal/frontend/public/widget/klai-chat.js
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -95,10 +95,7 @@ jobs:
               - '.github/workflows/quality.yml'
             portal_frontend:
               - 'klai-portal/frontend/**'
-              - 'klai-widget/src/**'
-              - 'klai-widget/package.json'
-              - 'klai-widget/package-lock.json'
-              - 'klai-widget/vite.config.ts'
+              - 'klai-widget/**'
               - '.github/workflows/portal-frontend.yml'
               - '.github/workflows/quality.yml'
             connector:

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -45,10 +45,10 @@ Billing (handled by Moneybird, see Stack table):
 
 ### Chat widgets
 
-Embeddable SolidJS bundle served from the portal origin (`/klai-chat.js`). One-tag embed:
+Embeddable SolidJS bundle served from the portal origin (`/widget/klai-chat.js`). One-tag embed:
 
 ```html
-<script src="https://getklai.com/klai-chat.js" data-widget-id="wgt_..."></script>
+<script src="https://my.getklai.com/widget/klai-chat.js" data-widget-id="wgt_..."></script>
 ```
 
 **Auth flow (JWT-only, no browser-visible API key):**

--- a/rules/tests/test_widget_distribution_contract.py
+++ b/rules/tests/test_widget_distribution_contract.py
@@ -1,0 +1,65 @@
+"""Source contracts for the widget bundle's portal distribution path."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PORTAL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "portal-frontend.yml"
+QUALITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "quality.yml"
+SNIPPET_SOURCE = (
+    REPO_ROOT
+    / "klai-portal"
+    / "frontend"
+    / "src"
+    / "features"
+    / "widgets"
+    / "embed"
+    / "snippet.ts"
+)
+PLATFORM_DOC = REPO_ROOT / "docs" / "architecture" / "platform.md"
+SCRIPT_URL = "https://my.getklai.com/widget/klai-chat.js"
+
+
+def _workflow(path: Path) -> dict[str, object]:
+    return yaml.load(path.read_text(), Loader=yaml.BaseLoader)
+
+
+def test_every_widget_build_input_selects_portal_quality_and_deploy() -> None:
+    portal = _workflow(PORTAL_WORKFLOW)
+    assert "klai-widget/**" in portal["on"]["push"]["paths"]
+
+    quality = _workflow(QUALITY_WORKFLOW)
+    filters_source = next(
+        step["with"]["filters"]
+        for step in quality["jobs"]["changes"]["steps"]
+        if step.get("uses") == "dorny/paths-filter@v4"
+    )
+    filters = yaml.safe_load(filters_source)
+    assert "klai-widget/**" in filters["portal_frontend"]
+
+
+def test_portal_build_verifies_and_copies_the_widget_bundle() -> None:
+    workflow = _workflow(PORTAL_WORKFLOW)
+    build = next(
+        step
+        for step in workflow["jobs"]["build-deploy"]["steps"]
+        if step.get("name") == "Build widget bundle"
+    )
+    commands = build["run"]
+
+    assert commands.index("npm run build") < commands.index("npm run check-size")
+    assert commands.index("npm run check-size") < commands.index(
+        "cp dist/klai-chat.js ../klai-portal/frontend/public/widget/klai-chat.js"
+    )
+
+
+def test_documented_and_product_snippets_use_the_served_portal_url() -> None:
+    assert SCRIPT_URL in SNIPPET_SOURCE.read_text()
+    assert SCRIPT_URL in PLATFORM_DOC.read_text()
+
+
+def test_removed_nested_widget_workflow_stays_removed() -> None:
+    assert not (
+        REPO_ROOT / "klai-widget" / ".github" / "workflows" / "release.yml"
+    ).exists()

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -138,8 +138,8 @@ assert_contains "$quality_workflow" \
   "              - 'klai-docs/**'" \
   'docs dependency updates must select the docs workflow'
 assert_contains "$quality_workflow" \
-  "              - 'klai-widget/package-lock.json'" \
-  'widget lockfile updates must select the portal-frontend workflow'
+  "              - 'klai-widget/**'" \
+  'every widget build input must select the portal-frontend workflow'
 assert_contains "$quality_workflow" \
   "              - '.github/workflows/validate-trivyignore.yml'" \
   'Trivy workflow updates must select the trivyignore validator'


### PR DESCRIPTION
## Summary
- run the widget gzip size budget before publishing the portal image
- cover every widget build input in workflow path filters
- document the canonical portal-hosted widget URL
- add regression coverage for the distribution contract

## Verification
- contract tests: 4 passed
- full rules suite: 47 passed
- actionlint: passed
- widget build and size check: 33 kB gzip, passed
- portal production build: passed
- deployed canonical bundle matched the local production bundle by SHA-256

Closes #1202