### PR TITLE
feat(graph): pre-flight build estimator + persist FalkorDB timeout (SPEC-GRAPH-SCALE-001 REQ-1/2)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1889,6 +1889,22 @@ services:
   falkordb:
     image: falkordb/falkordb:v4.20.3
     restart: unless-stopped
+    # SPEC-GRAPH-SCALE-001 REQ-2: the image bakes FALKORDB_ARGS="MAX_QUEUED_QUERIES 25
+    # TIMEOUT 1000 RESULTSET_SIZE 10000" into its own Dockerfile (FalkorDB/FalkorDB#1826),
+    # an undocumented 1 s read-query cap that graphiti's brute-force similarity scans
+    # exceeded from ~22k edges (84 accumulated timeouts by ~28k; the largest tenant now
+    # sits at ~30k edges, so this is steady state). `GRAPH.CONFIG SET TIMEOUT 5000` fixed
+    # it at runtime on 2026-08, but that reverts on every container recreate; this env
+    # var is the persistent form of exactly that proven setting. Only TIMEOUT changes
+    # vs the image defaults; MAX_QUEUED_QUERIES and RESULTSET_SIZE are restated because
+    # setting FALKORDB_ARGS replaces the baked-in value wholesale. Do NOT raise further:
+    # 15/30/60 s were tried and made throughput worse (slow queries occupy worker
+    # threads instead of failing fast) — 5000 is the smallest value that eliminated the
+    # failures. This is a stopgap buying headroom, not a fix; the real fix (ANN instead
+    # of brute-force scans) is SPEC-GRAPH-SCALE-001 REQ-3/4. Verify after deploy on a
+    # FRESHLY started container: redis-cli -p 6379 GRAPH.CONFIG GET TIMEOUT -> 5000.
+    environment:
+      FALKORDB_ARGS: "MAX_QUEUED_QUERIES 25 TIMEOUT 5000 RESULTSET_SIZE 10000"
     ports:
       - "127.0.0.1:6380:6379"
     volumes:

--- a/docs/specs/SPEC-GRAPH-SCALE-001/spec.md
+++ b/docs/specs/SPEC-GRAPH-SCALE-001/spec.md
@@ -1,0 +1,614 @@
+---
+id: SPEC-GRAPH-SCALE-001
+version: "0.1.0"
+status: draft (research complete, implementation not started)
+created: 2026-08-26
+updated: 2026-08-26
+author: Claude (Fable), commissioned by Mark Vletter
+priority: high
+related:
+  - SPEC-KB-011 (introduced graphiti-core; the stub-deps lesson in its history is why graphiti imports stay guarded)
+  - SPEC-RAG-GRAPH-CITE-002 (episode naming; unaffected by this SPEC, but its rename path is a consumer of the graph this SPEC keeps intact during migration)
+  - GetKlai/klai#1148 (canonical-English entity names across knowledge bases — the reason sub-tenant partitioning is a real trade-off, not a free lever)
+  - GetKlai/klai#1214 (edge fulltext O(hits × entities) fix in klai-libs/graphiti-compat — precedent for the patch mechanism this SPEC extends)
+roadmap: docs/architecture/retrieval-improvements-roadmap.md
+---
+
+# HISTORY
+
+| Version | Date       | Author | Change |
+|---------|------------|--------|--------|
+| 0.1.1   | 2026-08-26 | Claude (Fable) | REQ-1 + REQ-2 implemented; post-review amendments. (1) The edge ceiling is derived from the scan TAIL, not the average: timeouts were observed from ~22k edges under the 1000 ms cap while the average scan there was ~343 ms, so the ceiling formula gains a `graph_scan_tail_factor` (default 3.0): `0.6 × timeout / (15.6 µs × 3)` ≈ 64k edges — consistent with §1's ~110k-edges-at-5-s wall, where the earlier average-based formula (~192k) was not. (2) REQ-2 landed as `FALKORDB_ARGS="MAX_QUEUED_QUERIES 25 TIMEOUT 5000 RESULTSET_SIZE 10000"` — exactly the runtime-proven setting; `TIMEOUT_DEFAULT`/`TIMEOUT_MAX` were deliberately NOT used because they would newly cap write queries, untested behavior (operator handoff note 2026-08-26: 15/30/60 s were tried and made throughput worse; graph now at ~30k edges steady state). (3) The live-ingest scale-warning hook is fire-and-forget with socket + coroutine deadlines, and treats an empty COUNT result as an error, after a Sol review found the original inline await could block the episode semaphore indefinitely on a half-dead FalkorDB connection. (4) Review leftovers deliberately not fixed: none ≥ high; see PR discussion. |
+| 0.1.0   | 2026-08-26 | Claude (Fable), commissioned by Mark Vletter | Initial draft. Research-only: production measurements were taken beforehand on the live Voys graph (provided as input, not re-measured); code paths verified against graphiti-core 0.29.3 source and the klai repositories; external claims verified against FalkorDB docs/source, the getzep/graphiti issue tracker, and the entity-resolution literature. No code changes. |
+
+---
+
+# SPEC-GRAPH-SCALE-001: Knowledge-graph construction cost is quadratic in corpus size
+
+## Summary
+
+Klai builds a per-tenant knowledge graph with graphiti-core 0.29.3 on FalkorDB
+v4.20.3. For every episode it ingests, graphiti resolves the newly extracted
+entities and edges against the **entire existing tenant graph** using
+brute-force cosine scans in Cypher (`vec.cosineDistance()` over every
+`RELATES_TO.fact_embedding` and every `Entity.name_embedding`). Per-episode
+cost therefore grows linearly with graph size, and total build cost grows
+**quadratically with source-text volume**. The largest tenant (6.6M characters
+of source text → ~26,400 edges) already takes ~20 hours to rebuild and began
+hitting FalkorDB's 1,000 ms query timeout at ~22,000 edges. A tenant with ~2×
+the source text could not complete a rebuild inside a weekend; at ~10× the
+build would take on the order of **weeks** and fail on timeouts long before
+finishing — while today the system would happily start that build and go
+silent for days.
+
+This SPEC establishes the scaling law in source-text volume, ranks the levers
+with evidence, and specifies the work: (1) a cheap, separable **pre-flight
+estimate that refuses infeasible builds loudly**, (2) persisting the FalkorDB
+timeout raise that currently reverts on restart, (3) a **spike** deciding
+between FalkorDB's native HNSW vector index and Klai's existing Qdrant as the
+ANN candidate generator — the native index has a documented correctness risk
+under interleaved read/write — and (4) routing graphiti's candidate searches
+through that ANN index via graphiti's official `SearchInterface` extension
+point, delivered through the existing `klai-libs/graphiti-compat` patch
+mechanism. No fork, no framework swap, no per-knowledge-base partitioning.
+
+Everything in this document is labelled **[measured]** (taken on the live
+system before this SPEC), **[verified in source]** (read directly from
+graphiti-core 0.29.3 / FalkorDB source / this repository),
+**[cited]** (published material, linked), or **[judgement]** (our inference —
+each one names what would settle it).
+
+## Motivation
+
+### What is measured — the input, not re-derived here
+
+Largest tenant (Voys), Dutch knowledge bases only **[measured]**:
+
+    source text            6,593,861 characters across 726 documents
+    average document       9,082 characters
+    edges produced         ~17,400 new (~2,600 edges per million characters)
+    total graph            ~26,400 edges, ~8,000 entities, ~960 episodes
+    full rebuild           ~20 hours, sequential
+    throughput             88 documents/hour on a near-empty graph,
+                           degrading to 22–34/hour at 26,000 edges
+
+Query timings on the live graph at 18,031 edges **[measured]**:
+
+    pattern match only, no cosine                    200 ms
+    cosine over 2,000 edges                          3.2 ms
+    full graphiti edge-similarity query              281 ms
+    node equivalent (Entity.name_embedding, ~8k)     172 ms
+
+FalkorDB's effective query timeout is 1,000 ms; at ~22,000 edges these queries
+began exceeding it and episodes started failing. The timeout was raised to
+5,000 ms **at runtime only** — `deploy/docker-compose.yml` has no `command:`
+or `FALKORDB_ARGS` for the `falkordb` service, so the raise reverts on every
+container restart **[measured; compose verified in source
+`deploy/docker-compose.yml:1889`]**. The 1,000 ms cap is not the module
+default (which is 0 = unbounded): the official Docker image bakes
+`TIMEOUT 1000` into its own `FALKORDB_ARGS`, and that image-level `TIMEOUT`
+caps **read queries only** — writes complete while the reads feeding them are
+killed, which is exactly the "ingest reports success, resolution quietly
+degrades" shape **[cited:
+[FalkorDB/FalkorDB#1826](https://github.com/FalkorDB/FalkorDB/issues/1826)]**.
+
+Creating FalkorDB vector indexes on `Entity.name_embedding` and
+`RELATES_TO.fact_embedding` made **no measurable difference** and they were
+dropped again **[measured]**. This is expected, not a fluke — see "Why the
+index changed nothing" below.
+
+### Where the quadratic term lives — the per-episode query census
+
+Read directly from graphiti-core 0.29.3 **[verified in source]**:
+
+- **Node resolution.** `add_episode` → `resolve_extracted_nodes` →
+  `_semantic_candidate_search`
+  (`graphiti_core/utils/maintenance/node_operations.py:418`): **one**
+  brute-force `node_similarity_search` per extracted entity, wanting only the
+  top `NODE_DEDUP_CANDIDATE_LIMIT = 15` candidates above cosine 0.6 — but
+  computing the cosine against **every** `Entity.name_embedding` in the tenant
+  graph to find them.
+- **Edge resolution.** `resolve_extracted_edges`
+  (`graphiti_core/utils/maintenance/edge_operations.py:392-418`): **two**
+  hybrid searches per extracted edge (related-edges + invalidation-candidates,
+  both `EDGE_HYBRID_SEARCH_RRF`), each containing a brute-force
+  `edge_similarity_search` over **every** `RELATES_TO.fact_embedding`
+  (`search_utils.py:291`, the exact query quoted in the problem statement),
+  wanting only the top `RELEVANT_SCHEMA_LIMIT = 10`.
+- The edge **fulltext** leg of those hybrid searches is served by FalkorDB's
+  RediSearch index and is already fixed: the O(hits × entities) re-match
+  defect was patched in `klai-libs/graphiti-compat` (140+ s → 2.99 ms,
+  GetKlai/klai#1214). The similarity leg is what remains.
+
+So each episode issues on the order of *(entities extracted)* node scans plus
+*2 × (edges extracted)* edge scans. With Voys averages (~18 edges and ~10
+entities per episode — the ~2,600 edges/Mchar density over ~9 kchar
+documents), that is roughly **45–50 full-graph scans per episode**
+**[judgement — the extracted-per-episode counts are estimated from aggregate
+totals; `graphiti_episode_ingested` logs `entity_count`/`edge_count` per
+episode and would give the exact distribution]**.
+
+Per-scan cost from the measured timings: 281 ms at 18,031 edges ≈ **15.6 µs
+per edge** (the 200 ms "pattern match only" component is itself a scan of
+every edge, so the whole 281 ms scales with edge count, not just the cosine
+part); 172 ms over ~8,000 nodes ≈ **21.5 µs per node** **[derived from
+measured]**.
+
+### Why the vector index changed nothing
+
+`vec.cosineDistance()` is a plain scalar function in FalkorDB — its own source
+documents it as the shared math used both by the Cypher function *and* by
+per-result scoring "when materialising KNN results from a vector index", i.e.
+they share arithmetic, not an execution path. The **only** way to engage the
+HNSW index is the procedure call `db.idx.vector.queryNodes(...)` /
+`db.idx.vector.queryRelationships(...)`; there is no planner rewrite that
+turns an `ORDER BY vec.cosineDistance(...) LIMIT k` into an index scan
+**[cited: [FalkorDB vector-index
+docs](https://docs.falkordb.com/cypher/indexing/vector-index.html),
+[vec_distance.rs](https://raw.githubusercontent.com/FalkorDB/FalkorDB/main/graph/src/runtime/vec_distance.rs)]**.
+graphiti never calls those procedures — `get_vector_cosine_func_query()`
+hardcodes the scalar function for every driver, and
+`FalkorDriver.build_indices_and_constraints` creates only range and fulltext
+indexes **[verified in source]**. Creating an index the queries never touch
+is exactly a no-op, as observed.
+
+This is not a FalkorDB-vs-Neo4j gap: the Neo4j path in graphiti `main` is
+equally brute-force. Neo4j HNSW support was merged upstream (PR #859,
+2025-08), silently removed a week later (PR #894), and the re-proposal
+(issue #1793 with 41–45 s → 232–1,456 ms measurements on a 48k-node graph;
+draft PR #1796) has had no maintainer response. The equivalent FalkorDB PR
+(#1335, claiming ~3,000×) has been open unmerged for five months **[cited:
+[#1793](https://github.com/getzep/graphiti/issues/1793),
+[#1796](https://github.com/getzep/graphiti/pull/1796),
+[#1335](https://github.com/getzep/graphiti/pull/1335)]**. Zep's own paper and
+positioning are conversation-memory-shaped — many small per-user graphs, DMR
+conversations of ~60 messages — which is why a corpus-scale wall does not
+surface in their evaluations **[cited:
+[arXiv:2501.13956](https://arxiv.org/abs/2501.13956)]**.
+
+## 1. The scaling law, in source-text volume
+
+Model: total sequential build time `T(C) = a·C + b·C²` for `C` in millions of
+characters. The linear term is per-document extraction (LLM calls, embedding,
+the configured 10 s inter-episode delay); the quadratic term is the resolution
+scans, whose per-episode cost grows with the edge count that earlier documents
+created.
+
+Calibration **[derived from measured]**:
+
+- Near-empty throughput 88 docs/h → 41 s/document; at ~110 docs per million
+  characters this gives **a ≈ 1.25 h per Mchar**.
+- The measured 20 h total at C = 6.6 then fixes **b ≈ 0.27 h per Mchar²**.
+- Cross-check from the bottom up: ~46 scans/episode × 15.6 µs/edge at the
+  build's average edge count predicts ~6 h of scan time for the Voys rebuild —
+  the same order but smaller than the ~12 h the calibrated quadratic term
+  implies. The gap (factor ~2–3) is real degradation the pure scan model does
+  not capture: timeout-and-retry loops once queries crossed 1,000 ms, and
+  LLM dedup prompts that grow with candidate count are the two candidates
+  **[judgement — an instrumented probe run (REQ-6) attributes it; the
+  calibrated model is anchored to the measured 20 h either way]**.
+
+Projections (sequential, current code, per tenant) **[derived]**:
+
+| Source text | vs Voys | Predicted build | Verdict |
+|---|---|---|---|
+| 6.6M chars | 1× | ~20 h (calibration point) | painful, done once |
+| 10M chars | 1.5× | ~40 h | last size a weekend covers |
+| 13M chars | 2× | ~2.7 days | operationally unacceptable |
+| 20M chars | 3× | ~5.5 days | infeasible |
+| 66M chars | 10× | ~7 weeks | absurd — and it fails first (below) |
+
+The pure-quadratic extrapolation in the problem statement (~10× text ≈ ~100×
+time) and this calibrated model (~60×) agree on the order; the difference is
+the linear term's share.
+
+**The hard wall arrives before the wall-clock wall.** Query latency is linear
+in edge count (~15.6 µs/edge), so at the tail: failures began at ~22,000 edges
+under the 1,000 ms cap. Under the runtime-raised 5,000 ms cap the same tail
+crosses at roughly 5× the edge count, ~110,000 edges ≈ **28–42M characters**
+(the range reflects total-graph density 4,000/Mchar vs new-edge density
+2,600/Mchar) **[derived]**. And because the 5,000 ms setting is not
+persisted, any FalkorDB container restart snaps the wall back to ~22,000
+edges — **fractionally above the largest existing tenant** **[measured +
+verified in source]**.
+
+**Threshold to refuse (REQ-1).** Refuse a full build whose predicted time
+exceeds an operator budget (default 48 h). Under the current constants that is
+**C ≈ 11M characters (~29,000 predicted edges, ~1.7× the largest tenant)**
+**[judgement — the 48 h budget is a policy choice; the formula, not the
+number, is what the pre-flight encodes, so the threshold moves automatically
+when REQ-6 re-measures the constants after the ANN fix]**. Independently,
+refuse when the predicted final edge count would push the per-scan tail past
+the configured FalkorDB timeout (edge count ≳ 0.6 × timeout / (15.6 µs ×
+tail factor 3) ≈ 64k edges at 5 s — the tail factor because failures were
+observed at ~22k edges where the *average* scan was only ~343 ms).
+
+## 2. The levers, ranked
+
+**Lever 1 — index-based ANN for candidate search (do this).** Every
+brute-force scan exists to find a top-10/15 candidate set: this is
+approximate-nearest-neighbour blocking implemented as an exact linear scan.
+Replacing the scan with an ANN index removes the quadratic term structurally —
+per-episode cost stops depending on graph size. Evidence of magnitude:
+graphiti #1793 measured ~500× per query at 48k nodes on Neo4j HNSW; FalkorDB
+PR #1335 claims ~3,000×; HNSW query cost is near-O(log N) vs O(N·d)
+**[cited]**. Post-fix build time collapses to the linear term, ~1.25 h/Mchar
+sequential (66M chars ≈ 83 h sequential — and now parallelizable via the
+existing `--concurrency` dial, because the graph engine stops being the
+shared bottleneck; the LiteLLM budget becomes the ceiling). Two sub-options —
+**the choice is a spike, not an opinion** (REQ-3):
+
+- **1a. FalkorDB native vector index**, queried via
+  `db.idx.vector.queryRelationships('RELATES_TO', 'fact_embedding', k, …)` /
+  `queryNodes('Entity', 'name_embedding', k, …)`. Simplest topology — no new
+  stores, index lives with the data. Two documented risks: (i) a community PR
+  doing exactly this (graphiti #1287) was **withdrawn by its own author**
+  after measuring 83% empty/wrong HNSW results under interleaved read/write
+  (391 of 472 queries empty in a 42-episode build), tied to the still-open
+  [FalkorDB#716](https://github.com/FalkorDB/FalkorDB/issues/716) and
+  hnswlib's documented lack of search/insert synchronization **[cited]**;
+  (ii) FalkorDB vector queries support **no property filtering** — over-fetch
+  and post-filter is the only pattern **[cited: docs + discussion #633]**.
+  Risk (ii) is mostly moot for Klai: each tenant is its own FalkorDB
+  database, so `group_id` is uniform within any query's scope; the one
+  filtered search (`SearchFilters(edge_uuids=…)` on the related-edges pass)
+  targets edges between one specific node pair and can stay a direct indexed
+  `MATCH` instead of ANN. Risk (i) is the spike's whole reason to exist:
+  Klai's writes are serialized (`GRAPHITI_MAX_CONCURRENT=1`) but reads and
+  writes still interleave within a build, and #1287's failure mode was
+  measured on a different version/configuration than v4.20.3.
+- **1b. Qdrant as external candidate generator.** Klai already runs Qdrant
+  with HNSW at 1024 dimensions for chunk retrieval — proven at exactly the
+  vector shape needed (bge-m3), with none of FalkorDB's HNSW concurrency
+  history, and Qdrant's published benchmarks cover the closest analog to our
+  dimensionality (1M × 1536-dim) **[cited]**. Shape: mirror
+  `fact_embedding`/`name_embedding` into per-tenant sidecar collections at
+  episode-save time; candidate search = Qdrant top-k → fetch by uuid from
+  FalkorDB. Costs: dual-write consistency — **every** delete path in
+  `knowledge_ingest/graph.py` (`delete_kb_episodes`,
+  `sweep_orphan_episodes_org_wide`, `delete_orphan_episodes_for_artifact_ids`,
+  `wipe_org_graph`) must also clean the sidecar, and the connector-delete
+  matrix in the knowledge rules gains a row; plus new collections to
+  provision and monitor. External support for the pattern: two-stage
+  ANN-candidate-then-exact-resolve is the standard shape in the ER literature
+  (SC-Block: 99.5% recall at k = 100–200 on 100k–2M record sets, candidate
+  sets halved vs competing blockers, brute force "computationally infeasible"
+  at scale) **[cited: [arXiv:2303.03132](https://arxiv.org/abs/2303.03132)]**,
+  though no published writeup names the exact "vector DB blocks, graph DB
+  stores" combination — that gap is real, not a search miss.
+
+**Lever 2 — blocking / candidate narrowing.** In this codebase, lever 2 *is*
+lever 1: graphiti already narrows to top-10/15 candidates — the literature's
+"blocking is 10× more important than matching" is an argument for making that
+narrowing cheap (ANN), not for adding another narrowing stage. The only
+independent variant — dropping or scoping the second (invalidation-candidates)
+search per edge — halves edge scans at best while changing edge-invalidation
+semantics. Not worth the semantic risk for a 2× on a term lever 1 removes
+entirely **[judgement]**.
+
+**Lever 3 — pre-flight estimate + refusal.** Makes nothing faster; converts a
+multi-day silent failure into an immediate loud one. Cheapest item in this
+SPEC, zero dependencies, do it first (REQ-1).
+
+**Lever 4 — batch corpus construction as a separate path.** Upstream
+`add_episode_bulk` does **not** avoid the cost: it batches extraction but
+still runs `resolve_extracted_nodes`/`resolve_extracted_edges` per episode
+against the live graph through the same brute-force searches **[verified in
+source]**, returns no episode UUIDs (incompatible with the per-artifact
+bookkeeping `backfill.py` depends on), and has open LLM-shape fragility
+issues in its dedup path (#882, #879) **[cited]**. A Klai-built batch
+pipeline (extract-all fan-out → global resolution → bulk load, the
+GraphRAG/LightRAG shape) becomes interesting only if post-lever-1
+measurements show resolution still dominating — the external evidence says
+extraction, not resolution, dominates once blocking is cheap (58% of GraphRAG
+indexing tokens are extraction) **[cited]**. Extraction fan-out itself needs
+no new pipeline: `backfill.py --concurrency` already exists and the LLM
+budget is the ceiling. Deferred, with the decision gate named (REQ-6).
+
+**Lever 5 — reducing what enters the graph.** Already partially exercised
+(navigation-page skip saves ~26 LLM calls per page; meta-fact suppression;
+content-hash dedup). Further tightening trims constants, not the exponent.
+Worth doing opportunistically, never the answer **[judgement]**.
+
+**Lever 6 — partitioning below the tenant.** Rejected as a primary lever:
+Klai just made entity names canonical English (#1148) precisely so entities
+join **across** knowledge bases; per-KB partitions would fragment "Device"
+into one node per KB and undo that. Also unnecessary if lever 1 lands: ANN
+query cost grows logarithmically, so tenant-sized indexes are comfortable at
+any projected corpus. Keep in the back pocket only for a pathological tenant,
+priced honestly as "the graph stops joining across KBs" **[judgement]**.
+
+## 3. Reaching FalkorDB's vector index from graphiti — concretely
+
+**No fork is needed.** Two mechanisms, both compatible with the existing
+runtime-patch precedent:
+
+1. **`driver.search_interface`** — graphiti 0.29.3 ships an official
+   extension point
+   (`graphiti_core/driver/search_interface/search_interface.py`): every
+   search function in `search_utils` consults it first
+   (`edge_similarity_search` at `search_utils.py:301`,
+   `node_similarity_search` at `:664`, the fulltext variants likewise)
+   **[verified in source]**. A `KlaiFalkorSearchInterface` implementing
+   `edge_similarity_search` / `node_similarity_search` (and delegating the
+   rest) can be assigned to the driver at client construction in
+   `_get_graphiti()` — both in knowledge-ingest and retrieval-api.
+2. The existing `klai-libs/graphiti-compat` module-patch mechanism, which
+   already rewrites `edge_fulltext_search` the same way (#1214).
+
+Option 1 is the primary path (it is API, not monkey-patching); the compat
+package is where the implementation lives either way, next to the patches it
+extends. The maintainer response on
+[#1229](https://github.com/getzep/graphiti/issues/1229) signals upstream
+intent to solve this via per-backend driver refactoring, so an upstream
+contribution is plausible later but must not be the plan of record — the
+FalkorDB HNSW PR has sat unmerged for five months.
+
+**The query change** (edge case; node case is symmetric on
+`Entity.name_embedding`):
+
+```cypher
+-- today (search_utils.edge_similarity_search, FalkorDB branch):
+MATCH (n:Entity)-[e:RELATES_TO]->(m:Entity)
+WHERE e.group_id IN $group_ids
+WITH DISTINCT e, n, m,
+     (2 - vec.cosineDistance(e.fact_embedding, vecf32($search_vector)))/2 AS score
+WHERE score > $min_score
+ORDER BY score DESC LIMIT $limit
+
+-- proposed:
+CALL db.idx.vector.queryRelationships(
+    'RELATES_TO', 'fact_embedding', $k, vecf32($search_vector))
+YIELD relationship AS e, score
+WITH e, startNode(e) AS n, endNode(e) AS m, score
+-- score→similarity conversion per the index's similarityFunction;
+-- residual SearchFilters applied here as post-filter over the k results
+ORDER BY score_converted DESC
+LIMIT $limit
+```
+
+with `$k` over-fetched relative to `$limit` (e.g. 4×) to absorb post-filter
+loss, and the index created per tenant database as
+
+```cypher
+CREATE VECTOR INDEX FOR ()-[e:RELATES_TO]->() ON (e.fact_embedding)
+OPTIONS {dimension: 1024, similarityFunction: 'cosine'}
+CREATE VECTOR INDEX FOR (n:Entity) ON (n.name_embedding)
+OPTIONS {dimension: 1024, similarityFunction: 'cosine'}
+```
+
+hooked into the compat layer's `ensure_database_initialized` (the per-tenant
+init the clone patch already owns) **[cited: FalkorDB docs; verified in
+source for the hook point]**. Two things the spike must smoke-test rather
+than assume: the `score` semantics of `queryRelationships` on v4.20.3
+(distance vs similarity, and the historical always-0 bug
+[FalkorDB#525](https://github.com/FalkorDB/FalkorDB/issues/525), closed), and
+recall correctness under Klai's ingest pattern (the #1287 failure mode).
+
+If the spike rejects the native index, the identical `SearchInterface` seam
+takes the Qdrant implementation (option 1b) — the seam is the deliverable;
+the backend is a decision behind it.
+
+## 4. Batch pipeline: not now, and here is the gate
+
+Covered under lever 4. Recommendation **[judgement]**: keep incremental
+ingest as the only write path. A separate corpus-construction pipeline
+(extraction fan-out → global resolution → bulk load) costs a second write
+path with its own dedup semantics, invalidation story, resume/bookkeeping
+machinery, and drift risk against live ingest — the repo's own history
+(reconciliation SPECs, orphan sweeps) shows what parallel write paths cost.
+What it would buy — cheap global resolution — lever 1 buys without a second
+path. Revisit only if, after REQ-4 lands, REQ-6's re-measurement shows
+resolution still >30% of per-episode wall-clock at the largest tenant.
+
+## 5. Migration for existing tenants
+
+The decisive property: **lever 1 requires no re-extraction and no graph
+rebuild**. The embeddings already sit on every edge and node; only the lookup
+changes. Retrieval keeps working against the same graph throughout.
+
+Per tenant (largest first, since it proves the point):
+
+1. Create the two vector indexes on the live tenant database (online; ~26k +
+   ~8k vectors — the docs' memory formula puts 1M × 1024-dim at roughly 4 GB,
+   so tenant-sized indexes are trivial) **[cited: docs formula]**.
+2. Deploy the `SearchInterface` implementation behind a feature flag
+   (`GRAPH_ANN_ENABLED`, default off), in **both** knowledge-ingest and
+   retrieval-api — retrieval-api constructs its own graphiti client and
+   applies the compat layer independently (`graph_search.py:31`), so a
+   knowledge-ingest-only rollout would leave the read side on brute force
+   **[verified in source]**.
+3. Shadow-verify: with the flag off, run both paths side by side on a sample
+   of live queries per tenant; compare candidate sets (ANN recall vs exact
+   top-k) and latencies. Gate: recall ≥ 0.95 on top-10 against the exact
+   scan, no empty-result anomalies across a full ingest of ≥ 40 episodes (the
+   #1287 failure mode showed within ~5).
+4. Flip the flag per tenant; watch `graphiti_episode_ingested.ingest_ms` and
+   graph-leg latencies in VictoriaLogs.
+5. Rollback is the flag: brute force remains correct (only slow) at every
+   existing tenant's size.
+
+Independently and immediately (REQ-2): persist the timeout raise in
+`deploy/docker-compose.yml` via `FALKORDB_ARGS`, because until then a
+container restart re-arms the 1,000 ms wall just above the largest tenant's
+current edge count.
+
+## 6. Pre-flight estimate — refuse loudly, before spending days
+
+Today `backfill.py` starts any build and goes quiet; the only "estimate" is
+the operator noticing the rate line decay. Specified in REQ-1; deliberately
+separable and first.
+
+## Requirements
+
+### REQ-1 — Pre-flight build estimator with loud refusal
+
+A shared estimator in knowledge-ingest:
+`estimate_graph_build(total_chars, current_edge_count) -> {predicted_hours,
+predicted_final_edges, refusal: str | None}`, with the model
+`T = a·C + b·C²` and constants (`a`, `b`, edges-per-Mchar, per-scan µs/edge,
+budget hours, timeout ms) in `config.py` settings — constants are data, not
+code, so REQ-6's re-measurement is a config change.
+
+- `backfill.py` MUST call it before processing (it already counts artifacts
+  and can sum `length()` of chunk text; corpus chars come from the same
+  Qdrant scroll it already performs) and MUST refuse — non-zero exit, one
+  unmissable log line naming predicted hours, predicted edges, the threshold,
+  and this SPEC id — when `predicted_hours > budget` **or**
+  `predicted_final_edges` would push the per-scan tail past the configured
+  FalkorDB timeout. `--force` overrides with an explicit
+  "operator override" log line.
+- The estimator MUST be importable by the live ingest path for a
+  warning-level log (not refusal) when a tenant's cumulative corpus crosses
+  50% of threshold — connectors grow corpora gradually; the operator should
+  hear about the wall before a rebuild is needed.
+- Fail loudly, per the repo's prime directive: no silent fallback, no
+  best-effort start.
+
+### REQ-2 — Persist the FalkorDB timeout configuration
+
+`deploy/docker-compose.yml` `falkordb` service gains explicit
+`FALKORDB_ARGS` carrying the operationally-decided `TIMEOUT`/`TIMEOUT_DEFAULT`
+/`TIMEOUT_MAX` values (the current runtime state is 5,000 ms), replacing the
+image's baked-in 1,000 ms read cap. The values and their rationale are
+documented in the compose comment, including that image-level `TIMEOUT` caps
+reads only (FalkorDB#1826). Deployment follows the deploy-compose skill's
+boundaries.
+
+### REQ-3 — ANN backend spike (decision gate for REQ-4)
+
+A bounded spike (target: days, not weeks) on a copy of the largest tenant's
+graph, producing a written verdict:
+
+- FalkorDB v4.20.3 native path: create both vector indexes; replay ≥ 40
+  episodes of real ingest; measure per-query latency, `queryRelationships`
+  score semantics, and — the deciding measurement — **recall/emptiness of
+  index results interleaved with writes** (the #1287 failure mode: >80%
+  empty/wrong under mixed read/write on other versions).
+- Qdrant sidecar path: same replay with candidates served from a mirrored
+  collection; measure latency including the extra hop, and enumerate the
+  delete-path surface that dual-writing adds.
+- Verdict picks 1a or 1b with numbers. If both fail (native index incorrect
+  AND sidecar latency unacceptable), the SPEC's fallback ordering is: keep
+  brute force + REQ-1 refusal as the operating envelope, and escalate the
+  FalkorDB correctness finding upstream — that outcome must be reported, not
+  papered over.
+
+### REQ-4 — ANN candidate search via SearchInterface
+
+Implement the chosen backend as a `SearchInterface` in
+`klai-libs/graphiti-compat`, covering `edge_similarity_search` and
+`node_similarity_search` (fulltext stays on the existing patched path;
+`edge_uuids`-filtered pair lookups stay as direct indexed MATCH). Wired in
+both knowledge-ingest (`_get_graphiti`) and retrieval-api
+(`graph_search._get_graphiti`), behind `GRAPH_ANN_ENABLED` (default off
+until REQ-5 verifies). Index creation joins the per-tenant
+`ensure_database_initialized` path (1a) or collection provisioning joins
+tenant setup (1b). Tests pin: the interface is actually consulted (a
+graphiti bump that drops the `search_interface` hook must fail CI, in the
+spirit of the existing reach-pinning tests), over-fetch + post-filter
+semantics, and — for 1b — every delete path in `graph.py` cleaning the
+sidecar.
+
+### REQ-5 — Shadow verification and per-tenant rollout
+
+The migration sequence of §5: shadow comparison with recall ≥ 0.95 on top-10
+vs the exact scan, ≥ 40-episode ingest without empty-result anomalies, flag
+flip per tenant starting with the largest, rollback = flag. No period without
+graph retrieval at any point (the graph is never rebuilt or dropped).
+
+### REQ-6 — Re-measure and republish the scaling constants
+
+After REQ-4/5 on the largest tenant: an instrumented probe run measuring
+per-episode wall-clock split (LLM vs graph queries vs delay) at three graph
+sizes, updating the REQ-1 constants and the refusal threshold, and recording
+in this SPEC's HISTORY: the new sustainable corpus ceiling, and the lever-4
+gate verdict (resolution share of per-episode time — >30% reopens the batch
+pipeline question).
+
+## Acceptance criteria
+
+- **AC-1** (REQ-1) Unit: estimator returns the calibrated values for the
+  Voys inputs (6.6M chars → ~20 h ± tolerance); refusal fires above the
+  configured budget and above the timeout-derived edge ceiling; `--force`
+  logs the override. Integration: `backfill.py` against a fixture corpus
+  above threshold exits non-zero before any episode is ingested.
+- **AC-2** (REQ-2) The compose file pins `FALKORDB_ARGS`; after a container
+  recreate, `GRAPH.CONFIG GET` shows the intended values (verified on the
+  server per the deploy runbook, not assumed from the file).
+- **AC-3** (REQ-3) The spike report exists with all three measurements
+  (latency, score semantics, interleaved-write recall) and a named verdict.
+- **AC-4** (REQ-4) With the flag on, `GRAPH.EXPLAIN` of a candidate search
+  shows `ProcedureCall | db.idx.vector.queryRelationships` (1a) or the
+  Qdrant client is invoked (1b) — and with the flag off, byte-identical
+  behaviour to today. CI fails if `driver.search_interface` is no longer
+  consulted by the pinned graphiti version.
+- **AC-5** (REQ-5) Shadow-run artifact per migrated tenant: recall ≥ 0.95
+  top-10, zero empty-result anomalies over ≥ 40 episodes, before/after
+  `ingest_ms` distributions.
+- **AC-6** (REQ-6) Updated constants land in config with the probe data
+  linked from this SPEC's HISTORY; the pre-flight threshold changes
+  accordingly without code changes.
+
+## Non-goals
+
+- No separate batch/corpus-construction pipeline (lever 4 — gated on REQ-6's
+  measurement, not built here).
+- No partitioning below the tenant (lever 6 — conflicts with #1148's
+  cross-KB entity joins).
+- No graphiti fork and no framework swap (GraphRAG/LightRAG/iText2KG were
+  evaluated as patterns, not replacements: none fit a per-tenant FalkorDB +
+  incremental-sync stack without adopting their storage layers).
+- No change to extraction quality levers (language policy, meta-fact rules,
+  skip policy) — they are #1148's domain and orthogonal.
+- No upstreaming as the plan of record (a contribution can follow once the
+  Klai implementation is proven; upstream responsiveness on this problem
+  space is currently near-zero).
+
+## Risks
+
+- **FalkorDB HNSW correctness under interleaved read/write** — the central
+  risk of path 1a; documented at 83% failure in another setup, unmeasured on
+  v4.20.3 with Klai's serialized writes. Fully absorbed by REQ-3 before any
+  production wiring; path 1b exists precisely because this risk may confirm.
+- **ANN recall vs exact scan changes resolution behaviour** — a candidate the
+  exact scan would have found at rank 14 may be missed, changing an
+  entity-merge decision. Bounded by the shadow-run recall gate (≥ 0.95
+  top-10) and by the fact that resolution is already LLM-mediated and
+  approximate; the 0.6 cosine floor and top-15 cap mean marginal candidates
+  were already noise-dominated **[judgement]**.
+- **Dual-write drift (1b only)** — sidecar collections diverging from the
+  graph on partial failures. Mitigation: the delete-path test matrix in
+  REQ-4, plus a periodic count-comparison in the existing orphan-sweep
+  machinery.
+- **The calibration transfers imperfectly to other tenants** — 2,600
+  edges/Mchar is Voys's density; a different corpus type (transcripts,
+  contracts) may extract differently. The pre-flight uses the tenant's own
+  current edge count where available and the constants are per-config
+  adjustable; REQ-6 revisits after the first non-Voys large tenant.
+- **Model risk in the threshold** — the 3–5× gap between the bottom-up scan
+  model and measured degradation is attributed by hypothesis, not data. The
+  threshold is calibrated to the measured 20 h endpoint, so the refusal is
+  conservative in the direction that matters (refusing too early costs an
+  override; refusing too late costs days).
+
+## Not established — and what would settle each
+
+1. FalkorDB v4.20.3 vector-index correctness under Klai's actual ingest
+   pattern — settled by REQ-3's replay.
+2. `queryRelationships` score semantics on v4.20.3 (and whether the
+   historical always-0 defect is fully gone) — settled by a one-hour smoke
+   test inside REQ-3.
+3. Exact attribution of the throughput-degradation gap (retries vs LLM prompt
+   growth) — settled by REQ-6's instrumented probe.
+4. Extracted entities/edges per episode distribution (the census multiplier)
+   — settled by aggregating existing `graphiti_episode_ingested` log fields
+   in VictoriaLogs; no new instrumentation needed.
+5. Published production evidence for LLM KG construction at 10M+ chars with
+   disclosed methods and costs — a genuine gap in the public record (Diffbot
+   publishes scale without method; GraphRAG publishes cost without ER
+   detail); nothing to wait for.
+6. Whether upstream will take a vector-index contribution — unknowable from
+   outside; the design deliberately does not depend on it.
+7. Published HNSW benchmarks at exactly 1024 dims — nearest analogs are
+   128–1536-dim results; REQ-3 produces our own numbers at our exact shape.

--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -32,11 +32,13 @@ import argparse
 import asyncio
 import json
 import logging
+import sys
 import time
 
 from qdrant_client import AsyncQdrantClient
 
 from knowledge_ingest import pg_store
+from knowledge_ingest.build_estimate import estimate_graph_build
 from knowledge_ingest.config import settings
 from knowledge_ingest.db import cross_org_admin_connection
 from knowledge_ingest.enrichment_policy import (
@@ -77,12 +79,45 @@ def _has_graphiti_episode_record(raw_extra: str | dict | None) -> bool:
     return bool(extra.get("graphiti_episode_id"))
 
 
+def _get_current_edge_count(org_id: str) -> int:
+    """Current RELATES_TO edge count for org_id, via the direct falkordb client.
+
+    Same pattern as ``graph.sweep_orphan_episodes_org_wide`` /
+    ``graph.wipe_org_graph``: the graphiti async driver returns empty result
+    sets for COUNT queries against FalkorDB (a shape mismatch between the
+    FalkorDB and Neo4j driver return types), so this goes around it with the
+    synchronous ``falkordb`` client instead.
+
+    Raises on import failure or query failure — SPEC-GRAPH-SCALE-001's
+    pre-flight refusal must never run against a guessed edge count. Callers
+    decide what to do with the failure (fail loudly by default; ``--force``
+    is the only sanctioned override).
+    """
+    from falkordb import FalkorDB as FalkorDBClient
+
+    # Explicit socket deadlines: the client defaults to blocking forever, so a
+    # FalkorDB that accepts the connection but never answers would hang the
+    # pre-flight instead of reaching the refusal/--force path.
+    client = FalkorDBClient(
+        host=settings.falkordb_host,
+        port=settings.falkordb_port,
+        socket_connect_timeout=2.0,
+        socket_timeout=5.0,
+    )
+    graph = client.select_graph(org_id)
+    result = graph.query("MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS n")
+    if not result.result_set:
+        raise RuntimeError(f"FalkorDB edge-count query returned no result_set for org {org_id}")
+    return int(result.result_set[0][0] or 0)
+
+
 async def main(
     org_id: str,
     limit: int | None = None,
     kb_slugs: list[str] | None = None,
     concurrency: int = 1,
-) -> None:
+    force: bool = False,
+) -> int:
     qdrant = AsyncQdrantClient(
         url=settings.qdrant_url,
         api_key=settings.qdrant_api_key or None,
@@ -103,7 +138,7 @@ async def main(
         )
         if not exists:
             log.error("No artifacts for org %s — nothing to backfill", org_id)
-            return
+            return 0
         log.info("Org: %s", org_id)
 
         # ---- Get artifacts -------------------------------------------------
@@ -132,7 +167,7 @@ async def main(
                     ", ".join(missing),
                     ", ".join(sorted(known)),
                 )
-                return
+                return 0
             log.info("Knowledge bases: %s", ", ".join(sorted(kb_slugs)))
             rows = await conn.fetch(
                 """
@@ -166,7 +201,7 @@ async def main(
         )
         if not to_process:
             log.info("Nothing to do")
-            return
+            return 0
 
         if limit is not None:
             to_process = to_process[:limit]
@@ -199,6 +234,84 @@ async def main(
             total_points,
             len(chunks_by_artifact),
         )
+
+        # ---- SPEC-GRAPH-SCALE-001 REQ-1 — pre-flight build estimate --------
+        # graphiti resolves every extracted entity/edge against the ENTIRE
+        # existing tenant graph, so build time is quadratic in source-text
+        # volume. Without this, the only "estimate" is an operator noticing
+        # the rate line decay days into a build. Runs BEFORE any episode is
+        # ingested; refuses loudly instead of starting an infeasible build.
+        total_chars = sum(
+            len(text)
+            for row in to_process
+            for text in chunks_by_artifact.get(str(row["id"]), [])
+        )
+        try:
+            current_edge_count = _get_current_edge_count(org_id)
+        except Exception as exc:
+            if force:
+                log.warning(
+                    "operator override (--force): could not determine the current "
+                    "FalkorDB edge count for org %s (%s) — proceeding WITHOUT the "
+                    "SPEC-GRAPH-SCALE-001 pre-flight estimate",
+                    org_id,
+                    exc,
+                )
+                current_edge_count = None
+            else:
+                log.error(
+                    "Cannot run the SPEC-GRAPH-SCALE-001 pre-flight estimate: failed "
+                    "to read the current FalkorDB edge count for org %s (%s). No "
+                    "episode has been ingested. Re-run with --force to override.",
+                    org_id,
+                    exc,
+                )
+                return 1
+
+        if current_edge_count is not None:
+            estimate = estimate_graph_build(total_chars, current_edge_count)
+            if estimate.refusal:
+                if force:
+                    log.warning(
+                        "operator override (--force): %s — predicted_hours=%.1f "
+                        "predicted_final_edges=%d budget_hours=%.1f edge_ceiling=%d "
+                        "total_chars=%d current_edge_count=%d",
+                        estimate.refusal,
+                        estimate.predicted_hours,
+                        estimate.predicted_final_edges,
+                        estimate.budget_hours,
+                        estimate.edge_ceiling,
+                        total_chars,
+                        current_edge_count,
+                    )
+                else:
+                    log.error(
+                        "REFUSING build (SPEC-GRAPH-SCALE-001): %s — "
+                        "predicted_hours=%.1f predicted_final_edges=%d "
+                        "budget_hours=%.1f edge_ceiling=%d total_chars=%d "
+                        "current_edge_count=%d. No episode has been ingested. "
+                        "Re-run with --force to override.",
+                        estimate.refusal,
+                        estimate.predicted_hours,
+                        estimate.predicted_final_edges,
+                        estimate.budget_hours,
+                        estimate.edge_ceiling,
+                        total_chars,
+                        current_edge_count,
+                    )
+                    return 1
+            else:
+                log.info(
+                    "SPEC-GRAPH-SCALE-001 pre-flight estimate: predicted_hours=%.1f "
+                    "predicted_final_edges=%d (budget_hours=%.1f, edge_ceiling=%d, "
+                    "total_chars=%d, current_edge_count=%d)",
+                    estimate.predicted_hours,
+                    estimate.predicted_final_edges,
+                    estimate.budget_hours,
+                    estimate.edge_ceiling,
+                    total_chars,
+                    current_edge_count,
+                )
 
         # ---- Process (sequential) ------------------------------------------
         # ingest_episode() owns concurrency control via its own semaphore.
@@ -392,6 +505,7 @@ async def main(
             err_count,
             total_to_process,
         )
+        return 0
 
 
 if __name__ == "__main__":
@@ -419,12 +533,21 @@ if __name__ == "__main__":
         "sequential behaviour; raise it for a bulk rebuild. The real ceiling is "
         "the LiteLLM alias rpm/tpm, not this number.",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overrides the SPEC-GRAPH-SCALE-001 pre-flight refusal. The override "
+        "is logged.",
+    )
     args = parser.parse_args()
-    asyncio.run(
-        main(
-            org_id=args.org_id,
-            limit=args.limit,
-            kb_slugs=args.kb_slugs,
-            concurrency=args.concurrency,
+    sys.exit(
+        asyncio.run(
+            main(
+                org_id=args.org_id,
+                limit=args.limit,
+                kb_slugs=args.kb_slugs,
+                concurrency=args.concurrency,
+                force=args.force,
+            )
         )
     )

--- a/klai-knowledge-ingest/knowledge_ingest/build_estimate.py
+++ b/klai-knowledge-ingest/knowledge_ingest/build_estimate.py
@@ -1,0 +1,195 @@
+"""Pre-flight graph-build cost estimator + throttled scale-warning hook.
+
+SPEC-GRAPH-SCALE-001 REQ-1. graphiti-core resolves every newly extracted
+entity and edge against the ENTIRE existing tenant graph via brute-force
+cosine scans in Cypher, so per-episode cost grows linearly with graph size
+and total sequential build cost grows quadratically with source-text
+volume. Left unchecked, a backfill starts happily and goes silent for days
+before failing on FalkorDB's query timeout.
+
+This module gives two things:
+
+* ``estimate_graph_build`` — a pure function ``backfill.py`` calls before
+  processing a single episode, to refuse an infeasible build loudly instead
+  of starting it.
+* ``should_check_graph_scale`` / ``maybe_warn_graph_scale`` — a throttled
+  pair the live ingest path (``graph.py::ingest_episode``) calls after every
+  successful episode, so an operator hears about the approaching wall while
+  a connector's corpus is still growing gradually, not only at rebuild time.
+
+All model constants are read from ``config.py`` settings, not hardcoded here
+— REQ-6's future re-measurement of the scaling constants is a config change,
+not a code change.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import structlog
+
+from knowledge_ingest.config import settings
+
+logger = structlog.get_logger()
+
+# Throttle window shared by should_check_graph_scale and maybe_warn_graph_scale.
+# The two throttle INDEPENDENT things (see should_check_graph_scale's
+# docstring) but use the same window.
+_THROTTLE_SECONDS = 3600.0
+
+# org_id -> time.monotonic() of the last FalkorDB count query the live-ingest
+# hook was allowed to make.
+_scale_check_last_run: dict[str, float] = {}
+# org_id -> time.monotonic() of the last time maybe_warn_graph_scale actually
+# logged a warning.
+_scale_warn_last_run: dict[str, float] = {}
+
+
+def _edge_ceiling() -> int:
+    """Edge count where the SCAN TAIL approaches the FalkorDB query timeout.
+
+    Derived from the tail, not the average: production timeouts began at
+    ~22k edges under a 1000 ms cap while the average scan there was only
+    ~343 ms, so the failing tail runs ``graph_scan_tail_factor`` (~3x) above
+    the average. The 0.6 is headroom under the timeout, not a hard boundary.
+    """
+    return int(
+        0.6
+        * (settings.graph_falkordb_timeout_ms * 1000)
+        / (settings.graph_scan_us_per_edge * settings.graph_scan_tail_factor)
+    )
+
+
+@dataclass(frozen=True)
+class BuildEstimate:
+    predicted_hours: float
+    predicted_final_edges: int
+    edge_ceiling: int
+    budget_hours: float
+    refusal: str | None  # None = proceed; else human-readable reason
+
+
+def estimate_graph_build(total_chars: int, current_edge_count: int) -> BuildEstimate:
+    """Predict sequential graph-build time and refuse an infeasible build.
+
+    Model: ``T = a*C + b*C**2`` for ``C`` in millions of characters (Mchar),
+    calibrated on the Voys tenant (6,593,861 chars, 0 pre-existing edges ->
+    ~20h, ~17,100 new edges — SPEC-GRAPH-SCALE-001 §1). ``C0`` is the
+    Mchar-equivalent of the graph that already exists (derived from
+    ``current_edge_count`` via ``edges_per_mchar``), so a rebuild on top of a
+    large existing graph is charged the same quadratic resolution-scan cost
+    the real system would actually pay — the quadratic term is evaluated
+    over ``[C0, C0 + dC]``, not over ``[0, dC]``.
+
+    Refuses (sets ``refusal``) when the predicted build exceeds the operator
+    time budget, OR when the predicted final edge count would push
+    per-scan query latency past the configured FalkorDB timeout
+    (edge_ceiling = 0.6 * timeout / scan_us_per_edge; the 0.6 is tail
+    headroom under the timeout, not a hard boundary).
+    """
+    a = settings.graph_build_hours_per_mchar
+    b = settings.graph_build_quad_hours_per_mchar2
+    edges_per_mchar = settings.graph_edges_per_mchar
+    budget_hours = settings.graph_build_budget_hours
+
+    c0 = current_edge_count / edges_per_mchar
+    dc = total_chars / 1e6
+
+    predicted_hours = a * dc + b * ((c0 + dc) ** 2 - c0**2)
+    predicted_final_edges = current_edge_count + round(dc * edges_per_mchar)
+    edge_ceiling = _edge_ceiling()
+
+    refusal: str | None = None
+    if predicted_hours > budget_hours:
+        refusal = (
+            f"SPEC-GRAPH-SCALE-001: predicted build time {predicted_hours:.1f}h "
+            f"exceeds the operator budget of {budget_hours:.1f}h "
+            f"(predicted_final_edges={predicted_final_edges}, "
+            f"edge_ceiling={edge_ceiling})"
+        )
+    elif predicted_final_edges > edge_ceiling:
+        refusal = (
+            f"SPEC-GRAPH-SCALE-001: predicted final edge count "
+            f"{predicted_final_edges} exceeds the FalkorDB-timeout-derived "
+            f"edge ceiling of {edge_ceiling} "
+            f"(predicted build time {predicted_hours:.1f}h, "
+            f"budget_hours={budget_hours:.1f})"
+        )
+
+    return BuildEstimate(
+        predicted_hours=predicted_hours,
+        predicted_final_edges=predicted_final_edges,
+        edge_ceiling=edge_ceiling,
+        budget_hours=budget_hours,
+        refusal=refusal,
+    )
+
+
+def should_check_graph_scale(org_id: str) -> bool:
+    """Gate the FalkorDB edge-count query on the live ingest path.
+
+    Consulted FIRST, before any FalkorDB I/O — the live ingest hot path
+    must not pay a FalkorDB round-trip on every single episode. Returns
+    True at most once per org per hour per process, and marks the
+    timestamp when it does so a concurrent/immediately-following call is
+    throttled too.
+
+    This is a separate throttle from ``maybe_warn_graph_scale``'s own: this
+    one decides whether to spend the I/O at all, the other decides whether
+    a warning actually gets logged once the count is known.
+    """
+    now = time.monotonic()
+    last = _scale_check_last_run.get(org_id)
+    if last is not None and now - last < _THROTTLE_SECONDS:
+        return False
+    _scale_check_last_run[org_id] = now
+    return True
+
+
+def maybe_warn_graph_scale(org_id: str, current_edge_count: int) -> bool:
+    """Warn when a tenant's CURRENT graph alone is already past 50% of a limit.
+
+    Connectors grow a corpus gradually, so a rebuild-time refusal is not
+    enough — an operator should hear the wall is approaching before a
+    rebuild becomes necessary. Warns when either:
+
+    * the predicted full-rebuild time of the existing corpus-equivalent
+      (``a*C0 + b*C0**2``) exceeds 50% of the operator budget, or
+    * ``current_edge_count`` exceeds 50% of the timeout-derived edge
+      ceiling.
+
+    Pure aside from the log emission and throttle state — does no I/O; the
+    caller is responsible for fetching ``current_edge_count``. Throttled to
+    at most one warning per org per hour per process. Returns True iff a
+    warning was actually logged this call.
+    """
+    a = settings.graph_build_hours_per_mchar
+    b = settings.graph_build_quad_hours_per_mchar2
+    edges_per_mchar = settings.graph_edges_per_mchar
+    budget_hours = settings.graph_build_budget_hours
+
+    c0 = current_edge_count / edges_per_mchar
+    predicted_rebuild_hours = a * c0 + b * c0**2
+    edge_ceiling = _edge_ceiling()
+
+    over_hours = predicted_rebuild_hours > 0.5 * budget_hours
+    over_edges = current_edge_count > 0.5 * edge_ceiling
+    if not (over_hours or over_edges):
+        return False
+
+    now = time.monotonic()
+    last = _scale_warn_last_run.get(org_id)
+    if last is not None and now - last < _THROTTLE_SECONDS:
+        return False
+    _scale_warn_last_run[org_id] = now
+
+    logger.warning(
+        "graph_scale_warning",
+        org_id=org_id,
+        current_edge_count=current_edge_count,
+        edge_ceiling=edge_ceiling,
+        predicted_rebuild_hours=round(predicted_rebuild_hours, 2),
+        spec="SPEC-GRAPH-SCALE-001",
+    )
+    return True

--- a/klai-knowledge-ingest/knowledge_ingest/config.py
+++ b/klai-knowledge-ingest/knowledge_ingest/config.py
@@ -380,6 +380,28 @@ class Settings(BaseSettings):
     graphiti_llm_model: str = "klai-fast"
     graphiti_max_concurrent: int = 1  # concurrent episodes; increase with paid LLM plan
     graphiti_episode_delay: float = 10.0
+    # SPEC-GRAPH-SCALE-001 REQ-1 — pre-flight graph-build cost estimator
+    # constants. graphiti resolves every extracted entity/edge against the
+    # ENTIRE existing tenant graph via brute-force cosine scans, so build
+    # time is quadratic in source-text volume. Calibrated on the Voys
+    # tenant (largest known): 6,593,861 chars, 0 pre-existing edges -> ~20h
+    # sequential rebuild, ~17,400 new edges (~2,600 edges/Mchar). See
+    # knowledge_ingest/build_estimate.py and the SPEC's §1 scaling law.
+    # Constants are data, not code: REQ-6's future re-measurement of these
+    # values (after the ANN fix, REQ-4) is a config change, not a code one.
+    graph_build_hours_per_mchar: float = 1.25  # linear term "a" (extraction/LLM)
+    graph_build_quad_hours_per_mchar2: float = 0.27  # quadratic term "b" (resolution scans)
+    graph_edges_per_mchar: float = 2600.0  # measured new-edge density
+    graph_scan_us_per_edge: float = 15.6  # measured brute-force cosine-scan cost per edge
+    # Tail-to-average latency ratio for the edge ceiling. Timeouts were OBSERVED
+    # from ~22k edges under a 1000 ms cap, where the average scan was only
+    # ~344 us/edge * 22k = ~343 ms — the failing tail ran ~3x the average. The
+    # ceiling must be derived from the tail that actually times out, not the
+    # average that doesn't (Sol review 2026-08-26, verified against the SPEC's
+    # own ~110k-edges-at-5s wall in §1).
+    graph_scan_tail_factor: float = 3.0
+    graph_build_budget_hours: float = 48.0  # operator policy: refuse builds predicted past this
+    graph_falkordb_timeout_ms: int = 5000  # current runtime-raised FalkorDB query timeout
     # Portal integration for taxonomy (SPEC-KB-021)
     portal_url: str = "http://portal-api:8000"
     # Bearer token for outbound calls to portal-api internal endpoints

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -37,6 +37,7 @@ from klai_kb_slugs import episode_name
 
 import knowledge_ingest.qdrant_store as qdrant_store
 from knowledge_ingest import _patch_graphiti
+from knowledge_ingest.build_estimate import maybe_warn_graph_scale, should_check_graph_scale
 from knowledge_ingest.config import settings
 from knowledge_ingest.llm_throttle import TokenBucketLimiter, shared_klai_fast_limiter
 
@@ -822,6 +823,77 @@ async def flush_entity_graph_data(
     )
 
 
+async def _maybe_warn_graph_scale_from_falkordb(org_id: str) -> None:
+    """Live-ingest hook for SPEC-GRAPH-SCALE-001's throttled scale warning.
+
+    ``should_check_graph_scale`` is consulted FIRST, before any FalkorDB I/O,
+    so the count query below — the only I/O this hook does — runs at most
+    once per org per hour per process; every other call on the hot ingest
+    path returns immediately.
+
+    Uses the direct ``falkordb`` Python client (same pattern as
+    ``sweep_orphan_episodes_org_wide`` / ``wipe_org_graph`` above: the
+    graphiti async driver returns empty result sets for COUNT queries against
+    FalkorDB), wrapped in ``asyncio.to_thread`` since the client is
+    synchronous.
+
+    Never raises: this is a non-fatal, best-effort warning on the ingest
+    success path. Any failure (missing dependency, FalkorDB unreachable,
+    malformed result) is caught and logged at warning level — it must never
+    fail an episode ingest.
+    """
+    if not should_check_graph_scale(org_id):
+        return
+    try:
+        from falkordb import FalkorDB as FalkorDBClient
+
+        def _count_edges() -> int:
+            # Socket deadlines: the client defaults to blocking forever.
+            client = FalkorDBClient(
+                host=settings.falkordb_host,
+                port=settings.falkordb_port,
+                socket_connect_timeout=2.0,
+                socket_timeout=5.0,
+            )
+            graph = client.select_graph(org_id)
+            result = graph.query("MATCH ()-[r:RELATES_TO]->() RETURN count(r) AS n")
+            if not result.result_set:
+                # A valid Cypher count() returns one row even on an empty
+                # graph; an empty result_set is external drift, not zero.
+                # Raising keeps it loud (fail-loudly): the except below logs
+                # it instead of silently suppressing a scale warning.
+                raise RuntimeError(
+                    f"FalkorDB edge-count query returned no result_set for org {org_id}"
+                )
+            return int(result.result_set[0][0] or 0)
+
+        # Hard deadline on the count query. The falkordb client has no default
+        # socket timeout, so a FalkorDB that accepts the connection but never
+        # answers would otherwise park this coroutine forever WHILE it holds
+        # the episode semaphore — an optional warning must never be able to
+        # block ingestion. The worker thread may linger until the socket dies,
+        # which is acceptable for a once-per-org-per-hour hook.
+        current_edge_count = await asyncio.wait_for(
+            asyncio.to_thread(_count_edges), timeout=5.0
+        )
+        maybe_warn_graph_scale(org_id, current_edge_count)
+    except Exception:
+        logger.warning("graph_scale_warning_hook_failed", org_id=org_id, exc_info=True)
+
+
+# Strong references to in-flight scale-warning tasks: asyncio only keeps weak
+# references to tasks, so a bare create_task could be garbage-collected
+# mid-flight. Bounded in practice by the once-per-org-per-hour throttle.
+_scale_warning_tasks: set[asyncio.Task[None]] = set()
+
+
+def _spawn_graph_scale_warning(org_id: str) -> None:
+    """Run the scale-warning hook without coupling it to the episode result."""
+    task = asyncio.create_task(_maybe_warn_graph_scale_from_falkordb(org_id))
+    _scale_warning_tasks.add(task)
+    task.add_done_callback(_scale_warning_tasks.discard)
+
+
 async def ingest_episode(
     artifact_id: str,
     document_text: str,
@@ -952,6 +1024,14 @@ async def ingest_episode(
                                 "entity_graph_data_failed",
                                 artifact_id=artifact_id,
                             )
+
+                # SPEC-GRAPH-SCALE-001 — throttled scale warning on the live
+                # ingest path. Fire-and-forget: the hook catches its own
+                # exceptions and has its own 5 s deadline, and it must never
+                # delay the episode result — a caller deadline (backfill's
+                # 600 s wait_for) landing here would lose an episode_id whose
+                # episode already committed to the graph.
+                _spawn_graph_scale_warning(org_id)
 
                 break
 

--- a/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
+++ b/klai-knowledge-ingest/tests/test_backfill_episode_text_cap.py
@@ -113,6 +113,7 @@ async def test_backfill_creates_and_records_every_episode_for_a_long_document():
         patch("knowledge_ingest.backfill.cross_org_admin_connection", return_value=ctx),
         patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
         patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch("knowledge_ingest.backfill._get_current_edge_count", return_value=0),
     ):
         await backfill.main(org_id="org-1")
 

--- a/klai-knowledge-ingest/tests/test_backfill_preflight.py
+++ b/klai-knowledge-ingest/tests/test_backfill_preflight.py
@@ -1,0 +1,202 @@
+"""SPEC-GRAPH-SCALE-001 REQ-1 / AC-1 — backfill.py pre-flight integration.
+
+The pre-flight estimate must run BEFORE any episode is ingested, refuse a
+build predicted to be infeasible with a non-zero exit code, allow ``--force``
+to override with an explicit log line, and stay out of the way of an
+ordinary small backfill.
+
+Mocks ``knowledge_ingest.backfill._get_current_edge_count`` throughout —
+these tests must not need a live FalkorDB. Follows the mocking pattern in
+``tests/test_backfill_episode_text_cap.py`` /
+``tests/test_backfill_kb_scope.py``: ``cross_org_admin_connection`` and
+``AsyncQdrantClient`` are patched to avoid real Postgres/Qdrant, and
+``ingest_episode`` is patched to avoid real graphiti/LLM calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest import backfill
+from knowledge_ingest.build_estimate import estimate_graph_build
+
+
+def _admin_ctx(conn):
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=conn)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+def _conn_with_one_artifact():
+    conn = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=True)
+    conn.fetch = AsyncMock(
+        return_value=[
+            {
+                "id": "artifact-1",
+                "kb_slug": "support",
+                "path": "guide.md",
+                "content_type": "text/markdown",
+                "created_at": 1,
+                "extra": None,
+            }
+        ]
+    )
+    return conn
+
+
+def _qdrant_with_text(text: str):
+    qdrant = MagicMock()
+    qdrant.scroll = AsyncMock(
+        return_value=(
+            [SimpleNamespace(payload={"artifact_id": "artifact-1", "text": text})],
+            None,
+        )
+    )
+    return qdrant
+
+
+# Default constants: edge_ceiling = int(0.6 * 5,000,000us / (15.6us/edge * 3)) ~= 64,102.
+_CEILING = estimate_graph_build(total_chars=0, current_edge_count=0).edge_ceiling
+_NEAR_CEILING_EDGE_COUNT = _CEILING - 7  # a small corpus tips predicted_final_edges over
+_SMALL_TEXT = "x" * 20_000  # one episode part (MAX_TEXT_CHARS=30,000), no markdown links
+
+
+@pytest.mark.asyncio
+async def test_corpus_above_threshold_refuses_and_never_ingests():
+    conn = _conn_with_one_artifact()
+    qdrant = _qdrant_with_text(_SMALL_TEXT)
+    ingest_episode = AsyncMock()
+
+    # Sanity: this scenario really does predict a refusal before we assert
+    # on backfill's behaviour around it.
+    estimate = estimate_graph_build(
+        total_chars=len(_SMALL_TEXT), current_edge_count=_NEAR_CEILING_EDGE_COUNT
+    )
+    assert estimate.refusal is not None
+
+    with (
+        patch(
+            "knowledge_ingest.backfill.cross_org_admin_connection",
+            return_value=_admin_ctx(conn),
+        ),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch(
+            "knowledge_ingest.backfill._get_current_edge_count",
+            return_value=_NEAR_CEILING_EDGE_COUNT,
+        ),
+    ):
+        result = await backfill.main(org_id="org-1")
+
+    assert result != 0, "a refused build must exit non-zero"
+    ingest_episode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_overrides_the_refusal_and_logs_the_override(caplog):
+    conn = _conn_with_one_artifact()
+    qdrant = _qdrant_with_text(_SMALL_TEXT)
+    ingest_episode = AsyncMock(return_value="episode-1")
+
+    with (
+        patch(
+            "knowledge_ingest.backfill.cross_org_admin_connection",
+            return_value=_admin_ctx(conn),
+        ),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch(
+            "knowledge_ingest.backfill._get_current_edge_count",
+            return_value=_NEAR_CEILING_EDGE_COUNT,
+        ),
+        caplog.at_level(logging.WARNING, logger="backfill"),
+    ):
+        result = await backfill.main(org_id="org-1", force=True)
+
+    assert result == 0
+    ingest_episode.assert_awaited()
+    override_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if "operator override" in record.getMessage()
+    ]
+    assert override_lines, "no operator-override line was logged"
+    assert any("SPEC-GRAPH-SCALE-001" in line for line in override_lines)
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_proceeds_without_a_force_flag():
+    conn = _conn_with_one_artifact()
+    qdrant = _qdrant_with_text(_SMALL_TEXT)
+    ingest_episode = AsyncMock(return_value="episode-1")
+
+    with (
+        patch(
+            "knowledge_ingest.backfill.cross_org_admin_connection",
+            return_value=_admin_ctx(conn),
+        ),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch("knowledge_ingest.backfill._get_current_edge_count", return_value=0),
+    ):
+        result = await backfill.main(org_id="org-1")
+
+    assert result == 0
+    ingest_episode.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_falkordb_count_failure_refuses_by_default():
+    """The edge count must never be guessed -- an unreadable FalkorDB fails loudly."""
+    conn = _conn_with_one_artifact()
+    qdrant = _qdrant_with_text(_SMALL_TEXT)
+    ingest_episode = AsyncMock()
+
+    with (
+        patch(
+            "knowledge_ingest.backfill.cross_org_admin_connection",
+            return_value=_admin_ctx(conn),
+        ),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch(
+            "knowledge_ingest.backfill._get_current_edge_count",
+            side_effect=RuntimeError("connection refused"),
+        ),
+    ):
+        result = await backfill.main(org_id="org-1")
+
+    assert result != 0
+    ingest_episode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_overrides_a_falkordb_count_failure_too(caplog):
+    conn = _conn_with_one_artifact()
+    qdrant = _qdrant_with_text(_SMALL_TEXT)
+    ingest_episode = AsyncMock(return_value="episode-1")
+
+    with (
+        patch(
+            "knowledge_ingest.backfill.cross_org_admin_connection",
+            return_value=_admin_ctx(conn),
+        ),
+        patch("knowledge_ingest.backfill.AsyncQdrantClient", return_value=qdrant),
+        patch("knowledge_ingest.backfill.ingest_episode", ingest_episode),
+        patch(
+            "knowledge_ingest.backfill._get_current_edge_count",
+            side_effect=RuntimeError("connection refused"),
+        ),
+        caplog.at_level(logging.WARNING, logger="backfill"),
+    ):
+        result = await backfill.main(org_id="org-1", force=True)
+
+    assert result == 0
+    ingest_episode.assert_awaited()
+    assert any("operator override" in record.getMessage() for record in caplog.records)

--- a/klai-knowledge-ingest/tests/test_build_estimate.py
+++ b/klai-knowledge-ingest/tests/test_build_estimate.py
@@ -1,0 +1,174 @@
+"""SPEC-GRAPH-SCALE-001 REQ-1 / AC-1 — pre-flight graph-build estimator.
+
+Covers the calibrated Voys data point, both refusal paths (budget and
+edge-ceiling), and the throttled live-ingest warning hook.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from knowledge_ingest import build_estimate
+from knowledge_ingest.build_estimate import estimate_graph_build, maybe_warn_graph_scale
+
+
+def _reset_throttle_state() -> None:
+    build_estimate._scale_check_last_run.clear()
+    build_estimate._scale_warn_last_run.clear()
+
+
+def setup_function(_fn) -> None:
+    _reset_throttle_state()
+
+
+# ---------------------------------------------------------------------------
+# estimate_graph_build — calibration point
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_point_matches_the_voys_measurement():
+    """6,593,861 chars, 0 pre-existing edges -> ~20h, ~17,100 new edges."""
+    estimate = estimate_graph_build(total_chars=6_593_861, current_edge_count=0)
+
+    assert abs(estimate.predicted_hours - 20.0) <= 0.5
+    assert abs(estimate.predicted_final_edges - 17_100) <= 200
+    assert estimate.refusal is None
+
+
+def test_calibration_point_final_edges_is_an_int():
+    estimate = estimate_graph_build(total_chars=6_593_861, current_edge_count=0)
+    assert isinstance(estimate.predicted_final_edges, int)
+
+
+# ---------------------------------------------------------------------------
+# Refusal — predicted build time exceeds the operator budget
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_fires_above_the_configured_budget():
+    """~20x the Voys corpus, from an empty graph, blows well past 48h."""
+    estimate = estimate_graph_build(total_chars=66_000_000, current_edge_count=0)
+
+    assert estimate.refusal is not None
+    assert "SPEC-GRAPH-SCALE-001" in estimate.refusal
+    assert estimate.predicted_hours > estimate.budget_hours
+
+
+def test_refusal_is_none_comfortably_under_budget():
+    """A small corpus on an empty graph must proceed."""
+    estimate = estimate_graph_build(total_chars=100_000, current_edge_count=0)
+    assert estimate.refusal is None
+
+
+# ---------------------------------------------------------------------------
+# Refusal — predicted final edge count exceeds the timeout-derived ceiling
+# ---------------------------------------------------------------------------
+
+
+def test_refusal_fires_near_the_edge_ceiling_even_with_a_small_corpus():
+    """A graph already near the ceiling refuses even a tiny additional corpus.
+
+    Default constants put the ceiling at
+    0.6 * (5000ms * 1000) / 15.6us/edge ~= 192,307 edges. Starting one edge
+    below the ceiling and adding any new edges must push predicted_final_edges
+    over it, while predicted_hours alone (dominated by the small dC) stays
+    under budget -- isolating the edge-ceiling refusal path specifically.
+    """
+    ceiling_probe = estimate_graph_build(total_chars=0, current_edge_count=0)
+    ceiling = ceiling_probe.edge_ceiling
+
+    estimate = estimate_graph_build(total_chars=100_000, current_edge_count=ceiling - 10)
+
+    assert estimate.refusal is not None
+    assert "SPEC-GRAPH-SCALE-001" in estimate.refusal
+    assert estimate.predicted_final_edges > estimate.edge_ceiling
+
+
+def test_refusal_absent_comfortably_under_the_edge_ceiling():
+    estimate = estimate_graph_build(total_chars=1000, current_edge_count=100)
+    assert estimate.refusal is None
+
+
+# ---------------------------------------------------------------------------
+# maybe_warn_graph_scale — throttled 50%-of-limit warning
+# ---------------------------------------------------------------------------
+
+
+def test_warns_above_fifty_percent_of_the_edge_ceiling():
+    probe = estimate_graph_build(total_chars=0, current_edge_count=0)
+    ceiling = probe.edge_ceiling
+
+    with patch.object(build_estimate.logger, "warning") as mock_warn:
+        warned = maybe_warn_graph_scale("org-a", current_edge_count=int(ceiling * 0.6))
+
+    assert warned is True
+    mock_warn.assert_called_once()
+    args, kwargs = mock_warn.call_args
+    assert args[0] == "graph_scale_warning"
+    assert kwargs["org_id"] == "org-a"
+    assert kwargs["spec"] == "SPEC-GRAPH-SCALE-001"
+    assert kwargs["edge_ceiling"] == ceiling
+
+
+def test_does_not_warn_below_fifty_percent_of_either_limit():
+    probe = estimate_graph_build(total_chars=0, current_edge_count=0)
+    ceiling = probe.edge_ceiling
+
+    # 5%, not 10%: with the default constants 10% of the edge ceiling lands
+    # almost exactly on 50% of the budget-hours limit too (both derive from
+    # the same quadratic model), which made that boundary flaky. 5% is
+    # comfortably under both.
+    with patch.object(build_estimate.logger, "warning") as mock_warn:
+        warned = maybe_warn_graph_scale("org-b", current_edge_count=int(ceiling * 0.05))
+
+    assert warned is False
+    mock_warn.assert_not_called()
+
+
+def test_second_call_within_the_hour_is_throttled():
+    probe = estimate_graph_build(total_chars=0, current_edge_count=0)
+    ceiling = probe.edge_ceiling
+    hot_count = int(ceiling * 0.9)
+
+    with patch.object(build_estimate.logger, "warning") as mock_warn:
+        first = maybe_warn_graph_scale("org-c", current_edge_count=hot_count)
+        second = maybe_warn_graph_scale("org-c", current_edge_count=hot_count)
+
+    assert first is True
+    assert second is False
+    mock_warn.assert_called_once()
+
+
+def test_separate_orgs_throttle_independently():
+    probe = estimate_graph_build(total_chars=0, current_edge_count=0)
+    ceiling = probe.edge_ceiling
+    hot_count = int(ceiling * 0.9)
+
+    with patch.object(build_estimate.logger, "warning") as mock_warn:
+        first_org = maybe_warn_graph_scale("org-d", current_edge_count=hot_count)
+        second_org = maybe_warn_graph_scale("org-e", current_edge_count=hot_count)
+
+    assert first_org is True
+    assert second_org is True
+    assert mock_warn.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# should_check_graph_scale — throttle gating the FalkorDB query itself
+# ---------------------------------------------------------------------------
+
+
+def test_should_check_graph_scale_allows_first_call_and_throttles_second():
+    first = build_estimate.should_check_graph_scale("org-f")
+    second = build_estimate.should_check_graph_scale("org-f")
+
+    assert first is True
+    assert second is False
+
+
+def test_should_check_graph_scale_throttles_independently_per_org():
+    first_org = build_estimate.should_check_graph_scale("org-g")
+    other_org = build_estimate.should_check_graph_scale("org-h")
+
+    assert first_org is True
+    assert other_org is True


### PR DESCRIPTION
## Summary

Graph construction cost is quadratic in source-text volume: graphiti-core resolves every extracted entity/edge against the entire tenant graph via brute-force cosine scans (`vec.cosineDistance()` over every edge). The full research + plan is in the new `docs/specs/SPEC-GRAPH-SCALE-001/spec.md`; this PR ships the two cheapest, separable guards (REQ-1 + REQ-2). The real fix (ANN candidate search via graphiti's `SearchInterface`) is REQ-3/4, not in this PR.

- **SPEC-GRAPH-SCALE-001** (new): scaling law `T ≈ 1.25·C + 0.27·C²` h (C in Mchar, calibrated on the measured 20 h / 6.6 Mchar rebuild), ranked levers, ANN backend spike design, per-tenant migration path.
- **Pre-flight estimator** (`knowledge_ingest/build_estimate.py`): predicts build hours from corpus chars + current FalkorDB edge count; `backfill.py` refuses loudly above the 48 h budget or the tail-derived edge ceiling (~64k edges at the 5 s timeout) before ingesting anything; `--force` is a logged operator override. Throttled (1/org/hour) live-ingest warning at 50% of either limit. All constants in config so REQ-6's re-measurement is a config change.
- **deploy**: persist `FALKORDB_ARGS` `TIMEOUT 5000` — the runtime-proven raise that currently reverts on every container recreate (the image bakes in an undocumented `TIMEOUT 1000`, FalkorDB/FalkorDB#1826). Explicitly a stopgap. Post-deploy verify: `GRAPH.CONFIG GET TIMEOUT` → 5000 on a freshly started container.

## Test plan

- `uv run ruff check .` — clean
- `uv run pytest tests/` (knowledge-ingest) — 1687 passed, 6 skipped; includes 17 new tests (calibration point, both refusal paths, --force override, warning throttle, refusal-blocks-ingest integration)
- compose YAML / env-scope-guard / audit-compose — all green
- Sol (gpt-5.6-sol) two-pass review + one authorized fix round: 1 high fixed (warning hook could block the episode semaphore on a half-dead FalkorDB → fire-and-forget with socket + coroutine deadlines), edge ceiling recalibrated from the observed timeout tail, empty COUNT fails loudly. Remaining sub-high notes on the PR are deliberate non-fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)