### PR TITLE
style(knowledge): ruff format backfill.py + graph.py

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/backfill.py
+++ b/klai-knowledge-ingest/knowledge_ingest/backfill.py
@@ -242,9 +242,7 @@ async def main(
         # the rate line decay days into a build. Runs BEFORE any episode is
         # ingested; refuses loudly instead of starting an infeasible build.
         total_chars = sum(
-            len(text)
-            for row in to_process
-            for text in chunks_by_artifact.get(str(row["id"]), [])
+            len(text) for row in to_process for text in chunks_by_artifact.get(str(row["id"]), [])
         )
         try:
             current_edge_count = _get_current_edge_count(org_id)
@@ -536,8 +534,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Overrides the SPEC-GRAPH-SCALE-001 pre-flight refusal. The override "
-        "is logged.",
+        help="Overrides the SPEC-GRAPH-SCALE-001 pre-flight refusal. The override is logged.",
     )
     args = parser.parse_args()
     sys.exit(

--- a/klai-knowledge-ingest/knowledge_ingest/graph.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph.py
@@ -873,9 +873,7 @@ async def _maybe_warn_graph_scale_from_falkordb(org_id: str) -> None:
         # the episode semaphore — an optional warning must never be able to
         # block ingestion. The worker thread may linger until the socket dies,
         # which is acceptable for a once-per-org-per-hour hook.
-        current_edge_count = await asyncio.wait_for(
-            asyncio.to_thread(_count_edges), timeout=5.0
-        )
+        current_edge_count = await asyncio.wait_for(asyncio.to_thread(_count_edges), timeout=5.0)
         maybe_warn_graph_scale(org_id, current_edge_count)
     except Exception:
         logger.warning("graph_scale_warning_hook_failed", org_id=org_id, exc_info=True)


### PR DESCRIPTION
Fixes the red **Build and push knowledge-ingest** run on main after #1234: that workflow runs `ruff format --check`, while only `ruff check` (lint) ran locally. Formatting-only, no behavior change; lint + format + focused tests (189 passed) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)