### PR TITLE
fix(ci): guard production deploys and syncs to main

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -47,8 +47,8 @@ jobs:
           context: ./deploy/caddy
           push: true
           tags: |
-            ghcr.io/getklai/caddy-hetzner:latest
             ghcr.io/getklai/caddy-hetzner:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/caddy-hetzner:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -111,6 +111,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout of the TLS-terminating edge proxy. This
     # step used to be the tail of build-push, so a failing scan could not

--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -31,6 +31,11 @@ env:
 
 jobs:
   sync-compose:
+    # Production sync over SSH. Guarded on main for the same reason as every
+    # deploy job: workflow_dispatch accepts any ref, and without this a
+    # dispatch from a feature branch would sync that branch's compose and
+    # config to core-01. A deliberate dispatch on main still works.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-librechat-config.yml
+++ b/.github/workflows/deploy-librechat-config.yml
@@ -21,6 +21,11 @@ permissions:
 
 jobs:
   sync-librechat-config:
+    # Production sync over SSH. Guarded on main for the same reason as every
+    # deploy job: workflow_dispatch accepts any ref, and without this a
+    # dispatch from a feature branch would sync that branch's compose and
+    # config to core-01. A deliberate dispatch on main still works.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,8 +90,8 @@ jobs:
           context: ./klai-docs
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -147,6 +147,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # actually blocks production deploy: if scan job exits 1 on a HIGH/CRIT
     # finding, deploy is skipped.

--- a/.github/workflows/klai-connector.yml
+++ b/.github/workflows/klai-connector.yml
@@ -107,7 +107,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/getklai/klai-connector:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/klai-connector:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/klai-connector:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -163,6 +163,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/klai-docker-authz.yml
+++ b/.github/workflows/klai-docker-authz.yml
@@ -98,12 +98,12 @@ jobs:
           context: .
           file: klai-docker-authz/Dockerfile
           push: true
-          # `:latest` is published ONLY on push to main. PR builds publish
-          # only the SHA tag so a `docker pull :latest` cannot accidentally
-          # pull PR-build code. Mirrors klai-connector workflow.
+          # `:latest` is published only for main. The SHA tag stays
+          # unconditional so non-main builds cannot overwrite production's
+          # mutable tag.
           tags: |
             ghcr.io/getklai/klai-docker-authz:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/klai-docker-authz:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/klai-docker-authz:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -158,6 +158,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/klai-knowledge-mcp.yml
+++ b/.github/workflows/klai-knowledge-mcp.yml
@@ -118,16 +118,16 @@ jobs:
           # source. Same pattern as klai-knowledge-ingest.
           context: .
           file: klai-knowledge-mcp/Dockerfile
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ghcr.io/getklai/klai-knowledge-mcp:latest
             ghcr.io/getklai/klai-knowledge-mcp:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/klai-knowledge-mcp:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   scan:
     needs: build-push
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -177,6 +177,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/klai-mailer.yml
+++ b/.github/workflows/klai-mailer.yml
@@ -102,12 +102,12 @@ jobs:
           context: .
           file: klai-mailer/Dockerfile
           push: true
-          # `:latest` is published ONLY on push to main. PR builds publish
-          # only the SHA tag so a `docker pull :latest` cannot accidentally
-          # pull PR-build code. Mirrors klai-connector workflow.
+          # `:latest` is published only for main. The SHA tag stays
+          # unconditional so non-main builds cannot overwrite production's
+          # mutable tag.
           tags: |
             ghcr.io/getklai/klai-mailer:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/klai-mailer:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/klai-mailer:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -162,6 +162,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/knowledge-ingest.yml
+++ b/.github/workflows/knowledge-ingest.yml
@@ -207,12 +207,12 @@ jobs:
           context: .
           file: klai-knowledge-ingest/Dockerfile
           push: true
-          # `:latest` is published ONLY on push to main. PR builds publish
-          # only the SHA tag so `docker pull :latest` cannot accidentally
-          # pull PR-build code. Mirrors klai-connector / klai-mailer.
+          # `:latest` is published only for main. The SHA tag stays
+          # unconditional so non-main builds cannot overwrite production's
+          # mutable tag.
           tags: |
             ghcr.io/getklai/knowledge-ingest:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/knowledge-ingest:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/knowledge-ingest:latest' || '' }}
           # GHA layer cache disabled: it failed to invalidate on source code changes.
           # Builds are fast enough (~1 min) without caching.
 
@@ -267,6 +267,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/litellm-hook-deploy.yml
+++ b/.github/workflows/litellm-hook-deploy.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/portal-api.yml
+++ b/.github/workflows/portal-api.yml
@@ -418,12 +418,12 @@ jobs:
           context: .
           file: klai-portal/backend/Dockerfile
           push: true
-          # `:latest` is published ONLY on push to main. PR builds publish
-          # only the SHA tag so `docker pull :latest` cannot accidentally
-          # pull PR-build code. Mirrors klai-connector / klai-mailer.
+          # `:latest` is published only for main. The SHA tag stays
+          # unconditional so non-main builds cannot overwrite production's
+          # mutable tag.
           tags: |
             ghcr.io/getklai/portal-api:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/portal-api:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/portal-api:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -479,6 +479,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # actually blocks production deploy: if scan job exits 1 on a HIGH/CRIT
     # finding, deploy is skipped. Previously deploy only depended on

--- a/.github/workflows/retrieval-api.yml
+++ b/.github/workflows/retrieval-api.yml
@@ -106,16 +106,16 @@ jobs:
           # source. Same pattern as klai-knowledge-mcp (Phase B).
           context: .
           file: klai-retrieval-api/Dockerfile
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ghcr.io/getklai/retrieval-api:latest
             ghcr.io/getklai/retrieval-api:${{ github.sha }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/retrieval-api:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   scan:
     needs: build-push
-    if: github.event_name == 'push'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -165,6 +165,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.

--- a/.github/workflows/scribe-api.yml
+++ b/.github/workflows/scribe-api.yml
@@ -99,13 +99,12 @@ jobs:
           context: .
           file: klai-scribe/scribe-api/Dockerfile
           push: true
-          # `:latest` is published ONLY on push to main. PR builds publish
-          # only the SHA tag so `docker pull :latest` cannot accidentally
-          # pull PR-build code. Mirrors klai-connector / klai-mailer
-          # (post hotfix #322).
+          # `:latest` is published only for main. The SHA tag stays
+          # unconditional so non-main builds cannot overwrite production's
+          # mutable tag.
           tags: |
             ghcr.io/getklai/scribe-api:${{ github.sha }}
-            ${{ github.event_name == 'push' && 'ghcr.io/getklai/scribe-api:latest' || '' }}
+            ${{ github.ref == 'refs/heads/main' && 'ghcr.io/getklai/scribe-api:latest' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -160,6 +159,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     # `needs: scan` ensures the Trivy gate from SPEC-CI-TRIVY-POLICY-001 REQ-2
     # can actually block the rollout: this step used to be the tail of
     # build-push, so a failing scan could not stop it from deploying.


### PR DESCRIPTION
Closes #1200.

Every job that reaches core-01 over SSH now carries `if: github.ref == 'refs/heads/main'`, and `:latest` is published only from main.

Thirteen workflows: the eleven with a `deploy` job, plus `deploy-compose.yml` and `deploy-librechat-config.yml`, whose single sync job does the same thing under a different name. Those last two were not in the original issue — I had checked them and wrongly concluded they were safe, because my grep stopped short in a long trigger block. They both accept `workflow_dispatch`, and `deploy-compose` is the one that syncs the compose file and configs for the whole fleet.

## What was wrong

Those jobs had no `if:` at all, while most of the workflows also accept `workflow_dispatch`, which takes any ref. A run started from a feature branch would build that branch, publish it over the mutable tag production pulls, and roll it out — with no review, approval or branch check anywhere in the path.

The `:latest` half matters as much as the deploy half and is easier to miss: the tag is what a container restart or the next deploy resolves, so overwriting it from a branch changes production even when no deploy job runs. The `${{ github.sha }}` tag stays unconditional, so a branch build is still built, scanned and inspectable — it just cannot become production.

## Why `github.ref` and not `github.event_name`

These are reusable workflows that `quality.yml` calls on pull requests, and inside a called workflow the `github` context belongs to the caller — so a PR evaluates to `refs/pull/N/merge` and the guard is correctly false.

It also corrects a case the previous `github.event_name == 'push'` condition on `scribe-api` and friends got wrong in the other direction: a deliberate dispatch on `main` was denied its `:latest` tag.

**Deliberate manual redeploy from `main` keeps working.** That is the property that makes this safe to apply fleet-wide, and it is the reason for a ref check rather than dropping `workflow_dispatch`.

## Truth table

| | push main | dispatch main | dispatch branch | call from a PR |
|---|---|---|---|---|
| guard | true | true | false | false |
| tags | SHA + `latest` | SHA + `latest` | SHA only | SHA only, or no push at all |
| deploy | runs | runs | skipped | skipped |

Ref evaluation checked against `refs/heads/main`, `refs/heads/<feature>` and `refs/pull/N/merge`.

## Verification

Actions cannot be run from here, so this is verified statically:

- YAML parses for all 13 changed files
- `sh scripts/test-renovate-config.sh` -> PASS
- per-workflow assertions that every deploy/sync job carries the guard and every `:latest` *publication* is main-gated
- the remaining `:latest` references are `docker pull` inside the now-guarded deploy steps — consumption, not publication

`actionlint` was not available on this machine and was skipped; saying so rather than implying it passed.

## Follow-up worth considering

A GitHub Environment with required reviewers on these jobs is worth having as defence in depth, but it is not a substitute: an environment gates *who approves*, not *which ref may deploy*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)