### PR TITLE
feat(connector): structure-aware JSON feed ingestion (SPEC-KB-JSON-FEED-001)

### DIFF
--- a/docs/specs/SPEC-KB-JSON-FEED-001/spec.md
+++ b/docs/specs/SPEC-KB-JSON-FEED-001/spec.md
@@ -1,0 +1,325 @@
+---
+id: SPEC-KB-JSON-FEED-001
+version: "0.1.1"
+status: implemented (pending merge)
+created: 2026-08-25
+updated: 2026-08-25
+author: Claude (Fable), commissioned by Mark Vletter
+priority: high
+related:
+  - SPEC-RAG-SOURCE-SELECTION-001 (source selection defects observed in the same Voys week; this SPEC removes one of its stressors — a source whose chunks are indistinguishable)
+  - SPEC-INGEST-RECONCILE-001 (sync reconciliation + skip_reasons this SPEC extends with stale-ref cleanup for feed groups)
+  - SPEC-KB-021 (source_label / source_aware_select; json_feed source_label semantics stay unchanged)
+  - SPEC-CONNECTOR-CLEANUP-001 (connector-scoped deletion layers; group-doc cleanup must cover the same stores)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# HISTORY
+
+| Version | Date       | Author | Change |
+|---------|------------|--------|--------|
+| 0.1.1   | 2026-08-25 | Claude (Fable) | Post-implementation review amendments. (1) The safe record-line cap is **900 chars**, not the drafted implicit assumption that any single line under the chunk size survives: the chunker only accepts a `\n\n` soft boundary past the window midpoint, so lines must stay ≤ child_size/2 − overlap (2000/2 − 200); measured with the real chunker: 0/200 mid-record splits at 900, 132/200 at 1790. (2) Stale-group cleanup (REQ-5) gained a shrink guard: cleanup is refused (and logged as `stale_cleanup_refused_shrink`, baseline retained) when stale refs exceed half the previous baseline — a partially-returning feed must never wipe the KB. (3) Review items deliberately deferred to backlog: non-breaking cleanup-failure handling (collect-and-continue instead of fail-fast), slug-collision disambiguation via hash suffix, render-mode-flip guard, queued-enrichment cancellation on document delete, group_title_template config instead of the hardcoded `category/entity/brand` title. (4) Delta-review backlog: a 900–1800-char record now hard-fails its group (and thus the sync) instead of being emitted as a single-record document or truncated with a marker; and a refused shrink-cleanup latches permanently for intentional catalogue shrinks (>50%) with only a warning log — needs a two-consecutive-syncs escape hatch or surfacing on the sync_run row. |
+| 0.1.0   | 2026-08-25 | Claude (Fable), commissioned by Mark Vletter | Initial draft, written after a production trace of the 2026-08-18/20 Voys PriceRight sessions (org `368884765035593759`, KB `priceright-prijzen-voys`, connector `29a84f05-2476-4209-889c-4e714ce8f71b`). Implementation is delegated (Codex/Sol); this document is the complete, self-contained brief. |
+
+---
+
+# SPEC-KB-JSON-FEED-001: Structure-aware ingestion for JSON feed connectors
+
+## Summary
+
+The `json_feed` connector ingests an entire JSON endpoint as **one document**: it
+pretty-prints the parsed payload (`json.dumps(..., indent=2)`) and hands the whole
+blob to the generic ingest pipeline. For the real-world case it was built for — a
+pricing feed that is a flat array of thousands of small records — this produces one
+464 KB "article" that is:
+
+1. chunked by blind character windows (the chunker is markdown-heading-aware only;
+   raw JSON has no headings, no blank lines, no `". "` boundaries, so records are
+   cut mid-object and keys are separated from their values);
+2. silently excluded from LLM enrichment and HyPE question generation because it
+   exceeds the 200-chunk cap (`enrichment_policy.py` → `too_many_chunks`), which
+   removes one of the three RRF retrieval legs for exactly the content that needs
+   it most;
+3. embedded as raw JSON syntax, which a natural-language query matches poorly
+   compared to the prose help-centre articles it competes against;
+4. full of near-duplicate rows (the same product across countries/brands differs by
+   a few tokens), which makes chunk embeddings mutually indistinguishable and
+   reranking effectively random within the feed.
+
+The customer-visible symptom: a tenant uploads their pricing data and the assistant
+cannot reliably answer "wat kost X?" even when feed chunks reach the evidence pack.
+The Voys/PriceRight attempt (2026-08-18/20) went through three upload/delete cycles,
+one full KB purge, and source pinning — none of which could work, because the
+failure is in how the feed is turned into documents, not in retrieval settings.
+
+This SPEC makes the `json_feed` adapter structure-aware: it splits a feed into
+**per-group markdown documents** with **one verbalized line per record**, so that
+chunk boundaries always coincide with record boundaries, every chunk carries its
+group context, enrichment/HyPE run normally, and sync becomes incremental and
+cleanable per group. No new services, no LLM calls at ingest time, no retrieval-api
+changes.
+
+## Motivation
+
+### The production trace
+
+Org `368884765035593759` (Voys), 2026-08-18 12:30–13:21 UTC and onwards:
+
+- `ingest_complete` for the feed artifact: **247 chunks, one artifact**
+  (path = the Supabase RPC URL). After the KB was rebuilt on 2026-08-19 via the
+  dedicated `json_feed` connector: **310 chunks, one artifact**
+  (`Parsed text document 29a84f05-….json: 464569 characters`).
+- `enrichment_enqueue_skipped, reason: too_many_chunks` for both — the feed never
+  received context prefixes, HyPE questions, or entity extraction, and nothing
+  surfaced this to the user.
+- ~24 test queries on 18/08: feed chunks did reach the evidence pack (1–8 per
+  query, confidence often "high"), yet the user kept deleting and re-uploading —
+  the served chunks were arbitrary 1500–2000-char JSON slices, so the *right*
+  record for a specific country/brand was usually not among them.
+- The feed itself is a flat array of price records in effectively random order,
+  interleaving markets and brands, e.g.:
+
+  ```json
+  {"entity_brand_id":"at-voys","entity":"at","brand":"voys",
+   "name":"Nummer Italie","name_en":"Number Italy",
+   "category":"Telefoonnummers","propositie":"maatwerk",
+   "monthly":9.25,"once_new":23.50,"start_tariff":null,
+   "per_minute":null,"per_quarter_hour":null,
+   "updated_at":"2026-08-24T09:08:14.247+00:00"}
+  ```
+
+  Dozens of records differ only in a country name or a number
+  ("Nummer Italie €9,25" vs "Nummer Portugal €9,25"), which is the worst possible
+  input for windowed chunking + dense embedding.
+
+### Why this design (external grounding)
+
+Row-shaped structured data is a solved category in RAG practice, and the consensus
+is consistent across sources:
+
+- **Row/record-level chunking with schema context** — embed each record (or a
+  small, coherent group) as its own unit, always including field names, never
+  splitting a record across chunks. (Common practice; see e.g. "Chunking
+  Strategies for Structured Data in RAG Systems", HackerNoon 2025; row-level
+  chunking with schema headers is its explicit starting recommendation.)
+- **Verbalization beats raw serialization** — rendering a record as a natural
+  sentence/labelled line ("In 2024, ACME Corp had revenue of $450K…") retrieves
+  measurably better than embedding raw `key:value` JSON, because text embedders
+  are trained on prose (TabRAG, arXiv:2511.06582, shows NL descriptions of
+  structured rows outperform raw representations for both retrieval and
+  generation; the same conclusion appears in practitioner reports).
+- **Group by a low-cardinality dimension** so a chunk answers a whole family of
+  questions ("all number prices for market NL") instead of three random rows.
+- **Keep structure in metadata** for future filtering (Qdrant payload), and route
+  truly analytical queries to structured lookup — the latter is explicitly out of
+  scope here (see Non-goals) but the metadata this SPEC adds is its prerequisite.
+- Generic hierarchy-preserving JSON splitters exist (LangChain
+  `RecursiveJsonSplitter`, LlamaIndex `JSONNodeParser`) and inform REQ-6
+  (fallback for non-tabular JSON), but for flat record arrays the right unit is
+  the record group, not a byte-budgeted subtree.
+
+### Why not fix it in the chunker instead
+
+A JSON-aware chunker in knowledge-ingest would still receive one 464 KB artifact:
+the 200-chunk enrichment cap, the single content fingerprint (all-or-nothing
+re-ingest), the single citation URL, and the impossibility of per-group cleanup
+all live at the *document* boundary, not the chunk boundary. The adapter is the
+only place that still has the parsed structure and can choose document boundaries.
+Hence: fix document shaping in the adapter; the existing heading-aware chunker
+then does the right thing for free.
+
+## Requirements
+
+### REQ-1 — Per-group documents for flat record arrays
+
+When the fetched feed parses to a **flat array of objects** (all items are objects
+whose values are scalars/null; tolerance: items with ≤10% non-scalar fields are
+still treated as records, non-scalar fields rendered via compact `json.dumps`),
+the adapter MUST split it into multiple documents:
+
+- **Grouping key**: `connector.config.group_by` — an optional list of field names
+  (e.g. `["category", "entity", "brand"]`). Records are grouped by the tuple of
+  those field values (missing field → literal `"overig"` bucket).
+- **Default (no `group_by` configured)**: deterministic batching — preserve feed
+  order, split into consecutive batches of at most `max_records_per_doc`
+  (default 200) records per document. No value-based auto-detection heuristics
+  (they misfire silently; explicit config wins).
+- **Document identity**: `DocumentRef.path = "json-feed/{connector_id}/{group_slug}"`
+  and `source_ref = "json-feed:{connector_id}:{group_slug}"` where `group_slug`
+  is a stable slug of the group key values (or `part-{n:04d}` for default
+  batching). Stable across syncs so reconciliation and dedup work per group.
+- `content_type` stays `"kb_article"` (keeps the HyPE-enabled content profile).
+- `source_url` stays the credential-stripped origin (`_public_source_url`),
+  identical for every group doc.
+
+### REQ-2 — Record verbalization (deterministic, no LLM)
+
+Each document is rendered as **markdown**, one line per record:
+
+- Document head: `# {feed_title} — {group title}` (feed_title from
+  `connector.config.title`, fallback `"JSON feed"`; group title from the
+  `group_by` values, e.g. `Telefoonnummers — voys (nl)`), followed by one intro
+  line naming the fields present in this group (schema header).
+- Record line format: `- **{record label}** — {field}: {value}; {field}: {value}; …`
+  - Record label: value of the first present field from
+    `connector.config.record_label_fields` (default candidates:
+    `name`, `title`, `label`, `id`); if none present, the record's positional
+    index.
+  - All remaining fields as `humanized_field_name: value` pairs, in feed order.
+    `null`/empty values are **omitted**. Field names are humanized
+    (`per_minute` → `per minute`); an optional `connector.config.field_labels`
+    map overrides per-field display names (e.g. `{"monthly": "per maand (EUR)"}`).
+  - Numbers rendered trimmed (no float noise: `9.25`, not `9.25000`). No
+    currency/locale guessing — if the tenant wants `€`, they configure it via
+    `field_labels`.
+- **Records are separated by blank lines** (`\n\n`). This is load-bearing: the
+  size-splitter's first soft boundary is `\n\n`, so chunk cuts always fall
+  *between* records, never inside one (AC-3).
+- Sort records within a group by record label (stable output → stable content
+  fingerprint → downstream dedup keeps working when the feed reorders).
+- Exact duplicate records (identical rendered line) are collapsed to one.
+
+### REQ-3 — Size safety and enrichment cap
+
+- A group document exceeding `max_doc_chars` (default 120 000 — comfortably below
+  the 200-chunk enrichment cap at ~2 000 chars/chunk) MUST be split at record
+  boundaries into `… — deel {i}/{n}` documents with their own stable paths
+  (`{group_slug}--{i}`).
+- The adapter MUST guarantee no emitted document can trigger
+  `enrichment_enqueue_skipped: too_many_chunks` (assert via AC-5).
+- Existing feed-level limits stay: `_MAX_FEED_SIZE` (2 MiB), SSRF guard
+  (`validate_json_feed_url_strict`), `MAX_INGEST_CONTENT_CHARS` per document.
+
+### REQ-4 — Structured metadata passthrough
+
+For each group document, the adapter MUST provide an `extra` payload (existing
+connector→ingest→Qdrant passthrough) containing at least:
+
+```json
+{
+  "json_feed_group": {"category": "Telefoonnummers", "entity": "nl", "brand": "voys"},
+  "json_feed_record_count": 42
+}
+```
+
+(only the configured `group_by` fields; flat strings, no nesting beyond this).
+Per the "Procrastinate enrichment passthrough" rule, these fields MUST survive the
+enrichment re-upsert (`extra_payload`), verified by test. These payload fields are
+the prerequisite for future filtered retrieval; retrieval-api changes are out of
+scope here.
+
+### REQ-5 — Sync reconciliation and stale-group cleanup
+
+Today `get_cursor_state` returns `{}` (every sync refetches everything — fine, the
+feed is one HTTP GET) and vanished refs are never cleaned. With per-group docs:
+
+- Refetch-always stays (`get_cursor_state` → `{}`), but unchanged groups MUST NOT
+  produce duplicate chunks: identical rendered content ⇒ identical content
+  fingerprint ⇒ existing content-hash dedup skips re-ingest
+  (verify, don't assume — AC-4).
+- After a **successful** sync, group documents whose refs are in the previous
+  `synced_refs` but absent from the current `list_documents` output MUST be
+  deleted downstream (Qdrant chunks + `knowledge.artifacts` + graph episodes for
+  that artifact), using existing per-artifact/connector deletion paths in
+  knowledge-ingest. If no per-artifact deletion endpoint reachable from the
+  connector exists, add a minimal one (internal, `X-Internal-Secret`, org-scoped,
+  delete-by-`source_ref`). Never delete on a failed/partial sync (a transient
+  fetch error must not wipe the KB).
+- **Migration for existing connectors is this same mechanism**: the legacy
+  single-doc ref `json-feed/{connector_id}.json` simply stops being listed, so
+  the first sync after deploy cleans it up. A regression test MUST cover exactly
+  this transition.
+
+### REQ-6 — Fallback for non-tabular JSON (no more raw blobs)
+
+When the payload is **not** a flat record array (nested object, mixed array):
+
+- Render depth-first as markdown: top-level keys become `#`/`##` headings
+  (2 levels max), leaf values as `- {json.path}: {value}` lines with blank-line
+  separation; arrays of scalars inline, arrays of objects at deeper levels via
+  compact one-line JSON per item.
+- Split into multiple documents at top-level-key boundaries when over
+  `max_doc_chars` (same stable-path scheme, `{connector_id}/{top_level_key}`).
+- The literal `json.dumps(parsed, indent=2)` whole-feed output MUST NOT be
+  emitted in any code path anymore.
+
+### REQ-7 — Fail loudly, observably
+
+- A record that cannot be rendered (defensive: rendering is deterministic, so
+  this means malformed structure) fails its **group document** — counted in
+  `documents_failed` with an `error_details` entry naming group + record index.
+  No silent per-record skips.
+- The sync-complete log line MUST include: `groups_total`, `records_total`,
+  `duplicates_collapsed`, `stale_groups_deleted`.
+- Config errors (`group_by` naming a field absent from >50% of records) fail the
+  sync with an explicit message, not a semi-empty ingest.
+
+### REQ-8 — Scope guard
+
+- No changes to retrieval-api, the chunker, content profiles, portal UI, or the
+  crawler in this SPEC. `connector.config` keys are documented in the adapter
+  docstring; UI form support for `group_by`/`field_labels`/`title` is a
+  follow-up. (Config can be set through the existing connector-config JSON until
+  then.)
+- `source_label` remains the connector type (`"json_feed"`); label semantics are
+  owned by SPEC-KB-021 / SPEC-RAG-SOURCE-SELECTION-001.
+
+## Acceptance criteria
+
+- **AC-1** Unit: a flat-array fixture (Voys-shaped: ≥3 categories × ≥2 markets,
+  incl. nulls, duplicate rows, float noise `9.25000`) with
+  `group_by=["category","entity","brand"]` yields one document per non-empty
+  group, stable slugged paths, markdown head + schema line, one verbalized line
+  per record with humanized field names, nulls omitted, numbers trimmed,
+  duplicates collapsed, records sorted by label.
+- **AC-2** Unit: same fixture without `group_by` yields deterministic
+  `part-0001…` batching, ≤ `max_records_per_doc` records per doc, feed order
+  preserved.
+- **AC-3** Property/unit: for any emitted document, chunking with the production
+  chunker settings (2 000 chars / 200 overlap, `\n\n` soft boundary) never splits
+  a record line across two chunks, and every chunk contains the document's
+  heading context via the existing parent/heading mechanism. (Test imports the
+  real chunker from knowledge-ingest if importable in the connector test env;
+  otherwise replicate the boundary contract in a fixture-level test in
+  knowledge-ingest.)
+- **AC-4** Integration (fakes): two consecutive syncs of an unchanged feed
+  produce no duplicate ingests (content-hash dedup path exercised, not assumed).
+- **AC-5** Unit: a fixture large enough to exceed `max_doc_chars` splits at
+  record boundaries into `deel i/n` docs, each under the 200-chunk enrichment
+  cap.
+- **AC-6** Integration (fakes): sync N lists groups {A,B,C}; sync N+1 lists
+  {A,B} → C's artifacts are deleted downstream after the successful sync;
+  a failed sync N+2 deletes nothing. Plus the legacy-path migration case
+  (`json-feed/{id}.json` cleaned up on first new-style sync).
+- **AC-7** Unit: nested-object fixture renders via REQ-6 with headings and path
+  lines; asserting the output contains no `{`-prefixed pretty-printed blob.
+- **AC-8** Unit: `extra` payload contains `json_feed_group` +
+  `json_feed_record_count` and is included in the enrichment `extra_payload`
+  passthrough.
+- **AC-9** Retrieval smoke (fixture-level, no live services): embedding-input
+  text for a chunk containing "Nummer Italie" also contains its monthly price
+  and its group context (category/market) in the same chunk text.
+
+## Non-goals
+
+- Text-to-SQL / structured query tool over feed data (future SPEC; REQ-4's
+  metadata is its prerequisite).
+- Retrieval-api ranking changes (SPEC-RAG-SOURCE-SELECTION-001 owns that).
+- LLM-based verbalization at ingest (cost/latency/nondeterminism; deterministic
+  templates are sufficient for record-shaped data and testable).
+- Auto-detection of grouping fields (explicit config only).
+- Portal UI for the new config keys (follow-up).
+- Fixing the crawl-path secret leak (feed URLs with tokens logged in
+  knowledge-ingest `path` field for *crawl* ingests) — separate, pre-existing
+  issue; tracked outside this SPEC.
+
+## Risks
+
+- **Feeds that are huge flat arrays with no useful grouping** degrade to
+  `part-nnnn` batching — better than today (records stay whole, enrichment
+  runs), but chunk-level coherence depends on feed order. Mitigation: `group_by`
+  documentation + sync log counters make the shape visible.
+- **Stale-group deletion** is the only destructive step; gated on
+  successful-sync-only and covered by AC-6 both ways.
+- **Re-render churn**: changing the template later changes every fingerprint and
+  re-ingests all feeds. Accepted; note in HISTORY when it happens.

--- a/klai-connector/app/adapters/base.py
+++ b/klai-connector/app/adapters/base.py
@@ -53,6 +53,8 @@ class DocumentRef:
             no-normalisation contract as ``sender_email``.  Empty list when
             unavailable.  Uses ``field(default_factory=list)`` so instances
             never share a mutable default.
+        extra: Adapter-specific structured metadata forwarded to the ingest
+            payload. Empty by default so existing adapters remain unchanged.
     """
 
     path: str
@@ -65,6 +67,7 @@ class DocumentRef:
     images: list[ImageRef] | None = None
     sender_email: str = ""
     mentioned_emails: list[str] = field(default_factory=lambda: [])
+    extra: dict[str, Any] = field(default_factory=dict)
     # @MX:NOTE: content_fingerprint field (SPEC-CRAWL-003 REQ-12) removed in
     # SPEC-CRAWLER-004 Fase F — only WebCrawlerAdapter populated it, and that
     # adapter has been deleted now that bulk crawls go through the delegation
@@ -77,6 +80,10 @@ class BaseAdapter(ABC):
     Each connector type (GitHub, Notion, SharePoint, etc.)
     implements this interface.
     """
+
+    # Destructive reconciliation is opt-in because not every adapter's
+    # ``list_documents`` call is guaranteed to be a complete source snapshot.
+    stale_ref_cleanup_enabled = False
 
     @abstractmethod
     async def list_documents(
@@ -99,6 +106,10 @@ class BaseAdapter(ABC):
     async def get_cursor_state(self, connector: Any) -> dict[str, Any]:
         """Return the current cursor state for incremental sync."""
         ...
+
+    def get_sync_metrics(self, connector: Any) -> dict[str, int]:
+        """Return adapter-specific counters for the current sync lifecycle."""
+        return {}
 
     async def post_sync(self, connector: Any) -> None:
         """Called after all documents have been fetched for a sync run.

--- a/klai-connector/app/adapters/json_feed.py
+++ b/klai-connector/app/adapters/json_feed.py
@@ -1,9 +1,29 @@
-"""Generic adapter for importing a public JSON endpoint as one document."""
+"""Structure-aware adapter for public JSON feeds.
+
+Supported ``connector.config`` keys:
+
+* ``url`` (required): HTTPS endpoint fetched through the shared SSRF guard.
+* ``title``: document title, default ``"JSON feed"``.
+* ``group_by``: fields used to group flat record arrays.
+* ``record_label_fields``: preferred record label fields.
+* ``field_labels``: field-to-display-label overrides.
+* ``max_records_per_doc``: batch size without ``group_by`` (default 200).
+* ``max_doc_chars``: maximum rendered document size (default 120,000).
+
+Rendered documents are cached by connector id between ``list_documents`` and
+``post_sync``.  That interval is one sync lifecycle: ``fetch_document`` only
+reads the cache and never downloads the feed again for each emitted document.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
+import math
+import re
+import unicodedata
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -18,6 +38,29 @@ _MAX_FEED_SIZE = 2 * 1024 * 1024
 _REQUEST_TIMEOUT = 30.0
 _TOTAL_FETCH_TIMEOUT = 60.0
 _MIN_KNOWLEDGE_CHARS = 50
+_DEFAULT_MAX_RECORDS_PER_DOC = 200
+_DEFAULT_MAX_DOC_CHARS = 120_000
+# kb_article uses child_size=2000 and overlap=200. The chunker only accepts a
+# ``\n\n`` boundary above half the window, so record lines must stay at or below
+# roughly child_size / 2 - overlap. Empirically: 0/200 mid-record splits at 900,
+# versus 132/200 at 1790.
+_MAX_RECORD_LINE_CHARS = 900
+_DEFAULT_RECORD_LABEL_FIELDS = ("name", "title", "label", "id")
+_PART_SUFFIX_BUDGET = 32
+
+
+@dataclass(frozen=True)
+class _RenderedDocument:
+    content: bytes
+    extra: dict[str, Any]
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class _RenderedRecord:
+    index: int
+    label: str
+    line: str
 
 
 def _public_source_url(url: str) -> str:
@@ -27,8 +70,65 @@ def _public_source_url(url: str) -> str:
     return urlunsplit((parts.scheme, public_netloc, "", "", ""))
 
 
+def _slug(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-") or "overig"
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, str | int | float | bool)
+
+
+def _is_flat_record_array(parsed: Any) -> bool:
+    if not isinstance(parsed, list) or not parsed:
+        return False
+    for item in parsed:
+        if not isinstance(item, dict):
+            return False
+        non_scalar_count = sum(not _is_scalar(value) for value in item.values())
+        if item and non_scalar_count / len(item) > 0.1:
+            return False
+    return True
+
+
+def _is_empty(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def _display_value(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)[1:-1]
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("non-finite numbers are not supported")
+        return format(value, ".15g")
+    if isinstance(value, int):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+
+
+def _humanize(field_name: str, field_labels: dict[str, str]) -> str:
+    return field_labels.get(field_name, field_name.replace("_", " ").strip())
+
+
+def _group_title(group_by: list[str], values: tuple[str, ...]) -> str:
+    if group_by == ["category", "entity", "brand"]:
+        return f"{values[0]} — {values[2]} ({values[1]})"
+    return " — ".join(values)
+
+
 class JsonFeedAdapter(BaseAdapter):
-    """Fetch one HTTPS JSON URL and expose it as one knowledge document."""
+    """Fetch and render one HTTPS JSON URL as structure-aware Markdown documents."""
+
+    stale_ref_cleanup_enabled = True
+
+    def __init__(self) -> None:
+        self._documents_by_connector: dict[str, dict[str, _RenderedDocument]] = {}
+        self._metrics_by_connector: dict[str, dict[str, int]] = {}
 
     @staticmethod
     def _extract_url(connector: Any) -> str:
@@ -41,33 +141,135 @@ class JsonFeedAdapter(BaseAdapter):
             )
         return url.strip()
 
+    @staticmethod
+    def _config(connector: Any) -> tuple[dict[str, Any], list[str], list[str], dict[str, str], int, int]:
+        config: dict[str, Any] = connector.config or {}
+        group_by = config.get("group_by", [])
+        if not isinstance(group_by, list) or any(not isinstance(field, str) or not field for field in group_by):
+            raise ValueError("JSON feed connector config 'group_by' must be a list of non-empty field names")
+
+        label_fields = config.get("record_label_fields", list(_DEFAULT_RECORD_LABEL_FIELDS))
+        if not isinstance(label_fields, list) or any(
+            not isinstance(field, str) or not field for field in label_fields
+        ):
+            raise ValueError(
+                "JSON feed connector config 'record_label_fields' must be a list of non-empty field names"
+            )
+
+        field_labels = config.get("field_labels", {})
+        if not isinstance(field_labels, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str) for key, value in field_labels.items()
+        ):
+            raise ValueError("JSON feed connector config 'field_labels' must map field names to string labels")
+
+        max_records = config.get("max_records_per_doc", _DEFAULT_MAX_RECORDS_PER_DOC)
+        if isinstance(max_records, bool) or not isinstance(max_records, int) or max_records < 1:
+            raise ValueError("JSON feed connector config 'max_records_per_doc' must be a positive integer")
+
+        max_chars = config.get("max_doc_chars", _DEFAULT_MAX_DOC_CHARS)
+        if (
+            isinstance(max_chars, bool)
+            or not isinstance(max_chars, int)
+            or max_chars < 1
+            or max_chars > _DEFAULT_MAX_DOC_CHARS
+        ):
+            raise ValueError(
+                f"JSON feed connector config 'max_doc_chars' must be between 1 and {_DEFAULT_MAX_DOC_CHARS}"
+            )
+        return config, group_by, label_fields, field_labels, max_records, max_chars
+
     async def list_documents(
         self,
         connector: Any,
         cursor_context: dict[str, Any] | None = None,
     ) -> list[DocumentRef]:
-        """Validate the configured URL and return the feed as one stable ref."""
-        url = self._extract_url(connector)
+        """Fetch once, parse, group, render, and cache all refs for this sync."""
         connector_id = str(connector.id)
-        await validate_json_feed_url_strict(url, connector_id=connector_id)
-        return [
-            DocumentRef(
-                path=f"json-feed/{connector_id}.json",
-                ref=connector_id,
-                size=0,
-                content_type="kb_article",
-                source_ref=f"json-feed:{connector_id}",
-                source_url=_public_source_url(url),
+        self._documents_by_connector.pop(connector_id, None)
+        self._metrics_by_connector.pop(connector_id, None)
+        url = self._extract_url(connector)
+        config, group_by, label_fields, field_labels, max_records, max_chars = self._config(connector)
+        parsed = await self._fetch_json(url, connector_id)
+
+        if _is_flat_record_array(parsed):
+            rendered = self._render_flat_records(
+                parsed,
+                connector_id=connector_id,
+                config=config,
+                group_by=group_by,
+                label_fields=label_fields,
+                field_labels=field_labels,
+                max_records=max_records,
+                max_chars=max_chars,
             )
-        ]
+        else:
+            rendered = self._render_nested_json(
+                parsed,
+                connector_id=connector_id,
+                title=self._feed_title(config),
+                max_chars=max_chars,
+            )
+
+        rendered_chars = sum(len(document.content.decode("utf-8")) for document in rendered.values())
+        has_render_errors = any(document.error for document in rendered.values())
+        if not rendered or (rendered_chars < _MIN_KNOWLEDGE_CHARS and not has_render_errors):
+            raise ValueError(
+                "JSON feed contains too little knowledge "
+                f"(minimum {_MIN_KNOWLEDGE_CHARS} rendered characters)"
+            )
+
+        self._documents_by_connector[connector_id] = rendered
+        records_total = len(parsed) if _is_flat_record_array(parsed) else 0
+        rendered_record_count = sum(
+            int(document.extra.get("json_feed_record_count", 0)) for document in rendered.values()
+        )
+        self._metrics_by_connector[connector_id] = {
+            "groups_total": len(rendered),
+            "records_total": records_total,
+            "duplicates_collapsed": max(records_total - rendered_record_count, 0),
+        }
+        source_url = _public_source_url(url)
+        refs: list[DocumentRef] = []
+        for path, document in rendered.items():
+            group_slug = path.rsplit("/", 1)[-1]
+            refs.append(
+                DocumentRef(
+                    path=path,
+                    ref=f"json-feed:{connector_id}:{group_slug}",
+                    size=len(document.content),
+                    content_type="kb_article",
+                    source_ref=f"json-feed:{connector_id}:{group_slug}",
+                    source_url=source_url,
+                    extra=document.extra,
+                )
+            )
+        return refs
+
+    def get_sync_metrics(self, connector: Any) -> dict[str, int]:
+        """Return feed-shaping counters before ``post_sync`` clears the cache."""
+        return dict(self._metrics_by_connector.get(str(connector.id), {}))
 
     async def fetch_document(self, ref: DocumentRef, connector: Any) -> bytes:
-        """Download the feed through the shared SSRF guard and pinned transport."""
-        url = self._extract_url(connector)
+        """Return a rendered document cached for the current sync lifecycle."""
         connector_id = str(connector.id)
+        cached = self._documents_by_connector.get(connector_id, {}).get(ref.path)
+        if cached is None:
+            raise RuntimeError(
+                "JSON feed document is not cached for this sync; call list_documents before fetch_document"
+            )
+        if cached.error:
+            raise ValueError(cached.error)
+        return cached.content
+
+    async def post_sync(self, connector: Any) -> None:
+        """Release rendered feed documents at the end of the sync lifecycle."""
+        connector_id = str(connector.id)
+        self._documents_by_connector.pop(connector_id, None)
+        self._metrics_by_connector.pop(connector_id, None)
+
+    async def _fetch_json(self, url: str, connector_id: str) -> Any:
         validated = await validate_json_feed_url_strict(url, connector_id=connector_id)
         transport = PinnedResolverTransport({validated.hostname: validated.preferred_ip})
-
         try:
             async with asyncio.timeout(_TOTAL_FETCH_TIMEOUT):
                 async with (
@@ -80,7 +282,6 @@ class JsonFeedAdapter(BaseAdapter):
                 ):
                     if not 200 <= response.status_code < 300:
                         raise ValueError(f"JSON feed returned HTTP {response.status_code}")
-
                     content_length = response.headers.get("content-length")
                     if content_length:
                         try:
@@ -91,31 +292,15 @@ class JsonFeedAdapter(BaseAdapter):
                             raise ValueError(
                                 f"JSON feed is too large: {declared_size} bytes (max {_MAX_FEED_SIZE} bytes)"
                             )
-
                     content = bytearray()
                     async for chunk in response.aiter_bytes():
                         content.extend(chunk)
                         if len(content) > _MAX_FEED_SIZE:
                             raise ValueError(f"JSON feed is too large: more than {_MAX_FEED_SIZE} bytes")
-
                     try:
-                        parsed = json.loads(content)
+                        return json.loads(content)
                     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                         raise ValueError("JSON feed returned invalid JSON") from exc
-
-                    normalized = json.dumps(parsed, ensure_ascii=False, indent=2)
-                    normalized_length = len(normalized)
-                    if normalized_length < _MIN_KNOWLEDGE_CHARS:
-                        raise ValueError(
-                            f"JSON feed contains too little knowledge: {normalized_length} characters "
-                            f"(minimum {_MIN_KNOWLEDGE_CHARS})"
-                        )
-                    if normalized_length > MAX_INGEST_CONTENT_CHARS:
-                        raise ValueError(
-                            f"JSON feed produces {normalized_length} characters of text; "
-                            f"the ingest limit is {MAX_INGEST_CONTENT_CHARS} characters"
-                        )
-                    return normalized.encode("utf-8")
         except TimeoutError as exc:
             raise RuntimeError(
                 f"JSON feed request exceeded the {_TOTAL_FETCH_TIMEOUT:g}-second total deadline"
@@ -123,9 +308,342 @@ class JsonFeedAdapter(BaseAdapter):
         except ValueError:
             raise
         except httpx.HTTPError as exc:
-            # httpx exception strings include the full request URL. Do not
-            # leak query parameters into sync_run.error_details or logs.
             raise RuntimeError(f"JSON feed request failed ({type(exc).__name__})") from exc
+
+    @staticmethod
+    def _feed_title(config: dict[str, Any]) -> str:
+        title = config.get("title", "JSON feed")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError("JSON feed connector config 'title' must be a non-empty string")
+        return title.strip()
+
+    def _render_flat_records(
+        self,
+        records: list[dict[str, Any]],
+        *,
+        connector_id: str,
+        config: dict[str, Any],
+        group_by: list[str],
+        label_fields: list[str],
+        field_labels: dict[str, str],
+        max_records: int,
+        max_chars: int,
+    ) -> dict[str, _RenderedDocument]:
+        title = self._feed_title(config)
+        if group_by:
+            for field in group_by:
+                missing = sum(field not in record for record in records)
+                if missing > len(records) / 2:
+                    raise ValueError(
+                        f"JSON feed group_by field '{field}' is absent from {missing}/{len(records)} records (>50%)"
+                    )
+
+        if not group_by:
+            rendered_records = self._render_records(
+                list(enumerate(records)),
+                group_title="default batches",
+                label_fields=label_fields,
+                field_labels=field_labels,
+                sort_records=False,
+            )
+            documents: dict[str, _RenderedDocument] = {}
+            for start in range(0, len(rendered_records), max_records):
+                batch_number = start // max_records + 1
+                slug = f"part-{batch_number:04d}"
+                batch = rendered_records[start : start + max_records]
+                indexed_batch = [(item.index, records[item.index]) for item in batch]
+                documents.update(
+                    self._split_record_group(
+                        connector_id=connector_id,
+                        slug=slug,
+                        title=f"{title} — {slug}",
+                        schema=self._schema_fields(indexed_batch, field_labels),
+                        records=batch,
+                        group_values={},
+                        max_chars=max_chars,
+                    )
+                )
+            return documents
+
+        groups: OrderedDict[tuple[str, ...], list[tuple[int, dict[str, Any]]]] = OrderedDict()
+        for index, record in enumerate(records):
+            key = tuple(
+                "overig" if field not in record or _is_empty(record[field]) else _display_value(record[field])
+                for field in group_by
+            )
+            groups.setdefault(key, []).append((index, record))
+
+        documents: dict[str, _RenderedDocument] = {}
+        for key, indexed_records in groups.items():
+            slug = "-".join(_slug(value) for value in key)
+            group_title = _group_title(group_by, key)
+            group_values = dict(zip(group_by, key, strict=True))
+            try:
+                rendered_records = self._render_records(
+                    indexed_records,
+                    group_title=group_title,
+                    label_fields=label_fields,
+                    field_labels=field_labels,
+                    sort_records=True,
+                )
+                schema = self._schema_fields(indexed_records, field_labels)
+                group_documents = self._split_record_group(
+                    connector_id=connector_id,
+                    slug=slug,
+                    title=f"{title} — {group_title}",
+                    schema=schema,
+                    records=rendered_records,
+                    group_values=group_values,
+                    max_chars=max_chars,
+                )
+            except (TypeError, ValueError) as exc:
+                error = str(exc)
+                if not error.startswith("Failed to render JSON feed group"):
+                    error = f"Failed to render JSON feed group '{group_title}': {error}"
+                group_documents = {
+                    f"json-feed/{connector_id}/{slug}": _RenderedDocument(
+                        content=b"",
+                        extra={
+                            "json_feed_group": group_values,
+                            "json_feed_record_count": len(indexed_records),
+                        },
+                        error=error,
+                    )
+                }
+            overlap = documents.keys() & group_documents.keys()
+            if overlap:
+                raise ValueError(f"JSON feed group slugs collide: {', '.join(sorted(overlap))}")
+            documents.update(group_documents)
+        return documents
+
+    @staticmethod
+    def _schema_fields(
+        indexed_records: list[tuple[int, dict[str, Any]]],
+        field_labels: dict[str, str],
+    ) -> list[str]:
+        fields: list[str] = []
+        seen: set[str] = set()
+        for _, record in indexed_records:
+            for field in record:
+                if field not in seen:
+                    seen.add(field)
+                    fields.append(_humanize(field, field_labels))
+        return fields
+
+    @staticmethod
+    def _render_records(
+        indexed_records: list[tuple[int, dict[str, Any]]],
+        *,
+        group_title: str,
+        label_fields: list[str],
+        field_labels: dict[str, str],
+        sort_records: bool,
+    ) -> list[_RenderedRecord]:
+        rendered: list[_RenderedRecord] = []
+        for index, record in indexed_records:
+            try:
+                label_field = next(
+                    (field for field in label_fields if field in record and not _is_empty(record[field])),
+                    None,
+                )
+                label = _display_value(record[label_field]) if label_field else str(index + 1)
+                pairs = [
+                    f"{_humanize(field, field_labels)}: {_display_value(value)}"
+                    for field, value in record.items()
+                    if field != label_field and not _is_empty(value)
+                ]
+                line = f"- **{label}**"
+                if pairs:
+                    line += f" — {'; '.join(pairs)}"
+                if len(line) > _MAX_RECORD_LINE_CHARS:
+                    raise ValueError(
+                        f"rendered record line is {len(line)} characters; maximum is {_MAX_RECORD_LINE_CHARS}"
+                    )
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Failed to render JSON feed group '{group_title}' record index {index}: {exc}"
+                ) from exc
+            rendered.append(_RenderedRecord(index=index, label=label, line=line))
+
+        if sort_records:
+            rendered.sort(key=lambda item: (item.label.casefold(), item.index))
+        unique: list[_RenderedRecord] = []
+        seen_lines: set[str] = set()
+        for item in rendered:
+            if item.line not in seen_lines:
+                seen_lines.add(item.line)
+                unique.append(item)
+        return unique
+
+    def _split_record_group(
+        self,
+        *,
+        connector_id: str,
+        slug: str,
+        title: str,
+        schema: list[str],
+        records: list[_RenderedRecord],
+        group_values: dict[str, str],
+        max_chars: int,
+    ) -> dict[str, _RenderedDocument]:
+        intro = f"Velden: {', '.join(schema)}"
+        full_content = self._compose_document(title, intro, [record.line for record in records])
+        if len(full_content) <= max_chars:
+            parts = [records]
+        else:
+            part_limit = max_chars - _PART_SUFFIX_BUDGET
+            parts = self._partition_blocks(title, intro, records, part_limit)
+
+        documents: dict[str, _RenderedDocument] = {}
+        total = len(parts)
+        for part_index, part in enumerate(parts, start=1):
+            part_slug = slug if total == 1 else f"{slug}--{part_index}"
+            part_title = title if total == 1 else f"{title} — deel {part_index}/{total}"
+            content = self._compose_document(part_title, intro, [record.line for record in part])
+            self._validate_document_size(content, max_chars)
+            path = f"json-feed/{connector_id}/{part_slug}"
+            documents[path] = _RenderedDocument(
+                content=content.encode("utf-8"),
+                extra={
+                    "json_feed_group": group_values,
+                    "json_feed_record_count": len(part),
+                },
+            )
+        return documents
+
+    @staticmethod
+    def _partition_blocks(
+        title: str,
+        intro: str,
+        records: list[_RenderedRecord],
+        limit: int,
+    ) -> list[list[_RenderedRecord]]:
+        parts: list[list[_RenderedRecord]] = []
+        current: list[_RenderedRecord] = []
+        for record in records:
+            candidate = [*current, record]
+            content = JsonFeedAdapter._compose_document(title, intro, [item.line for item in candidate])
+            if len(content) <= limit:
+                current = candidate
+                continue
+            if not current:
+                configured_limit = limit + _PART_SUFFIX_BUDGET
+                raise ValueError(
+                    f"JSON feed record index {record.index} cannot fit within max_doc_chars={configured_limit}"
+                )
+            parts.append(current)
+            current = [record]
+        if current:
+            parts.append(current)
+        return parts
+
+    @staticmethod
+    def _compose_document(title: str, intro: str, blocks: list[str]) -> str:
+        components = [f"# {title}", intro, *blocks]
+        return "\n\n".join(components)
+
+    @staticmethod
+    def _validate_document_size(content: str, max_chars: int) -> None:
+        if len(content) > max_chars:
+            raise ValueError(
+                f"JSON feed document produces {len(content)} characters; max_doc_chars is {max_chars}"
+            )
+        if len(content) > MAX_INGEST_CONTENT_CHARS:
+            raise ValueError(
+                f"JSON feed document produces {len(content)} characters; "
+                f"the ingest limit is {MAX_INGEST_CONTENT_CHARS} characters"
+            )
+
+    def _render_nested_json(
+        self,
+        parsed: Any,
+        *,
+        connector_id: str,
+        title: str,
+        max_chars: int,
+    ) -> dict[str, _RenderedDocument]:
+        if isinstance(parsed, dict):
+            sections = [
+                (str(key), self._nested_blocks(value, path=str(key), depth=1))
+                for key, value in parsed.items()
+            ]
+            sections = [(key, blocks) for key, blocks in sections if blocks]
+            combined_blocks = [
+                block
+                for key, section_blocks in sections
+                for block in [f"## {key}", *section_blocks]
+            ]
+        elif isinstance(parsed, list) and parsed:
+            sections = [("document", self._nested_blocks(parsed, path="document", depth=1))]
+            combined_blocks = sections[0][1]
+        else:
+            return {}
+
+        if not sections:
+            return {}
+        combined_content = "\n\n".join([f"# {title}", *combined_blocks])
+        if len(combined_content) <= max_chars:
+            self._validate_document_size(combined_content, max_chars)
+            return {
+                f"json-feed/{connector_id}/document": _RenderedDocument(
+                    content=combined_content.encode("utf-8"),
+                    extra={},
+                )
+            }
+
+        documents: dict[str, _RenderedDocument] = {}
+        for key, blocks in sections:
+            slug = _slug(key)
+            section_title = f"{title} — {key}"
+            parts = self._partition_text_blocks(section_title, blocks, max_chars)
+            total = len(parts)
+            for part_index, part in enumerate(parts, start=1):
+                part_slug = slug if total == 1 else f"{slug}--{part_index}"
+                part_title = section_title if total == 1 else f"{section_title} — deel {part_index}/{total}"
+                content = "\n\n".join([f"# {part_title}", *part])
+                self._validate_document_size(content, max_chars)
+                path = f"json-feed/{connector_id}/{part_slug}"
+                if path in documents:
+                    raise ValueError(f"JSON feed top-level key slugs collide at '{slug}'")
+                documents[path] = _RenderedDocument(content=content.encode("utf-8"), extra={})
+        return documents
+
+    def _nested_blocks(self, value: Any, *, path: str, depth: int) -> list[str]:
+        if isinstance(value, dict):
+            blocks: list[str] = []
+            for key, child in value.items():
+                child_path = f"{path}.{key}"
+                if isinstance(child, dict) and depth == 1:
+                    blocks.append(f"## {key}")
+                    blocks.extend(self._nested_blocks(child, path=child_path, depth=depth + 1))
+                else:
+                    blocks.extend(self._nested_blocks(child, path=child_path, depth=depth + 1))
+            return blocks
+        if isinstance(value, list):
+            if all(_is_scalar(item) for item in value):
+                return [f"- {path}: {_display_value(value)}"]
+            return [f"- {path}[{index}]: {_display_value(item)}" for index, item in enumerate(value)]
+        if value is None:
+            return [f"- {path}: null"]
+        return [f"- {path}: {_display_value(value)}"]
+
+    @staticmethod
+    def _partition_text_blocks(title: str, blocks: list[str], max_chars: int) -> list[list[str]]:
+        part_limit = max_chars - _PART_SUFFIX_BUDGET
+        parts: list[list[str]] = []
+        current: list[str] = []
+        for block in blocks:
+            candidate = [*current, block]
+            if len("\n\n".join([f"# {title}", *candidate])) <= part_limit:
+                current = candidate
+                continue
+            if not current:
+                raise ValueError(f"JSON feed value at '{block.split(':', 1)[0]}' cannot fit within max_doc_chars")
+            parts.append(current)
+            current = [block]
+        if current:
+            parts.append(current)
+        return parts
 
     async def get_cursor_state(self, connector: Any) -> dict[str, Any]:
         """Omit last_synced_at so reconciliation fetches every manual sync."""

--- a/klai-connector/app/clients/knowledge_ingest.py
+++ b/klai-connector/app/clients/knowledge_ingest.py
@@ -35,6 +35,7 @@ def _build_payload(
     connector_type: str = "",
     sender_email: str = "",
     mentioned_emails: list[str] | None = None,
+    document_extra: dict[str, object] | None = None,
     user_id: str | None = None,
 ) -> dict:
     """Build the JSON payload for the knowledge-ingest endpoint."""
@@ -62,7 +63,7 @@ def _build_payload(
         host = urlparse(source_url).hostname
         if host:
             payload["source_domain"] = host
-    extra: dict[str, object] = {}
+    extra: dict[str, object] = dict(document_extra or {})
     if source_url:
         extra["source_url"] = source_url
     if image_urls:
@@ -114,6 +115,7 @@ class KnowledgeIngestClient:
         image_urls: list[str] | None = None,
         connector_type: str = "",
         user_id: str | None = None,
+        document_extra: dict[str, object] | None = None,
     ) -> None:
         """Send a parsed document to knowledge-ingest for embedding.
 
@@ -128,6 +130,8 @@ class KnowledgeIngestClient:
             allowed_assertion_modes: Optional connector-level hint for which assertion modes
                 this source can produce. Used in knowledge-ingest when content has no frontmatter.
             image_urls: Optional list of presigned S3 URLs for images extracted from the document.
+            document_extra: Adapter-specific structured metadata forwarded in
+                the ingest request's ``extra`` object.
             user_id: Zitadel user_id of the connector creator. Forwarded as
                 ``req.user_id`` so knowledge-ingest can pass the
                 personal-KB owner-binding check (``personal_kb_owner_mismatch``).
@@ -166,6 +170,7 @@ class KnowledgeIngestClient:
             image_urls=image_urls,
             connector_type=connector_type,
             user_id=user_id,
+            document_extra=document_extra,
         )
         if allowed_assertion_modes is not None:
             payload["allowed_assertion_modes"] = allowed_assertion_modes
@@ -177,6 +182,31 @@ class KnowledgeIngestClient:
         )
         response.raise_for_status()
         logger.info("Ingested document: %s", path)
+
+    async def delete_connector_document(
+        self,
+        *,
+        org_id: str,
+        kb_slug: str,
+        source_connector_id: str,
+        source_ref: str,
+    ) -> None:
+        """Delete one connector artifact by its stable provider reference."""
+        response = await self._client.delete(
+            "/ingest/v1/connector/document",
+            params={
+                "org_id": org_id,
+                "kb_slug": kb_slug,
+                "connector_id": source_connector_id,
+                "source_ref": source_ref,
+            },
+            headers={
+                "X-Internal-Secret": self._internal_secret,
+                "X-Caller-Service": "connector",
+            },
+        )
+        response.raise_for_status()
+        logger.info("Deleted stale connector document: %s", source_ref)
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -159,6 +159,11 @@ class SyncEngine:
         documents_total = 0
         documents_ok = 0
         documents_failed = 0
+        groups_total = 0
+        records_total = 0
+        duplicates_collapsed = 0
+        stale_groups_deleted = 0
+        stale_cleanup_refused = False
         # SPEC-INGEST-RECONCILE-001 AC-6 — per-sync skip-reason aggregation
         # ``{PersistSkipReason: count}``. Persisted to
         # ``connector.sync_runs.skip_reasons`` JSONB at the end of the run
@@ -300,6 +305,11 @@ class SyncEngine:
                 # cursor_context still passed for adapters that use it (e.g. webcrawler).
                 cursor_context = prev_cursor or None
                 refs = await adapter.list_documents(portal_config, cursor_context=cursor_context)
+                adapter_metrics = adapter.get_sync_metrics(portal_config)
+                if isinstance(adapter_metrics, dict):
+                    groups_total = int(adapter_metrics.get("groups_total", 0))
+                    records_total = int(adapter_metrics.get("records_total", 0))
+                    duplicates_collapsed = int(adapter_metrics.get("duplicates_collapsed", 0))
 
                 # Reconciliation: decide which refs need syncing.
                 # - New: not in prev_synced_refs → always sync
@@ -393,6 +403,7 @@ class SyncEngine:
                             image_urls=image_urls,
                             connector_type=portal_config.connector_type,
                             user_id=portal_config.owner_user_id,
+                            document_extra=ref.extra,
                         )
                         documents_ok += 1
                         resume_ingested_refs.add(ref_key)
@@ -417,6 +428,52 @@ class SyncEngine:
                         )
 
                 await adapter.post_sync(portal_config)
+
+                # REQ-5: only adapters whose discovery is a complete snapshot may
+                # opt into destructive stale-ref reconciliation. A partial run is
+                # never allowed to delete downstream state.
+                if (
+                    documents_failed == 0
+                    and adapter.stale_ref_cleanup_enabled is True
+                ):
+                    current_refs = {ref.source_ref or ref.path for ref in refs}
+                    stale_refs = sorted(prev_synced_refs - current_refs)
+                    if len(stale_refs) > max(1, len(prev_synced_refs) // 2):
+                        stale_cleanup_refused = True
+                        logger.warning(
+                            "Refusing stale cleanup for connector %s after listing shrink",
+                            connector_id,
+                            extra={
+                                "event": "stale_cleanup_refused_shrink",
+                                "connector_id": str(connector_id),
+                                "previous_ref_count": len(prev_synced_refs),
+                                "current_ref_count": len(current_refs),
+                            },
+                        )
+                    else:
+                        for stale_ref in stale_refs:
+                            try:
+                                await self._ingest_client.delete_connector_document(
+                                    org_id=portal_config.zitadel_org_id,
+                                    kb_slug=portal_config.kb_slug,
+                                    source_connector_id=str(connector_id),
+                                    source_ref=stale_ref,
+                                )
+                            except Exception as cleanup_err:
+                                status = SyncStatus.FAILED
+                                error_details.append({
+                                    "error": "Stale source_ref cleanup failed",
+                                    "source_ref": stale_ref,
+                                    "reason": str(cleanup_err),
+                                })
+                                logger.exception(
+                                    "Failed to delete stale source_ref %s for connector %s",
+                                    stale_ref,
+                                    connector_id,
+                                    extra={"connector_id": str(connector_id)},
+                                )
+                                break
+                            stale_groups_deleted += 1
 
                 # @MX:NOTE: Layer C boilerplate detection and CanaryMismatchError /
                 #   CrawlJobPendingError handling were removed in SPEC-CRAWLER-004
@@ -512,9 +569,14 @@ class SyncEngine:
             # refs disappear. The sync engine compares against this on the next run.
             if status == SyncStatus.COMPLETED and cursor_state is not None:
                 failed_refs = {e.get("file", "") for e in error_details}
-                cursor_state["synced_refs"] = sorted(
-                    (r.source_ref or r.path) for r in refs if (r.source_ref or r.path) not in failed_refs
-                )
+                discovered_refs = {
+                    r.source_ref or r.path
+                    for r in refs
+                    if (r.source_ref or r.path) not in failed_refs
+                }
+                if stale_cleanup_refused:
+                    discovered_refs.update(prev_synced_refs)
+                cursor_state["synced_refs"] = sorted(discovered_refs)
             sync_run.cursor_state = cursor_state
             await session.commit()
 
@@ -536,6 +598,11 @@ class SyncEngine:
                     ),
                     "skip_reasons": dict(skip_reasons),
                     "bytes_processed": bytes_processed,
+                    "groups_total": groups_total,
+                    "records_total": records_total,
+                    "duplicates_collapsed": duplicates_collapsed,
+                    "stale_groups_deleted": stale_groups_deleted,
+                    "stale_cleanup_refused": stale_cleanup_refused,
                 },
             )
 

--- a/klai-connector/tests/adapters/test_json_feed.py
+++ b/klai-connector/tests/adapters/test_json_feed.py
@@ -1,8 +1,10 @@
-"""Contract tests for the generic JSON feed adapter."""
+"""Contract tests for the structure-aware JSON feed adapter."""
 
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,157 +13,322 @@ import pytest
 from klai_image_storage import PinnedResolverTransport
 
 from app.adapters.json_feed import JsonFeedAdapter
-from app.clients.knowledge_ingest import MAX_INGEST_CONTENT_CHARS
+from app.clients.knowledge_ingest import _build_payload
 from app.services.url_guard import PersistedUrlRejectedError
 
 
-def _connector(url: str = "https://data.example.com/feed.json?token=secret") -> SimpleNamespace:
-    return SimpleNamespace(id="connector-123", config={"url": url})
+def _connector(
+    url: str = "https://data.example.com/feed.json?token=secret",
+    **config: object,
+) -> SimpleNamespace:
+    return SimpleNamespace(id="connector-123", config={"url": url, **config})
 
 
-async def test_list_documents_exposes_one_stable_json_document() -> None:
-    adapter = JsonFeedAdapter()
-    validated = SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
+def _voys_records() -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for category in ("Telefoonnummers", "Gesprekken", "Abonnementen"):
+        for entity in ("nl", "be"):
+            records.append(
+                {
+                    "category": category,
+                    "entity": entity,
+                    "brand": "voys",
+                    "name": f"{category} {entity}",
+                    "monthly": 9.25000,
+                    "per_minute": None,
+                }
+            )
+    records.insert(
+        0,
+        {
+            "category": "Telefoonnummers",
+            "entity": "nl",
+            "brand": "voys",
+            "name": "Nummer Portugal",
+            "monthly": 9.25000,
+            "per_minute": None,
+        },
+    )
+    records.insert(
+        0,
+        {
+            "category": "Telefoonnummers",
+            "entity": "nl",
+            "brand": "voys",
+            "name": "Nummer Italie",
+            "monthly": 9.25000,
+            "per_minute": None,
+        },
+    )
+    records.insert(1, dict(records[0]))
+    return records
 
-    with patch(
-        "app.adapters.json_feed.validate_json_feed_url_strict",
-        new=AsyncMock(return_value=validated),
+
+async def _list_payload(
+    adapter: JsonFeedAdapter,
+    payload: object,
+    connector: SimpleNamespace | None = None,
+) -> tuple[list, MagicMock, AsyncMock]:
+    response = _StreamingResponse(status_code=200, headers={}, chunks=[json.dumps(payload).encode()])
+    client_factory = MagicMock(return_value=_StreamingClient(response))
+    validator = AsyncMock(
+        return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
+    )
+    with (
+        patch("app.adapters.json_feed.validate_json_feed_url_strict", new=validator),
+        patch("app.adapters.json_feed.httpx.AsyncClient", client_factory),
     ):
-        refs = await adapter.list_documents(_connector())
+        refs = await adapter.list_documents(connector or _connector())
+    return refs, client_factory, validator
 
-    assert len(refs) == 1
-    assert refs[0].path == "json-feed/connector-123.json"
-    assert refs[0].content_type == "kb_article"
-    assert refs[0].source_ref == "json-feed:connector-123"
-    assert refs[0].source_url == "https://data.example.com"
-    assert "secret" not in refs[0].source_url
+
+async def test_ac1_flat_records_are_grouped_verbalized_sorted_and_deduplicated() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(
+        group_by=["category", "entity", "brand"],
+        title="Prijzen",
+        field_labels={"monthly": "per maand (EUR)"},
+    )
+    refs, _, _ = await _list_payload(adapter, _voys_records(), connector)
+
+    assert len(refs) == 6
+    ref = next(item for item in refs if item.path.endswith("/telefoonnummers-nl-voys"))
+    assert ref.content_type == "kb_article"
+    assert ref.source_ref == "json-feed:connector-123:telefoonnummers-nl-voys"
+    assert ref.source_url == "https://data.example.com"
+    assert ref.extra == {
+        "json_feed_group": {"category": "Telefoonnummers", "entity": "nl", "brand": "voys"},
+        "json_feed_record_count": 3,
+    }
+    content = (await adapter.fetch_document(ref, connector)).decode()
+    assert content.startswith("# Prijzen — Telefoonnummers — voys (nl)\n\nVelden: ")
+    assert content.count("**Nummer Italie**") == 1
+    assert content.index("**Nummer Italie**") < content.index("**Nummer Portugal**")
+    assert "per maand (EUR): 9.25" in content
+    assert "per minute:" not in content
+    assert "secret" not in ref.source_url
+    assert adapter.get_sync_metrics(connector) == {
+        "groups_total": 6,
+        "records_total": 9,
+        "duplicates_collapsed": 1,
+    }
+
+
+async def test_ac2_without_group_by_batches_in_feed_order() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(max_records_per_doc=2)
+    records = [{"name": name, "price": index} for index, name in enumerate(("Zulu", "Alpha", "Mike", "Bravo", "Echo"))]
+    refs, _, _ = await _list_payload(adapter, records, connector)
+
+    assert [ref.path for ref in refs] == [
+        "json-feed/connector-123/part-0001",
+        "json-feed/connector-123/part-0002",
+        "json-feed/connector-123/part-0003",
+    ]
+    assert [ref.extra["json_feed_record_count"] for ref in refs] == [2, 2, 1]
+    first = (await adapter.fetch_document(refs[0], connector)).decode()
+    assert first.index("**Zulu**") < first.index("**Alpha**")
+
+
+async def test_ac3_documents_preserve_chunker_soft_boundaries() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(group_by=["category"])
+    records = [
+        {"category": "prijzen", "name": f"Product {index:02d}", "description": "x" * 300}
+        for index in range(6)
+    ]
+    refs, _, _ = await _list_payload(adapter, records, connector)
+
+    for ref in refs:
+        content = (await adapter.fetch_document(ref, connector)).decode()
+        assert content.startswith("# ")
+        record_lines = [line for line in content.splitlines() if line.startswith("- **")]
+        assert record_lines
+        assert all(len(line) <= 900 for line in record_lines)
+        assert all(f"{line}\n\n" in f"{content}\n\n" for line in record_lines)
+
+
+async def test_ac5_oversized_group_splits_at_record_boundaries_below_cap() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(group_by=["category"], max_doc_chars=700)
+    records = [
+        {"category": "prijzen", "name": f"Product {index:02d}", "description": "x" * 240}
+        for index in range(8)
+    ]
+    refs, _, _ = await _list_payload(adapter, records, connector)
+
+    assert len(refs) > 1
+    assert [ref.path for ref in refs] == [
+        f"json-feed/connector-123/prijzen--{index}" for index in range(1, len(refs) + 1)
+    ]
+    seen_labels: list[str] = []
+    for index, ref in enumerate(refs, start=1):
+        content = (await adapter.fetch_document(ref, connector)).decode()
+        assert len(content) <= 700
+        assert f"— deel {index}/{len(refs)}" in content.splitlines()[0]
+        assert len(content) < 200 * 2_000
+        seen_labels.extend(line for line in content.splitlines() if line.startswith("- **"))
+    assert len(seen_labels) == len(records)
+
+
+async def test_ac7_nested_json_uses_headings_and_path_lines() -> None:
+    adapter = JsonFeedAdapter()
+    payload = {
+        "catalogus": {
+            "telefoon": {"monthly": 9.25, "countries": ["NL", "BE"]},
+            "support": "inbegrepen",
+        },
+        "updated_at": "2026-08-25",
+    }
+    refs, _, _ = await _list_payload(adapter, payload, _connector(title="Prijzen"))
+
+    assert [ref.path for ref in refs] == ["json-feed/connector-123/document"]
+    content = (await adapter.fetch_document(refs[0], _connector())).decode()
+    assert content.startswith("# Prijzen")
+    assert "## catalogus" in content
+    assert "- catalogus.telefoon.monthly: 9.25" in content
+    assert '- catalogus.telefoon.countries: ["NL","BE"]' in content
+    assert not any(line.startswith("{") for line in content.splitlines())
+
+
+async def test_ac8_extra_reaches_ingest_and_enrichment_payload_contract() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(group_by=["category"])
+    refs, _, _ = await _list_payload(
+        adapter,
+        [{"category": "Telefoonnummers", "name": "Nummer Italie", "monthly": 9.25}],
+        connector,
+    )
+    ref = refs[0]
+
+    payload = _build_payload(
+        org_id="org-1",
+        kb_slug="prices",
+        path=ref.path,
+        content=(await adapter.fetch_document(ref, connector)).decode(),
+        source_connector_id="connector-123",
+        source_ref=ref.source_ref,
+        content_type=ref.content_type,
+        document_extra=ref.extra,
+    )
+
+    assert payload["extra"]["json_feed_group"] == {"category": "Telefoonnummers"}
+    assert payload["extra"]["json_feed_record_count"] == 1
+    ingest_route = Path(__file__).parents[3] / "klai-knowledge-ingest" / "knowledge_ingest" / "routes" / "ingest.py"
+    assert "extra_payload.update(req.extra)" in ingest_route.read_text()
+
+
+async def test_ac9_record_text_contains_price_and_group_context() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(group_by=["category", "entity"])
+    refs, _, _ = await _list_payload(
+        adapter,
+        [
+            {
+                "category": "Telefoonnummers",
+                "entity": "nl",
+                "name": "Nummer Italie",
+                "monthly": 9.25,
+            }
+        ],
+        connector,
+    )
+    content = (await adapter.fetch_document(refs[0], connector)).decode()
+
+    assert "Telefoonnummers — nl" in content
+    assert "Nummer Italie" in content
+    assert "monthly: 9.25" in content
+
+
+async def test_list_documents_fetches_once_and_cache_lives_until_post_sync() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector()
+    refs, client_factory, validator = await _list_payload(
+        adapter,
+        [{"name": "Support", "description": "A sufficiently detailed service description"}],
+        connector,
+    )
+
+    first = await adapter.fetch_document(refs[0], connector)
+    second = await adapter.fetch_document(refs[0], connector)
+    assert first == second
+    assert client_factory.call_count == 1
+    assert validator.await_count == 1
+
+    await adapter.post_sync(connector)
+    assert adapter.get_sync_metrics(connector) == {}
+    with pytest.raises(RuntimeError, match="not cached"):
+        await adapter.fetch_document(refs[0], connector)
+
+
+async def test_group_by_field_missing_from_more_than_half_fails_explicitly() -> None:
+    adapter = JsonFeedAdapter()
+    with pytest.raises(ValueError, match=r"group_by field 'category'.*absent.*>50%"):
+        await _list_payload(
+            adapter,
+            [{"name": "A"}, {"name": "B"}, {"category": "prijzen", "name": "C"}],
+            _connector(group_by=["category"]),
+        )
+
+
+async def test_oversized_record_fails_with_group_and_record_index() -> None:
+    adapter = JsonFeedAdapter()
+    connector = _connector(group_by=["category"])
+    refs, _, _ = await _list_payload(
+        adapter,
+        [{"category": "prijzen", "name": "A", "description": "x" * 900}],
+        connector,
+    )
+
+    with pytest.raises(ValueError, match=r"group 'prijzen' record index 0"):
+        await adapter.fetch_document(refs[0], connector)
 
 
 async def test_list_documents_requires_a_url() -> None:
     adapter = JsonFeedAdapter()
-
     with pytest.raises(ValueError, match="missing required field 'url'"):
         await adapter.list_documents(SimpleNamespace(id="connector-123", config={}))
 
 
 async def test_list_documents_reports_missing_url_when_config_is_null() -> None:
     adapter = JsonFeedAdapter()
-
     with pytest.raises(ValueError, match="missing required field 'url'"):
         await adapter.list_documents(SimpleNamespace(id="connector-123", config=None))
-
-
-async def test_list_documents_strips_url_credentials_from_citation() -> None:
-    adapter = JsonFeedAdapter()
-    validated = SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
-
-    with patch(
-        "app.adapters.json_feed.validate_json_feed_url_strict",
-        new=AsyncMock(return_value=validated),
-    ):
-        refs = await adapter.list_documents(_connector("https://user:password@data.example.com/feed.json?token=secret"))
-
-    assert refs[0].source_url == "https://data.example.com"
-
-
-async def test_list_documents_strips_url_path_secrets_from_citation() -> None:
-    adapter = JsonFeedAdapter()
-    validated = SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
-
-    with patch(
-        "app.adapters.json_feed.validate_json_feed_url_strict",
-        new=AsyncMock(return_value=validated),
-    ):
-        refs = await adapter.list_documents(
-            _connector("https://data.example.com/private/path-token/feed.json")
-        )
-
-    assert refs[0].source_url == "https://data.example.com"
-    assert "path-token" not in refs[0].source_url
 
 
 @pytest.mark.parametrize(
     ("url", "expected_source_url"),
     [
-        (
-            "https://user:password@[2001:db8::1]:8443/private/feed.json?token=secret",
-            "https://[2001:db8::1]:8443",
-        ),
-        (
-            "https://data.example.com:8443/private/feed.json?token=secret",
-            "https://data.example.com:8443",
-        ),
+        ("https://user:password@data.example.com/private/feed.json?token=secret", "https://data.example.com"),
+        ("https://data.example.com/private/path-token/feed.json", "https://data.example.com"),
+        ("https://user:password@[2001:db8::1]:8443/private/feed.json", "https://[2001:db8::1]:8443"),
+        ("https://data.example.com:8443/private/feed.json", "https://data.example.com:8443"),
     ],
 )
-async def test_list_documents_preserves_origin_port_and_ipv6_syntax(
+async def test_list_documents_exposes_only_credential_stripped_origin(
     url: str,
     expected_source_url: str,
 ) -> None:
     adapter = JsonFeedAdapter()
-    validated = SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
-
-    with patch(
-        "app.adapters.json_feed.validate_json_feed_url_strict",
-        new=AsyncMock(return_value=validated),
-    ):
-        refs = await adapter.list_documents(_connector(url))
-
+    refs, _, _ = await _list_payload(
+        adapter,
+        [{"name": "Support", "description": "A sufficiently detailed service description"}],
+        _connector(url),
+    )
     assert refs[0].source_url == expected_source_url
     assert "password" not in refs[0].source_url
     assert "secret" not in refs[0].source_url
+    assert "path-token" not in refs[0].source_url
 
 
-async def test_fetch_document_returns_json_bytes() -> None:
+async def test_list_documents_normalizes_utf16_json_to_utf8() -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
-    response = _StreamingResponse(
-        status_code=200,
-        headers={"content-type": "application/json; charset=utf-8"},
-        chunks=[b'[{"service":', b'"Support","price":42}]'],
-    )
-
-    with (
-        patch(
-            "app.adapters.json_feed.validate_json_feed_url_strict",
-            new=AsyncMock(return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")),
-        ),
-        patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
-    ):
-        content = await adapter.fetch_document(ref, _connector())
-
-    assert content == b'[\n  {\n    "service": "Support",\n    "price": 42\n  }\n]'
-
-
-async def test_fetch_document_accepts_valid_json_with_legacy_content_type() -> None:
-    adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
-    response = _StreamingResponse(
-        status_code=200,
-        headers={"content-type": "text/plain"},
-        chunks=[b'{"description":"A sufficiently detailed price description","price":42}'],
-    )
-
-    with (
-        patch(
-            "app.adapters.json_feed.validate_json_feed_url_strict",
-            new=AsyncMock(return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")),
-        ),
-        patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
-    ):
-        content = await adapter.fetch_document(ref, _connector())
-
-    assert content == (b'{\n  "description": "A sufficiently detailed price description",\n  "price": 42\n}')
-
-
-async def test_fetch_document_normalizes_utf16_json_to_utf8() -> None:
-    adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
+    payload = {"description": "Uitgebreide prijsinformatie", "price": 42}
     response = _StreamingResponse(
         status_code=200,
         headers={"content-type": "application/json"},
-        chunks=['{"service":"Ondersteuning","description":"Uitgebreide prijsinformatie","price":42}'.encode("utf-16")],
+        chunks=[json.dumps(payload).encode("utf-16")],
     )
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -169,39 +336,15 @@ async def test_fetch_document_normalizes_utf16_json_to_utf8() -> None:
         ),
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
     ):
-        content = await adapter.fetch_document(ref, _connector())
+        refs = await adapter.list_documents(_connector())
 
-    assert content.decode("utf-8") == (
-        '{\n  "service": "Ondersteuning",\n  "description": "Uitgebreide prijsinformatie",\n  "price": 42\n}'
-    )
-
-
-async def test_fetch_document_rejects_feed_that_exceeds_ingest_character_limit() -> None:
-    adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
-    response = _StreamingResponse(
-        status_code=200,
-        headers={"content-type": "application/json"},
-        chunks=[('"' + ("x" * MAX_INGEST_CONTENT_CHARS) + '"').encode()],
-    )
-
-    with (
-        patch(
-            "app.adapters.json_feed.validate_json_feed_url_strict",
-            new=AsyncMock(return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")),
-        ),
-        patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
-        pytest.raises(ValueError, match=r"ingest limit is 500000 characters"),
-    ):
-        await adapter.fetch_document(ref, _connector())
+    assert "Uitgebreide prijsinformatie" in (await adapter.fetch_document(refs[0], _connector())).decode()
 
 
 @pytest.mark.parametrize("payload", [b"[]", b"{}", b"null", b"42"])
-async def test_fetch_document_rejects_json_with_too_little_knowledge(payload: bytes) -> None:
+async def test_list_documents_rejects_json_with_too_little_knowledge(payload: bytes) -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
     response = _StreamingResponse(status_code=200, headers={}, chunks=[payload])
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -210,14 +353,12 @@ async def test_fetch_document_rejects_json_with_too_little_knowledge(payload: by
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
         pytest.raises(ValueError, match="too little knowledge"),
     ):
-        await adapter.fetch_document(ref, _connector())
+        await adapter.list_documents(_connector())
 
 
-async def test_fetch_document_rejects_invalid_json() -> None:
+async def test_list_documents_rejects_invalid_json() -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
-    response = _StreamingResponse(status_code=200, headers={"content-type": "application/json"}, chunks=[b"<html />"])
-
+    response = _StreamingResponse(status_code=200, headers={}, chunks=[b"<html />"])
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -226,14 +367,12 @@ async def test_fetch_document_rejects_invalid_json() -> None:
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
         pytest.raises(ValueError, match="invalid JSON"),
     ):
-        await adapter.fetch_document(ref, _connector())
+        await adapter.list_documents(_connector())
 
 
-async def test_fetch_document_rejects_redirects_without_leaking_url() -> None:
+async def test_list_documents_rejects_redirects_without_leaking_url() -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
     response = _StreamingResponse(status_code=302, headers={"location": "https://elsewhere.example/"}, chunks=[])
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -242,31 +381,17 @@ async def test_fetch_document_rejects_redirects_without_leaking_url() -> None:
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
         pytest.raises(ValueError) as exc_info,
     ):
-        await adapter.fetch_document(ref, _connector())
-
+        await adapter.list_documents(_connector())
     assert "HTTP 302" in str(exc_info.value)
     assert "secret" not in str(exc_info.value)
 
 
-async def test_fetch_document_configures_pinned_transport_and_disables_redirects() -> None:
+async def test_list_documents_uses_pinned_transport_without_redirects() -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
-    response = _StreamingResponse(
-        status_code=200,
-        headers={},
-        chunks=[b'{"description":"This payload is deliberately long enough to ingest."}'],
+    _, client_factory, _ = await _list_payload(
+        adapter,
+        [{"name": "Support", "description": "A sufficiently detailed service description"}],
     )
-    client_factory = MagicMock(return_value=_StreamingClient(response))
-
-    with (
-        patch(
-            "app.adapters.json_feed.validate_json_feed_url_strict",
-            new=AsyncMock(return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")),
-        ),
-        patch("app.adapters.json_feed.httpx.AsyncClient", client_factory),
-    ):
-        await adapter.fetch_document(ref, _connector())
-
     kwargs = client_factory.call_args.kwargs
     assert kwargs["follow_redirects"] is False
     assert isinstance(kwargs["transport"], PinnedResolverTransport)
@@ -274,7 +399,7 @@ async def test_fetch_document_configures_pinned_transport_and_disables_redirects
 
 
 @pytest.mark.parametrize("declared_size", ["11", "invalid"])
-async def test_fetch_document_enforces_stream_limit_even_with_untrusted_content_length(
+async def test_list_documents_enforces_stream_limit_with_untrusted_content_length(
     monkeypatch: pytest.MonkeyPatch,
     declared_size: str,
 ) -> None:
@@ -282,13 +407,11 @@ async def test_fetch_document_enforces_stream_limit_even_with_untrusted_content_
 
     monkeypatch.setattr(json_feed_module, "_MAX_FEED_SIZE", 10)
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
     response = _StreamingResponse(
         status_code=200,
         headers={"content-length": declared_size},
         chunks=[b'{"value":', b'"long"}'],
     )
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -297,21 +420,19 @@ async def test_fetch_document_enforces_stream_limit_even_with_untrusted_content_
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
         pytest.raises(ValueError, match="too large"),
     ):
-        await adapter.fetch_document(ref, _connector())
+        await adapter.list_documents(_connector())
 
 
-async def test_fetch_document_has_a_total_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_list_documents_has_a_total_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     import app.adapters.json_feed as json_feed_module
 
-    monkeypatch.setattr(json_feed_module, "_TOTAL_FETCH_TIMEOUT", 0.001, raising=False)
+    monkeypatch.setattr(json_feed_module, "_TOTAL_FETCH_TIMEOUT", 0.001)
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
     response = _SlowStreamingResponse(
         status_code=200,
         headers={},
         chunks=[b'{"description":"This response never arrives in time."}'],
     )
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -320,17 +441,15 @@ async def test_fetch_document_has_a_total_deadline(monkeypatch: pytest.MonkeyPat
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_StreamingClient(response)),
         pytest.raises(RuntimeError, match="deadline"),
     ):
-        await adapter.fetch_document(ref, _connector())
+        await adapter.list_documents(_connector())
 
 
-async def test_fetch_document_network_error_does_not_leak_query_token() -> None:
+async def test_list_documents_network_error_does_not_leak_query_token() -> None:
     adapter = JsonFeedAdapter()
-    ref = (await _listed_ref(adapter))[0]
     error = httpx.ConnectError(
         "failed",
         request=httpx.Request("GET", "https://data.example.com/feed.json?token=secret"),
     )
-
     with (
         patch(
             "app.adapters.json_feed.validate_json_feed_url_strict",
@@ -339,45 +458,30 @@ async def test_fetch_document_network_error_does_not_leak_query_token() -> None:
         patch("app.adapters.json_feed.httpx.AsyncClient", return_value=_FailingStreamingClient(error)),
         pytest.raises(RuntimeError) as exc_info,
     ):
-        await adapter.fetch_document(ref, _connector())
-
+        await adapter.list_documents(_connector())
     assert "secret" not in str(exc_info.value)
     assert "data.example.com" not in str(exc_info.value)
 
 
-async def test_fetch_document_revalidates_before_constructing_http_client() -> None:
+async def test_list_documents_stops_when_url_revalidation_fails() -> None:
     adapter = JsonFeedAdapter()
-    validated = SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")
     rejected = PersistedUrlRejectedError(
         error_code="ssrf_blocked_persisted_json_feed_url",
         hostname="data.example.com",
         message="blocked",
     )
-    validator = AsyncMock(side_effect=[validated, rejected])
     client_factory = MagicMock()
-
-    with patch("app.adapters.json_feed.validate_json_feed_url_strict", new=validator):
-        ref = (await adapter.list_documents(_connector()))[0]
-        with (
-            patch("app.adapters.json_feed.httpx.AsyncClient", client_factory),
-            pytest.raises(PersistedUrlRejectedError),
-        ):
-            await adapter.fetch_document(ref, _connector())
-
-    assert validator.await_count == 2
+    with (
+        patch("app.adapters.json_feed.validate_json_feed_url_strict", new=AsyncMock(side_effect=rejected)),
+        patch("app.adapters.json_feed.httpx.AsyncClient", client_factory),
+        pytest.raises(PersistedUrlRejectedError),
+    ):
+        await adapter.list_documents(_connector())
     client_factory.assert_not_called()
 
 
 async def test_cursor_state_omits_last_synced_at_to_force_every_manual_fetch() -> None:
     assert await JsonFeedAdapter().get_cursor_state(_connector()) == {}
-
-
-async def _listed_ref(adapter: JsonFeedAdapter):
-    with patch(
-        "app.adapters.json_feed.validate_json_feed_url_strict",
-        new=AsyncMock(return_value=SimpleNamespace(hostname="data.example.com", preferred_ip="203.0.113.10")),
-    ):
-        return await adapter.list_documents(_connector())
 
 
 class _StreamingResponse:
@@ -411,7 +515,6 @@ class _StreamContext:
 
 class _StreamingClient:
     def __init__(self, response: _StreamingResponse) -> None:
-        self._response = response
         self.stream = MagicMock(return_value=_StreamContext(response))
 
     async def __aenter__(self) -> _StreamingClient:
@@ -421,11 +524,11 @@ class _StreamingClient:
         return None
 
 
-class _FailingStreamContext:
+class _RaisingStreamContext:
     def __init__(self, error: httpx.HTTPError) -> None:
         self._error = error
 
-    async def __aenter__(self) -> _StreamingResponse:
+    async def __aenter__(self):
         raise self._error
 
     async def __aexit__(self, *_args: object) -> None:
@@ -434,10 +537,7 @@ class _FailingStreamContext:
 
 class _FailingStreamingClient:
     def __init__(self, error: httpx.HTTPError) -> None:
-        self._error = error
-
-    def stream(self, *_args: object, **_kwargs: object) -> _FailingStreamContext:
-        return _FailingStreamContext(self._error)
+        self.stream = MagicMock(return_value=_RaisingStreamContext(error))
 
     async def __aenter__(self) -> _FailingStreamingClient:
         return self

--- a/klai-connector/tests/test_knowledge_ingest_payload.py
+++ b/klai-connector/tests/test_knowledge_ingest_payload.py
@@ -5,7 +5,7 @@ Focus: source_type / source_domain derivation for web_crawler (SPEC-KB-021).
 
 from pathlib import Path
 from runpy import run_path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -88,6 +88,39 @@ class TestExtraPassthrough:
     def test_connector_type_preserved(self):
         payload = _build_payload(**_base_kwargs())
         assert payload["connector_type"] == "web_crawler"
+
+
+@pytest.mark.asyncio
+async def test_delete_connector_document_sends_scoped_internal_request():
+    client = KnowledgeIngestClient("http://knowledge-ingest", "internal-secret")
+    await client._client.aclose()
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    http_client = MagicMock()
+    http_client.delete = AsyncMock(return_value=response)
+    client._client = http_client
+
+    await client.delete_connector_document(
+        org_id="org-1",
+        kb_slug="prices",
+        source_connector_id="connector-1",
+        source_ref="json-feed:connector-1:group-a",
+    )
+
+    http_client.delete.assert_awaited_once_with(
+        "/ingest/v1/connector/document",
+        params={
+            "org_id": "org-1",
+            "kb_slug": "prices",
+            "connector_id": "connector-1",
+            "source_ref": "json-feed:connector-1:group-a",
+        },
+        headers={
+            "X-Internal-Secret": "internal-secret",
+            "X-Caller-Service": "connector",
+        },
+    )
+    response.raise_for_status.assert_called_once_with()
 
 
 class TestSenderEmailAndMentionedEmails:

--- a/klai-connector/tests/test_sync_engine_stale_cleanup.py
+++ b/klai-connector/tests/test_sync_engine_stale_cleanup.py
@@ -1,0 +1,397 @@
+"""REQ-5/REQ-7 integration tests for JSON-feed sync reconciliation."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.adapters.base import DocumentRef
+from app.core.enums import SyncStatus
+from app.services.portal_client import PortalConnectorConfig
+from app.services.sync_engine import SyncEngine
+
+CONNECTOR_ID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def _portal_config() -> PortalConnectorConfig:
+    return PortalConnectorConfig(
+        connector_id=str(CONNECTOR_ID),
+        kb_id=42,
+        kb_slug="prices",
+        zitadel_org_id="org-test",
+        connector_type="json_feed",
+        config={"url": "https://data.example.com/prices.json"},
+        schedule=None,
+        is_enabled=True,
+    )
+
+
+def _ref(group: str, *, records: int = 1) -> DocumentRef:
+    source_ref = f"json-feed:{CONNECTOR_ID}:{group}"
+    return DocumentRef(
+        path=f"json-feed/{CONNECTOR_ID}/{group}",
+        ref=source_ref,
+        size=100,
+        content_type="kb_article",
+        source_ref=source_ref,
+        source_url="https://data.example.com",
+        extra={
+            "json_feed_group": {"category": group},
+            "json_feed_record_count": records,
+        },
+    )
+
+
+def _sync_run() -> MagicMock:
+    run = MagicMock()
+    run.status = SyncStatus.PENDING
+    run.cursor_state = None
+    run.error_details = None
+    run.quality_status = None
+    run.skip_reasons = {}
+    return run
+
+
+def _session_maker(*runs: MagicMock) -> Any:
+    pending = iter(runs)
+
+    @asynccontextmanager
+    async def _ctx() -> Any:
+        session = AsyncMock()
+        session.get = AsyncMock(return_value=next(pending))
+        session.commit = AsyncMock()
+        yield session
+
+    return _ctx
+
+
+def _adapter(refs: list[DocumentRef]) -> MagicMock:
+    adapter = MagicMock()
+    adapter.stale_ref_cleanup_enabled = True
+    adapter.get_cursor_state = AsyncMock(side_effect=lambda _connector: {})
+    adapter.list_documents = AsyncMock(return_value=refs)
+    adapter.fetch_document = AsyncMock(return_value=b"rendered feed document")
+    adapter.get_sync_metrics = MagicMock(
+        return_value={
+            "groups_total": len(refs),
+            "records_total": sum(ref.extra.get("json_feed_record_count", 0) for ref in refs),
+            "duplicates_collapsed": 1,
+        }
+    )
+    adapter.post_sync = AsyncMock(return_value=None)
+    return adapter
+
+
+def _engine(
+    *,
+    runs: list[MagicMock],
+    adapter: MagicMock,
+    ingest_client: Any,
+    previous_run: MagicMock | None,
+) -> SyncEngine:
+    portal_client = MagicMock()
+    portal_client.get_connector_config = AsyncMock(return_value=_portal_config())
+    portal_client.report_sync_status = AsyncMock()
+    registry = MagicMock()
+    registry.get = MagicMock(return_value=adapter)
+    engine = SyncEngine(
+        session_maker=_session_maker(*runs),
+        registry=registry,
+        ingest_client=ingest_client,
+        portal_client=portal_client,
+        settings=MagicMock(),
+        image_store=None,
+        crawl_sync_client=MagicMock(),
+    )
+    engine._get_last_successful_run = AsyncMock(return_value=previous_run)  # type: ignore[method-assign]
+    engine._get_last_pending_run = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return engine
+
+
+@pytest.fixture(autouse=True)
+def _parse_feed_markdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsed = MagicMock()
+    parsed.text = "This rendered JSON-feed document is long enough for ingest. " * 2
+    parsed.images = []
+    monkeypatch.setattr(
+        "app.services.sync_engine.parse_document_with_images",
+        lambda _content, _filename: parsed,
+    )
+
+
+@pytest.mark.asyncio
+async def test_successful_sync_deletes_stale_group_and_forwards_extra(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """AC-6 + REQ-4 + REQ-7: cleanup is scoped and observable after success."""
+    refs = [_ref("a"), _ref("b", records=2)]
+    previous = MagicMock()
+    previous.cursor_state = {
+        "synced_refs": [refs[0].source_ref, refs[1].source_ref, f"json-feed:{CONNECTOR_ID}:c"]
+    }
+    current = _sync_run()
+    adapter = _adapter(refs)
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()
+    ingest_client.delete_connector_document = AsyncMock()
+    engine = _engine(
+        runs=[current],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    caplog.set_level(logging.INFO)
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert current.status == SyncStatus.COMPLETED
+    ingest_client.delete_connector_document.assert_awaited_once_with(
+        org_id="org-test",
+        kb_slug="prices",
+        source_connector_id=str(CONNECTOR_ID),
+        source_ref=f"json-feed:{CONNECTOR_ID}:c",
+    )
+    assert [call.kwargs["document_extra"] for call in ingest_client.ingest_document.await_args_list] == [
+        refs[0].extra,
+        refs[1].extra,
+    ]
+    assert current.cursor_state["synced_refs"] == sorted(ref.source_ref for ref in refs)
+
+    complete = next(record for record in caplog.records if getattr(record, "event", None) == "sync_complete")
+    assert complete.groups_total == 2
+    assert complete.records_total == 3
+    assert complete.duplicates_collapsed == 1
+    assert complete.stale_groups_deleted == 1
+
+
+@pytest.mark.asyncio
+async def test_shrunken_listing_refuses_cleanup_and_preserves_baseline_for_recovery(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A transient subset cannot erase the KB and a later full listing still reconciles."""
+    previous_refs = [_ref(chr(ord("a") + index)) for index in range(10)]
+    subset_refs = previous_refs[:2]
+    recovered_refs = previous_refs[:-1]
+    previous = MagicMock()
+    previous.cursor_state = {"synced_refs": [ref.source_ref for ref in previous_refs]}
+    refused_run = _sync_run()
+    recovered_run = _sync_run()
+    adapter = _adapter(subset_refs)
+    adapter.list_documents = AsyncMock(side_effect=[subset_refs, recovered_refs])
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()
+    ingest_client.delete_connector_document = AsyncMock()
+    engine = _engine(
+        runs=[refused_run, recovered_run],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    caplog.set_level(logging.INFO)
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert refused_run.status == SyncStatus.COMPLETED
+    ingest_client.delete_connector_document.assert_not_awaited()
+    assert refused_run.cursor_state["synced_refs"] == sorted(
+        ref.source_ref for ref in previous_refs
+    )
+    refused = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "stale_cleanup_refused_shrink"
+    )
+    assert refused.connector_id == str(CONNECTOR_ID)
+    assert refused.previous_ref_count == 10
+    assert refused.current_ref_count == 2
+    complete = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "sync_complete"
+    )
+    assert complete.stale_cleanup_refused is True
+
+    caplog.clear()
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    ingest_client.delete_connector_document.assert_awaited_once_with(
+        org_id="org-test",
+        kb_slug="prices",
+        source_connector_id=str(CONNECTOR_ID),
+        source_ref=previous_refs[-1].source_ref,
+    )
+    assert recovered_run.cursor_state["synced_refs"] == sorted(
+        ref.source_ref for ref in recovered_refs
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_sync_never_deletes_stale_groups() -> None:
+    """AC-6: one failed document gates every destructive reconciliation call."""
+    refs = [_ref("a"), _ref("b")]
+    previous = MagicMock()
+    previous.cursor_state = {
+        "synced_refs": [refs[0].source_ref, refs[1].source_ref, f"json-feed:{CONNECTOR_ID}:c"]
+    }
+    current = _sync_run()
+    adapter = _adapter(refs)
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock(side_effect=[RuntimeError("ingest failed"), None])
+    ingest_client.delete_connector_document = AsyncMock()
+    engine = _engine(
+        runs=[current],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert current.status == SyncStatus.FAILED
+    ingest_client.delete_connector_document.assert_not_awaited()
+    assert "synced_refs" not in current.cursor_state
+
+
+@pytest.mark.asyncio
+async def test_adapters_without_explicit_opt_in_never_delete_missing_refs() -> None:
+    """REQ-5 safety gate: complete-snapshot semantics must be explicit per adapter."""
+    ref = _ref("a")
+    previous = MagicMock()
+    previous.cursor_state = {"synced_refs": [ref.source_ref, "provider:missing"]}
+    current = _sync_run()
+    adapter = _adapter([ref])
+    adapter.stale_ref_cleanup_enabled = False
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()
+    ingest_client.delete_connector_document = AsyncMock()
+    engine = _engine(
+        runs=[current],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert current.status == SyncStatus.COMPLETED
+    ingest_client.delete_connector_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_document_ref_is_deleted_on_first_group_sync() -> None:
+    """AC-6 migration: the WP1 legacy source_ref is stale on the first new sync."""
+    current_ref = _ref("category-a")
+    legacy_ref = f"json-feed:{CONNECTOR_ID}"
+    previous = MagicMock()
+    previous.cursor_state = {"synced_refs": [legacy_ref]}
+    current = _sync_run()
+    adapter = _adapter([current_ref])
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()
+    ingest_client.delete_connector_document = AsyncMock()
+    engine = _engine(
+        runs=[current],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    ingest_client.delete_connector_document.assert_awaited_once_with(
+        org_id="org-test",
+        kb_slug="prices",
+        source_connector_id=str(CONNECTOR_ID),
+        source_ref=legacy_ref,
+    )
+    assert current.status == SyncStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_fails_run_and_retries_from_successful_baseline() -> None:
+    """REQ-7: cleanup failure is visible and the same ref is retried next sync."""
+    ref = _ref("a")
+    stale_ref = f"json-feed:{CONNECTOR_ID}:stale"
+    previous = MagicMock()
+    previous.cursor_state = {"synced_refs": [ref.source_ref, stale_ref]}
+    first = _sync_run()
+    second = _sync_run()
+    adapter = _adapter([ref])
+    ingest_client = MagicMock()
+    ingest_client.ingest_document = AsyncMock()
+    ingest_client.delete_connector_document = AsyncMock(
+        side_effect=[RuntimeError("downstream delete failed"), None]
+    )
+    engine = _engine(
+        runs=[first, second],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert first.status == SyncStatus.FAILED
+    assert first.error_details == [
+        {
+            "error": "Stale source_ref cleanup failed",
+            "source_ref": stale_ref,
+            "reason": "downstream delete failed",
+        }
+    ]
+    assert "synced_refs" not in first.cursor_state
+    assert second.status == SyncStatus.COMPLETED
+    assert ingest_client.delete_connector_document.await_count == 2
+
+
+class _ContentHashDedupFake:
+    """Knowledge-ingest boundary fake implementing its content-hash decision seam."""
+
+    def __init__(self) -> None:
+        self._hashes: dict[str, str] = {}
+        self.requests = 0
+        self.ingests = 0
+
+    async def ingest_document(self, *, path: str, content: str, **_kwargs: Any) -> None:
+        self.requests += 1
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        if self._hashes.get(path) == content_hash:
+            return
+        self._hashes[path] = content_hash
+        self.ingests += 1
+
+    async def delete_connector_document(self, **_kwargs: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_two_unchanged_syncs_reach_dedup_but_create_one_ingest() -> None:
+    """AC-4: refetch-always reaches content-hash dedup and creates no duplicate."""
+    ref = _ref("a")
+    previous = MagicMock()
+    previous.cursor_state = {"synced_refs": [ref.source_ref]}
+    first = _sync_run()
+    second = _sync_run()
+    adapter = _adapter([ref])
+    ingest_client = _ContentHashDedupFake()
+    engine = _engine(
+        runs=[first, second],
+        adapter=adapter,
+        ingest_client=ingest_client,
+        previous_run=previous,
+    )
+
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+    await engine.run_sync(CONNECTOR_ID, uuid.uuid4())
+
+    assert ingest_client.requests == 2
+    assert ingest_client.ingests == 1
+    assert first.status == SyncStatus.COMPLETED
+    assert second.status == SyncStatus.COMPLETED

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -520,6 +520,170 @@ async def get_episode_ids_for_document_history(
     return [str(row["episode_id"]) for row in rows]
 
 
+async def soft_delete_connector_artifacts_by_source_ref(
+    conn: asyncpg.Connection,
+    org_id: str,
+    kb_slug: str,
+    connector_id: str,
+    source_ref: str,
+) -> int:
+    """Close active versions of one connector document before external cleanup."""
+    rows = await conn.fetch(
+        """
+        UPDATE knowledge.artifacts
+        SET belief_time_end = $5
+        WHERE org_id = $1
+          AND kb_slug = $2
+          AND extra::jsonb->>'source_connector_id' = $3
+          AND extra::jsonb->>'source_ref' = $4
+          AND belief_time_end = $6
+        RETURNING id
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+        source_ref,
+        int(time.time()),
+        _SENTINEL,
+    )
+    return len(rows)
+
+
+async def list_connector_artifact_ids_by_source_ref(
+    conn: asyncpg.Connection,
+    org_id: str,
+    kb_slug: str,
+    connector_id: str,
+    source_ref: str,
+) -> list[str]:
+    """List every stored version of one connector document."""
+    rows = await conn.fetch(
+        """
+        SELECT id::text AS id
+        FROM knowledge.artifacts
+        WHERE org_id = $1
+          AND kb_slug = $2
+          AND extra::jsonb->>'source_connector_id' = $3
+          AND extra::jsonb->>'source_ref' = $4
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+        source_ref,
+    )
+    return [str(row["id"]) for row in rows]
+
+
+async def delete_connector_artifacts_by_source_ref(
+    conn: asyncpg.Connection,
+    org_id: str,
+    kb_slug: str,
+    connector_id: str,
+    source_ref: str,
+) -> int:
+    """Hard-delete every PostgreSQL row owned by one connector source_ref."""
+    params = (org_id, kb_slug, connector_id, source_ref)
+
+    async with conn.transaction():
+        await conn.execute(
+            """
+            UPDATE knowledge.artifacts SET superseded_by = NULL
+            WHERE superseded_by IN (
+                SELECT id FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            )
+            """,
+            *params,
+        )
+        await conn.execute(
+            """
+            DELETE FROM knowledge.embedding_queue WHERE artifact_id IN (
+                SELECT id FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            )
+            """,
+            *params,
+        )
+        await conn.execute(
+            """
+            DELETE FROM knowledge.artifact_entities WHERE artifact_id IN (
+                SELECT id FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            )
+            """,
+            *params,
+        )
+        await conn.execute(
+            """
+            DELETE FROM knowledge.derivations
+            WHERE child_id IN (
+                SELECT id FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            ) OR parent_id IN (
+                SELECT id FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            )
+            """,
+            *params,
+        )
+        await conn.execute(
+            """
+            DELETE FROM knowledge.crawled_pages
+            WHERE org_id = $1 AND kb_slug = $2 AND url IN (
+                SELECT path FROM knowledge.artifacts
+                WHERE org_id = $1 AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+            )
+            """,
+            *params,
+        )
+        await conn.execute(
+            """
+            DELETE FROM knowledge.page_links
+            WHERE org_id = $1 AND kb_slug = $2 AND (
+                from_url IN (
+                    SELECT path FROM knowledge.artifacts
+                    WHERE org_id = $1 AND kb_slug = $2
+                      AND extra::jsonb->>'source_connector_id' = $3
+                      AND extra::jsonb->>'source_ref' = $4
+                ) OR to_url IN (
+                    SELECT path FROM knowledge.artifacts
+                    WHERE org_id = $1 AND kb_slug = $2
+                      AND extra::jsonb->>'source_connector_id' = $3
+                      AND extra::jsonb->>'source_ref' = $4
+                )
+            )
+            """,
+            *params,
+        )
+        result = await conn.fetchval(
+            """
+            WITH deleted AS (
+                DELETE FROM knowledge.artifacts
+                WHERE org_id = $1
+                  AND kb_slug = $2
+                  AND extra::jsonb->>'source_connector_id' = $3
+                  AND extra::jsonb->>'source_ref' = $4
+                RETURNING id
+            )
+            SELECT COUNT(*) FROM deleted
+            """,
+            *params,
+        )
+    return int(result or 0)
+
+
 async def list_stale_connector_artifact_paths(
     conn: asyncpg.Connection,
     org_id: str,

--- a/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/qdrant_store.py
@@ -411,6 +411,29 @@ async def delete_document(org_id: str, kb_slug: str, path: str) -> None:
     )
 
 
+async def delete_connector_document(
+    org_id: str,
+    kb_slug: str,
+    connector_id: str,
+    source_ref: str,
+) -> None:
+    """Delete one connector document without touching sibling source refs."""
+    client = get_client()
+    await client.delete(
+        COLLECTION,
+        points_selector=Filter(
+            must=[
+                FieldCondition(key="org_id", match=MatchValue(value=org_id)),
+                FieldCondition(key="kb_slug", match=MatchValue(value=kb_slug)),
+                FieldCondition(
+                    key="source_connector_id", match=MatchValue(value=connector_id)
+                ),
+                FieldCondition(key="source_ref", match=MatchValue(value=source_ref)),
+            ]
+        ),
+    )
+
+
 async def delete_kb(org_id: str, kb_slug: str) -> None:
     """Delete all Qdrant chunks for an entire knowledge base."""
     client = get_client()

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -1339,6 +1339,61 @@ async def delete_connector_route(
     }
 
 
+@router.delete("/ingest/v1/connector/document")
+async def delete_connector_document_route(
+    request: Request,
+    org_id: str,
+    kb_slug: str,
+    connector_id: str,
+    source_ref: str,
+) -> dict:
+    """Delete one connector artifact and its vectors and graph episodes."""
+    _verify_internal_secret(request)
+    verified_org_id = await assert_caller_identity_tenant_only(
+        request, claimed_org_id=org_id
+    )
+
+    async with tenant_scoped_connection(verified_org_id) as conn:
+        # Close active rows first. Enrichment and Graphiti workers both abort
+        # when an artifact is no longer active, preventing cleanup races from
+        # recreating external state while this request is in progress.
+        await pg_store.soft_delete_connector_artifacts_by_source_ref(
+            conn, verified_org_id, kb_slug, connector_id, source_ref
+        )
+        artifact_ids = await pg_store.list_connector_artifact_ids_by_source_ref(
+            conn, verified_org_id, kb_slug, connector_id, source_ref
+        )
+        episode_ids = await pg_store.get_episode_ids_for_document_history(
+            conn, verified_org_id, artifact_ids
+        )
+
+        # PostgreSQL remains the retry ledger until both external stores are
+        # confirmed clean. If either call fails, the endpoint raises and a
+        # later sync can recover the same artifact/episode identifiers.
+        await graph_module.delete_kb_episodes(verified_org_id, episode_ids)
+        await qdrant_store.delete_connector_document(
+            verified_org_id, kb_slug, connector_id, source_ref
+        )
+        artifacts_deleted = await pg_store.delete_connector_artifacts_by_source_ref(
+            conn, verified_org_id, kb_slug, connector_id, source_ref
+        )
+
+    logger.info(
+        "connector_document_deleted",
+        org_id=verified_org_id,
+        kb_slug=kb_slug,
+        connector_id=connector_id,
+        source_ref=source_ref,
+        artifacts_deleted=artifacts_deleted,
+        episodes_deleted=len(episode_ids),
+    )
+    return {
+        "status": "ok",
+        "artifacts_deleted": artifacts_deleted,
+        "episodes_deleted": len(episode_ids),
+    }
+
+
 @router.patch("/ingest/v1/kb/visibility")
 async def update_kb_visibility_route(request: Request, req: UpdateKBVisibilityRequest) -> dict:
     """Update visibility for a KB: persists to kb_config table and backfills all Qdrant chunks."""

--- a/klai-knowledge-ingest/tests/test_chunker_record_boundary_contract.py
+++ b/klai-knowledge-ingest/tests/test_chunker_record_boundary_contract.py
@@ -1,0 +1,25 @@
+"""AC-3 contract between JSON-feed record shaping and the production chunker."""
+
+from knowledge_ingest.chunker import chunk_markdown_with_parents
+from knowledge_ingest.content_profiles import get_profile
+
+
+def test_kb_article_chunker_never_splits_adapter_record_lines() -> None:
+    record_lengths = [120, 275, 450, 625, 800, 900] * 3
+    record_lines = [
+        f"- **Product {index:02d}** — description: "
+        + chr(ord("a") + index % 26) * (length - len(f"- **Product {index:02d}** — description: "))
+        for index, length in enumerate(record_lengths)
+    ]
+    document = "# JSON feed — prijzen\n\n" + "\n\n".join(record_lines)
+    profile = get_profile("kb_article")
+
+    chunks, _parents = chunk_markdown_with_parents(
+        document,
+        child_size=profile.chunk_tokens_max * 4,
+        child_overlap=200,
+    )
+
+    assert len(document) > profile.chunk_tokens_max * 4
+    for record_line in record_lines:
+        assert sum(record_line in chunk.text for chunk in chunks) == 1

--- a/klai-knowledge-ingest/tests/test_delete_connector_document.py
+++ b/klai-knowledge-ingest/tests/test_delete_connector_document.py
@@ -1,0 +1,142 @@
+"""REQ-5 contract tests for connector document cleanup by source_ref."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import qdrant_store
+
+
+def test_delete_endpoint_cleans_every_store_in_retry_safe_order(client) -> None:
+    """The scoped endpoint closes PG state, clears external stores, then hard-deletes PG."""
+    conn = MagicMock()
+    steps: list[str] = []
+
+    @asynccontextmanager
+    async def _tenant_connection(org_id: str):
+        assert org_id == "org-verified"
+        yield conn
+
+    async def _soft_delete(*_args, **_kwargs):
+        steps.append("soft_delete")
+        return 1
+
+    async def _list_ids(*_args, **_kwargs):
+        steps.append("list_ids")
+        return ["artifact-1"]
+
+    async def _episodes(*_args, **_kwargs):
+        steps.append("episodes")
+        return ["episode-1"]
+
+    async def _graph(*_args, **_kwargs):
+        steps.append("graph")
+
+    async def _qdrant(*_args, **_kwargs):
+        steps.append("qdrant")
+
+    async def _hard_delete(*_args, **_kwargs):
+        steps.append("hard_delete")
+        return 1
+
+    with (
+        patch(
+            "knowledge_ingest.routes.ingest.assert_caller_identity_tenant_only",
+            new_callable=AsyncMock,
+        ) as identity,
+        patch("knowledge_ingest.routes.ingest.tenant_scoped_connection", _tenant_connection),
+        patch(
+            "knowledge_ingest.routes.ingest.pg_store.soft_delete_connector_artifacts_by_source_ref",
+            side_effect=_soft_delete,
+        ) as soft_delete,
+        patch(
+            "knowledge_ingest.routes.ingest.pg_store.list_connector_artifact_ids_by_source_ref",
+            side_effect=_list_ids,
+        ) as list_ids,
+        patch(
+            "knowledge_ingest.routes.ingest.pg_store.get_episode_ids_for_document_history",
+            side_effect=_episodes,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.graph_module.delete_kb_episodes",
+            side_effect=_graph,
+        ) as delete_graph,
+        patch(
+            "knowledge_ingest.routes.ingest.qdrant_store.delete_connector_document",
+            side_effect=_qdrant,
+        ) as delete_qdrant,
+        patch(
+            "knowledge_ingest.routes.ingest.pg_store.delete_connector_artifacts_by_source_ref",
+            side_effect=_hard_delete,
+        ) as hard_delete,
+    ):
+        identity.return_value = "org-verified"
+        response = client.delete(
+            "/ingest/v1/connector/document",
+            params={
+                "org_id": "org-1",
+                "kb_slug": "prices",
+                "connector_id": "connector-1",
+                "source_ref": "json-feed:connector-1:group-a",
+            },
+            headers={"X-Caller-Service": "connector"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "artifacts_deleted": 1,
+        "episodes_deleted": 1,
+    }
+    identity.assert_awaited_once()
+    assert identity.await_args.kwargs == {"claimed_org_id": "org-1"}
+    scope = (conn, "org-verified", "prices", "connector-1", "json-feed:connector-1:group-a")
+    soft_delete.assert_awaited_once_with(*scope)
+    list_ids.assert_awaited_once_with(*scope)
+    delete_graph.assert_awaited_once_with("org-verified", ["episode-1"])
+    delete_qdrant.assert_awaited_once_with(
+        "org-verified", "prices", "connector-1", "json-feed:connector-1:group-a"
+    )
+    hard_delete.assert_awaited_once_with(*scope)
+    assert steps == ["soft_delete", "list_ids", "episodes", "graph", "qdrant", "hard_delete"]
+
+
+def test_delete_endpoint_requires_internal_secret(client) -> None:
+    response = client.delete(
+        "/ingest/v1/connector/document",
+        params={
+            "org_id": "org-1",
+            "kb_slug": "prices",
+            "connector_id": "connector-1",
+            "source_ref": "json-feed:connector-1:group-a",
+        },
+        headers={"X-Internal-Secret": "wrong-secret", "X-Caller-Service": "connector"},
+    )
+
+    assert response.status_code == 401
+    assert "X-Internal-Secret" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_qdrant_delete_is_org_kb_connector_and_source_ref_scoped(monkeypatch) -> None:
+    qdrant = MagicMock()
+    qdrant.delete = AsyncMock()
+    monkeypatch.setattr(qdrant_store, "get_client", lambda: qdrant)
+
+    await qdrant_store.delete_connector_document(
+        "org-1", "prices", "connector-1", "json-feed:connector-1:group-a"
+    )
+
+    selector = qdrant.delete.await_args.kwargs["points_selector"]
+    conditions = {
+        condition.key: condition.match.value for condition in selector.must
+    }
+    assert conditions == {
+        "org_id": "org-1",
+        "kb_slug": "prices",
+        "source_connector_id": "connector-1",
+        "source_ref": "json-feed:connector-1:group-a",
+    }

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -81,6 +81,94 @@ async def test_skips_when_content_unchanged():
 
 
 @pytest.mark.asyncio
+async def test_two_identical_connector_requests_upsert_chunks_once():
+    """AC-4: the second unchanged request exits at the real hash decision seam."""
+    req = _make_request("# Prices\nA stable rendered JSON-feed group document.")
+    req.source_connector_id = "connector-1"
+    req.source_ref = "json-feed:connector-1:group-a"
+    conn = _make_mock_conn()
+    stored_hash = AsyncMock(side_effect=[None, _sha256(req.content)])
+
+    with (
+        patch(
+            "knowledge_ingest.pg_store.get_active_content_hash",
+            new=stored_hash,
+        ),
+        patch(
+            "knowledge_ingest.pg_store.soft_delete_artifact",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.pg_store.create_artifact",
+            new_callable=AsyncMock,
+            return_value="artifact-uuid-1",
+        ),
+        patch("knowledge_ingest.pg_store.set_superseded_by", new_callable=AsyncMock),
+        patch("knowledge_ingest.pg_store.update_artifact_extra", new_callable=AsyncMock),
+        patch(
+            "knowledge_ingest.pg_store.set_artifact_ingest_status",
+            new_callable=AsyncMock,
+            return_value={"artifact_id": "artifact-uuid-1", "path": req.path},
+        ),
+        patch(
+            "knowledge_ingest.pg_store.insert_parent_chunks",
+            new_callable=AsyncMock,
+            return_value=[1],
+        ),
+        patch(
+            "knowledge_ingest.embedder.embed",
+            new_callable=AsyncMock,
+            return_value=[[0.1] * 10],
+        ) as embed,
+        patch(
+            "knowledge_ingest.qdrant_store.upsert_chunks",
+            new_callable=AsyncMock,
+        ) as upsert,
+        patch(
+            "knowledge_ingest.org_config.is_enrichment_enabled",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.kb_config.get_kb_visibility",
+            new_callable=AsyncMock,
+            return_value="internal",
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.fetch_taxonomy_nodes",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.routes.ingest.generate_content_label",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
+            "knowledge_ingest.connector_state.connector_is_active",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
+    ):
+        mock_settings.graphiti_enabled = False
+        mock_settings.chunk_size = 1500
+        mock_settings.chunk_overlap = 200
+
+        from knowledge_ingest.routes.ingest import ingest_document
+
+        first = await ingest_document(conn, req)
+        second = await ingest_document(conn, req)
+
+    assert first["status"] == "ok"
+    assert second == {"status": "skipped", "reason": "content unchanged", "chunks": 0}
+    assert stored_hash.await_count == 2
+    assert embed.await_count == 1
+    assert upsert.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_proceeds_when_content_changed():
     """ingest_document runs the full pipeline when content hash differs."""
     req = _make_request("# New content\nDifferent text")

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -699,3 +699,39 @@ async def test_org_orphan_sweep_keeps_all_referenced_episode_ids():
     assert "graphiti_episode_ids" in sql
     assert "jsonb_array_elements_text" in sql
     assert "jsonb_build_array" in sql
+
+
+@pytest.mark.asyncio
+async def test_connector_source_ref_cleanup_queries_are_fully_tenant_scoped() -> None:
+    conn = _make_conn()
+    conn.fetch = AsyncMock(return_value=[])
+    conn.fetchval = AsyncMock(return_value=0)
+
+    await pg_store.soft_delete_connector_artifacts_by_source_ref(
+        conn, "org-1", "prices", "connector-1", "json-feed:connector-1:group-a"
+    )
+    await pg_store.list_connector_artifact_ids_by_source_ref(
+        conn, "org-1", "prices", "connector-1", "json-feed:connector-1:group-a"
+    )
+    await pg_store.delete_connector_artifacts_by_source_ref(
+        conn, "org-1", "prices", "connector-1", "json-feed:connector-1:group-a"
+    )
+
+    calls = [
+        *conn.fetch.await_args_list,
+        *conn.execute.await_args_list,
+        *conn.fetchval.await_args_list,
+    ]
+    assert calls
+    for call in calls:
+        sql, *params = call.args
+        assert "org_id" in sql
+        assert "kb_slug" in sql
+        assert "source_connector_id" in sql
+        assert "source_ref" in sql
+        assert params[:4] == [
+            "org-1",
+            "prices",
+            "connector-1",
+            "json-feed:connector-1:group-a",
+        ]


### PR DESCRIPTION
A JSON feed is no longer ingested as one pretty-printed blob. The json_feed adapter now renders per-group markdown documents (one verbalized line per record, blank-line separated so chunk boundaries never split a record), passes group metadata to Qdrant, and cleans up stale group documents after fully successful syncs — with a shrink guard so a partially-returning feed can never wipe a knowledge base. Adds an internal org/kb/connector/source_ref-scoped document-delete endpoint in knowledge-ingest.

Root cause traced from the Voys/PriceRight production sessions of 2026-08-18/20: one 464K-char artifact, 310 blind chunks, enrichment silently skipped (too_many_chunks), raw JSON embedded verbatim. Full brief in docs/specs/SPEC-KB-JSON-FEED-001/spec.md.

Implemented by GPT-5.6 Sol (Codex, 3 work packages); reviewed by Claude Opus + klai-tenant-review (0 HARD findings; 5 >=high findings fixed, delta-review verdict "ready to commit"). Suites: connector 468 passed, knowledge-ingest 1659 passed, ruff clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)