### PR TITLE
fix(mcp): validate the JSON-RPC envelope, not just the params shape

### DIFF
--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -51,7 +51,7 @@ from mcp.server.transport_security import (
     TransportSecurityMiddleware,
     TransportSecuritySettings,
 )
-from mcp.types import LATEST_PROTOCOL_VERSION, InitializeRequest
+from mcp.types import LATEST_PROTOCOL_VERSION, InitializeRequest, JSONRPCRequest
 
 from logging_setup import setup_logging
 from shield_compliance import check_compliance as _shield_check_compliance
@@ -1778,6 +1778,7 @@ async def shield_prepare_prompt(
 from starlette.applications import Starlette  # noqa: E402
 from starlette.middleware import Middleware  # noqa: E402
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint  # noqa: E402
+from starlette.requests import ClientDisconnect  # noqa: E402
 from starlette.requests import Request as StarletteRequest  # noqa: E402
 from starlette.responses import JSONResponse, Response  # noqa: E402
 from starlette.routing import Mount, Route  # noqa: E402
@@ -1999,14 +2000,30 @@ class _WWWAuthenticateMiddleware(BaseHTTPMiddleware):
                     # the stream without setting it and the SDK receives an
                     # empty body -- initialize would break, which is why the
                     # handshake test below exists.
+                    content_length = request.headers.get("content-length")
+                    if content_length is not None:
+                        try:
+                            declared_size = int(content_length)
+                        except ValueError:
+                            pass
+                        else:
+                            if declared_size > mcp.session_manager.max_request_body_size:
+                                return Response("Request body too large", status_code=413)
+
                     body = bytearray()
-                    async for chunk in request.stream():
-                        if len(body) + len(chunk) > mcp.session_manager.max_request_body_size:
-                            return Response("Request body too large", status_code=413)
-                        body.extend(chunk)
+                    try:
+                        async for chunk in request.stream():
+                            if len(body) + len(chunk) > mcp.session_manager.max_request_body_size:
+                                return Response("Request body too large", status_code=413)
+                            body.extend(chunk)
+                    except ClientDisconnect:
+                        return Response("Client disconnected", status_code=400)
                     request._body = bytes(body)
 
                     try:
+                        envelope = JSONRPCRequest.model_validate_json(request._body)
+                        if envelope.method != "initialize":
+                            raise ValueError
                         InitializeRequest.model_validate_json(request._body)
                     except ValueError:
                         return JSONResponse(

--- a/klai-knowledge-mcp/tests/test_mcp_hygiene.py
+++ b/klai-knowledge-mcp/tests/test_mcp_hygiene.py
@@ -16,15 +16,75 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import nullcontext
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from klai_identity_assert.mcp_token_client import McpTokenVerifyResult
 from starlette.testclient import TestClient
+from starlette.types import Message, Scope
 
 MAIN_PY = Path(__file__).resolve().parents[1] / "main.py"
 DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
 CADDYFILE = Path(__file__).resolve().parents[2] / "deploy" / "caddy" / "Caddyfile"
+
+_VALID_INITIALIZE_PARAMS = (
+    b'{"protocolVersion":"2025-06-18","capabilities":{},'
+    b'"clientInfo":{"name":"klai-session-guard-test","version":"1"}}'
+)
+_SESSIONLESS_BODY_CORPUS = (
+    (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":'
+        + _VALID_INITIALIZE_PARAMS
+        + b"}",
+        200,
+    ),
+    (b'{"params":' + _VALID_INITIALIZE_PARAMS + b"}", 400),
+    (b'{"jsonrpc":"2.0","id":1,"params":' + _VALID_INITIALIZE_PARAMS + b"}", 400),
+    (b'{"jsonrpc":"2.0","method":"initialize","params":' + _VALID_INITIALIZE_PARAMS + b"}", 400),
+    (b'{"id":1,"method":"initialize","params":' + _VALID_INITIALIZE_PARAMS + b"}", 400),
+    (
+        b'{"jsonrpc":"1.0","id":1,"method":"initialize","params":'
+        + _VALID_INITIALIZE_PARAMS
+        + b"}",
+        400,
+    ),
+    (
+        b'{"jsonrpc":"2.0","id":{},"method":"initialize","params":'
+        + _VALID_INITIALIZE_PARAMS
+        + b"}",
+        400,
+    ),
+    (
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","method":"ping","params":'
+        + _VALID_INITIALIZE_PARAMS
+        + b"}",
+        400,
+    ),
+    (b'{"jsonrpc":"2.0","id":1,"method":"ping"}', 400),
+    (
+        b'[{"jsonrpc":"2.0","id":1,"method":"initialize","params":'
+        + _VALID_INITIALIZE_PARAMS
+        + b"}]",
+        400,
+    ),
+    (b"{}", 400),
+    (b"{", 400),
+)
+_SESSIONLESS_BODY_CORPUS_IDS = (
+    "valid-initialize",
+    "methodless-valid-params",
+    "methodless-jsonrpc-id",
+    "notification-shaped-initialize",
+    "missing-jsonrpc",
+    "jsonrpc-1.0",
+    "object-id",
+    "duplicate-method-initialize-then-ping",
+    "ping",
+    "batch",
+    "empty-object",
+    "malformed-json",
+)
 
 
 @pytest.fixture(scope="module")
@@ -150,6 +210,151 @@ def test_rejected_foreign_origins_do_not_consume_mcp_sessions(mcp_client: TestCl
     response = mcp_client.post("/mcp", headers=headers, json=body)
 
     assert response.status_code == 403
+    assert len(session_manager._server_instances) == sessions_before
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_status"),
+    _SESSIONLESS_BODY_CORPUS,
+    ids=_SESSIONLESS_BODY_CORPUS_IDS,
+)
+def test_sessionless_guard_matches_the_sdk_envelope_contract_without_leaking_sessions(
+    mcp_client: TestClient,
+    body: bytes,
+    expected_status: int,
+) -> None:
+    """Every rejected legacy sessionless envelope must leave session state unchanged."""
+    import main
+
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Authorization": "Bearer klai_mcp_verified-corpus",
+        "Host": "mcp.getklai.com",
+    }
+    session_manager = main.mcp.session_manager
+    sessions_before = len(session_manager._server_instances)
+
+    with patch(
+        "main._mcp_token_asserter.verify",
+        new_callable=AsyncMock,
+        return_value=McpTokenVerifyResult.allow(
+            user_id="verified-user",
+            org_id="verified-org",
+            org_slug="verified-org",
+            scopes=("mcp:knowledge",),
+            resource_uri="https://mcp.getklai.com/mcp",
+        ),
+    ):
+        response = mcp_client.post("/mcp", headers=headers, content=body)
+
+    assert response.status_code == expected_status, response.text
+    if response.status_code != 200:
+        assert len(session_manager._server_instances) == sessions_before
+        return
+
+    session_headers = {
+        **headers,
+        "Mcp-Session-Id": response.headers["mcp-session-id"],
+        "MCP-Protocol-Version": "2025-06-18",
+    }
+    deleted = mcp_client.delete("/mcp", headers=session_headers)
+    assert deleted.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_sessionless_disconnect_returns_a_response_without_allocating_a_session() -> None:
+    """A client abort during the guard's body drain must not escape the ASGI app."""
+    import main
+
+    scope = cast(
+        Scope,
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"mcp.getklai.com"),
+                (b"authorization", b"Bearer klai_mcp_disconnect"),
+                (b"accept", b"application/json, text/event-stream"),
+                (b"content-type", b"application/json"),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("mcp.getklai.com", 443),
+        },
+    )
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    session_manager = main.mcp.session_manager
+    sessions_before = len(session_manager._server_instances)
+
+    await main.app(scope, receive, send)
+
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 400
+    assert len(session_manager._server_instances) == sessions_before
+
+
+@pytest.mark.asyncio
+async def test_declared_oversized_sessionless_body_is_rejected_before_body_read() -> None:
+    """The outer guard must preserve the SDK's header-only body-limit rejection."""
+    import main
+
+    declared_size = main.mcp.session_manager.max_request_body_size + 1
+    scope = cast(
+        Scope,
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"mcp.getklai.com"),
+                (b"authorization", b"Bearer klai_mcp_oversized"),
+                (b"accept", b"application/json, text/event-stream"),
+                (b"content-type", b"application/json"),
+                (b"content-length", str(declared_size).encode("ascii")),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("mcp.getklai.com", 443),
+        },
+    )
+    sent: list[Message] = []
+    receive_calls = 0
+
+    async def receive() -> Message:
+        nonlocal receive_calls
+        receive_calls += 1
+        raise AssertionError("oversized declared body must not be read")
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    session_manager = main.mcp.session_manager
+    sessions_before = len(session_manager._server_instances)
+
+    await main.app(scope, receive, send)
+
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 413
+    assert receive_calls == 0
     assert len(session_manager._server_instances) == sessions_before
 
 


### PR DESCRIPTION
Closes #1198 — this time with the measurement to back it.

## The bypass

The sessionless guard from #1208 was bypassable. `mcp.types.InitializeRequest.model_fields["method"]` is `required=False, default='initialize'`, so a body carrying only well-formed `params` validates as an initialize with **no `method`, no `jsonrpc` and no `id`**:

```json
{"params":{"protocolVersion":"","capabilities":{},"clientInfo":{"name":"","version":""}}}
```

The guard waved it through, the SDK allocated and registered a transport, then rejected the body as invalid JSON-RPC — and the session was retained for the process lifetime.

#1213 removed the dangerous half by verifying the bearer token before allocation, so this is no longer reachable without an account. Measured on this branch's base:

| caller | 50x method-less body | session delta |
|---|---|---|
| unauthenticated | `401` | 0 |
| authenticated (verification mocked to succeed) | `400` | **50** |

After this change the authenticated case is **delta 0**.

## The fix

`JSONRPCRequest` has `jsonrpc`, `id` and `method` all required, which is exactly the gap. Validate the envelope first, then the params shape.

The property that matters is not "rejects more" but **agrees with the SDK it fronts** — a guard that refuses what the transport would have accepted breaks real clients, which is worse than the leak. Verified per payload against the same app with the guard removed:

| payload | with guard | SDK itself (guard removed) |
|---|---|---|
| valid initialize | 200 (+1) | 200 (+1) |
| method-less + params | 400 (0) | 400 (**+1**) |
| method-less + jsonrpc + id | 400 (0) | 400 (**+1**) |
| notification-shaped (no `id`) | 400 (0) | 400 (**+1**) |
| missing `jsonrpc` | 400 (0) | 400 (**+1**) |
| `jsonrpc: "1.0"` | 400 (0) | 400 (**+1**) |
| `id` as an object | 400 (0) | 400 (**+1**) |
| duplicate `method` key | 400 (0) | 400 (**+1**) |
| `ping` / batch array / `{}` / malformed JSON | 400 (0) | 400 (**+1**) |

Same verdict on every row. The only difference is the session that no longer gets stranded. **Zero payloads where the guard rejects and the SDK would have accepted.**

## The tests are the other half, and arguably the more important half

Every payload in the previous tests carried an explicit `method` key — precisely the axis the guard failed on — so they were green while it leaked 50 out of 50. They asserted the fix's assumption rather than the invariant.

They now parametrise over the corpus above and assert the contract directly: **for any response that is not 200, the session count must be unchanged.** Status codes were never the contract here.

## Two smaller defects from the same review

Both were still present on this base:

- `ClientDisconnect` from `request.stream()` escaped the ASGI app on a mid-body abort, so uvicorn logged a traceback per aborted sessionless POST — an attacker-controlled error-rate amplifier. Now caught.
- The guard runs outside the SDK's `RequestBodyLimitMiddleware`, losing its cheap `Content-Length` rejection: 0 bytes read before, 4.26 MB after. Now checked before the drain loop.

## Legitimate clients unaffected

| Host | initialize | notifications/initialized | tools/list | DELETE |
|---|---|---|---|---|
| `mcp.getklai.com` | 200 | 202 | 200 | 200 |
| `klai-knowledge-mcp:8080` | 200 | 202 | 200 | 200 |

A modern-protocol (`2026-07-28`) sessionless request still returns 200 with no session growth.

## Verification

`ruff check` 0, `ruff format --check` 0, `pyright` 0 errors, `pytest` **183 passed**. Red/green reproduced independently during review by removing the envelope check (6 failures) and restoring it (34 passed). The agreement table above was re-measured independently, not taken from the implementing agent's report.

## Residual

The SDK still allocates before validating the body, so this protection depends on the outer middleware staying mounted. That is now pinned by tests that assert the session count rather than the status code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)