### PR TITLE
feat(privacy): PII masking for every tenant, not one

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -457,7 +457,6 @@ services:
       # SPEC-PRIVACY-MISTRAL-PII-001 Phase 3 (REQ-7): the single switch that
       # keeps klai_pii_enforce.py inert. Default OFF/unset — with it off,
       # masking/restore never runs at all (no analyzer call, no map entry).
-      # ACTIVATED 2026-08-21 for Voys only (see the allowlist below).
       # Verified end-to-end against real Mistral calls before flipping:
       # masking, non-streaming restore, AND streaming restore — the last is
       # the path LibreChat uses and the one we had to build ourselves
@@ -465,18 +464,32 @@ services:
       # (REQ-0a). Rollback is reverting this line.
       KLAI_PII_ENFORCE: ${KLAI_PII_ENFORCE:-true}
       # Activation hardening (see klai_pii_enforce.py's `_org_is_enforced`):
-      # comma-separated org_id allowlist. KLAI_PII_ENFORCE alone applies to
-      # every tenant identically the moment it flips; this lets the FIRST
-      # activation be exactly one org. Empty/unset means enforce for NO org
-      # even if KLAI_PII_ENFORCE is "true" — the safe reading, not "every
-      # org" — so turning enforcement on for anyone is a deliberate
-      # two-variable action, never a single flag flip.
+      # comma-separated org_id allowlist. The hook treats an absent or empty
+      # value as "enforce for NO org" even when KLAI_PII_ENFORCE is "true".
+      # Since GA the Compose default below fills in `*` when the HOST
+      # variable is unset, so the off switch an operator reaches for is an
+      # explicitly empty value — `KLAI_PII_ENFORCE_ORG_IDS=` — and NOT
+      # deleting the variable, which now yields `*`.
       #
-      # 368884765035593759 = Voys (portal_orgs.id 8). First and currently
-      # ONLY activated tenant. Every other org takes the same early-return
-      # path it did yesterday, which is what makes this reversible per
-      # tenant rather than platform-wide.
-      KLAI_PII_ENFORCE_ORG_IDS: ${KLAI_PII_ENFORCE_ORG_IDS:-368884765035593759}
+      # `*` = general availability, 2026-08-25: every request that carries
+      # an org_id is enforced. The staged rollout it replaces (one named
+      # org, 2026-08-21 to 2026-08-25) is done. Enumerating org_ids instead
+      # would go stale at the next signup, and in the unsafe direction — the
+      # new tenant would be the uncovered one.
+      #
+      # What this does NOT turn on: the seven RETURN_SET entities stay
+      # per-org and default off (`portal_orgs.pii_masked_entities`), so an
+      # org that has opted into nothing gets SECRET and NL_BSN masked and
+      # nothing else. Defaulting the return set on is a separate decision.
+      #
+      # `-` and NOT `:-`, deliberately. `${VAR:-*}` substitutes the default
+      # for unset AND empty, which would turn the documented emergency-off
+      # (set the variable to empty -> enforce for NO org) into its exact
+      # opposite: enforce for EVERY org, during whatever incident made
+      # someone reach for it. With `-`, unset means GA, explicitly empty
+      # means nobody, and a named list means those orgs. Pinned by
+      # test_compose_allowlist_preserves_the_empty_kill_switch.
+      KLAI_PII_ENFORCE_ORG_IDS: ${KLAI_PII_ENFORCE_ORG_IDS-*}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/litellm/klai_pii_enforce.py
+++ b/deploy/litellm/klai_pii_enforce.py
@@ -115,13 +115,21 @@ def _parse_org_allowlist(value: str) -> frozenset[str]:
 # be exactly one org while the rest of the tenant base is provably
 # untouched -- wired into deploy/docker-compose.yml next to
 # KLAI_PII_ENFORCE.
+#
+# `*` is the general-availability value: every request that carries an
+# org_id is enforced. It exists because the only other way to reach "all
+# tenants" is enumerating org_ids, and an enumerated list is wrong the
+# moment a customer signs up -- silently, and in the unsafe direction (the
+# new tenant is the one NOT covered). A wildcard cannot drift.
+_ALL_ORGS_WILDCARD = "*"
+
 KLAI_PII_ENFORCE_ORG_IDS = _parse_org_allowlist(os.getenv("KLAI_PII_ENFORCE_ORG_IDS", ""))
 
 
 def _org_is_enforced(org_id: Any) -> bool:
     """Whether masking/restore should run at all for THIS request's org.
 
-    Two deliberate decisions, each argued rather than assumed:
+    Three deliberate decisions, each argued rather than assumed:
 
     1. EMPTY allowlist + KLAI_PII_ENFORCE=true means enforcement for NO
        org -- not "every org", which would be the reading that reproduces
@@ -157,10 +165,24 @@ def _org_is_enforced(org_id: Any) -> bool:
        same as every other entity -- there is no path left that masks
        unconditionally across the whole tenant base while the allowlist
        is not yet "every org", which is what makes the rollout actually
-       gradual rather than gradual-except-for-credentials-and-BSN.
+       gradual rather than gradual-except-for-credentials-and-BSN. That
+       rollout is now complete: the deployed value is `*` (see 3), so the
+       "not yet every org" state this paragraph describes is history
+       rather than current behaviour.
+
+    3. `*` in the allowlist means every request that DOES carry an org_id
+       is enforced. This is general availability, and it deliberately does
+       not weaken (1) or (2): an absent or empty value still means no
+       orgs HERE, and a request with no org_id is still never enforced,
+       because `*` widens which identities match, not whether an identity
+       is required. Note where that first guarantee now stops: Compose
+       fills in `*` when the host variable is unset, so at the deployment
+       the off switch is an explicitly empty value, not a deleted one.
     """
     if not org_id:
         return False
+    if _ALL_ORGS_WILDCARD in KLAI_PII_ENFORCE_ORG_IDS:
+        return True
     return org_id in KLAI_PII_ENFORCE_ORG_IDS
 
 

--- a/deploy/litellm/tests/test_litellm_compose_mounts.py
+++ b/deploy/litellm/tests/test_litellm_compose_mounts.py
@@ -48,3 +48,19 @@ def test_litellm_prisma_migrations_are_preflight_gated():
     assert "no env-drift services resolved; refusing an all-services compose up" in (
         deploy_compose_text
     )
+
+
+def test_compose_allowlist_preserves_the_empty_kill_switch():
+    """`${VAR-*}`, never `${VAR:-*}`, for the PII enforcement allowlist.
+
+    `_org_is_enforced` documents an explicitly empty allowlist as "enforce
+    for NO org" and `test_empty_allowlist_means_enforcement_for_no_org_even_with_flag_on`
+    pins that in the hook. The colon form would make it unreachable from
+    the deployment: Compose substitutes the default for unset AND empty, so
+    an operator emptying the variable to switch enforcement off would get
+    `*` and switch it on for every tenant instead.
+    """
+    compose_text = COMPOSE_FILE.read_text(encoding="utf-8")
+
+    assert "KLAI_PII_ENFORCE_ORG_IDS: ${KLAI_PII_ENFORCE_ORG_IDS-*}" in compose_text
+    assert "${KLAI_PII_ENFORCE_ORG_IDS:-" not in compose_text

--- a/deploy/litellm/tests/test_pii_enforce.py
+++ b/deploy/litellm/tests/test_pii_enforce.py
@@ -885,6 +885,101 @@ def test_parse_org_allowlist_trims_whitespace_and_drops_empties():
     assert _parse_org_allowlist("   ") == frozenset()
 
 
+@pytest.mark.asyncio
+async def test_wildcard_allowlist_enforces_an_org_it_never_names(monkeypatch):
+    """General availability: `*` covers a tenant that appears after the
+    variable was set, which is the case an enumerated list gets wrong --
+    silently, and in the unsafe direction."""
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "*"})
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    text = "mijn bsn is 111222333 graag verwerken"
+    start, end = text.index("111222333"), text.index("111222333") + len("111222333")
+    client = _ScriptedAnalyzerClient(
+        script={text: [{"entity_type": "NL_BSN", "start": start, "end": end, "score": 0.85}]}
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-wildcard-1",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("an-org-nobody-listed"), None, data, "completion"
+    )
+    user_message = [m for m in result["messages"] if m.get("role") == "user"][0]
+    assert "<NL_BSN_1>" in user_message["content"]
+    assert client.calls
+
+
+@pytest.mark.asyncio
+async def test_wildcard_still_never_enforces_a_request_without_org_id(monkeypatch):
+    """`*` widens which identities match, not whether an identity is
+    required. The org-less master-key path stays exempt, so decision (2)
+    in `_org_is_enforced` survives general availability."""
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "*"})
+    client = _ScriptedAnalyzerClient(raise_exc=AssertionError("must not call analyzer"))
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-wildcard-2",
+        "messages": [{"role": "user", "content": "mijn bsn is 111222333"}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key(org_id=None), None, data, "completion"
+    )
+    assert result is data
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_wildcard_masks_never_restore_entities_for_an_org_with_empty_policy(monkeypatch):
+    """What "on for all tenants" actually delivers on day one: an org that
+    has opted into nothing still gets SECRET and NL_BSN masked, and still
+    gets no RETURN_SET entity masked. Guards against the wildcard being
+    mistaken for "every entity on for everyone"."""
+    mod = _load_enforcer(monkeypatch, enforce=True, extra_env={"KLAI_PII_ENFORCE_ORG_IDS": "*"})
+    _stub_org_policy(mod, monkeypatch, frozenset())
+
+    email = "jan@example.nl"
+    text = f"mijn bsn is 111222333 en mijn mail is {email}"
+    bsn_start = text.index("111222333")
+    email_start = text.index(email)
+    client = _ScriptedAnalyzerClient(
+        script={
+            text: [
+                {
+                    "entity_type": "NL_BSN",
+                    "start": bsn_start,
+                    "end": bsn_start + len("111222333"),
+                    "score": 0.85,
+                },
+                {
+                    "entity_type": "EMAIL_ADDRESS",
+                    "start": email_start,
+                    "end": email_start + len(email),
+                    "score": 1.0,
+                },
+            ]
+        }
+    )
+    _install_analyzer(mod, monkeypatch, client)
+
+    data = {
+        "model": "klai-primary",
+        "litellm_call_id": "call-wildcard-3",
+        "messages": [{"role": "user", "content": text}],
+    }
+    result = await mod.klai_pii_enforcer.async_pre_call_hook(
+        _user_api_key("org-with-no-opt-ins"), None, data, "completion"
+    )
+    sent = [m for m in result["messages"] if m.get("role") == "user"][0]["content"]
+    assert "<NL_BSN_1>" in sent, "never-restore entities apply the moment the org is enforced"
+    assert email in sent, "a RETURN_SET entity stays unmasked until the org opts into it"
+
+
 # ===========================================================================
 # System-review finding M4 — length cap / chunking on the enforce path
 # ===========================================================================

--- a/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
+++ b/docs/specs/SPEC-PRIVACY-MISTRAL-PII-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-PRIVACY-MISTRAL-PII-001
-version: "0.9.0"
+version: "1.0.0"
 status: draft
 created: 2026-08-20
-updated: 2026-08-20
+updated: 2026-08-25
 author: Mark Vletter
 priority: high
 related:
@@ -17,6 +17,7 @@ roadmap: docs/architecture/knowledge-rag-improvement-plan.md
 
 | Version | Date       | Author       | Change |
 |---------|------------|--------------|--------|
+| 1.0.0   | 2026-08-25 | Mark Vletter | **General availability.** `KLAI_PII_ENFORCE_ORG_IDS=*`: every request carrying an `org_id` is enforced, replacing the one-named-org rollout that ran from 2026-08-21. The allowlist gained a wildcard rather than an enumerated list of org_ids, because an enumerated list goes stale at the next signup and does so in the unsafe direction — the new tenant would be the uncovered one. Neither of the two guarantees the staged rollout was built on changes: an absent or empty value still means no orgs at the hook, and a request with no `org_id` is still never enforced. Where that stops: Compose supplies `*` when the host variable is unset, so the deployment-level off switch is an explicitly empty `KLAI_PII_ENFORCE_ORG_IDS=`, not a deleted one. Capacity was measured before flipping rather than assumed: presidio-analyzer sits at 214MiB/512MiB and 0.01% CPU while the Phase 2 observer already calls `/analyze` for every tenant, so enforcement roughly doubles a volume of ~3 calls per minute. The residual risk is availability, not capacity — REQ-10 fails closed, so the analyzer being down is now a chat outage for every tenant instead of one; `container_down` in `infra-rules.yaml` already covers `klai-core-.*`. Also records what GA does NOT cover: the `org_id=None` path carried 1619 of 1650 observed detections over 2026-08-18 to 2026-08-25, against 29 on attributable tenant chat, and masking cannot reach it. |
 | 0.9.0   | 2026-08-21 | Mark Vletter | Phase 3 merged and deployed **inert** (`adde54046`), analyzer image carrying the four system-review fixes pinned (`060459e28`). Verified on core-01 rather than assumed: `KLAI_PII_ENFORCE=false`, seven Phase 3 modules mounted with no import errors, the observer still emitting counts and changing nothing, and all four recogniser fixes confirmed against the running analyzer — `Factuurdatum 20200201` no longer masked, `bearer` prose no longer a SECRET, `2026 en` no longer a postcode, Rotterdam `010` still detected. Everything between LiteLLM and Mistral is now built and in place; the only remaining step to activate is the flag. |
 | 0.8.0   | 2026-08-20 | Mark Vletter | **System review of the merged stack** — the first review of the pieces together rather than each PR alone, and it found what per-diff review structurally cannot. REQ-8's overlap rule was wrong: it said "drop any span *contained* in one already taken", derived from the single IBAN⊃PHONE example, but the recogniser set produces pairs where the higher-scoring span sits INSIDE the lower-scoring one (`NL_BSN` 1.00 inside `NL_BTW` 0.70; a JWT span inside a Bearer span). A containment-only rule accepts both and corrupts the text. Now: drop any **overlap**, and never-restore entities win exact ties, because `NL_BSN` and `NL_KVK` can produce a byte-identical span with an identical score and a tie must not decide whether a value becomes restorable. The Phase 3 implementation already dropped overlaps — the defect was in this document, not the code. Three irreversible-false-positive fixes shipped alongside: 8-digit BSN now needs context (9.1% of `YYYYMMDD` dates passed the elfproef and were destroyed unrestorably), the `Bearer` pattern is anchored to an `Authorization:` header (it matched two words of ordinary Dutch prose), and the postcode letter pair is case-sensitive again (registry `IGNORECASE` made `2026 en` a postcode). A1 marked partly falsified. |
 | 0.7.0   | 2026-08-20 | Mark Vletter | Maintenance pass — the SPEC is a working document, not a record of what we once believed. Adds a **Status** table (per-phase state with the commit that proves it) so this doubles as the progress overview, plus a short "what this SPEC got wrong, and how it was caught" table: three of four errors were found by measuring, not reading, and two had already been written down as confident conclusions. Removed three claims that are now false: that the LiteLLM integration is configuration rather than code (REQ-5 and REQ-0a each measured otherwise), that `PHONE_NUMBER` is a stock built-in enabled via a YAML region key (the loader drops it — it is `NLPhoneRecognizer` now), and assumption A6 (struck through with the real root cause and the fixing commits). Re-validated every `file:line` anchor **semantically**, not just for range: the `MISTRAL_API_KEY` anchor had drifted from 388-389 to 421-422 as compose grew, still pointing inside the file and therefore passing a naive check while being wrong. |
@@ -67,12 +68,20 @@ the table is right and the text is stale — say so rather than working around i
 | **0** — prove the restore path | **Done, answered** | Ran on core-01. `output_parse_pii` restores non-streaming, returns an **empty map on streaming**. Verbatim-token instruction takes `PHONE_NUMBER` survival 58.3% → 95.8%. See the RESULT block under Phase 0 |
 | **1** — recognizer pack | **Live** | `d55d6adeb`, `d2aa35fd2`. Nine recognizers loaded across en/nl/de, spaCy disabled per language, verified in production logs. Rotterdam fix `4af66f4e0` + `b5b592051`, verified live |
 | **2** — read-only observer | **Live, measuring** | `c6dd946e4`. Real `pii_observed` events in VictoriaLogs, including `org_id=None` requests the existing hook skips. Changes no payload |
-| **3** — mask + restore | **Live, inert** | `adde54046` + `060459e28`. Verified on core-01: `KLAI_PII_ENFORCE=false`, seven modules mounted, no import errors, observer unaffected. Klai owns mask/map/restore because Phase 0 measured the native path unusable for streaming. **Activation is a flag flip** |
+| **3** — mask + restore | **Live, all tenants** | `adde54046` + `060459e28` shipped it inert; one named org from 2026-08-21; `KLAI_PII_ENFORCE_ORG_IDS=*` from 2026-08-25. Klai owns mask/map/restore because Phase 0 measured the native path unusable for streaming |
 | **4** — `PERSON` via GLiNER | **Blocked, deliberately** | No PERSON detector is deployed at all (REQ-2 disables SpacyRecognizer). REQ-0b's PERSON half is unmeasurable until GLiNER lands |
 
-**Nothing is being masked today.** The guardrail has no `default_on` and enforcement is off,
-so production payloads reach Mistral unchanged. Phases 1 and 2 detect and count; they do not
-alter.
+**What is masked today.** `SECRET` and `NL_BSN`, for every request that carries an `org_id`.
+The seven `RETURN_SET` entities remain per-org and default off, so a tenant that has opted
+into nothing gets those two and nothing else. Defaulting the return set on is a separate
+decision, not implied by general availability.
+
+**What is still never masked.** A request with no `org_id` — the widget and internal
+service-key paths, including knowledge-graph extraction and query rewriting. Measured over
+2026-08-18 to 2026-08-25, that path carried 1619 of the 1650 observed detections, against 29
+on attributable tenant chat. General availability therefore covers the chat call and not the
+larger flow behind it; closing that is its own work, and the gap should not be described to
+customers as covered.
 
 ### What this SPEC got wrong, and how it was caught
 
@@ -691,10 +700,10 @@ safe to assert.
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
 | GLiNER blows the latency budget on CPU | medium | medium | It is the only model in the path. Every other REQ-3 entity is regex-plus-checksum and unaffected, so the documented response is to disable `PERSON` and ship the rest |
-| Over-detection: a nine-digit order number read as a BSN | medium | medium | The elfproef makes an accidental match roughly 1 in 11 — an assumption, not a measurement (see Assumptions). Bounded in practice because enforcement ships off by default and the first activation is per-org, so a bad rate shows on one tenant, not all |
+| Over-detection: a nine-digit order number read as a BSN | medium | medium | The elfproef makes an accidental match roughly 1 in 11 — an assumption, not a measurement (see Assumptions). The per-org bound this row used to claim is gone as of GA (2026-08-25): a bad rate now shows on every tenant at once, and `NL_BSN` is never restored, so a false positive is irreversible. What remains is the 8-digit context gate (`klai_pii_recognizers.py`, `NLBSNRecognizer.analyze`), which removed the `YYYYMMDD` collision that made this likely; the 9-digit form still stands on the checksum alone |
 | A tenant genuinely needs a BSN to reach the model | low | medium | REQ-7's audited statutory-basis exception. If there is no statutory basis, the correct outcome is that it does not reach the model |
 | `PERSON` recall varies by language even with multilingual GLiNER | medium | medium | REQ-2 requires Phase 2 telemetry to carry detected language so this is measured per language rather than assumed uniform. A material gap gates REQ-9, and the checksum entities are unaffected either way |
-| Fail-closed turns a Presidio outage into a chat outage | low | high | Enforcement ships behind `KLAI_PII_ENFORCE`, default off, so the code runs in production inert before it can reject anything. Bounded by the 60 ms NFR, and the flag is the rollback |
+| Fail-closed turns a Presidio outage into a chat outage | low | critical | No longer bounded to a pilot: as of GA (2026-08-25) an analyzer outage rejects chat for every tenant carrying an `org_id`, so likelihood stays low but the blast radius is now platform-wide. `container_down` in `deploy/grafana/provisioning/alerting/infra-rules.yaml` covers `klai-core-.*` and therefore the analyzer. Rollback is two levels: `KLAI_PII_ENFORCE=false`, or an explicitly empty `KLAI_PII_ENFORCE_ORG_IDS` — which is why the Compose default uses `${VAR-*}` and not `${VAR:-*}` |
 | Presidio's upstream governance move stalls and the project goes quiet | low | medium | MIT-licensed and self-hosted; a frozen dependency stays working. Our recognizer pack is our own code and portable |
 | Someone re-proposes Piiranha because it supports Dutch | medium | low | Rejected in the Motivation with the licence quoted, so the answer is on file |
 


### PR DESCRIPTION
`KLAI_PII_ENFORCE_ORG_IDS=*`: every request that carries an `org_id` is enforced, replacing the single-org rollout that ran from 2026-08-21.

## Why a wildcard and not a list of org_ids

An enumerated list is wrong the moment a customer signs up, and wrong in the unsafe direction: the new tenant would be the uncovered one. A wildcard cannot drift.

## What this does not turn on

The seven `RETURN_SET` entities stay per-org and default off (`portal_orgs.pii_masked_entities`). A tenant that has opted into nothing gets `SECRET` and `NL_BSN` masked and nothing else. Defaulting the return set on is a separate decision.

## The Compose default uses `${VAR-*}`, not `${VAR:-*}`

Caught by review and reproduced against `docker compose config` before fixing. The colon form substitutes the default for unset **and** empty, which would have turned the documented emergency-off (empty allowlist means enforce for no org) into its exact opposite, during whatever incident made someone reach for it:

| host variable | `${VAR:-*}` | `${VAR-*}` (shipped) |
|---|---|---|
| unset | `*` | `*` |
| explicitly empty | `*` — inverted | `` — off, as documented |
| `org1,org2` | `org1,org2` | `org1,org2` |

Pinned by `test_compose_allowlist_preserves_the_empty_kill_switch`.

## Measured, not assumed

presidio-analyzer sits at 214MiB/512MiB and 0.01% CPU while the Phase 2 observer already calls `/analyze` for every tenant, so enforcement roughly doubles a volume of ~3 calls per minute. Capacity is not the constraint.

The residual risk is availability: REQ-10 fails closed, so the analyzer being down is now a chat outage for every tenant instead of one. `container_down` in `deploy/grafana/provisioning/alerting/infra-rules.yaml` already covers `klai-core-.*`. The SPEC's risk table claimed that blast radius was bounded to a pilot; both stale rows are rewritten rather than layered over.

## Not covered, and stated as such

Requests with no `org_id` (widget and internal service keys, including graph extraction and query rewriting) carried 1619 of 1650 observed detections over 2026-08-18 to 2026-08-25, against 29 on attributable tenant chat. Masking cannot reach that path. It should not be described to customers as covered.

## Tests

846 passed, run exactly as `litellm-tests.yml` does. Three new tests on the wildcard (one confirming the org-less path stays exempt, one confirming an empty org policy still yields only `SECRET`/`NL_BSN`), plus the Compose kill-switch test. Red-checked: the two behavioural tests fail with the wildcard branch disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)