### PR TITLE
chore(privacy): pin the analyzer image carrying the EU recogniser pack

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -516,15 +516,17 @@ services:
   # Neither takes a secret, so this adds no `env_file` scope and no
   # `SECRETS_MATRIX.md` entry.
   presidio-analyzer:
-    # PLACEHOLDER DIGEST — deploy/presidio/analyzer-image-build.yml has not
-    # run against this change yet (it runs on push to `main`; this PR does
-    # not push or deploy). Replace with the real digest from that workflow's
-    # step summary. Bootstrap complete: presidio-analyzer-image-build.yml
-    # published this digest from d55d6adeb (tag 2.2.362-klai.1-d55d6adeb0ec),
-    # built FROM the same ghcr.io/data-privacy-stack digest Phase 0 pinned.
+    # Digest published by presidio-analyzer-image-build.yml from c0d198b9d
+    # (tag 2.2.362-klai.1-c0d198b9da7b), carrying the EU-wide VAT recogniser,
+    # the Belgian enterprise number and the six-language registry.
+    #
+    # This pin is a SEPARATE step from merging a recogniser change: the build
+    # runs on push to main and publishes a digest, and until this line points
+    # at it the analyzer keeps serving the previous pack. A recogniser PR that
+    # merges without a follow-up bump changes nothing in production.
     # This is where REQ-3's Dutch recognizers (BSN/KvK/BTW/postcode) and
     # REQ-4's SECRET recognizer actually enter the request path.
-    image: ghcr.io/getklai/presidio-analyzer@sha256:47151487c449f8762a3d9760279514f9bbfc3b312d2d731c12761465bd27e003
+    image: ghcr.io/getklai/presidio-analyzer@sha256:23f1c064761baadc030786aac60b58a42c5157bbf0c6e4a0201c538dc262241d
     restart: unless-stopped
     networks:
       - inference


### PR DESCRIPTION
Third and last step of the PII rollout. #1219 turned masking on for every tenant, #1222 widened detection to the EU, and neither reaches the analyzer until this pin moves.

`presidio-analyzer` is digest-pinned, so merging a recogniser change does not deploy it: the image build runs on push to main and publishes a digest, and this line has to point at it. Until then the container keeps serving the previous pack.

- Digest: `sha256:23f1c064761baadc030786aac60b58a42c5157bbf0c6e4a0201c538dc262241d`
- Built from `c0d198b9d`, tag `2.2.362-klai.1-c0d198b9da7b`
- Manifest confirmed pullable with `docker manifest inspect` before pinning, rather than taken from the build log
- `check-klai-presidio-digest.test.sh` passes (7 checks)

Also replaces the `PLACEHOLDER DIGEST` paragraph. It has described the Phase 1 bootstrap build since then and by now documented neither the current pin nor the process, so the comment now states the two-step contract instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)