### PR TITLE
fix(rag): hold the model to graphiti's schema instead of merely showing it

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -201,6 +201,52 @@ English entity name, and that is correct.
 """
 
 
+def _install_strict_structured_output() -> None:
+    """Make graphiti ask the model to OBEY its schema, not merely to see it.
+
+    ``OpenAIGenericClient._build_response_format`` sends json_schema without
+    ``strict: true``, with the comment that strict "requires the schema to meet
+    OpenAI's strict subset ... So adherence is best-effort on OpenAI-proper;
+    constrained-decoding servers (vLLM, llama.cpp) still enforce it."
+
+    Mistral behind LiteLLM is neither of those. Without the flag it treats the
+    schema as advice and drifts once a response carries many items, which is
+    silent until pydantic rejects the result and the whole episode is lost:
+
+        extracted_entities.26.episode_indices
+          Input should be a valid list [input_value=0, input_type=int]
+        extracted_entities.15.entity_type_id
+          Field required [input_value={'entity_type_id_id': 0, ...}]
+
+    Both are the same failure — the model inventing shapes at entity 15, 26, 36
+    while the first dozen are fine. Measured on 2026-08-24 with graphiti's own
+    ``ExtractedEntities.model_json_schema()`` through this LiteLLM: without the
+    flag the #1148 rebuild lost 2 of every 4 documents; with it, 39 entities in
+    one response and none malformed.
+
+    The concern graphiti's comment raises is real but not ours to inherit: the
+    schema either satisfies the provider or the provider rejects the request
+    outright, which is loud. Best-effort adherence fails silently instead, and
+    costs the document.
+    """
+    from graphiti_core.llm_client import openai_generic_client as _ogc
+
+    client_cls = _ogc.OpenAIGenericClient
+    if getattr(client_cls, "_klai_strict_schema", False):
+        return
+    original = client_cls._build_response_format
+
+    def _build_response_format(self, response_model):
+        payload = original(self, response_model)
+        if payload.get("type") == "json_schema":
+            payload["json_schema"]["strict"] = True
+        return payload
+
+    client_cls._build_response_format = _build_response_format
+    client_cls._klai_strict_schema = True
+    logger.info("graph_strict_structured_output_installed")
+
+
 def _install_language_policy() -> None:
     """Replace graphiti's default language instruction with ``_LANGUAGE_POLICY``.
 
@@ -407,6 +453,7 @@ def _get_graphiti() -> Graphiti:
         # instruction to every system message, and its default ends in
         # "Otherwise, output English".
         _install_language_policy()
+        _install_strict_structured_output()
         # The FalkorDB compatibility layer, applied here rather than only in
         # app.py. Its edge-search rewrite is what keeps the fulltext join from
         # scanning every RELATES_TO edge once per hit (GetKlai/klai#1214); on

--- a/klai-knowledge-ingest/tests/test_graphiti_strict_schema.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_strict_schema.py
@@ -1,0 +1,76 @@
+"""graphiti asks the model to see its schema, not to obey it.
+
+GetKlai/klai#1148. `OpenAIGenericClient._build_response_format` sends
+json_schema deliberately without `strict: true`, reasoning that
+constrained-decoding servers enforce it anyway. Mistral behind LiteLLM does
+not: without the flag it treats the schema as advice and invents shapes once a
+response carries many items, while the first dozen are fine.
+
+    extracted_entities.26.episode_indices
+      Input should be a valid list [input_value=0, input_type=int]
+    extracted_entities.15.entity_type_id
+      Field required [input_value={'entity_type_id_id': 0, ...}]
+
+Pydantic rejects the response and the whole episode is lost. Measured
+2026-08-24 with graphiti's own ExtractedEntities schema through this LiteLLM:
+without the flag the rebuild lost 2 of every 4 documents; with it, 39 entities
+in one response and none malformed.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from knowledge_ingest import graph as graph_module
+
+
+class _Model(BaseModel):
+    name: str
+
+
+def _client():
+    from graphiti_core.llm_client import openai_generic_client as ogc
+
+    graph_module._install_strict_structured_output()
+    return ogc.OpenAIGenericClient.__new__(ogc.OpenAIGenericClient)
+
+
+def test_json_schema_requests_are_strict():
+    client = _client()
+    client.structured_output_mode = "json_schema"
+
+    payload = client._build_response_format(_Model)
+
+    assert payload["type"] == "json_schema"
+    assert payload["json_schema"]["strict"] is True, (
+        "the model is shown the schema but not held to it -- it drifts once a "
+        "response carries many items, and the episode is lost"
+    )
+    assert payload["json_schema"]["schema"], "the schema itself must still be sent"
+
+
+def test_json_object_mode_is_left_alone():
+    """There is no schema to be strict about; adding the flag would be nonsense."""
+    client = _client()
+    client.structured_output_mode = "json_object"
+
+    payload = client._build_response_format(_Model)
+
+    assert payload == {"type": "json_object"}
+
+
+def test_no_response_model_is_left_alone():
+    client = _client()
+    client.structured_output_mode = "json_schema"
+
+    assert client._build_response_format(None) == {"type": "json_object"}
+
+
+def test_install_is_idempotent():
+    """Runs on every client construction; must not wrap itself."""
+    from graphiti_core.llm_client import openai_generic_client as ogc
+
+    graph_module._install_strict_structured_output()
+    first = ogc.OpenAIGenericClient._build_response_format
+    graph_module._install_strict_structured_output()
+    assert ogc.OpenAIGenericClient._build_response_format is first


### PR DESCRIPTION
Second of two defects behind the failed #1148 rebuild. The first was the unpatched edge fulltext search (#1215); with that merged the run went from **0 successes in 20** to **2 in 4**. This takes the rest.

## The line

`OpenAIGenericClient._build_response_format` sends `json_schema` **deliberately without** `strict: true`:

> We intentionally omit "strict": true — strict mode requires the schema to meet OpenAI's strict subset […] So adherence is best-effort on OpenAI-proper; constrained-decoding servers (vLLM, llama.cpp) still enforce it.

Mistral behind LiteLLM is neither OpenAI-proper nor a constrained-decoding server. Without the flag it treats the schema as advice and starts inventing shapes once a response carries many items — while the first dozen come back correct:

```
extracted_entities.26.episode_indices
  Input should be a valid list [input_value=0, input_type=int]

extracted_entities.15.entity_type_id
  Field required [input_value={'entity_type_id_id': 0, ...}]
```

Pydantic rejects the whole response and the episode is lost, after three retries that each drift somewhere different.

## Measured

Through this LiteLLM, with graphiti's own `ExtractedEntities.model_json_schema()`:

| | |
|---|---|
| as graphiti sends it | rebuild lost **2 of every 4** documents |
| with `strict: true` | **39 entities in one response, none malformed** |

## On graphiti's stated concern

That `model_json_schema()` may violate OpenAI's strict subset is real, but it is not ours to inherit. A schema the provider will not accept is **rejected outright** — loud, and immediately visible. Best-effort adherence fails silently and costs the document. Verified against graphiti's actual schema, which this provider accepts.

Tests: 1648 passed, 6 skipped. Four new, including that `json_object` mode and the no-model case are left untouched.

Refs #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)