### PR TITLE
feat(knowledge): rebuild stale graph episodes on KB refresh and upload reindex

### DIFF
--- a/klai-knowledge-ingest/alembic/versions/0003_artifacts_unique_active_path.py
+++ b/klai-knowledge-ingest/alembic/versions/0003_artifacts_unique_active_path.py
@@ -1,7 +1,7 @@
 """SPEC-INGEST-UNIQUE-ARTIFACT-001 -- partial UNIQUE index on knowledge.artifacts.
 
 Closes the race window where two concurrent ``ingest_document()`` calls with
-identical ``(org_id, kb_slug, path)`` both pass ``get_active_content_hash``
+identical ``(org_id, kb_slug, path)`` both pass ``get_active_artifact_state``
 (see no active row), both call ``soft_delete_artifact`` (idempotent), and
 both call ``create_artifact`` -- leaving two active rows for the same path.
 

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -39,7 +39,10 @@ from qdrant_client import AsyncQdrantClient
 from knowledge_ingest import pg_store
 from knowledge_ingest.config import settings
 from knowledge_ingest.db import cross_org_admin_connection
-from knowledge_ingest.enrichment_policy import graph_episode_skip_reason
+from knowledge_ingest.enrichment_policy import (
+    GRAPHITI_EXTRACTION_VERSION,
+    graph_episode_skip_reason,
+)
 from knowledge_ingest.episode_text import MAX_TEXT_CHARS, split_episode_text
 from knowledge_ingest.graph import EntityGraphData, flush_entity_graph_data, ingest_episode
 
@@ -286,7 +289,12 @@ async def main(
                         "UPDATE knowledge.artifacts "
                         "SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb "
                         "WHERE id = $2::uuid",
-                        json.dumps({"graphiti_episode_id": f"skipped:{skip_reason}"}),
+                        json.dumps(
+                            {
+                                "graphiti_episode_id": f"skipped:{skip_reason}",
+                                "graphiti_extraction_version": GRAPHITI_EXTRACTION_VERSION,
+                            }
+                        ),
                         artifact_id,
                     )
                     return
@@ -340,6 +348,7 @@ async def main(
                             {
                                 "graphiti_episode_complete": True,
                                 "graphiti_model": settings.graphiti_llm_model,
+                                "graphiti_extraction_version": GRAPHITI_EXTRACTION_VERSION,
                             }
                         ),
                         artifact_id,

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_policy.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_policy.py
@@ -10,6 +10,12 @@ from knowledge_ingest.config import settings
 
 _DEFAULT_MAX_CHUNKS = 200
 
+# Version 1 is the implicit, never-stamped legacy ruleset from before #1148.
+# Version 2 is the subject-facts, navigation-page skip, cross-language entity
+# naming ruleset used for the 2026-08-22 Voys rebuild. Bump this whenever the
+# extraction prompt in graph.py or the skip rules below change semantically.
+GRAPHITI_EXTRACTION_VERSION = 2
+
 
 def _configured_max_chunks() -> int:
     value = getattr(settings, "enrichment_max_chunks", _DEFAULT_MAX_CHUNKS)

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -43,7 +43,10 @@ from knowledge_ingest import (
 from knowledge_ingest.content_profiles import get_profile
 from knowledge_ingest.db import cross_org_admin_connection, tenant_scoped_connection
 from knowledge_ingest.document_normalizer import normalize_document_for_chunking
-from knowledge_ingest.enrichment_policy import enrichment_skip_reason
+from knowledge_ingest.enrichment_policy import (
+    GRAPHITI_EXTRACTION_VERSION,
+    enrichment_skip_reason,
+)
 from knowledge_ingest.episode_text import split_episode_text
 
 logger = structlog.get_logger()
@@ -350,6 +353,7 @@ def _register_tasks(procrastinate_app: Any) -> None:
         belief_time_start: int,
         kb_slug: str = "",
         path: str = "",
+        replace_stale: bool = False,
     ) -> None:
         """Ingest a document into the Graphiti knowledge graph.
 
@@ -394,13 +398,36 @@ def _register_tasks(procrastinate_app: Any) -> None:
                     org_id=org_id,
                 )
                 return
+            from knowledge_ingest import graph as graph_module
+
+            if replace_stale:
+                # Delete at execution time so old episodes stay readable while
+                # the bulk queue drains; retries also remove partial episodes.
+                stale_ids = await pg_store.get_episode_ids_for_document_history(
+                    conn, org_id, [artifact_id]
+                )
+                if stale_ids:
+                    await graph_module.delete_kb_episodes(org_id, stale_ids)
+                # Null the legacy scalar too: append_graphiti_episode_id keeps
+                # an existing scalar via COALESCE, so leaving the old value in
+                # place would pin it to a just-deleted episode uuid forever.
+                await pg_store.update_artifact_extra(
+                    conn,
+                    artifact_id,
+                    {"graphiti_episode_ids": [], "graphiti_episode_id": None},
+                )
+                logger.info(
+                    "graphiti_stale_episodes_replaced",
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                    deleted=len(stale_ids),
+                )
             logger.info(
                 "graphiti_episode_started",
                 artifact_id=artifact_id,
                 org_id=org_id,
                 content_type=content_type,
             )
-            from knowledge_ingest import graph as graph_module
 
             episode_parts = split_episode_text(document_text)
             await pg_store.update_artifact_extra(
@@ -487,7 +514,10 @@ def _register_tasks(procrastinate_app: Any) -> None:
             await pg_store.update_artifact_extra(
                 conn,
                 artifact_id,
-                {"graphiti_episode_complete": True},
+                {
+                    "graphiti_episode_complete": True,
+                    "graphiti_extraction_version": GRAPHITI_EXTRACTION_VERSION,
+                },
             )
 
     procrastinate_app.ingest_graphiti_episode = ingest_graphiti_episode  # type: ignore[attr-defined]

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -411,10 +411,18 @@ def _register_tasks(procrastinate_app: Any) -> None:
                 # Null the legacy scalar too: append_graphiti_episode_id keeps
                 # an existing scalar via COALESCE, so leaving the old value in
                 # place would pin it to a just-deleted episode uuid forever.
+                # complete/part_count reset in the same write: a worker kill
+                # between this statement and the part-count update below must
+                # not leave a row that reads as "complete with zero episodes".
                 await pg_store.update_artifact_extra(
                     conn,
                     artifact_id,
-                    {"graphiti_episode_ids": [], "graphiti_episode_id": None},
+                    {
+                        "graphiti_episode_ids": [],
+                        "graphiti_episode_id": None,
+                        "graphiti_episode_complete": False,
+                        "graphiti_episode_part_count": 0,
+                    },
                 )
                 logger.info(
                     "graphiti_stale_episodes_replaced",

--- a/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
@@ -86,9 +86,7 @@ async def _refresh_stale_graph(
 
     graph_skip = graph_episode_skip_reason(indexable_content)
     if graph_skip:
-        stale_ids = await pg_store.get_episode_ids_for_document_history(
-            conn, org_id, [artifact_id]
-        )
+        stale_ids = await pg_store.get_episode_ids_for_document_history(conn, org_id, [artifact_id])
         if stale_ids:
             await graph_module.delete_kb_episodes(org_id, stale_ids)
         await pg_store.update_artifact_extra(

--- a/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
@@ -1,5 +1,15 @@
+"""Version-gated knowledge-graph refresh for already-ingested documents.
+
+A refresh (connector re-sync with unchanged content, or an upload reindex)
+rebuilds the graph episodes of a document whose extraction predates
+``GRAPHITI_EXTRACTION_VERSION`` — without re-chunking, re-embedding, or
+re-enrichment. The caller MUST pass a connection scoped to exactly this
+``org_id`` (asyncpg tenant GUCs are connection-local).
+"""
+
 from __future__ import annotations
 
+import asyncpg
 import structlog
 
 from knowledge_ingest import graph as graph_module
@@ -14,7 +24,7 @@ logger = structlog.get_logger()
 
 
 async def maybe_refresh_stale_graph(
-    conn,
+    conn: asyncpg.Connection,
     *,
     artifact_id: str,
     extra: dict,
@@ -25,8 +35,52 @@ async def maybe_refresh_stale_graph(
     belief_time_start: int,
     indexable_content: str,
 ) -> str | None:
+    """Queue (or apply) a graph rebuild when the artifact's extraction is stale.
+
+    Returns ``"queued"``, ``"already_queued"``, ``"skipped:<reason>"``, or
+    ``None`` when the graph is current or graphiti is disabled. Never raises:
+    the refresh is opportunistic — the caller's contract (content-unchanged
+    skip, upload reindex) must not fail on a FalkorDB or queue hiccup, matching
+    how the ingest route swallows its other graph operations ("a stranded
+    episode costs a citation, not correctness").
+    """
     if not settings.graphiti_enabled:
         return None
+    try:
+        return await _refresh_stale_graph(
+            conn,
+            artifact_id=artifact_id,
+            extra=extra,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+            content_type=content_type,
+            belief_time_start=belief_time_start,
+            indexable_content=indexable_content,
+        )
+    except Exception:
+        logger.exception(
+            "graph_refresh_failed",
+            artifact_id=artifact_id,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+        )
+        return None
+
+
+async def _refresh_stale_graph(
+    conn: asyncpg.Connection,
+    *,
+    artifact_id: str,
+    extra: dict,
+    org_id: str,
+    kb_slug: str,
+    path: str,
+    content_type: str,
+    belief_time_start: int,
+    indexable_content: str,
+) -> str | None:
     if extra.get("graphiti_extraction_version", 1) >= GRAPHITI_EXTRACTION_VERSION:
         return None
 
@@ -58,13 +112,18 @@ async def maybe_refresh_stale_graph(
         )
         return f"skipped:{graph_skip}"
 
+    from procrastinate.exceptions import AlreadyEnqueued
+
     from knowledge_ingest import enrichment_tasks
 
     proc_app = enrichment_tasks.get_app()
     try:
-        from procrastinate.exceptions import AlreadyEnqueued
-
+        # ``queueing_lock`` dedups only while the earlier job is still todo;
+        # ``lock`` also serialises against a job that is already executing,
+        # so a refresh can never delete the episodes an in-flight extraction
+        # for the same artifact is appending.
         await proc_app.ingest_graphiti_episode.configure(  # type: ignore[attr-defined]
+            lock=f"graphiti:{artifact_id}",
             queueing_lock=f"graphiti:{artifact_id}",
         ).defer_async(
             artifact_id=artifact_id,
@@ -84,6 +143,7 @@ async def maybe_refresh_stale_graph(
             kb_slug=kb_slug,
             path=path,
         )
+        return "already_queued"
     logger.info(
         "graph_refresh_queued",
         artifact_id=artifact_id,

--- a/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import structlog
+
+from knowledge_ingest import graph as graph_module
+from knowledge_ingest import pg_store
+from knowledge_ingest.config import settings
+from knowledge_ingest.enrichment_policy import (
+    GRAPHITI_EXTRACTION_VERSION,
+    graph_episode_skip_reason,
+)
+
+logger = structlog.get_logger()
+
+
+async def maybe_refresh_stale_graph(
+    conn,
+    *,
+    artifact_id: str,
+    extra: dict,
+    org_id: str,
+    kb_slug: str,
+    path: str,
+    content_type: str,
+    belief_time_start: int,
+    indexable_content: str,
+) -> str | None:
+    if not settings.graphiti_enabled:
+        return None
+    if extra.get("graphiti_extraction_version", 1) >= GRAPHITI_EXTRACTION_VERSION:
+        return None
+
+    graph_skip = graph_episode_skip_reason(indexable_content)
+    if graph_skip:
+        stale_ids = await pg_store.get_episode_ids_for_document_history(
+            conn, org_id, [artifact_id]
+        )
+        if stale_ids:
+            await graph_module.delete_kb_episodes(org_id, stale_ids)
+        await pg_store.update_artifact_extra(
+            conn,
+            artifact_id,
+            {
+                "graphiti_episode_ids": [],
+                "graphiti_episode_part_count": 0,
+                "graphiti_episode_complete": True,
+                "graphiti_episode_id": f"skipped:{graph_skip}",
+                "graphiti_extraction_version": GRAPHITI_EXTRACTION_VERSION,
+            },
+        )
+        logger.info(
+            "graph_refresh_skipped",
+            artifact_id=artifact_id,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+            reason=graph_skip,
+        )
+        return f"skipped:{graph_skip}"
+
+    from knowledge_ingest import enrichment_tasks
+
+    proc_app = enrichment_tasks.get_app()
+    try:
+        from procrastinate.exceptions import AlreadyEnqueued
+
+        await proc_app.ingest_graphiti_episode.configure(  # type: ignore[attr-defined]
+            queueing_lock=f"graphiti:{artifact_id}",
+        ).defer_async(
+            artifact_id=artifact_id,
+            document_text=indexable_content,
+            org_id=org_id,
+            content_type=content_type,
+            belief_time_start=belief_time_start,
+            kb_slug=kb_slug,
+            path=path,
+            replace_stale=True,
+        )
+    except AlreadyEnqueued:
+        logger.info(
+            "graph_refresh_already_queued",
+            artifact_id=artifact_id,
+            org_id=org_id,
+            kb_slug=kb_slug,
+            path=path,
+        )
+    logger.info(
+        "graph_refresh_queued",
+        artifact_id=artifact_id,
+        org_id=org_id,
+        kb_slug=kb_slug,
+        path=path,
+    )
+    return "queued"

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -85,13 +85,13 @@ async def _insert_derivation_edges(
     )
 
 
-async def get_active_content_hash(
+async def get_active_artifact_state(
     conn: asyncpg.Connection, org_id: str, kb_slug: str, path: str
-) -> str | None:
-    """Return the content_hash of the current synced active artifact, or None."""
-    row = await conn.fetchval(
+) -> dict | None:
+    """Return graph-refresh state for the current synced active artifact."""
+    row = await conn.fetchrow(
         """
-        SELECT content_hash
+        SELECT id::text AS id, content_hash, extra, belief_time_start, content_type
         FROM knowledge.artifacts
         WHERE org_id = $1 AND kb_slug = $2 AND path = $3
           AND belief_time_end = $4
@@ -104,7 +104,20 @@ async def get_active_content_hash(
         path,
         _SENTINEL,
     )
-    return row
+    if row is None:
+        return None
+    raw_extra = row["extra"]
+    if isinstance(raw_extra, str):
+        extra: dict = json.loads(raw_extra) if raw_extra else {}
+    else:
+        extra = dict(raw_extra) if raw_extra else {}
+    return {
+        "id": str(row["id"]),
+        "content_hash": row["content_hash"],
+        "extra": extra,
+        "belief_time_start": row["belief_time_start"],
+        "content_type": row["content_type"],
+    }
 
 
 async def list_active_synced_artifacts(conn: asyncpg.Connection, created_before: int) -> list[dict]:

--- a/klai-knowledge-ingest/knowledge_ingest/pg_store.py
+++ b/klai-knowledge-ingest/knowledge_ingest/pg_store.py
@@ -91,7 +91,7 @@ async def get_active_artifact_state(
     """Return graph-refresh state for the current synced active artifact."""
     row = await conn.fetchrow(
         """
-        SELECT id::text AS id, content_hash, extra, belief_time_start, content_type
+        SELECT id::text AS id, content_hash, extra, belief_time_start
         FROM knowledge.artifacts
         WHERE org_id = $1 AND kb_slug = $2 AND path = $3
           AND belief_time_end = $4
@@ -116,7 +116,6 @@ async def get_active_artifact_state(
         "content_hash": row["content_hash"],
         "extra": extra,
         "belief_time_start": row["belief_time_start"],
-        "content_type": row["content_type"],
     }
 
 

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -47,9 +47,11 @@ from knowledge_ingest.db import tenant_scoped_connection
 from knowledge_ingest.docs_provenance import build_docs_source_extra
 from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 from knowledge_ingest.enrichment_policy import (
+    GRAPHITI_EXTRACTION_VERSION,
     enrichment_skip_reason,
     graph_episode_skip_reason,
 )
+from knowledge_ingest.graph_refresh import maybe_refresh_stale_graph
 from knowledge_ingest.identity import assert_caller_identity, assert_caller_identity_tenant_only
 from knowledge_ingest.models import (
     BulkSyncRequest,
@@ -411,16 +413,34 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         req.content if req.skip_chunking else normalize_document_for_chunking(req.content)
     )
     content_hash = req.content_hash or hashlib.sha256(indexable_content.encode()).hexdigest()
-    stored_hash = await pg_store.get_active_content_hash(conn, req.org_id, req.kb_slug, req.path)
-    if stored_hash is not None and stored_hash == content_hash:
+    active_artifact = await pg_store.get_active_artifact_state(
+        conn, req.org_id, req.kb_slug, req.path
+    )
+    if active_artifact is not None and active_artifact["content_hash"] == content_hash:
+        graph_refresh = await maybe_refresh_stale_graph(
+            conn,
+            artifact_id=active_artifact["id"],
+            extra=active_artifact["extra"],
+            org_id=req.org_id,
+            kb_slug=req.kb_slug,
+            path=req.path,
+            content_type=req.content_type,
+            belief_time_start=active_artifact["belief_time_start"],
+            indexable_content=indexable_content,
+        )
+        log_fields = {"graph_refresh": graph_refresh} if graph_refresh is not None else {}
         logger.info(
             "ingest_skipped",
             reason="content_unchanged",
             kb_slug=req.kb_slug,
             path=req.path,
             org_id=req.org_id,
+            **log_fields,
         )
-        return {"status": "skipped", "reason": "content unchanged", "chunks": 0}
+        result = {"status": "skipped", "reason": "content unchanged", "chunks": 0}
+        if graph_refresh is not None:
+            result["graph_refresh"] = graph_refresh
+        return result
 
     # Determine chunks: skip_chunking uses pre-provided chunks or content as single chunk
     parent_chunk_ids: list[int | None] | None = None
@@ -926,7 +946,12 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         # picking the page up, and nothing would show why the graph has no
         # episode for a document that plainly has content.
         await pg_store.update_artifact_extra(
-            conn, artifact_id, {"graphiti_episode_id": f"skipped:{graph_skip}"}
+            conn,
+            artifact_id,
+            {
+                "graphiti_episode_id": f"skipped:{graph_skip}",
+                "graphiti_extraction_version": GRAPHITI_EXTRACTION_VERSION,
+            },
         )
         logger.info(
             "graphiti_episode_skipped",

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -964,7 +964,11 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
         from knowledge_ingest import enrichment_tasks
 
         proc_app = enrichment_tasks.get_app()
+        # ``lock`` (execution) alongside ``queueing_lock`` (dedup): a stale-graph
+        # refresh for the same artifact must serialise against this job, not
+        # run concurrently and delete the episodes it is appending.
         await proc_app.ingest_graphiti_episode.configure(  # type: ignore[attr-defined]
+            lock=f"graphiti:{artifact_id}",
             queueing_lock=f"graphiti:{artifact_id}",
         ).defer_async(
             artifact_id=artifact_id,

--- a/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/kb_sources.py
@@ -41,6 +41,7 @@ from pydantic import BaseModel, Field
 
 from knowledge_ingest import enrichment_tasks, pg_store, qdrant_store
 from knowledge_ingest.db import tenant_scoped_connection
+from knowledge_ingest.graph_refresh import maybe_refresh_stale_graph
 from knowledge_ingest.identity import assert_caller_identity_tenant_only
 
 logger = structlog.get_logger()
@@ -257,6 +258,30 @@ async def reindex_upload(
         updated = await pg_store.set_artifact_index_status(
             conn, artifact_id, verified_org_id, "pending"
         )
+        if updated is not None:
+            artifact = await pg_store.read_artifact_for_enrichment(conn, artifact_id)
+            if artifact is None:
+                raise RuntimeError(f"artifact {artifact_id} disappeared after status update")
+            extra = artifact["extra"] or {}
+            document_text = extra.get("document_text", "") or ""
+            if not document_text:
+                logger.warning(
+                    "graph_refresh_unavailable",
+                    artifact_id=artifact_id,
+                    reason="no document_text",
+                )
+            else:
+                await maybe_refresh_stale_graph(
+                    conn,
+                    artifact_id=artifact_id,
+                    extra=extra,
+                    org_id=verified_org_id,
+                    kb_slug=artifact["kb_slug"],
+                    path=artifact["path"],
+                    content_type=artifact["content_type"],
+                    belief_time_start=artifact["belief_time_start"],
+                    indexable_content=document_text,
+                )
     if updated is None:
         raise HTTPException(status_code=404, detail="artifact not found")
 

--- a/klai-knowledge-ingest/tests/test_centroid_lookup_failure_logging.py
+++ b/klai-knowledge-ingest/tests/test_centroid_lookup_failure_logging.py
@@ -57,7 +57,7 @@ async def test_centroid_lookup_failure_logs_at_warning_with_structured_fields():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ),

--- a/klai-knowledge-ingest/tests/test_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_dedup.py
@@ -88,7 +88,7 @@ def _base_patches(mock_app, *, enrichment_enabled: bool = True):
                 return_value=[[0.1] * 10],
             ),
             patch(
-                "knowledge_ingest.routes.ingest.pg_store.get_active_content_hash",
+                "knowledge_ingest.routes.ingest.pg_store.get_active_artifact_state",
                 new_callable=AsyncMock,
                 return_value=None,
             ),

--- a/klai-knowledge-ingest/tests/test_extra_payload_contract.py
+++ b/klai-knowledge-ingest/tests/test_extra_payload_contract.py
@@ -199,7 +199,7 @@ async def _run_with_mocks(
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ),

--- a/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
+++ b/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
@@ -221,6 +221,59 @@ async def test_upload_reindex_always_enriches_and_only_refreshes_legacy_graph(
         assert app.ingest_graphiti_episode.defer_async.await_args.kwargs["replace_stale"] is True
 
 
+@pytest.mark.asyncio
+async def test_graph_refresh_failure_does_not_fail_the_unchanged_content_skip() -> None:
+    """A FalkorDB/queue hiccup in the refresh must not 500 a previously
+    side-effect-free "content unchanged" ingest."""
+    content = "\n".join(f"* [Page {number}](https://example.test/{number})" for number in range(8))
+    req = _request(content)
+    app = _ProcApp()
+
+    with (
+        patch.object(
+            pg_store,
+            "get_episode_ids_for_document_history",
+            AsyncMock(return_value=["episode-old"]),
+        ),
+        patch(
+            "knowledge_ingest.graph.delete_kb_episodes",
+            AsyncMock(side_effect=RuntimeError("falkordb down")),
+        ),
+    ):
+        result = await _ingest_unchanged(req, extra={}, app=app)
+
+    assert result == {"status": "skipped", "reason": "content unchanged", "chunks": 0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_of_job_already_waiting_in_queue_reports_already_queued() -> None:
+    from procrastinate.exceptions import AlreadyEnqueued
+
+    req = _request()
+    app = _ProcApp()
+    app.ingest_graphiti_episode.defer_async = AsyncMock(side_effect=AlreadyEnqueued())
+
+    result = await _ingest_unchanged(req, extra={}, app=app)
+
+    assert result["graph_refresh"] == "already_queued"
+
+
+@pytest.mark.asyncio
+async def test_refresh_job_serialises_against_a_running_extraction_via_lock() -> None:
+    """queueing_lock dedups only todo jobs; the execution lock is what stops a
+    refresh from running concurrently with an in-flight extraction and deleting
+    the episodes it is appending."""
+    req = _request()
+    app = _ProcApp()
+
+    await _ingest_unchanged(req, extra={}, app=app)
+
+    assert app.ingest_graphiti_episode.configure.call_args.kwargs == {
+        "lock": f"graphiti:{_ARTIFACT_ID}",
+        "queueing_lock": f"graphiti:{_ARTIFACT_ID}",
+    }
+
+
 @pytest.fixture
 def graphiti_task() -> object:
     app = _CapturingApp()
@@ -246,7 +299,12 @@ async def _run_graphiti_task(graphiti_task: object, *, replace_stale: bool = Fal
     )
 
     async def _update(_conn, _artifact_id, values):
-        if values == {"graphiti_episode_ids": [], "graphiti_episode_id": None}:
+        if values == {
+            "graphiti_episode_ids": [],
+            "graphiti_episode_id": None,
+            "graphiti_episode_complete": False,
+            "graphiti_episode_part_count": 0,
+        }:
             events.append("reset")
 
     store.update_artifact_extra = AsyncMock(side_effect=_update)

--- a/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
+++ b/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import hashlib
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
+
+import pytest
+
+import knowledge_ingest
+from knowledge_ingest import enrichment_tasks, pg_store
+from knowledge_ingest.config import settings
+from knowledge_ingest.models import IngestRequest
+from knowledge_ingest.routes import ingest as ingest_route
+from knowledge_ingest.routes import kb_sources
+
+_ARTIFACT_ID = "0f9c1a2b-3d4e-4f50-9a61-72b83c94d5e6"
+_ORG_ID = "org-graph-refresh"
+_KB_SLUG = "support"
+_PATH = "guides/page.md"
+
+
+class _TaskHandle:
+    def __init__(self) -> None:
+        self.configure = MagicMock(return_value=self)
+        self.defer_async = AsyncMock(return_value=None)
+
+
+class _ProcApp:
+    def __init__(self) -> None:
+        self.ingest_graphiti_episode = _TaskHandle()
+        self.enrich_document_interactive = _TaskHandle()
+
+
+class _CapturingApp:
+    def __init__(self) -> None:
+        self.tasks: dict[str, object] = {}
+
+    def task(self, **_kwargs):
+        def _decorator(fn):
+            self.tasks[fn.__name__] = fn
+            return fn
+
+        return _decorator
+
+
+def _request(
+    content: str = "# Calling guide\n\nKlai routes calls to the right colleague.",
+) -> IngestRequest:
+    return IngestRequest(
+        org_id=_ORG_ID,
+        kb_slug=_KB_SLUG,
+        path=_PATH,
+        content=content,
+        source_type="docs",
+        content_type="kb_article",
+    )
+
+
+def _artifact_state(req: IngestRequest, extra: dict) -> dict:
+    return {
+        "id": _ARTIFACT_ID,
+        "content_hash": hashlib.sha256(req.content.encode()).hexdigest(),
+        "extra": extra,
+        "belief_time_start": 1_755_820_800,
+        "content_type": "stored/type",
+    }
+
+
+def _mock_conn() -> MagicMock:
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock(return_value=None)
+    return conn
+
+
+@asynccontextmanager
+async def _tenant_connection(_org_id: str):
+    yield SimpleNamespace()
+
+
+async def _ingest_unchanged(req: IngestRequest, *, extra: dict, app: _ProcApp) -> dict:
+    state = _artifact_state(req, extra)
+    conn = _mock_conn()
+    with (
+        patch.object(
+            pg_store,
+            "get_active_artifact_state",
+            AsyncMock(return_value=state),
+            create=True,
+        ),
+        patch.object(settings, "graphiti_enabled", True),
+        patch("knowledge_ingest.enrichment_tasks.get_app", return_value=app),
+    ):
+        return await ingest_route.ingest_document(conn, req)
+
+
+@pytest.mark.asyncio
+async def test_unchanged_content_with_legacy_graph_rules_queues_replacement() -> None:
+    req = _request()
+    app = _ProcApp()
+
+    result = await _ingest_unchanged(req, extra={}, app=app)
+
+    assert result == {
+        "status": "skipped",
+        "reason": "content unchanged",
+        "chunks": 0,
+        "graph_refresh": "queued",
+    }
+    app.ingest_graphiti_episode.defer_async.assert_awaited_once_with(
+        artifact_id=_ARTIFACT_ID,
+        document_text=req.content,
+        org_id=_ORG_ID,
+        content_type="kb_article",
+        belief_time_start=1_755_820_800,
+        kb_slug=_KB_SLUG,
+        path=_PATH,
+        replace_stale=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unchanged_content_with_current_graph_rules_does_not_refresh() -> None:
+    req = _request()
+    app = _ProcApp()
+
+    result = await _ingest_unchanged(
+        req,
+        extra={"graphiti_extraction_version": 2},
+        app=app,
+    )
+
+    assert result == {"status": "skipped", "reason": "content unchanged", "chunks": 0}
+    app.ingest_graphiti_episode.defer_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_navigation_page_replaces_history_with_current_skip_marker() -> None:
+    content = "\n".join(f"* [Page {number}](https://example.test/{number})" for number in range(8))
+    req = _request(content)
+    app = _ProcApp()
+    stale_ids = ["episode-old-1", "episode-old-2"]
+
+    with (
+        patch.object(
+            pg_store,
+            "get_episode_ids_for_document_history",
+            AsyncMock(return_value=stale_ids),
+        ) as get_history,
+        patch.object(pg_store, "update_artifact_extra", AsyncMock()) as update_extra,
+        patch("knowledge_ingest.graph.delete_kb_episodes", AsyncMock()) as delete_episodes,
+    ):
+        result = await _ingest_unchanged(req, extra={}, app=app)
+
+    assert result["graph_refresh"] == "skipped:navigation_page"
+    get_history.assert_awaited_once_with(ANY, _ORG_ID, [_ARTIFACT_ID])
+    delete_episodes.assert_awaited_once_with(_ORG_ID, stale_ids)
+    update_extra.assert_awaited_once_with(
+        ANY,
+        _ARTIFACT_ID,
+        {
+            "graphiti_episode_ids": [],
+            "graphiti_episode_part_count": 0,
+            "graphiti_episode_complete": True,
+            "graphiti_episode_id": "skipped:navigation_page",
+            "graphiti_extraction_version": 2,
+        },
+    )
+    app.ingest_graphiti_episode.defer_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("extra", "expected_graph_jobs"),
+    [({}, 1), ({"graphiti_extraction_version": 2}, 0)],
+    ids=["legacy-graph-rules", "current-graph-rules"],
+)
+async def test_upload_reindex_always_enriches_and_only_refreshes_legacy_graph(
+    extra: dict,
+    expected_graph_jobs: int,
+) -> None:
+    app = _ProcApp()
+    row = {
+        "artifact_id": _ARTIFACT_ID,
+        "org_id": _ORG_ID,
+        "kb_slug": _KB_SLUG,
+        "path": _PATH,
+        "content_type": "application/pdf",
+        "belief_time_start": 1_755_820_800,
+        "extra": {"document_text": "Klai routes calls to the right colleague.", **extra},
+    }
+    with (
+        patch.object(
+            kb_sources,
+            "assert_caller_identity_tenant_only",
+            AsyncMock(return_value=_ORG_ID),
+        ),
+        patch.object(kb_sources, "tenant_scoped_connection", _tenant_connection),
+        patch.object(
+            pg_store,
+            "set_artifact_index_status",
+            AsyncMock(return_value={"artifact_id": _ARTIFACT_ID, "path": _PATH}),
+        ),
+        patch.object(pg_store, "read_artifact_for_enrichment", AsyncMock(return_value=row)),
+        patch.object(settings, "graphiti_enabled", True),
+        patch.object(enrichment_tasks, "get_app", return_value=app),
+    ):
+        response = await kb_sources.reindex_upload(
+            MagicMock(),
+            artifact_id=_ARTIFACT_ID,
+            org_id=_ORG_ID,
+        )
+
+    assert response.index_status == "pending"
+    assert app.enrich_document_interactive.defer_async.await_count == 1
+    assert app.ingest_graphiti_episode.defer_async.await_count == expected_graph_jobs
+    if expected_graph_jobs:
+        assert app.ingest_graphiti_episode.defer_async.await_args.kwargs["replace_stale"] is True
+
+
+@pytest.fixture
+def graphiti_task() -> object:
+    app = _CapturingApp()
+    enrichment_tasks._register_tasks(app)
+    return app.tasks["ingest_graphiti_episode"]
+
+
+async def _run_graphiti_task(graphiti_task: object, *, replace_stale: bool = False):
+    events: list[str] = []
+    graph_module = MagicMock()
+    graph_module.EntityGraphData.return_value = SimpleNamespace()
+    graph_module.delete_kb_episodes = AsyncMock(side_effect=lambda *_args: events.append("delete"))
+    graph_module.ingest_episode = AsyncMock(
+        side_effect=lambda **_kwargs: events.append("ingest") or "episode-new"
+    )
+    graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
+
+    store = MagicMock()
+    store.artifact_exists = AsyncMock(return_value=True)
+    store.artifact_is_active = AsyncMock(return_value=True)
+    store.get_episode_ids_for_document_history = AsyncMock(
+        side_effect=lambda *_args: events.append("history") or ["episode-old"]
+    )
+
+    async def _update(_conn, _artifact_id, values):
+        if values == {"graphiti_episode_ids": [], "graphiti_episode_id": None}:
+            events.append("reset")
+
+    store.update_artifact_extra = AsyncMock(side_effect=_update)
+    store.append_graphiti_episode_id = AsyncMock(return_value=None)
+
+    with (
+        patch.object(knowledge_ingest, "pg_store", store),
+        patch.object(knowledge_ingest, "graph", graph_module),
+        patch.object(enrichment_tasks, "tenant_scoped_connection", _tenant_connection),
+    ):
+        await graphiti_task(
+            artifact_id=_ARTIFACT_ID,
+            document_text="Klai routes calls to the right colleague.",
+            org_id=_ORG_ID,
+            content_type="kb_article",
+            belief_time_start=1_755_820_800,
+            kb_slug=_KB_SLUG,
+            path=_PATH,
+            replace_stale=replace_stale,
+        )
+    return events, store, graph_module
+
+
+@pytest.mark.asyncio
+async def test_replacement_run_deletes_and_resets_history_before_new_extraction(
+    graphiti_task,
+) -> None:
+    events, store, graph_module = await _run_graphiti_task(graphiti_task, replace_stale=True)
+
+    assert events[:4] == ["history", "delete", "reset", "ingest"]
+    graph_module.delete_kb_episodes.assert_awaited_once_with(_ORG_ID, ["episode-old"])
+    assert store.update_artifact_extra.await_args_list[-1] == call(
+        ANY,
+        _ARTIFACT_ID,
+        {"graphiti_episode_complete": True, "graphiti_extraction_version": 2},
+    )
+
+
+@pytest.mark.asyncio
+async def test_normal_graph_run_stamps_current_extraction_version(graphiti_task) -> None:
+    _events, store, graph_module = await _run_graphiti_task(graphiti_task)
+
+    graph_module.delete_kb_episodes.assert_not_awaited()
+    store.get_episode_ids_for_document_history.assert_not_awaited()
+    assert store.update_artifact_extra.await_args_list[-1] == call(
+        ANY,
+        _ARTIFACT_ID,
+        {"graphiti_episode_complete": True, "graphiti_extraction_version": 2},
+    )

--- a/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
@@ -177,7 +177,8 @@ async def test_short_document_creates_one_episode_and_records_both_id_keys(graph
         "graphiti_episode_complete": False,
     }
     assert pg_store.update_artifact_extra.await_args_list[-1].args[2] == {
-        "graphiti_episode_complete": True
+        "graphiti_episode_complete": True,
+        "graphiti_extraction_version": 2,
     }
     graph_module.flush_entity_graph_data.assert_awaited_once()
 

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -56,6 +56,16 @@ def _sha256(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+def _active_state(content_hash: str) -> dict:
+    return {
+        "id": "active-artifact-id",
+        "content_hash": content_hash,
+        "extra": {"graphiti_extraction_version": 2},
+        "belief_time_start": 0,
+        "content_type": "kb_article",
+    }
+
+
 @pytest.mark.asyncio
 async def test_skips_when_content_unchanged():
     """ingest_document returns 'skipped' without calling embed when hash matches."""
@@ -65,9 +75,9 @@ async def test_skips_when_content_unchanged():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
-            return_value=stored_hash,
+            return_value=_active_state(stored_hash),
         ),
         patch("knowledge_ingest.embedder.embed", new_callable=AsyncMock) as mock_embed,
     ):
@@ -177,9 +187,9 @@ async def test_proceeds_when_content_changed():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
-            return_value=old_hash,  # different from current content
+            return_value=_active_state(old_hash),  # different from current content
         ),
         patch(
             "knowledge_ingest.pg_store.soft_delete_artifact",
@@ -272,7 +282,7 @@ async def test_proceeds_when_no_previous_artifact():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,  # no previous artifact
         ),
@@ -344,7 +354,7 @@ async def test_content_hash_stored_on_create():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ),
@@ -416,7 +426,7 @@ async def test_qdrant_failure_leaves_artifact_pending_for_retry():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ),
@@ -488,7 +498,7 @@ async def test_content_hash_override_used_for_prechunked_ingest():
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ) as mock_get_hash,
@@ -572,7 +582,7 @@ async def test_docling_skip_chunking_writes_parent_chunks() -> None:
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         ),

--- a/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
+++ b/klai-knowledge-ingest/tests/test_ingest_content_hash_dedup.py
@@ -97,12 +97,12 @@ async def test_two_identical_connector_requests_upsert_chunks_once():
     req.source_connector_id = "connector-1"
     req.source_ref = "json-feed:connector-1:group-a"
     conn = _make_mock_conn()
-    stored_hash = AsyncMock(side_effect=[None, _sha256(req.content)])
+    stored_state = AsyncMock(side_effect=[None, _active_state(_sha256(req.content))])
 
     with (
         patch(
-            "knowledge_ingest.pg_store.get_active_content_hash",
-            new=stored_hash,
+            "knowledge_ingest.pg_store.get_active_artifact_state",
+            new=stored_state,
         ),
         patch(
             "knowledge_ingest.pg_store.soft_delete_artifact",
@@ -173,7 +173,7 @@ async def test_two_identical_connector_requests_upsert_chunks_once():
 
     assert first["status"] == "ok"
     assert second == {"status": "skipped", "reason": "content unchanged", "chunks": 0}
-    assert stored_hash.await_count == 2
+    assert stored_state.await_count == 2
     assert embed.await_count == 1
     assert upsert.await_count == 1
 

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -231,7 +231,6 @@ async def test_get_active_artifact_state_only_uses_synced_artifacts():
         "content_hash": "sha256",
         "extra": {"graphiti_extraction_version": 2},
         "belief_time_start": 123,
-        "content_type": "kb_article",
     }
     sql = conn.fetchrow.call_args[0][0]
     assert "index_status = 'synced'" in sql

--- a/klai-knowledge-ingest/tests/test_pg_store.py
+++ b/klai-knowledge-ingest/tests/test_pg_store.py
@@ -212,14 +212,28 @@ async def test_create_artifact_with_derived_from_recovers_unique_race_inside_sav
 
 
 @pytest.mark.asyncio
-async def test_get_active_content_hash_only_uses_synced_artifacts():
+async def test_get_active_artifact_state_only_uses_synced_artifacts():
     conn = _make_conn()
-    conn.fetchval = AsyncMock(return_value="sha256")
+    conn.fetchrow = AsyncMock(
+        return_value={
+            "id": "artifact-id",
+            "content_hash": "sha256",
+            "extra": '{"graphiti_extraction_version": 2}',
+            "belief_time_start": 123,
+            "content_type": "kb_article",
+        }
+    )
 
-    result = await pg_store.get_active_content_hash(conn, "org", "kb", "path.md")
+    result = await pg_store.get_active_artifact_state(conn, "org", "kb", "path.md")
 
-    assert result == "sha256"
-    sql = conn.fetchval.call_args[0][0]
+    assert result == {
+        "id": "artifact-id",
+        "content_hash": "sha256",
+        "extra": {"graphiti_extraction_version": 2},
+        "belief_time_start": 123,
+        "content_type": "kb_article",
+    }
+    sql = conn.fetchrow.call_args[0][0]
     assert "index_status = 'synced'" in sql
 
 

--- a/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
+++ b/klai-knowledge-ingest/tests/test_reindex_and_delete_endpoints.py
@@ -60,6 +60,24 @@ def _make_mock_conn() -> MagicMock:
     return conn
 
 
+def _artifact_for_enrichment() -> dict:
+    return {
+        "id": _ARTIFACT,
+        "org_id": _ORG,
+        "kb_slug": _KB,
+        "path": _PATH,
+        "user_id": None,
+        "content_type": "application/pdf",
+        "synthesis_depth": 0,
+        "assertion_mode": "factual",
+        "provenance_type": "observed",
+        "confidence": "medium",
+        "belief_time_start": 0,
+        "belief_time_end": 253402300800,
+        "extra": {},
+    }
+
+
 @contextmanager
 def _client_with_conn(conn: MagicMock):  # type: ignore[return]
     """Build a TestClient that yields *conn* from tenant_scoped_connection."""
@@ -100,6 +118,7 @@ class TestReindexHappyPath:
                     "belief_time_end": 253402300800,
                 },
                 {"artifact_id": _ARTIFACT, "path": _PATH},
+                _artifact_for_enrichment(),
             ]
         )
 
@@ -142,6 +161,7 @@ class TestReindexHappyPath:
                     "belief_time_end": 253402300800,
                 },
                 {"artifact_id": _ARTIFACT, "path": _PATH},
+                _artifact_for_enrichment(),
             ]
         )
 
@@ -191,6 +211,7 @@ class TestReindexHappyPath:
                     "belief_time_end": 253402300800,
                 },
                 {"artifact_id": _ARTIFACT, "path": _PATH},
+                _artifact_for_enrichment(),
             ]
         )
 
@@ -232,6 +253,7 @@ class TestReindexHappyPath:
                     "belief_time_end": 1779974993,
                 },
                 {"artifact_id": _ARTIFACT, "path": _PATH},
+                _artifact_for_enrichment(),
             ]
         )
 

--- a/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
+++ b/klai-knowledge-ingest/tests/test_renamed_connector_page_supersedes_by_source_ref.py
@@ -67,7 +67,7 @@ def _ingest_patches(
         )
         _p("knowledge_ingest.enrichment_tasks.get_app", return_value=_make_procrastinate_app())
         _p(
-            "knowledge_ingest.pg_store.get_active_content_hash",
+            "knowledge_ingest.pg_store.get_active_artifact_state",
             new_callable=AsyncMock,
             return_value=None,
         )


### PR DESCRIPTION
## What

A manual refresh of an existing knowledge base now rebuilds the knowledge graph for documents whose graph episodes predate the current extraction rules — per KB, on demand, at the moment someone re-syncs a connector or reindexes an upload. No re-chunking, re-embedding, or re-enrichment.

Context: the 2026-08-25 product update (product_updates id 22) promises subject-facts extraction, navigation-page skipping, and one entity name across NL/EN/DE. Those improvements live at ingest time and only apply to re-extracted content; only Voys has had a rebuild. This closes that gap for every other tenant without a platform-wide operator run.

## How

- `GRAPHITI_EXTRACTION_VERSION` (=2) in `enrichment_policy.py`; version 1 is the implicit, never-stamped legacy ruleset. Stamped in `artifacts.extra` on every completed episode run, on nav-page skip markers, and by `backfill.py`.
- The content-unchanged early-exit in `ingest_document` and `reindex_upload` both call `maybe_refresh_stale_graph`: version-gated, re-evaluates the nav-page skip rule against current content, then enqueues `ingest_graphiti_episode(replace_stale=True)` under both the queueing lock and the execution lock (`graphiti:{artifact_id}`).
- `replace_stale` deletes the document-history episodes at **execution** time (via `get_episode_ids_for_document_history`), so during a large-KB refresh each document keeps its old episodes until minutes before the replacements land instead of hours while the graphiti-bulk queue drains. Delete-before-extract is deliberate: old and new episodes share the name `doc:<kb>:<path>`, so keeping both would serve contradictory facts with valid-looking citations; a failed run leaves the version unstamped, so the next refresh retries.
- The refresh never raises: a FalkorDB or queue hiccup logs `graph_refresh_failed` and the caller's contract (skip response / reindex) is unaffected.
- `get_active_content_hash` → `get_active_artifact_state` (same WHERE clause, richer row; single production call site).

## Deliberately not done

- No cost indicator in the UI (the sync button can now trigger real LLM cost) — worth a separate, product-owned change.
- `no-chunks` markers stay unstamped so a refresh with live content retries them.
- Pre-existing gaps flagged by review but out of scope here (tracked in the PR conversation): tenant binding of `bulk_sync_kb_route`/Gitea webhook, webhook replay protection, org-wide Entity sweep running per artifact under concurrency.

## Ops (after deploy)

One-time stamp for Voys (already rebuilt on the current ruleset, 2026-08-22) so the sync button does not trigger a redundant rebuild there — SQL in the deploy notes.

## Tests

New contract suite `test_graph_refresh_on_stale_extraction_version.py` (10 tests, red→green verified against the pre-change source), full knowledge-ingest suite green: 1663 passed, 6 skipped; ruff clean. Reviewed by two independent model passes (tenant-isolation + correctness); all verified findings addressed or explicitly deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)