### PR TITLE
feat(knowledge-ingest): resource-key cancellation + generation fencing (SPEC-CONNECTOR-CANCEL-001)

### DIFF
--- a/.claude/rules/klai/projects/knowledge.md
+++ b/.claude/rules/klai/projects/knowledge.md
@@ -153,33 +153,40 @@ stores.
 auto-clean on the current code path (after the 2026-04-30 fix). Garage images
 remain a known gap — see SPEC-CONNECTOR-CLEANUP-001 follow-up notes.
 
-## Connector-delete leaves in-flight enrichment jobs behind (HIGH)
+## Connector-scoped async jobs require a resource key and fence (HIGH)
 
-`delete_connector_artifacts` + `qdrant_store.delete_connector` only remove rows
-that EXIST at the moment of the call. Any `enrich-bulk` / `graphiti-bulk`
-Procrastinate job that is already enqueued for the same artifact_ids will
-keep running afterwards and silently write NEW rows into Qdrant (and
-knowledge graph) with the same `source_connector_id`. Net result: a freshly
-deleted connector regrows Qdrant chunks for several minutes while the queue
-drains. Observed on Redcactus E2E — post-delete, Qdrant chunk count climbed
-from 15 → 26 → 40+ as ~76 queued enrichment jobs finished.
+Every Procrastinate job that can write connector-owned knowledge carries the
+same top-level authority key for its sync generation:
+`connector:{org_id}:{kb_slug}:{connector_id}:{generation}`. This applies to
+`crawl-jobs`, `enrich-bulk`, and `graphiti-bulk`. Artifact-scoped jobs keep
+`artifact_id` as their work item and also carry `resource_key`; the artifact
+row stores the key in `extra`.
 
-**Why:** Ingest enqueues enrichment asynchronously; enrichment reads only
-from `extra_payload` so it has no visibility into whether the owning
-artifact still exists.
+Delete/rebuild first changes the generation fence, then requests cancellation
+by exact `args->>'resource_key'` for live `todo`/`doing` jobs. Cancellation uses
+`abort=True, delete_job=False`; abort-requested running jobs remain `doing`
+until they cooperate and then become `aborted`. Never query or count the legacy
+`aborting` status. A one-deploy compatibility fallback may match old enrichment
+and Graphiti jobs by top-level `artifact_id`, but resource keys are the primary
+index.
 
-**Prevention:** A proper fix requires either:
-1. Cancelling in-flight Procrastinate jobs scoped to the deleted artifact_ids
-   at delete time (`cancel_job_by_id` for every queued enrich/graphiti task),
-   or
-2. Adding an existence check at the top of every enrichment task that
-   aborts if the artifact has been deleted since enqueue.
+Cancellation is best effort. Each writer must check the fence before expensive
+work and again immediately before Qdrant/Graphiti writes. Artifact existence is
+a secondary guard: an existing artifact can still belong to a stale generation.
+Fence lookup errors fail closed. Crawl per-page checks use the <=5 second cache
+to avoid a database roundtrip per page; enrichment and Graphiti pre-write checks
+are fresh.
 
-Option 1 is cleaner (no wasted LLM/embedding calls). Until either lands,
-callers should delete → wait for enrich-bulk queue to drain → re-run Qdrant
-`delete_connector` as a second pass. Tracked for follow-up; not
-auto-retriable because procrastinate job cancellation is a separate API
-surface.
+Runbook query for one generation (Procrastinate 3.x vocabulary):
+
+```sql
+SELECT status, count(*)
+FROM procrastinate_jobs
+WHERE args->>'resource_key' = 'connector:<org>:<kb>:<connector>:<generation>'
+  AND status IN ('todo', 'doing', 'cancelled', 'aborted', 'failed', 'succeeded')
+GROUP BY status
+ORDER BY status;
+```
 
 ## Graph-first, content-second for bulk crawls (HIGH)
 

--- a/.moai/specs/SPEC-CONNECTOR-CANCEL-001/acceptance.md
+++ b/.moai/specs/SPEC-CONNECTOR-CANCEL-001/acceptance.md
@@ -1,0 +1,148 @@
+---
+id: SPEC-CONNECTOR-CANCEL-001
+version: "1.0"
+status: draft
+---
+
+# Acceptance Criteria
+
+## REQ-CONNECTOR-CANCEL-001-01 — Resource key on jobs
+
+```gherkin
+Given a connector sync for org O, kb K, connector C, generation G
+When the system enqueues crawl, enrichment and graphiti work
+Then every connector-owned procrastinate job has args.resource_key = "connector:O:K:C:G"
+  And manual upload jobs without source_connector_id may omit resource_key
+  And no connector-owned writer job depends on queueing_lock as its ownership key
+```
+
+## REQ-CONNECTOR-CANCEL-001-02 — Cancel by exact resource key
+
+```gherkin
+Given procrastinate_jobs contains live jobs for resource_key R
+  And live jobs for resource_key R2
+When connector delete for R starts
+Then jobs for R with status todo or doing receive a cancellation request
+  And jobs for R2 are untouched
+  And connector-purge jobs are untouched
+  And the cancellation query uses args->>'resource_key' = R
+  And the cancellation query does not use args::text LIKE
+```
+
+## REQ-CONNECTOR-CANCEL-001-03 — Stale generation fence
+
+```gherkin
+Given connector C has current generation G2
+  And an old enrichment job has resource_key generation G1
+  And the artifact row still exists
+When the old enrichment job starts
+Then the fence returns stale_generation
+  And the job logs connector_resource_job_skipped
+  And no LLM call is made
+  And no embedding call is made
+  And no Qdrant upsert is made
+```
+
+## REQ-CONNECTOR-CANCEL-001-04 — Deleted connector fence
+
+```gherkin
+Given connector C has been deleted
+  And a graphiti job for C is still doing
+When the job reaches the pre-write checkpoint
+Then the fence returns deleted
+  And no Graphiti episode is written
+  And knowledge.artifacts.extra is not patched with graphiti_episode_id
+```
+
+## REQ-CONNECTOR-CANCEL-001-05 — Artifact guard remains
+
+```gherkin
+Given an artifact-scoped job has artifact_id A and resource_key R
+  And artifact A no longer exists
+When the job starts
+Then the job skips successfully
+  And the skip log includes artifact_id A
+  And the skip log includes resource_key R when available
+```
+
+## REQ-CONNECTOR-CANCEL-001-06 — Cleanup is idempotent
+
+```gherkin
+Given connector C has already been purged once
+When purge_connector runs again for the same resource
+Then it returns successfully
+  And deletion counts are zero or lower than the first run
+  And no Qdrant, Graphiti, Postgres or Garage delete step raises because rows are already gone
+```
+
+## REQ-CONNECTOR-CANCEL-001-07 — Rebuild uses new generation
+
+```gherkin
+Given connector C generation G1 has queued jobs
+When connector C is rebuilt
+Then generation G1 is fenced
+  And live G1 jobs are cancelled
+  And rebuild enqueues new jobs with generation G2
+  And G1 jobs that survive cancellation skip before writes
+  And G2 jobs can write normally
+```
+
+## REQ-CONNECTOR-CANCEL-001-08 — Monitoring counts statuses correctly
+
+```gherkin
+Given procrastinate_jobs contains one job for resource_key R in each status:
+  | status    |
+  | todo      |
+  | doing     |
+  | cancelled |
+  | aborted   |
+  | failed    |
+  | succeeded |
+When get_resource_job_counts(R) runs
+Then raw counts are:
+  | status    | count |
+  | todo      | 1     |
+  | doing     | 1     |
+  | cancelled | 1     |
+  | aborted   | 1     |
+  | failed    | 1     |
+  | succeeded | 1     |
+  And pending = 1
+  And running = 1
+  And terminal = 4
+  And failed_visible = 1
+```
+
+## REQ-CONNECTOR-CANCEL-001-09 — Queue lane contract
+
+```gherkin
+Given queues.py defines IO_QUEUES and LLM_QUEUES
+When connector writer queues are validated
+Then crawl-jobs is included as a cancellable connector writer queue
+  And enrich-bulk is included as a cancellable connector writer queue
+  And graphiti-bulk is included as a cancellable connector writer queue
+  And connector-purge is not cancelled as a child writer job
+  And IO_QUEUES and LLM_QUEUES remain disjoint
+```
+
+## Definition of Done
+
+- [ ] `resource_jobs.py` or equivalent central helper exists.
+- [ ] Connector-owned Procrastinate jobs carry top-level `resource_key`.
+- [ ] Delete/rebuild cancellation filters exact `args->>'resource_key'`.
+- [ ] Fence checks run before expensive work and before writes.
+- [ ] Artifact existence checks remain in enrichment and Graphiti paths.
+- [ ] Cleanup remains idempotent under repeated purge.
+- [ ] Monitoring returns raw and derived status counts.
+- [ ] Tests cover resource key construction, cancellation, fencing, monitoring and rebuild generation.
+- [ ] `tests/test_queues_constants.py` or a dedicated test prevents connector writer queues from being omitted.
+- [ ] Live smoke proves old-generation jobs do not regrow Qdrant/Graphiti after delete or rebuild.
+
+## Regression Watch List
+
+- `POST /ingest/v1/document` connector path.
+- `POST /ingest/v1/crawl/sync` and `POST /ingest/v1/crawl/sync/{job_id}/cancel`.
+- `connector_cleanup.purge_connector`.
+- `connector_purge_task` retries.
+- `enrich-bulk` and `graphiti-bulk` backlog drain after delete.
+- Rebuild jobs that enqueue while old generation is still cancelling.

--- a/.moai/specs/SPEC-CONNECTOR-CANCEL-001/plan.md
+++ b/.moai/specs/SPEC-CONNECTOR-CANCEL-001/plan.md
@@ -1,0 +1,200 @@
+---
+id: SPEC-CONNECTOR-CANCEL-001
+version: "1.0"
+status: draft
+---
+
+# Implementation Plan
+
+Do this as small, revertable phases. The goal is to replace task-specific ownership inference with one connector resource contract.
+
+Branch: `fix/SPEC-CONNECTOR-CANCEL-001`
+
+---
+
+## Fase 1 — Resource key model
+
+**Goal:** one place builds and parses connector resource keys.
+
+**Files:**
+
+- `klai-knowledge-ingest/knowledge_ingest/resource_jobs.py` (new)
+- `klai-knowledge-ingest/tests/test_resource_jobs.py` (new)
+
+**Tasks:**
+
+1. Add `connector_resource_key(org_id, kb_slug, connector_id, generation) -> str`.
+2. Add parser/validator for `connector:{org_id}:{kb_slug}:{connector_id}:{generation}`.
+3. Add `CONNECTOR_WRITER_QUEUES = [CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK]`.
+4. Add tests for stable key construction, malformed keys and queue-list membership.
+
+**Exit:** tests prove the key is exact-matchable and queues are explicit.
+
+---
+
+## Fase 2 — Enqueue payload threading
+
+**Goal:** all connector-owned jobs carry `resource_key` from enqueue.
+
+**Files:**
+
+- `routes/ingest.py`
+- `crawl_tasks.py`
+- `enrichment_tasks.py`
+- connector/crawl enqueue code as needed
+- tests around existing ingest/crawl enqueue flows
+
+**Tasks:**
+
+1. Determine the generation source. v1 decision: caller-supplied at sync start (sync-run id or epoch from the sync orchestrator) — no portal-api schema migration. An explicit portal generation column is a documented follow-up, not part of this SPEC.
+2. Thread `resource_key` into `run_crawl` when `connector_id` is present.
+3. Store the same `resource_key` on artifact `extra` so enrichment can load it from Postgres.
+4. Thread `resource_key` into `enrich_document_bulk` and `ingest_graphiti_episode` args.
+5. Keep manual upload paths unchanged unless they are connector-owned.
+
+**Exit:** queued crawl/enrich/graphiti jobs for the same connector generation have the same top-level `args.resource_key`.
+
+---
+
+## Fase 3 — Cancellation helper
+
+**Goal:** delete/rebuild cancels live jobs by exact resource key.
+
+**Files:**
+
+- `resource_jobs.py`
+- `connector_cleanup.py`
+- `routes/crawl_sync.py` only if shared helper replaces local logic
+- tests
+
+**Tasks:**
+
+1. Add `list_live_jobs_by_resource_key(pool, resource_key, queues)`.
+2. Add `cancel_jobs_by_resource_key(proc_app, resource_key, queues)` using `cancel_job_by_id_async(..., abort=True, delete_job=False)`.
+3. Filter `status IN ('todo', 'doing')` (Procrastinate 3.x: `aborting` is legacy/unused; abort-requested jobs stay `doing`).
+4. Replace connector cleanup's artifact-id/json-path cancellation with resource-key cancellation where payloads exist. Note: the current `_cancel_enrichment_jobs` filter on `args->'extra_payload'->>'source_connector_id'` is dead code (enrichment args carry only `artifact_id` since SPEC-INGEST-CONTENT-PG-001) — remove it, don't preserve it.
+5. Keep a compatibility fallback for old queued jobs that do not yet carry `resource_key` during rollout: match enrichment/graphiti jobs via `args->>'artifact_id' = ANY(<snapshot ids>)` using the artifact-id snapshot that purge already takes. Remove the fallback in a follow-up after one deploy window.
+
+**Exit:** cancellation is exact-match on `args->>'resource_key'`, not `args::text LIKE`.
+
+---
+
+## Fase 4 — Fence checks
+
+**Goal:** stale jobs that survive cancellation cannot write.
+
+**Files:**
+
+- `connector_state.py`
+- `resource_jobs.py`
+- `crawl_tasks.py`
+- `enrichment_tasks.py`
+- tests
+
+**Tasks:**
+
+1. Add `check_connector_resource_fence(resource_key) -> FenceState`.
+2. Implement `active`, `stale_generation`, `deleting`, `deleted`, `unknown_error`.
+3. Call the fence before each crawl per-page ingest/write loop.
+4. Call the fence after artifact load and before enrichment LLM/embedding work.
+5. Call the fence immediately before Qdrant upsert.
+6. Call the fence before Graphiti ingest and before `graphiti_episode_id` persistence.
+7. Preserve artifact existence checks.
+
+**Exit:** a stale resource key skips with structured logs and performs no writes.
+
+---
+
+## Fase 5 — Monitoring query
+
+**Goal:** one status report for connector-scoped jobs.
+
+**Files:**
+
+- `resource_jobs.py`
+- `tests/test_connector_resource_monitoring.py`
+
+**Tasks:**
+
+1. Add `get_resource_job_counts(pool, resource_key)`. Helper + runbook query only — no new route or admin endpoint in v1 (YAGNI; add one when a UI consumer exists).
+2. Count raw statuses: `todo`, `doing`, `cancelled`, `aborted`, `failed`, `succeeded` (3.x vocabulary; no `aborting`).
+3. Add derived buckets: `pending`, `running`, `terminal`, `failed_visible`.
+4. Ensure `cancelled` and `aborted` do not appear as user-visible failures for delete/rebuild.
+
+**Exit:** seeded status tests pass and the query uses `args->>'resource_key' = $1`.
+
+---
+
+## Fase 6 — Delete/rebuild integration
+
+**Goal:** connector delete and rebuild establish the fence before cleanup and before new work.
+
+**Files:**
+
+- `connector_cleanup.py`
+- `connector_purge_tasks.py`
+- portal/connector rebuild orchestration as needed
+- regression tests
+
+**Tasks:**
+
+1. Mark old generation fenced before cancellation.
+2. Cancel by old resource key.
+3. Run idempotent cleanup.
+4. For rebuild, create/increment generation and enqueue new work with the new resource key.
+5. Add regression: old queued enrichment/graphiti jobs skip while new generation writes normally.
+
+**Exit:** delete/rebuild no longer depends on artifact-id snapshots as the primary guard.
+
+---
+
+## Fase 7 — Docs and operational checks
+
+**Goal:** future connector-scoped jobs cannot miss the contract.
+
+**Tasks:**
+
+1. Update `.claude/rules/klai/projects/knowledge.md` with a new rule: connector-scoped async jobs must carry `resource_key` and fence before writes.
+2. Add a short runbook query for resource-key job counts.
+3. Update relevant spec status/progress if implementation lands.
+
+**Exit:** new workers have a clear rule and a monitoring query.
+
+---
+
+## Verification
+
+Run focused tests:
+
+```bash
+cd klai-knowledge-ingest
+uv run pytest tests/test_resource_jobs.py tests/test_connector_resource_fencing.py tests/test_connector_resource_monitoring.py
+```
+
+Run existing relevant tests:
+
+```bash
+cd klai-knowledge-ingest
+uv run pytest tests/test_connector_cleanup.py tests/test_worker_lifecycle.py tests/test_queues_constants.py tests/test_rebuild_tasks.py
+```
+
+Live smoke after deploy:
+
+1. Start a connector sync with enough pages to create `enrich-bulk` and `graphiti-bulk` backlog.
+2. Record `resource_key`.
+3. Delete or rebuild the connector before the queues drain.
+4. Verify live job counts move from `todo/doing` to `cancelled` or terminal skip.
+5. Verify Qdrant and Graphiti counts for the old resource key stay at zero after cleanup.
+6. Verify the new generation, if rebuild, writes only under the new connector generation.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Existing queued jobs do not have `resource_key` during deploy | Keep compatibility fallback for one deploy window, then remove in a follow-up. |
+| Generation source is ambiguous | Prefer explicit connector generation column over timestamps. If using timestamps, document precision and monotonicity. |
+| `doing` jobs ignore cancellation until after a long LLM call | Fence immediately before writes, not only before expensive calls. |
+| Monitoring treats cancelled as failed | Add dedicated derived bucket where `cancelled` is terminal but not `failed_visible`. |
+| New connector-scoped queue is added later without cancellation | Test `CONNECTOR_WRITER_QUEUES` against queue constants and require explicit opt-in. |

--- a/.moai/specs/SPEC-CONNECTOR-CANCEL-001/spec.md
+++ b/.moai/specs/SPEC-CONNECTOR-CANCEL-001/spec.md
@@ -1,0 +1,289 @@
+---
+id: SPEC-CONNECTOR-CANCEL-001
+version: "1.0"
+status: draft
+created: 2026-05-08
+updated: 2026-05-08
+author: Mark Vletter
+priority: high
+issue_number: 0
+---
+
+## HISTORY
+
+| Version | Date | Author | Change |
+|---------|------|--------|--------|
+| 1.0 | 2026-05-08 | Mark Vletter | Initial draft. Generalise the connector-delete race fixes into one resource-key + cancellation + fencing contract for connector-scoped async jobs. |
+
+---
+
+# SPEC-CONNECTOR-CANCEL-001: Resource-key cancellation and fencing for connector-scoped async jobs
+
+## Context
+
+Klai's connector delete/rebuild path is no longer a simple row delete. One connector sync can enqueue work across multiple lanes:
+
+- `crawl-jobs` on the I/O lane.
+- `enrich-bulk` on the LLM lane.
+- `graphiti-bulk` on the LLM lane.
+- `connector-purge` on the I/O lane.
+
+The correctness risk is not queue throughput. The risk is ownership drift: work that was valid when enqueued can become invalid before it writes.
+
+The current code already contains targeted guards from earlier specs:
+
+- `connector_cleanup.purge_connector` snapshots artifact ids, attempts to cancel selected enrichment/graphiti jobs, deletes artifacts, Graphiti episodes, Qdrant chunks and Garage keys. **However, `_cancel_enrichment_jobs` is currently dead code**: it filters on `args->'extra_payload'->>'source_connector_id'`, but since SPEC-INGEST-CONTENT-PG-001 enrichment jobs are deferred with only `artifact_id` — the WHERE clause never matches a live row, so enrichment-job cancellation on connector delete silently returns 0. This strengthens the case for this SPEC: the "targeted guard" for enrichment is already broken by an unrelated refactor, exactly the drift class this contract prevents.
+- `enrichment_tasks._load_and_enrich` re-reads the artifact by `artifact_id` instead of carrying stale document payload in Procrastinate args.
+- `ingest_graphiti_episode` checks artifact existence before writing to Graphiti.
+- `_enrich_document` checks `connector_is_active(source_connector_id)` before doing LLM and Qdrant work.
+- `crawl_sync_cancel` can cancel one `run_crawl` job by `knowledge.crawl_jobs.id`.
+
+Those are good repairs, but they are still ad hoc. Some jobs can be cancelled by connector id, some by artifact id, some by crawl job id, and monitoring queries have to reverse-engineer ownership from task-specific JSON paths. A future connector-scoped task can accidentally skip the guard and reintroduce the same regrow bug.
+
+## Problem Statement
+
+Deleting or rebuilding connector `C` must establish a fence: no async job that belongs to the old generation of `C` may write new artifacts, Qdrant points, Graphiti episodes or image references after the fence.
+
+Today the fence is implicit and spread across task-specific logic:
+
+- Enrichment jobs now take only `artifact_id`, so queued job args no longer include `source_connector_id`.
+- Graphiti jobs include `artifact_id`, but not `source_connector_id`.
+- Crawl jobs include `connector_id`, but are cancelled through a crawl-job route by `job_id`.
+- Procrastinate's native `queueing_lock` prevents duplicates, but it is not an ownership index and is not a sufficient cancellation filter.
+- `connector_cleanup` has to discover artifact ids before delete and then use separate JSON filters for enrichment and Graphiti.
+
+That makes delete/rebuild correctness depend on every future task remembering the same local convention.
+
+## Design Summary
+
+Introduce a small connector-scoped job contract:
+
+1. Every connector-scoped Procrastinate job carries a canonical `resource_key`.
+2. The resource key identifies the mutable resource and generation the job is allowed to write to.
+3. Deleting/rebuilding a connector cancels live jobs by `resource_key` before data cleanup.
+4. Every write-side task checks a fence immediately before expensive work and again immediately before irreversible writes.
+5. Cleanup remains idempotent and is allowed to run more than once.
+6. Monitoring counts jobs by resource key and status using the same semantics as the cancellation code.
+
+The first resource family is connector-scoped:
+
+```text
+connector:{org_id}:{kb_slug}:{connector_id}:{generation}
+```
+
+`generation` is a monotonically increasing value tied to the portal connector row. It can be `sync_epoch`, `delete_epoch`, `updated_at` converted to an integer, or a new explicit column. The exact storage choice is implementation detail; the contract is that old jobs can be fenced out when the connector is deleted or rebuilt.
+
+For jobs that are artifact-scoped but produced by a connector, the payload still carries the connector resource key:
+
+```json
+{
+  "artifact_id": "...",
+  "resource_key": "connector:org:kb:connector:generation"
+}
+```
+
+The artifact id remains the work item. The resource key is the authority/fence.
+
+## Requirements
+
+### REQ-01: Canonical resource_key on connector-scoped jobs
+
+**Ubiquitous.** Every new Procrastinate job that can write connector-owned knowledge data shall carry `resource_key` as a top-level task argument or in a shared metadata envelope.
+
+Applies to:
+
+- `run_crawl` when `connector_id` is present.
+- `enrich_document_bulk` for artifacts whose `extra.source_connector_id` is present.
+- `ingest_graphiti_episode` for artifacts whose `extra.source_connector_id` is present.
+- future connector-scoped backfills that write Qdrant, Graphiti, `knowledge.artifacts`, `knowledge.crawled_pages`, `knowledge.page_links`, `knowledge.parent_chunks` or Garage image refs.
+
+Acceptance:
+
+- Procrastinate args for connector-owned jobs include `resource_key`.
+- Manual uploads and Gitea jobs without `source_connector_id` may omit `resource_key`.
+- Tests assert that connector sync enqueues crawl/enrich/graphiti work with the same resource key.
+
+### REQ-02: resource_key is the cancellation index
+
+**Event-driven.** When connector delete or rebuild starts, the system shall cancel all live Procrastinate jobs for the connector's current resource key before deleting data stores.
+
+Live means `status IN ('todo', 'doing')`. Note on Procrastinate 3.x semantics: the `aborting` status is legacy and unused in 3.x; abort is a request flag on a `doing` job (`abort_requested`), and a job that cooperates with abort ends in terminal status `aborted`. `todo` jobs that are cancelled end in terminal status `cancelled`.
+
+Cancellation rules:
+
+- Use Procrastinate's job manager (`cancel_job_by_id_async`) for each discovered job.
+- `abort=True` for `doing` jobs (sets `abort_requested`; delivery relies on the task cooperating or on the fence check — REQ-03 is the guarantee, abort is best-effort).
+- `delete_job=False` by default so monitoring and audit can see `cancelled`/`aborted`.
+- Scope to queues that can write connector-owned knowledge data: `crawl-jobs`, `enrich-bulk`, `graphiti-bulk`, and any future connector-scoped writer queue.
+- Do not cancel `connector-purge` itself.
+
+Acceptance:
+
+- Delete/rebuild logs `connector_resource_jobs_cancel_requested` with `resource_key`, `jobs_found`, `jobs_cancelled`, `jobs_failed_to_cancel`.
+- Jobs for another connector id or another generation are untouched.
+- A missing or already terminal job is a no-op.
+
+### REQ-03: Fencing table/check prevents stale writes
+
+**State-driven.** Before a connector-owned task performs expensive work or writes, it shall verify that its `resource_key` is still current and active.
+
+The fence check returns one of:
+
+- `active`: task may continue.
+- `stale_generation`: connector exists, but this job belongs to an old generation.
+- `deleting`: connector exists but is being deleted.
+- `deleted`: connector no longer exists.
+- `unknown_error`: lookup failed; write-side tasks fail closed.
+
+Acceptance:
+
+- `run_crawl` checks before each per-page ingest/write loop.
+- `enrich_document_bulk` checks after loading the artifact and before LLM/embedding calls.
+- `_enrich_document` checks again immediately before Qdrant upsert.
+- `ingest_graphiti_episode` checks before Graphiti ingest and before persisting `graphiti_episode_id`.
+- `unknown_error` aborts the write path and logs at warning or error level.
+
+### REQ-04: Artifact existence remains a secondary guard
+
+**Ubiquitous.** Artifact existence checks remain in place for artifact-scoped jobs, but they are not the primary connector fence.
+
+Why: during rebuild, an artifact can still exist while its connector generation is stale. Artifact existence alone cannot distinguish "old connector generation" from "current connector generation".
+
+Acceptance:
+
+- Enrichment and Graphiti skip if the artifact row is gone.
+- If the artifact exists but `resource_key` is stale/deleting/deleted, the job skips before LLM, embedding, Qdrant or Graphiti writes.
+- Skip logs include both `artifact_id` and `resource_key` when available.
+
+### REQ-05: Idempotent cleanup and rebuild semantics
+
+**Ubiquitous.** Connector purge and rebuild cleanup shall be safe to run repeatedly.
+
+Delete/rebuild order:
+
+1. Mark connector generation fenced (`deleting`, `rebuilding`, or generation increment).
+2. Cancel live jobs by old resource key.
+3. Snapshot artifact ids and episode ids still associated with the old generation.
+4. Delete Postgres artifacts/crawl rows, Graphiti episodes, Qdrant chunks and Garage refs.
+5. Run janitor sweeps for late Graphiti/Garage orphans.
+6. For rebuild, enqueue new work with a new resource key.
+
+Acceptance:
+
+- Running cleanup twice returns zero or lower counts on the second run and does not raise.
+- A rebuild never reuses the old resource key.
+- Old jobs that survive cancellation skip because their resource key is stale.
+
+### REQ-06: Monitoring query uses one status vocabulary
+
+**Ubiquitous.** Add one helper/query that reports connector-scoped job counts by `resource_key` and Procrastinate status.
+
+It must count at least (Procrastinate 3.x status vocabulary):
+
+- `todo`
+- `doing`
+- `cancelled`
+- `aborted`
+- `failed`
+- `succeeded`
+
+And expose derived buckets:
+
+- `pending = todo`
+- `running = doing` (including abort-requested jobs, which stay `doing` until they cooperate)
+- `terminal = cancelled + aborted + failed + succeeded`
+- `failed_visible = failed` only; `cancelled` and `aborted` are not failures for delete/rebuild.
+
+Acceptance:
+
+- The query filters by top-level `args->>'resource_key' = $1`.
+- It does not use `args::text LIKE`.
+- Existing taxonomy/backfill status mapping is not silently reused for connector purge monitoring because that mapping treats `cancelled` as `failed`.
+- Tests seed all statuses and assert exact counts.
+
+### REQ-07: Queue lane interaction is explicit
+
+**Ubiquitous.** The implementation shall keep queue lane semantics intact.
+
+Rules:
+
+- Cancellation helpers know the writer queues explicitly or import them from `queues.py`.
+- `connector-purge` remains in `IO_QUEUES`.
+- `crawl-jobs` remains in `IO_QUEUES`.
+- `enrich-bulk` and `graphiti-bulk` remain in `LLM_QUEUES`.
+- Adding a new connector-scoped writer queue requires updating the resource-key cancellation queue list and `tests/test_queues_constants.py` or a dedicated resource-job queue test.
+
+Acceptance:
+
+- Tests fail if a connector-scoped writer queue is added without being included in cancellation monitoring.
+- No worker lane is merged back into `ALL_QUEUES` single-worker mode.
+
+### REQ-08: Tests cover cancellation, fencing and status reporting
+
+**Ubiquitous.** The implementation shall include focused tests for the contract and one regression scenario that reproduces the old regrow shape.
+
+Minimum test coverage:
+
+- Resource key construction.
+- Enqueue payloads for crawl/enrich/graphiti.
+- Cancellation filters exact `resource_key`.
+- Fencing skips stale generation after artifact still exists.
+- Fencing skips deleted connector after artifact missing.
+- Pre-write guard prevents Qdrant upsert.
+- Pre-write guard prevents Graphiti ingest.
+- Monitoring counts `todo`, `doing`, `cancelled`, `aborted`, `failed`, `succeeded` correctly.
+- Full delete/rebuild regression: old jobs do not write after the new connector generation starts.
+
+## Files
+
+Likely touched implementation files:
+
+- `klai-knowledge-ingest/knowledge_ingest/queues.py`
+- `klai-knowledge-ingest/knowledge_ingest/worker.py`
+- `klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py`
+- `klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py`
+- `klai-knowledge-ingest/knowledge_ingest/connector_purge_tasks.py`
+- `klai-knowledge-ingest/knowledge_ingest/crawl_tasks.py`
+- `klai-knowledge-ingest/knowledge_ingest/routes/ingest.py`
+- `klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py`
+- `klai-knowledge-ingest/knowledge_ingest/connector_state.py`
+- `klai-knowledge-ingest/knowledge_ingest/pg_store.py`
+
+Likely new files:
+
+- `klai-knowledge-ingest/knowledge_ingest/resource_jobs.py`
+- `klai-knowledge-ingest/tests/test_resource_jobs.py`
+- `klai-knowledge-ingest/tests/test_connector_resource_fencing.py`
+- `klai-knowledge-ingest/tests/test_connector_resource_monitoring.py`
+
+Portal/connector files may be touched only if the chosen generation storage lives in `portal_connectors` or klai-connector's rebuild orchestration.
+
+## Non-goals
+
+- A generic workflow engine for all Procrastinate jobs.
+- Retrofitting unrelated taxonomy, rag-eval or clustering jobs unless they become connector-scoped writers.
+- Backfilling historical orphan Qdrant/Graphiti data from old production incidents.
+- Changing LLM lane concurrency or queue prioritisation.
+- Hiding cancelled jobs from Procrastinate tables; cancellation is observable state.
+
+## Constraints
+
+- No `args::text LIKE` for the new cancellation path.
+- No reliance on `queueing_lock` as the ownership key.
+- Fail closed on connector-state lookup errors before writes.
+- Fence lookups must not add a DB roundtrip per crawled page. A short-lived in-process cache (max ~5s) or per-batch fence check is acceptable for the "before expensive work" checkpoint; the "immediately before irreversible write" checkpoint must be fresh (uncached) or accept the ≤5s window as documented residual risk.
+- v1 does not add a portal-api schema migration for `generation`. The generation value is caller-supplied at sync start (e.g. sync-run id or epoch provided by the orchestrator that triggers the sync). An explicit portal column can be a follow-up if the caller-supplied value proves fragile.
+- Keep cleanup idempotent; retries must be safe.
+- Keep existing artifact existence checks as defence-in-depth.
+- Do not delete Procrastinate job rows unless there is a specific retention reason.
+
+## References
+
+- `.claude/rules/klai/projects/knowledge.md` — connector-delete cleanup, in-flight jobs, worker lanes.
+- `.moai/specs/SPEC-CONNECTOR-DELETE-RACE-001/` — original observed race and targeted mitigation.
+- `.moai/specs/SPEC-CONNECTOR-CLEANUP-001/` — connector cleanup architecture and cross-store cleanup context.
+- `klai-knowledge-ingest/knowledge_ingest/queues.py` — `IO_QUEUES` / `LLM_QUEUES`.
+- `klai-knowledge-ingest/knowledge_ingest/worker.py` — lane workers.
+- `klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py` — enrichment and Graphiti tasks.
+- `klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py` — current purge orchestration.
+- `klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py` — single crawl-job cancellation shape.

--- a/klai-connector/app/clients/knowledge_ingest.py
+++ b/klai-connector/app/clients/knowledge_ingest.py
@@ -29,6 +29,7 @@ def _build_payload(
     content: str,
     source_connector_id: str,
     source_ref: str,
+    resource_generation: str | None = None,
     source_url: str = "",
     content_type: str = "unknown",
     image_urls: list[str] | None = None,
@@ -52,6 +53,8 @@ def _build_payload(
         "content_type": content_type,
         "source_type": source_type,
     }
+    if resource_generation:
+        payload["resource_generation"] = resource_generation
     # user_id: connector owner's Zitadel user_id. Required by knowledge-ingest's
     # personal-KB owner-binding check (personal_kb_owner_mismatch). Without it,
     # syncs to a personal-{user} KB return 403.
@@ -116,6 +119,7 @@ class KnowledgeIngestClient:
         connector_type: str = "",
         user_id: str | None = None,
         document_extra: dict[str, object] | None = None,
+        resource_generation: str | None = None,
     ) -> None:
         """Send a parsed document to knowledge-ingest for embedding.
 
@@ -165,6 +169,7 @@ class KnowledgeIngestClient:
             content=content,
             source_connector_id=source_connector_id,
             source_ref=source_ref,
+            resource_generation=resource_generation,
             source_url=source_url,
             content_type=content_type,
             image_urls=image_urls,
@@ -252,6 +257,7 @@ class CrawlSyncClient:
         connector_id: str,
         org_id: str,
         kb_slug: str,
+        generation: str,
         config: dict,
     ) -> dict:
         """Enqueue a bulk crawl via ``POST /ingest/v1/crawl/sync``.
@@ -267,6 +273,7 @@ class CrawlSyncClient:
             "connector_id": connector_id,
             "org_id": org_id,
             "kb_slug": kb_slug,
+            "generation": generation,
             "base_url": config["base_url"],
             "max_pages": int(config.get("max_pages", 200)),
             "max_depth": int(config.get("max_depth", 3)),

--- a/klai-connector/app/services/sync_engine.py
+++ b/klai-connector/app/services/sync_engine.py
@@ -394,6 +394,7 @@ class SyncEngine:
                             path=ref.path,
                             content=text,
                             source_connector_id=str(connector_id),
+                            resource_generation=str(sync_run_id),
                             source_ref=ref.source_ref,
                             source_url=ref.source_url,
                             content_type=ref.content_type,
@@ -674,6 +675,7 @@ class SyncEngine:
                     connector_id=str(connector_id),
                     org_id=portal_config.zitadel_org_id,
                     kb_slug=portal_config.kb_slug,
+                    generation=str(sync_run_id),
                     config=portal_config.config,
                 )
                 remote_job_id = enqueue_resp["job_id"]

--- a/klai-connector/tests/test_knowledge_ingest_payload.py
+++ b/klai-connector/tests/test_knowledge_ingest_payload.py
@@ -192,3 +192,9 @@ def test_client_content_limit_matches_knowledge_ingest_request_contract() -> Non
     )
 
     assert downstream_limit == MAX_INGEST_CONTENT_CHARS
+
+
+def test_connector_payload_forwards_sync_generation() -> None:
+    payload = _build_payload(**_base_kwargs(), resource_generation="sync-run-42")
+
+    assert payload["resource_generation"] == "sync-run-42"

--- a/klai-connector/tests/test_sync_engine_web_delegation.py
+++ b/klai-connector/tests/test_sync_engine_web_delegation.py
@@ -134,6 +134,7 @@ class TestFireAndForgetDelegation:
         assert call_kwargs["connector_id"] == str(connector_id)
         assert call_kwargs["org_id"] == "100000000000000002"
         assert call_kwargs["kb_slug"] == "support"
+        assert call_kwargs["generation"] == str(sync_run_id)
 
         # AC-01.1: cursor_state stores remote_job_id; status stays RUNNING.
         assert sync_run.cursor_state == {
@@ -235,6 +236,7 @@ class TestCrawlSyncClientContract:
             connector_id="abc",
             org_id="100000000000000002",
             kb_slug="support",
+            generation="sync-run-42",
             config={
                 "base_url": "https://help.voys.nl",
                 "max_pages": 20,
@@ -252,6 +254,7 @@ class TestCrawlSyncClientContract:
         assert body["connector_id"] == "abc"
         assert body["org_id"] == "100000000000000002"
         assert body["kb_slug"] == "support"
+        assert body["generation"] == "sync-run-42"
         assert body["base_url"] == "https://help.voys.nl"
         assert body["max_pages"] == 20
         assert body["max_depth"] == 2

--- a/klai-knowledge-ingest/alembic/versions/0013_connector_resource_fences.py
+++ b/klai-knowledge-ingest/alembic/versions/0013_connector_resource_fences.py
@@ -1,0 +1,45 @@
+"""SPEC-CONNECTOR-CANCEL-001 — connector generation fences.
+
+Revision ID: e7b3c6a10f42
+Revises: c4a11d9b7e20
+Create Date: 2026-09-01
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "e7b3c6a10f42"
+down_revision: str | None = "c4a11d9b7e20"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE knowledge.connector_resource_fences (
+          org_id text NOT NULL,
+          kb_slug text NOT NULL,
+          connector_id text NOT NULL,
+          current_generation text NOT NULL,
+          state text NOT NULL CHECK (state IN ('active', 'deleting')),
+          updated_at timestamptz NOT NULL DEFAULT now(),
+          PRIMARY KEY (org_id, kb_slug, connector_id)
+        )
+        """
+    )
+    op.execute("ALTER TABLE knowledge.connector_resource_fences ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE knowledge.connector_resource_fences FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON knowledge.connector_resource_fences
+          AS RESTRICTIVE
+          USING (org_id = knowledge._rls_current_org_id())
+          WITH CHECK (org_id = knowledge._rls_current_org_id())
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS knowledge.connector_resource_fences")

--- a/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
+++ b/klai-knowledge-ingest/knowledge_ingest/adapters/crawler.py
@@ -60,6 +60,7 @@ from knowledge_ingest.reason_codes import (
     FetchReasonCode,
     PersistSkipReason,
 )
+from knowledge_ingest.resource_jobs import parse_connector_resource_key
 from knowledge_ingest.utils.auth_wall_classifier import classify_auth_wall
 from knowledge_ingest.utils.auth_wall_detector import (
     AuthWallSignal,
@@ -800,6 +801,7 @@ async def run_crawl_job(
     canary_url: str | None = None,
     canary_fingerprint: str | None = None,
     connector_id: str | None = None,
+    resource_key: str | None = None,
     discovery_seed_url: str | None = None,
 ) -> None:
     """
@@ -1137,6 +1139,22 @@ async def run_crawl_job(
 
         for result in results:
             url = result.url
+            if resource_key:
+                from knowledge_ingest.connector_state import (
+                    FenceState,
+                    check_connector_resource_fence,
+                )
+
+                fence_state = await check_connector_resource_fence(resource_key)
+                if fence_state is not FenceState.ACTIVE:
+                    logger.warning(
+                        "connector_resource_job_skipped",
+                        resource_key=resource_key,
+                        fence_state=fence_state.value,
+                        job_id=job_id,
+                        url=url,
+                    )
+                    continue
             # SPEC-CRAWLER-004 Fase B: detect login-indicator trigger.
             # crawl4ai returns success=False when the injected wait_for times
             # out on the login selector; surfacing that as AuthWallDetected
@@ -1159,6 +1177,7 @@ async def run_crawl_job(
                             login_indicator_selector=login_indicator_selector,
                             authenticated_context=bool(cookies or login_indicator_selector),
                             connector_id=connector_id,
+                            resource_key=resource_key,
                         )
                         pages_done += 1
                     except AuthWallDetected:
@@ -1499,6 +1518,7 @@ async def _ingest_crawl_result(
     login_indicator_selector: str | None = None,
     authenticated_context: bool = False,
     connector_id: str | None = None,
+    resource_key: str | None = None,
 ) -> None:
     """Process a crawl result: dedup, extract links, ingest.
 
@@ -1783,6 +1803,8 @@ async def _ingest_crawl_result(
         # Before this, every crawl chunk had source_connector_id=None and
         # neither Qdrant nor artifact delete matched.
         extra["source_connector_id"] = connector_id
+        if resource_key:
+            extra["resource_key"] = resource_key
     if is_pdf and front_matter:
         extra["front_matter"] = front_matter
 
@@ -1850,6 +1872,10 @@ async def _ingest_crawl_result(
             content_type=content_type,
             synthesis_depth=1,
             extra=extra,
+            source_connector_id=connector_id,
+            resource_generation=(
+                parse_connector_resource_key(resource_key).generation if resource_key else None
+            ),
         ),
     )
 

--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -28,7 +28,12 @@ import structlog
 
 from knowledge_ingest import graph as graph_module
 from knowledge_ingest import pg_store, qdrant_store
+from knowledge_ingest.connector_state import mark_connector_resource_deleting
 from knowledge_ingest.db import get_pool, tenant_scoped_connection
+from knowledge_ingest.resource_jobs import (
+    cancel_jobs_by_resource_key,
+    connector_resource_key,
+)
 
 logger = structlog.get_logger()
 
@@ -96,21 +101,69 @@ async def _list_artifact_ids(
     return [r["id"] for r in rows]
 
 
-async def _cancel_enrichment_jobs(proc_app: Any, connector_id: str) -> int:
-    """Cancel queued + in-flight enrich_document_* jobs for this connector.
+async def _list_resource_keys(
+    conn: asyncpg.Connection, org_id: str, kb_slug: str, connector_id: str
+) -> list[str]:
+    """Snapshot connector generations represented by artifacts or crawl runs."""
+    artifact_rows = await conn.fetch(
+        """
+        SELECT DISTINCT extra::jsonb->>'resource_key' AS resource_key
+          FROM knowledge.artifacts
+         WHERE org_id = $1
+           AND kb_slug = $2
+           AND extra::jsonb->>'source_connector_id' = $3
+           AND extra::jsonb->>'resource_key' IS NOT NULL
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+    )
+    crawl_rows = await conn.fetch(
+        """
+        SELECT DISTINCT config::jsonb->>'generation' AS generation
+          FROM knowledge.crawl_jobs
+         WHERE org_id = $1
+           AND kb_slug = $2
+           AND config::jsonb->>'connector_id' = $3
+           AND config::jsonb->>'generation' IS NOT NULL
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+    )
+    current_generation = await conn.fetchval(
+        """
+        SELECT current_generation
+          FROM knowledge.connector_resource_fences
+         WHERE org_id = $1 AND kb_slug = $2 AND connector_id = $3
+        """,
+        org_id,
+        kb_slug,
+        connector_id,
+    )
+    keys = {str(row["resource_key"]) for row in artifact_rows}
+    keys.update(
+        connector_resource_key(org_id, kb_slug, connector_id, row["generation"])
+        for row in crawl_rows
+    )
+    if current_generation is not None:
+        keys.add(connector_resource_key(org_id, kb_slug, connector_id, current_generation))
+    return sorted(keys)
 
-    Filter: ``args->'extra_payload'->>'source_connector_id' = connector_id``.
-    Procrastinate ``cancel_job_by_id_async`` is per-id — we discover IDs
-    via a single SELECT then loop.
 
-    ``abort=True`` marks running jobs for asyncio.CancelledError delivery
-    via Postgres NOTIFY (Procrastinate native). ``delete_job=True`` purges
-    the row from the queue table after cancellation so it never replays.
+async def _cancel_enrichment_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
+    """Cancel legacy artifact-only enrichment jobs during rollout.
+
+    New jobs are cancelled by exact resource key. This fallback intentionally
+    matches only jobs without one, using the pre-cleanup artifact-id snapshot.
+    Procrastinate cancellation is per-id, so discover the IDs once and loop.
 
     SPEC-TI-003-FOLLOWUP-001 AC-2 exception: this query targets the
     procrastinate_jobs table, not knowledge.*, so a raw pool acquire
     is allowed here.
     """
+    if not artifact_ids:
+        return 0
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
@@ -118,17 +171,18 @@ async def _cancel_enrichment_jobs(proc_app: Any, connector_id: str) -> int:
             SELECT id FROM procrastinate_jobs
              WHERE task_name = ANY($1::text[])
                AND status IN ('todo', 'doing')
-               AND args->'extra_payload'->>'source_connector_id' = $2
+               AND args->>'resource_key' IS NULL
+               AND args->>'artifact_id' = ANY($2::text[])
             """,
             list(_ENRICHMENT_TASKS),
-            connector_id,
+            artifact_ids,
         )
     job_ids = [int(r["id"]) for r in rows]
 
     cancelled = 0
     for jid in job_ids:
         try:
-            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=True)
+            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=False)
             cancelled += 1
         except Exception:
             # Job may have just transitioned from todo->doing->finished
@@ -137,7 +191,7 @@ async def _cancel_enrichment_jobs(proc_app: Any, connector_id: str) -> int:
             logger.warning(
                 "cancel_job_failed",
                 job_id=jid,
-                connector_id=connector_id,
+                artifact_ids=artifact_ids,
                 exc_info=True,
             )
     return cancelled
@@ -164,6 +218,7 @@ async def _cancel_graphiti_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
             SELECT id FROM procrastinate_jobs
              WHERE task_name = ANY($1::text[])
                AND status IN ('todo', 'doing')
+               AND args->>'resource_key' IS NULL
                AND args->>'artifact_id' = ANY($2::text[])
             """,
             list(_GRAPHITI_TASKS),
@@ -174,7 +229,7 @@ async def _cancel_graphiti_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
     cancelled = 0
     for jid in job_ids:
         try:
-            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=True)
+            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=False)
             cancelled += 1
         except Exception:
             logger.warning("cancel_graphiti_job_failed", job_id=jid, exc_info=True)
@@ -223,11 +278,20 @@ async def purge_connector(
     async with tenant_scoped_connection(org_id) as conn:
         # Step 1: capture artifact UUIDs before they vanish.
         artifact_ids = await _list_artifact_ids(conn, org_id, kb_slug, connector_id)
+        resource_keys = await _list_resource_keys(conn, org_id, kb_slug, connector_id)
         log.info("connector_purge_step_artifacts_listed", count=len(artifact_ids))
 
-        # Step 2: cancel enrichment jobs (uses extra_payload.source_connector_id).
-        # Runs against procrastinate_jobs -- own pool acquire inside the helper.
-        enrichment_cancelled = await _cancel_enrichment_jobs(proc_app, connector_id)
+        # Resource keys are the primary ownership index. Artifact ids remain a
+        # one-deploy compatibility fallback for jobs queued before this contract.
+        for resource_key in resource_keys:
+            await mark_connector_resource_deleting(conn, resource_key)
+        pool = await get_pool()
+        resource_cancelled = 0
+        for resource_key in resource_keys:
+            cancellation = await cancel_jobs_by_resource_key(proc_app, pool, resource_key)
+            resource_cancelled += cancellation.jobs_cancelled
+
+        enrichment_cancelled = await _cancel_enrichment_jobs(proc_app, artifact_ids)
         log.info(
             "connector_purge_step_enrichment_jobs_cancelled",
             cancelled=enrichment_cancelled,
@@ -370,6 +434,18 @@ async def purge_connector(
 
         s3_images_deleted += janitor_s3_deleted
 
+        # Keep the row in deleting state throughout every cross-store cleanup.
+        # Once cleanup is complete, absence is the durable "deleted" fence.
+        await conn.execute(
+            """
+            DELETE FROM knowledge.connector_resource_fences
+             WHERE org_id = $1 AND kb_slug = $2 AND connector_id = $3
+            """,
+            org_id,
+            kb_slug,
+            connector_id,
+        )
+
         # NOTE: connector.sync_runs cleanup is invoked by the portal-side
         # delete-orchestration BEFORE it asks knowledge-ingest to purge. That
         # keeps cross-service auth + tenant-scoping aligned with how the rest
@@ -378,7 +454,7 @@ async def purge_connector(
         # becomes redundant (the portal_connectors row delete cascades).
 
         report = CleanupReport(
-            enrichment_jobs_cancelled=enrichment_cancelled,
+            enrichment_jobs_cancelled=enrichment_cancelled + resource_cancelled,
             graphiti_jobs_cancelled=graphiti_cancelled,
             artifacts_deleted=artifacts_deleted,
             crawl_jobs_deleted=crawl_jobs_deleted,

--- a/klai-knowledge-ingest/knowledge_ingest/connector_state.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_state.py
@@ -19,10 +19,12 @@ chunk that becomes orphan data.
 from __future__ import annotations
 
 import time
+from enum import StrEnum
 
 import structlog
 
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.db import get_pool, tenant_scoped_connection
+from knowledge_ingest.resource_jobs import parse_connector_resource_key
 
 logger = structlog.get_logger()
 
@@ -34,6 +36,126 @@ _CACHE_TTL_SECONDS = 5.0
 
 # {connector_id: (state, expires_at_monotonic)}
 _state_cache: dict[str, tuple[str, float]] = {}
+
+
+class FenceState(StrEnum):
+    ACTIVE = "active"
+    STALE_GENERATION = "stale_generation"
+    DELETING = "deleting"
+    DELETED = "deleted"
+    UNKNOWN_ERROR = "unknown_error"
+
+
+_fence_cache: dict[str, tuple[FenceState, float]] = {}
+
+
+async def activate_connector_resource(conn, resource_key: str) -> None:
+    resource = parse_connector_resource_key(resource_key)
+    await conn.execute(
+        """
+        INSERT INTO knowledge.connector_resource_fences
+            (org_id, kb_slug, connector_id, current_generation, state, updated_at)
+        VALUES ($1, $2, $3, $4, 'active', now())
+        ON CONFLICT (org_id, kb_slug, connector_id) DO UPDATE
+          SET current_generation = EXCLUDED.current_generation,
+              state = 'active',
+              updated_at = now()
+        """,
+        resource.org_id,
+        resource.kb_slug,
+        resource.connector_id,
+        resource.generation,
+    )
+    _fence_cache.pop(resource_key, None)
+
+
+async def get_current_connector_resource_key(conn, resource_key: str) -> str | None:
+    resource = parse_connector_resource_key(resource_key)
+    generation = await conn.fetchval(
+        """
+        SELECT current_generation
+          FROM knowledge.connector_resource_fences
+         WHERE org_id = $1 AND kb_slug = $2 AND connector_id = $3
+        """,
+        resource.org_id,
+        resource.kb_slug,
+        resource.connector_id,
+    )
+    if generation is None:
+        return None
+    from knowledge_ingest.resource_jobs import connector_resource_key
+
+    return connector_resource_key(
+        resource.org_id, resource.kb_slug, resource.connector_id, generation
+    )
+
+
+async def mark_connector_resource_deleting(conn, resource_key: str) -> None:
+    resource = parse_connector_resource_key(resource_key)
+    await conn.execute(
+        """
+        UPDATE knowledge.connector_resource_fences
+           SET state = 'deleting', updated_at = now()
+         WHERE org_id = $1
+           AND kb_slug = $2
+           AND connector_id = $3
+           AND current_generation = $4
+        """,
+        resource.org_id,
+        resource.kb_slug,
+        resource.connector_id,
+        resource.generation,
+    )
+    _fence_cache.pop(resource_key, None)
+
+
+async def check_connector_resource_fence(resource_key: str, *, fresh: bool = False) -> FenceState:
+    """Fail closed unless this is the connector's active current generation."""
+    now = time.monotonic()
+    cached = _fence_cache.get(resource_key)
+    if not fresh and cached is not None and cached[1] > now:
+        return cached[0]
+    try:
+        resource = parse_connector_resource_key(resource_key)
+        async with tenant_scoped_connection(resource.org_id) as conn:
+            row = await conn.fetchrow(
+                """
+                SELECT f.current_generation,
+                       f.state,
+                       p.state AS connector_state
+                  FROM knowledge.connector_resource_fences AS f
+                  LEFT JOIN portal_connectors AS p ON p.id = f.connector_id::uuid
+                 WHERE f.org_id = $1 AND f.kb_slug = $2 AND f.connector_id = $3
+                """,
+                resource.org_id,
+                resource.kb_slug,
+                resource.connector_id,
+            )
+    except Exception:
+        logger.warning(
+            "connector_resource_fence_lookup_failed",
+            resource_key=resource_key,
+            exc_info=True,
+        )
+        return FenceState.UNKNOWN_ERROR
+
+    if row is None:
+        result = FenceState.DELETED
+    elif row.get("connector_state", "active") is None:
+        result = FenceState.DELETED
+    elif row.get("connector_state", "active") != "active":
+        result = FenceState.DELETING
+    elif str(row["current_generation"]) != resource.generation:
+        result = FenceState.STALE_GENERATION
+    elif row["state"] == "deleting":
+        result = FenceState.DELETING
+    elif row["state"] == "active":
+        result = FenceState.ACTIVE
+    else:
+        result = FenceState.UNKNOWN_ERROR
+    if not fresh:
+        _fence_cache[resource_key] = (result, now + _CACHE_TTL_SECONDS)
+    return result
 
 
 async def connector_is_active(connector_id: str | None) -> bool:
@@ -103,5 +225,6 @@ def invalidate_cache(connector_id: str | None = None) -> None:
     """
     if connector_id is None:
         _state_cache.clear()
+        _fence_cache.clear()
     else:
         _state_cache.pop(connector_id, None)

--- a/klai-knowledge-ingest/knowledge_ingest/crawl_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl_tasks.py
@@ -55,6 +55,7 @@ def register_crawl_tasks(procrastinate_app: Any) -> None:
         content_selector: str | None = None,
         login_indicator_selector: str | None = None,
         connector_id: str | None = None,
+        resource_key: str | None = None,
         canary_url: str | None = None,
         canary_fingerprint: str | None = None,
         discovery_seed_url: str | None = None,
@@ -101,6 +102,7 @@ def register_crawl_tasks(procrastinate_app: Any) -> None:
             canary_url=canary_url,
             canary_fingerprint=canary_fingerprint,
             connector_id=connector_id,
+            resource_key=resource_key,
         )
 
     procrastinate_app.run_crawl = run_crawl  # type: ignore[attr-defined]

--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -131,7 +131,7 @@ def init_app(connector: Any) -> Any:
     return _procrastinate_app
 
 
-async def _load_and_enrich(artifact_id: str) -> None:
+async def _load_and_enrich(artifact_id: str, resource_key: str | None = None) -> None:
     """SPEC-INGEST-CONTENT-PG-001 (audit finding 1): single entry point for
     both enrichment task variants.
 
@@ -168,6 +168,9 @@ async def _load_and_enrich(artifact_id: str) -> None:
         return
 
     extra: dict = artifact["extra"] or {}
+    resource_key = resource_key or extra.get("resource_key")
+    if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=False):
+        return
     document_text: str = extra.get("document_text", "") or ""
     prechunked_skip = enrichment_skip_reason(
         chunk_count=int(extra.get("docling_chunk_count") or 0),
@@ -244,7 +247,30 @@ async def _load_and_enrich(artifact_id: str) -> None:
         parents=parents_serialised,
         parent_index_per_child=parent_index_per_child,
         heading_path_per_child=heading_path_per_child,
+        resource_key=resource_key,
     )
+
+
+async def _resource_fence_blocks(
+    resource_key: str | None, *, artifact_id: str, fresh: bool
+) -> bool:
+    if not resource_key:
+        return False
+    from knowledge_ingest.connector_state import (
+        FenceState,
+        check_connector_resource_fence,
+    )
+
+    state = await check_connector_resource_fence(resource_key, fresh=fresh)
+    if state is FenceState.ACTIVE:
+        return False
+    logger.warning(
+        "connector_resource_job_skipped",
+        artifact_id=artifact_id,
+        resource_key=resource_key,
+        fence_state=state.value,
+    )
+    return True
 
 
 class ArtifactIndexStatusUpdateError(RuntimeError):
@@ -328,12 +354,12 @@ def _register_tasks(procrastinate_app: Any) -> None:
         # jobs, so ride out the whole 429 burst a concurrent crawl produces.
         retry=procrastinate.RetryStrategy(max_attempts=5, exponential_wait=4),
     )
-    async def enrich_document_bulk(artifact_id: str) -> None:
+    async def enrich_document_bulk(artifact_id: str, resource_key: str | None = None) -> None:
         """Enrich chunks for crawl/import jobs (lower priority).
 
         SPEC-INGEST-CONTENT-PG-001: takes only ``artifact_id``.
         """
-        await _load_and_enrich(artifact_id)
+        await _load_and_enrich(artifact_id, resource_key)
 
     # Expose task functions via app attributes for use in ingest.py
     procrastinate_app.enrich_document_interactive = enrich_document_interactive  # type: ignore[attr-defined]
@@ -354,6 +380,7 @@ def _register_tasks(procrastinate_app: Any) -> None:
         kb_slug: str = "",
         path: str = "",
         replace_stale: bool = False,
+        resource_key: str | None = None,
     ) -> None:
         """Ingest a document into the Graphiti knowledge graph.
 
@@ -397,6 +424,8 @@ def _register_tasks(procrastinate_app: Any) -> None:
                     artifact_id=artifact_id,
                     org_id=org_id,
                 )
+                return
+            if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=False):
                 return
             from knowledge_ingest import graph as graph_module
 
@@ -466,6 +495,8 @@ def _register_tasks(procrastinate_app: Any) -> None:
                             org_id=org_id,
                         )
                         return
+                if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=True):
+                    return
                 episode_id = await graph_module.ingest_episode(
                     artifact_id=artifact_id,
                     document_text=episode_text,
@@ -489,6 +520,9 @@ def _register_tasks(procrastinate_app: Any) -> None:
                         f"{part_index + 1} of {len(episode_parts)}"
                     )
                 episode_ids.append(episode_id)
+                if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=True):
+                    await graph_module.delete_kb_episodes(org_id, [episode_id])
+                    return
                 # A worker retry starts with a fresh Python list, so the SQL
                 # append must retain IDs written before a mid-loop worker kill.
                 await pg_store.append_graphiti_episode_id(conn, artifact_id, episode_id)
@@ -519,6 +553,8 @@ def _register_tasks(procrastinate_app: Any) -> None:
                 )
             except Exception:
                 logger.exception("entity_graph_data_failed", artifact_id=artifact_id)
+            if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=True):
+                return
             await pg_store.update_artifact_extra(
                 conn,
                 artifact_id,
@@ -546,6 +582,7 @@ async def _enrich_document(
     parents: list[dict] | None = None,
     parent_index_per_child: list[int | None] | None = None,
     heading_path_per_child: list[str] | None = None,
+    resource_key: str | None = None,
 ) -> None:
     """
     Core enrichment logic shared by both task variants.
@@ -723,7 +760,10 @@ async def _enrich_document(
                     if parent_idx is not None and 0 <= parent_idx < len(inserted_ids):
                         parent_chunk_ids[i] = inserted_ids[parent_idx]
 
-        # Step 4: Upsert enriched chunks to Qdrant
+        # Step 4: Upsert enriched chunks to Qdrant. This checkpoint is fresh;
+        # the earlier pre-LLM check may be served from the <=5s cache.
+        if await _resource_fence_blocks(resource_key, artifact_id=artifact_id, fresh=True):
+            return
         t0 = time.monotonic()
         await qdrant_store.upsert_enriched_chunks(
             org_id=org_id,

--- a/klai-knowledge-ingest/knowledge_ingest/models.py
+++ b/klai-knowledge-ingest/knowledge_ingest/models.py
@@ -37,6 +37,7 @@ class IngestRequest(BaseModel):
     chunks: list[str] | None = None  # Pre-computed chunks (used with skip_chunking=True)
     content_hash: str | None = None  # Optional full-source hash for pre-chunked/truncated content
     source_connector_id: str | None = None  # ID of the connector that produced this document
+    resource_generation: str | None = None  # Caller-supplied connector sync generation
     source_ref: str | None = None  # Source reference (e.g. URL, Notion page ID, repo path)
     synthesis_depth: int | None = None  # Optional override (adapters set this explicitly)
     # Connector-level hint: expected modes for this source

--- a/klai-knowledge-ingest/knowledge_ingest/resource_jobs.py
+++ b/klai-knowledge-ingest/knowledge_ingest/resource_jobs.py
@@ -1,0 +1,143 @@
+"""Connector-scoped Procrastinate job ownership helpers."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+
+from knowledge_ingest.queues import CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK
+
+CONNECTOR_WRITER_QUEUES = (CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK)
+RESOURCE_JOB_STATUSES = ("todo", "doing", "cancelled", "aborted", "failed", "succeeded")
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorResource:
+    org_id: str
+    kb_slug: str
+    connector_id: str
+    generation: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceJobCancellation:
+    jobs_found: int
+    jobs_cancelled: int
+    jobs_failed_to_cancel: int
+
+
+def _validate_component(name: str, value: object) -> str:
+    component = str(value)
+    if not component or ":" in component:
+        raise ValueError(f"connector resource key {name} must be non-empty and contain no ':'")
+    return component
+
+
+def connector_resource_key(
+    org_id: object,
+    kb_slug: object,
+    connector_id: object,
+    generation: object,
+) -> str:
+    """Build the canonical authority key for one connector generation."""
+    parts = (
+        _validate_component("org_id", org_id),
+        _validate_component("kb_slug", kb_slug),
+        _validate_component("connector_id", connector_id),
+        _validate_component("generation", generation),
+    )
+    return "connector:" + ":".join(parts)
+
+
+def parse_connector_resource_key(resource_key: str) -> ConnectorResource:
+    """Validate and split a canonical connector resource key."""
+    parts = resource_key.split(":")
+    if len(parts) != 5 or parts[0] != "connector" or any(not part for part in parts[1:]):
+        raise ValueError("invalid connector resource key")
+    return ConnectorResource(*parts[1:])
+
+
+async def list_live_jobs_by_resource_key(
+    pool: Any,
+    resource_key: str,
+    queues: tuple[str, ...] = CONNECTOR_WRITER_QUEUES,
+) -> list[int]:
+    """List live writer jobs owned by exactly one connector generation."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id
+              FROM procrastinate_jobs
+             WHERE queue_name = ANY($1::text[])
+               AND status IN ('todo', 'doing')
+               AND args->>'resource_key' = $2
+            """,
+            list(queues),
+            resource_key,
+        )
+    return [int(row["id"]) for row in rows]
+
+
+async def cancel_jobs_by_resource_key(
+    proc_app: Any,
+    pool: Any,
+    resource_key: str,
+    queues: tuple[str, ...] = CONNECTOR_WRITER_QUEUES,
+) -> ResourceJobCancellation:
+    """Request cancellation without deleting the auditable job rows."""
+    job_ids = await list_live_jobs_by_resource_key(pool, resource_key, queues)
+    cancelled = 0
+    failed = 0
+    for job_id in job_ids:
+        try:
+            await proc_app.job_manager.cancel_job_by_id_async(
+                job_id,
+                abort=True,
+                delete_job=False,
+            )
+            cancelled += 1
+        except Exception:
+            failed += 1
+            logger.warning(
+                "connector_resource_job_cancel_failed",
+                resource_key=resource_key,
+                job_id=job_id,
+                exc_info=True,
+            )
+    report = ResourceJobCancellation(len(job_ids), cancelled, failed)
+    logger.info(
+        "connector_resource_jobs_cancel_requested",
+        resource_key=resource_key,
+        jobs_found=report.jobs_found,
+        jobs_cancelled=report.jobs_cancelled,
+        jobs_failed_to_cancel=report.jobs_failed_to_cancel,
+    )
+    return report
+
+
+async def get_resource_job_counts(pool: Any, resource_key: str) -> dict[str, int]:
+    """Return raw Procrastinate 3.x statuses and delete/rebuild buckets."""
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT status::text AS status, count(*)::bigint AS count
+              FROM procrastinate_jobs
+             WHERE args->>'resource_key' = $1
+               AND status::text = ANY($2::text[])
+             GROUP BY status
+            """,
+            resource_key,
+            list(RESOURCE_JOB_STATUSES),
+        )
+    counts = {status: 0 for status in RESOURCE_JOB_STATUSES}
+    for row in rows:
+        counts[str(row["status"])] = int(row["count"])
+    counts["pending"] = counts["todo"]
+    counts["running"] = counts["doing"]
+    counts["terminal"] = sum(
+        counts[status] for status in ("cancelled", "aborted", "failed", "succeeded")
+    )
+    counts["failed_visible"] = counts["failed"]
+    return counts

--- a/klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/crawl_sync.py
@@ -38,7 +38,12 @@ from knowledge_ingest.connector_cookies import (
     ConnectorOrgMismatchError,
     load_connector_cookies,
 )
-from knowledge_ingest.db import get_pool
+from knowledge_ingest.connector_state import (
+    activate_connector_resource,
+    get_current_connector_resource_key,
+)
+from knowledge_ingest.db import get_pool, tenant_scoped_connection
+from knowledge_ingest.resource_jobs import cancel_jobs_by_resource_key, connector_resource_key
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -56,6 +61,7 @@ class CrawlSyncRequest(BaseModel):
     """
 
     connector_id: uuid.UUID
+    generation: str
     org_id: str
     kb_slug: str
     base_url: str
@@ -225,6 +231,12 @@ async def crawl_sync(req: CrawlSyncRequest) -> CrawlSyncResponse:
     from knowledge_ingest import enrichment_tasks
 
     proc_app = enrichment_tasks.get_app()
+    resource_key = connector_resource_key(req.org_id, req.kb_slug, req.connector_id, req.generation)
+    async with tenant_scoped_connection(req.org_id) as conn:
+        old_resource_key = await get_current_connector_resource_key(conn, resource_key)
+        await activate_connector_resource(conn, resource_key)
+    if old_resource_key and old_resource_key != resource_key:
+        await cancel_jobs_by_resource_key(proc_app, pool, old_resource_key)
     await proc_app.run_crawl.defer_async(  # type: ignore[attr-defined]
         job_id=job_id,
         org_id=req.org_id,
@@ -241,6 +253,7 @@ async def crawl_sync(req: CrawlSyncRequest) -> CrawlSyncResponse:
         # REQ-05.4: connector_id only — plaintext cookies never enter the
         # Procrastinate args column or the worker's "Starting job" log.
         connector_id=str(req.connector_id),
+        resource_key=resource_key,
         canary_url=req.canary_url,
         canary_fingerprint=req.canary_fingerprint,
     )

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -43,7 +43,7 @@ from knowledge_ingest.clustering import classify_by_centroid, load_centroids
 from knowledge_ingest.config import settings
 from knowledge_ingest.content_labeler import generate_content_label
 from knowledge_ingest.content_profiles import get_profile
-from knowledge_ingest.db import tenant_scoped_connection
+from knowledge_ingest.db import get_pool, tenant_scoped_connection
 from knowledge_ingest.docs_provenance import build_docs_source_extra
 from knowledge_ingest.document_normalizer import normalize_document_for_chunking
 from knowledge_ingest.enrichment_policy import (
@@ -61,6 +61,7 @@ from knowledge_ingest.models import (
     UpdateKBVisibilityRequest,
 )
 from knowledge_ingest.portal_client import fetch_taxonomy_nodes
+from knowledge_ingest.resource_jobs import connector_resource_key
 from knowledge_ingest.source_profiles import (
     SourceKnowledgeProfile,
     resolve_source_knowledge_profile,
@@ -100,6 +101,7 @@ def _sanitize_ingest_request(req: IngestRequest) -> None:
     req.chunks = _strip_postgres_nul(req.chunks)
     req.content_hash = _strip_postgres_nul(req.content_hash)
     req.source_connector_id = _strip_postgres_nul(req.source_connector_id)
+    req.resource_generation = _strip_postgres_nul(req.resource_generation)
     req.source_ref = _strip_postgres_nul(req.source_ref)
     req.kb_name = _strip_postgres_nul(req.kb_name)
     req.connector_type = _strip_postgres_nul(req.connector_type)
@@ -390,7 +392,11 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     # source_connector_id pass through unchanged.
     if req.source_connector_id:
         source_connector_id = req.source_connector_id
-        from knowledge_ingest.connector_state import connector_is_active
+        from knowledge_ingest.connector_state import (
+            activate_connector_resource,
+            connector_is_active,
+            get_current_connector_resource_key,
+        )
 
         if not await connector_is_active(source_connector_id):
             logger.info(
@@ -405,6 +411,29 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
                 "reason": "connector deleting or deleted",
                 "chunks": 0,
             }
+        if req.resource_generation:
+            resource_key = connector_resource_key(
+                req.org_id,
+                req.kb_slug,
+                req.source_connector_id,
+                req.resource_generation,
+            )
+            if req.source_type != "crawl":
+                old_resource_key = await get_current_connector_resource_key(conn, resource_key)
+                await activate_connector_resource(conn, resource_key)
+                if old_resource_key and old_resource_key != resource_key:
+                    from knowledge_ingest import enrichment_tasks
+                    from knowledge_ingest.resource_jobs import cancel_jobs_by_resource_key
+
+                    await cancel_jobs_by_resource_key(
+                        enrichment_tasks.get_app(),
+                        await get_pool(),
+                        old_resource_key,
+                    )
+        else:
+            resource_key = None
+    else:
+        resource_key = None
 
     # Early exit if indexable content is unchanged since last ingest. Docs pages
     # are stored as BlockNote JSON for editor fidelity; hash the normalized
@@ -792,6 +821,8 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
     visibility = await kb_config.get_kb_visibility(conn, req.org_id, req.kb_slug)
 
     extra_payload: dict = {"title": title, "artifact_id": artifact_id}
+    if resource_key:
+        extra_payload["resource_key"] = resource_key
 
     # SPEC-RAG-REBUILD-KB-001 follow-up: persist the original document
     # body on the artifact row so future rebuild_kb runs don't need to
@@ -913,7 +944,10 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
 
             await task_fn.configure(
                 queueing_lock=f"{req.org_id}:{req.kb_slug}:{req.path}:{artifact_id}",
-            ).defer_async(artifact_id=artifact_id)
+            ).defer_async(
+                artifact_id=artifact_id,
+                **({"resource_key": resource_key} if resource_key else {}),
+            )
         except AlreadyEnqueued:
             logger.info(
                 "enrichment_already_queued",
@@ -978,6 +1012,7 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             belief_time_start=kf["belief_time_start"],
             kb_slug=req.kb_slug,
             path=req.path,
+            **({"resource_key": resource_key} if resource_key else {}),
         )
 
     ingest_ms = int((time.monotonic() - t_ingest) * 1000)

--- a/klai-knowledge-ingest/tests/test_connector_cleanup.py
+++ b/klai-knowledge-ingest/tests/test_connector_cleanup.py
@@ -13,7 +13,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from knowledge_ingest.connector_cleanup import CleanupReport, purge_connector
+from knowledge_ingest.connector_cleanup import CleanupReport, _list_resource_keys, purge_connector
+from knowledge_ingest.resource_jobs import connector_resource_key
 
 
 @pytest.fixture
@@ -190,3 +191,14 @@ async def test_cleanup_report_serialises_for_logging() -> None:
     assert d["crawl_jobs_deleted"] == 2
     assert d["falkor_episodes_deleted"] == 15
     assert d["sync_runs_deleted"] is None
+
+
+@pytest.mark.asyncio
+async def test_resource_key_snapshot_includes_current_fence_without_artifacts() -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(side_effect=[[], []])
+    conn.fetchval = AsyncMock(return_value="sync-run-42")
+
+    keys = await _list_resource_keys(conn, "org-zid", "support", "conn-uuid")
+
+    assert keys == [connector_resource_key("org-zid", "support", "conn-uuid", "sync-run-42")]

--- a/klai-knowledge-ingest/tests/test_connector_resource_fencing.py
+++ b/klai-knowledge-ingest/tests/test_connector_resource_fencing.py
@@ -1,0 +1,95 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from knowledge_ingest.connector_state import (
+    FenceState,
+    check_connector_resource_fence,
+    invalidate_cache,
+)
+
+
+@asynccontextmanager
+async def _connection_returning(row):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+    yield conn
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        ({"current_generation": "g1", "state": "active"}, FenceState.ACTIVE),
+        (
+            {"current_generation": "g2", "state": "active"},
+            FenceState.STALE_GENERATION,
+        ),
+        ({"current_generation": "g1", "state": "deleting"}, FenceState.DELETING),
+        (None, FenceState.DELETED),
+    ],
+)
+async def test_connector_resource_fence_states(row, expected) -> None:
+    invalidate_cache()
+    with patch(
+        "knowledge_ingest.connector_state.tenant_scoped_connection",
+        return_value=_connection_returning(row),
+    ):
+        assert await check_connector_resource_fence("connector:org-1:kb:connector-1:g1") is expected
+
+
+@pytest.mark.asyncio
+async def test_connector_resource_fence_fails_closed_on_lookup_error() -> None:
+    invalidate_cache()
+
+    @asynccontextmanager
+    async def failing_connection():
+        raise RuntimeError("database unavailable")
+        yield
+
+    with patch(
+        "knowledge_ingest.connector_state.tenant_scoped_connection",
+        return_value=failing_connection(),
+    ):
+        assert (
+            await check_connector_resource_fence("connector:org-1:kb:connector-1:g1")
+            is FenceState.UNKNOWN_ERROR
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_enrichment_skips_before_chunking() -> None:
+    artifact = {
+        "artifact_id": "artifact-1",
+        "org_id": "org-1",
+        "kb_slug": "kb",
+        "path": "page.md",
+        "belief_time_end": 253402300800,
+        "extra": {"document_text": "# Page\n\nBody"},
+    }
+
+    @asynccontextmanager
+    async def admin_connection():
+        yield MagicMock()
+
+    with (
+        patch(
+            "knowledge_ingest.enrichment_tasks.cross_org_admin_connection",
+            return_value=admin_connection(),
+        ),
+        patch(
+            "knowledge_ingest.enrichment_tasks.pg_store.read_artifact_for_enrichment",
+            new=AsyncMock(return_value=artifact),
+        ),
+        patch(
+            "knowledge_ingest.connector_state.check_connector_resource_fence",
+            new=AsyncMock(return_value=FenceState.STALE_GENERATION),
+        ),
+        patch("knowledge_ingest.enrichment_tasks.chunker.chunk_markdown_with_parents") as chunk,
+    ):
+        from knowledge_ingest.enrichment_tasks import _load_and_enrich
+
+        await _load_and_enrich("artifact-1", "connector:org-1:kb:connector-1:old-generation")
+
+    chunk.assert_not_called()

--- a/klai-knowledge-ingest/tests/test_connector_resource_monitoring.py
+++ b/klai-knowledge-ingest/tests/test_connector_resource_monitoring.py
@@ -1,0 +1,40 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge_ingest.resource_jobs import get_resource_job_counts
+
+
+@pytest.mark.asyncio
+async def test_monitoring_reports_raw_and_derived_connector_job_counts() -> None:
+    conn = MagicMock()
+    conn.fetch = AsyncMock(
+        return_value=[
+            {"status": status, "count": 1}
+            for status in ("todo", "doing", "cancelled", "aborted", "failed", "succeeded")
+        ]
+    )
+    acquired = MagicMock()
+    acquired.__aenter__ = AsyncMock(return_value=conn)
+    acquired.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire.return_value = acquired
+
+    counts = await get_resource_job_counts(pool, "connector:org:kb:connector:generation")
+
+    assert counts["pending"] == 1
+    assert counts["running"] == 1
+    assert counts["terminal"] == 4
+    assert counts["failed_visible"] == 1
+    assert set(counts) == {
+        "todo",
+        "doing",
+        "cancelled",
+        "aborted",
+        "failed",
+        "succeeded",
+        "pending",
+        "running",
+        "terminal",
+        "failed_visible",
+    }

--- a/klai-knowledge-ingest/tests/test_crawl_sync_endpoint.py
+++ b/klai-knowledge-ingest/tests/test_crawl_sync_endpoint.py
@@ -112,6 +112,14 @@ def _client_with_patches(pool: MagicMock):
             client.headers.update(
                 {"X-Internal-Secret": os.environ["KNOWLEDGE_INGEST_SECRET"]},
             )
+            original_post = client.post
+
+            def post_with_generation(url, **kwargs):
+                if url == "/ingest/v1/crawl/sync" and isinstance(kwargs.get("json"), dict):
+                    kwargs["json"].setdefault("generation", "test-sync-run")
+                return original_post(url, **kwargs)
+
+            client.post = post_with_generation
             yield client, defer_async
 
 
@@ -208,6 +216,7 @@ class TestCrawlSyncEndpoint:
                 "/ingest/v1/crawl/sync",
                 json={
                     "connector_id": sent_connector_id,
+                    "generation": "sync-run-42",
                     "org_id": "42",
                     "kb_slug": "support",
                     "base_url": "https://help.voys.nl",
@@ -241,6 +250,7 @@ class TestCrawlSyncEndpoint:
         defer_mock.assert_awaited_once()
         kwargs = defer_mock.await_args.kwargs
         assert kwargs["connector_id"] == sent_connector_id
+        assert kwargs["resource_key"] == (f"connector:42:support:{sent_connector_id}:sync-run-42")
         assert "cookies" not in kwargs
         for plaintext in expected_cookies:
             # Strong guarantee: the raw cookie value never appears in any kwarg.

--- a/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
+++ b/klai-knowledge-ingest/tests/test_crawler_login_indicator.py
@@ -200,6 +200,7 @@ class TestRunCrawlJobAuthWall:
             login_indicator_selector="#login-form",
             authenticated_context=True,
             connector_id=None,
+            resource_key=None,
         )
 
         # Verify at least one UPDATE marked the job as failed with auth_wall_detected.
@@ -292,6 +293,7 @@ class TestRunCrawlJobAuthWall:
             login_indicator_selector=None,
             authenticated_context=True,
             connector_id=None,
+            resource_key=None,
         )
 
         terminal_updates = [

--- a/klai-knowledge-ingest/tests/test_enrichment_dedup.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_dedup.py
@@ -42,6 +42,10 @@ def _make_mock_app(side_effect=None):
     mock_app = MagicMock()
     mock_app.enrich_document_bulk = task_fn
     mock_app.enrich_document_interactive = interactive_task_fn
+    graphiti_configured = MagicMock()
+    graphiti_configured.defer_async = AsyncMock(return_value=None)
+    mock_app.ingest_graphiti_episode.configure = MagicMock(return_value=graphiti_configured)
+    mock_app.graphiti_configured = graphiti_configured
     return mock_app, task_fn, configured
 
 
@@ -54,7 +58,7 @@ def _make_mock_conn() -> MagicMock:
     return conn
 
 
-def _base_patches(mock_app, *, enrichment_enabled: bool = True):
+def _base_patches(mock_app, *, enrichment_enabled: bool = True, graphiti_enabled: bool = False):
     """Return a context manager stack with all ingest_document dependencies mocked.
 
     SPEC-TI-003-FOLLOWUP-001: ingest_document now takes conn explicitly,
@@ -147,7 +151,7 @@ def _base_patches(mock_app, *, enrichment_enabled: bool = True):
         ):
             # Disable the graphiti enqueue branch — these tests focus on
             # the enrichment-defer contract, not the FalkorDB pipeline.
-            mock_settings.graphiti_enabled = False
+            mock_settings.graphiti_enabled = graphiti_enabled
             mock_settings.chunk_size = 1500
             mock_settings.chunk_overlap = 200
             mock_settings.enrichment_enabled = True
@@ -307,6 +311,37 @@ async def test_connector_ingest_still_finishes_raw_index_as_synced():
 
     assert result["status"] == "ok"
     calls.set_ingest_status.assert_awaited_once_with(conn, "art-test", "org-1", "synced")
+
+
+@pytest.mark.asyncio
+async def test_connector_ingest_threads_resource_key_to_artifact_and_writer_jobs():
+    from knowledge_ingest.models import IngestRequest
+    from knowledge_ingest.routes.ingest import ingest_document
+
+    mock_app, _, enrichment_configured = _make_mock_app()
+    conn = _make_mock_conn()
+    req = IngestRequest(
+        org_id="org-1",
+        kb_slug="my-kb",
+        path="connector/page.md",
+        content="# Connector page\n\nContent.",
+        source_type="connector",
+        source_connector_id="connector-1",
+        resource_generation="sync-run-42",
+        content_type="plain_text",
+    )
+
+    async with _base_patches(mock_app, graphiti_enabled=True):
+        await ingest_document(conn, req)
+
+    resource_key = "connector:org-1:my-kb:connector-1:sync-run-42"
+    assert enrichment_configured.defer_async.await_args.kwargs == {
+        "artifact_id": "art-test",
+        "resource_key": resource_key,
+    }
+    assert (
+        mock_app.graphiti_configured.defer_async.await_args.kwargs["resource_key"] == resource_key
+    )
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
+++ b/klai-knowledge-ingest/tests/test_enrichment_loads_from_pg.py
@@ -605,16 +605,13 @@ async def test_load_and_enrich_skips_superseded_artifact():
 # ---------------------------------------------------------------------------
 
 
-def test_task_variants_have_single_arg_signature():
-    """SPEC-INGEST-CONTENT-PG-001: the public task signature must be
-    ``(artifact_id: str)`` — anything else means task-args still carry
-    content and the audit finding 1 race regression is back.
-    """
+def test_task_variants_only_carry_artifact_id_and_resource_key():
+    """Content stays in PostgreSQL; the ownership fence is the only metadata arg."""
     import inspect
 
     from knowledge_ingest import enrichment_tasks
 
     sig = inspect.signature(enrichment_tasks._load_and_enrich)
     params = list(sig.parameters.values())
-    assert len(params) == 1, f"_load_and_enrich must take 1 param, got {params}"
-    assert params[0].name == "artifact_id"
+    assert [param.name for param in params] == ["artifact_id", "resource_key"]
+    assert params[1].default is None

--- a/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
@@ -28,6 +28,7 @@ import pytest
 
 import knowledge_ingest
 from knowledge_ingest import enrichment_tasks, queues
+from knowledge_ingest.connector_state import FenceState
 from knowledge_ingest.episode_text import MAX_TEXT_CHARS
 from knowledge_ingest.routes import ingest as ingest_route
 
@@ -70,7 +71,14 @@ async def _fake_conn(org_id):
     yield SimpleNamespace()
 
 
-async def _run(graphiti_task, *, exists: bool, active: bool):
+async def _run(
+    graphiti_task,
+    *,
+    exists: bool,
+    active: bool,
+    resource_key: str | None = None,
+    fence_state: FenceState = FenceState.ACTIVE,
+):
     """Run the task against a stubbed pg_store; return the ingest_episode mock."""
     ingest_episode = AsyncMock(return_value="episode-uuid")
     graph_module = MagicMock()
@@ -91,6 +99,10 @@ async def _run(graphiti_task, *, exists: bool, active: bool):
         patch.object(knowledge_ingest, "pg_store", pg_store),
         patch.object(knowledge_ingest, "graph", graph_module),
         patch.object(enrichment_tasks, "tenant_scoped_connection", _fake_conn),
+        patch(
+            "knowledge_ingest.connector_state.check_connector_resource_fence",
+            new=AsyncMock(return_value=fence_state),
+        ),
     ):
         await graphiti_task(
             artifact_id=_ARTIFACT_ID,
@@ -98,6 +110,7 @@ async def _run(graphiti_task, *, exists: bool, active: bool):
             org_id=_ORG_ID,
             content_type="text/markdown",
             belief_time_start=0,
+            resource_key=resource_key,
         )
     return ingest_episode
 
@@ -154,6 +167,27 @@ async def test_active_artifact_still_reaches_the_graph(graphiti_task):
     """The guard must not break the normal path it is wrapped around."""
     ingest_episode = await _run(graphiti_task, exists=True, active=True)
     ingest_episode.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rebuild_fences_old_graphiti_generation_but_allows_new_generation(graphiti_task):
+    old_job = await _run(
+        graphiti_task,
+        exists=True,
+        active=True,
+        resource_key="connector:368884765035593759:support:connector-1:old-run",
+        fence_state=FenceState.STALE_GENERATION,
+    )
+    new_job = await _run(
+        graphiti_task,
+        exists=True,
+        active=True,
+        resource_key="connector:368884765035593759:support:connector-1:new-run",
+        fence_state=FenceState.ACTIVE,
+    )
+
+    old_job.assert_not_awaited()
+    new_job.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_resource_jobs.py
+++ b/klai-knowledge-ingest/tests/test_resource_jobs.py
@@ -1,0 +1,123 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge_ingest.queues import CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK
+from knowledge_ingest.resource_jobs import (
+    CONNECTOR_WRITER_QUEUES,
+    ConnectorResource,
+    cancel_jobs_by_resource_key,
+    connector_resource_key,
+    get_resource_job_counts,
+    list_live_jobs_by_resource_key,
+    parse_connector_resource_key,
+)
+
+
+def test_connector_resource_key_is_stable_and_exact_matchable() -> None:
+    assert (
+        connector_resource_key("org-1", "support", "connector-7", "run-42")
+        == "connector:org-1:support:connector-7:run-42"
+    )
+
+
+def test_parse_connector_resource_key_returns_all_authority_fields() -> None:
+    assert parse_connector_resource_key("connector:org-1:support:connector-7:run-42") == (
+        ConnectorResource(
+            org_id="org-1",
+            kb_slug="support",
+            connector_id="connector-7",
+            generation="run-42",
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "resource_key",
+    [
+        "",
+        "artifact:org-1:support:connector-7:run-42",
+        "connector:org-1:support:connector-7",
+        "connector:org-1:support:connector-7:run-42:extra",
+        "connector:org-1::connector-7:run-42",
+        "connector:org-1:support:connector-7:",
+    ],
+)
+def test_parse_connector_resource_key_rejects_malformed_keys(resource_key: str) -> None:
+    with pytest.raises(ValueError, match="connector resource key"):
+        parse_connector_resource_key(resource_key)
+
+
+def test_connector_resource_key_rejects_delimiter_in_components() -> None:
+    with pytest.raises(ValueError, match="generation"):
+        connector_resource_key("org-1", "support", "connector-7", "run:42")
+
+
+def test_connector_writer_queues_are_explicit() -> None:
+    assert CONNECTOR_WRITER_QUEUES == (CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK)
+
+
+def _pool_with_rows(rows):
+    conn = MagicMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    acquire = MagicMock()
+    acquire.__aenter__ = AsyncMock(return_value=conn)
+    acquire.__aexit__ = AsyncMock(return_value=None)
+    pool = MagicMock()
+    pool.acquire.return_value = acquire
+    return pool, conn
+
+
+@pytest.mark.asyncio
+async def test_live_job_lookup_filters_exact_resource_key_and_3x_live_statuses() -> None:
+    pool, conn = _pool_with_rows([{"id": 11}, {"id": 12}])
+
+    assert await list_live_jobs_by_resource_key(pool, "connector:o:k:c:g") == [11, 12]
+
+    sql = conn.fetch.await_args.args[0]
+    assert "args->>'resource_key' = $2" in sql
+    assert "status IN ('todo', 'doing')" in sql
+    assert "aborting" not in sql
+    assert "args::text" not in sql
+
+
+@pytest.mark.asyncio
+async def test_cancel_jobs_preserves_rows_and_requests_abort() -> None:
+    pool, _ = _pool_with_rows([{"id": 11}])
+    proc_app = MagicMock()
+    proc_app.job_manager.cancel_job_by_id_async = AsyncMock()
+
+    report = await cancel_jobs_by_resource_key(proc_app, pool, "connector:o:k:c:g")
+
+    assert (report.jobs_found, report.jobs_cancelled, report.jobs_failed_to_cancel) == (1, 1, 0)
+    proc_app.job_manager.cancel_job_by_id_async.assert_awaited_once_with(
+        11, abort=True, delete_job=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_job_counts_use_procrastinate_3x_taxonomy() -> None:
+    pool, conn = _pool_with_rows(
+        [
+            {"status": status, "count": 1}
+            for status in ("todo", "doing", "cancelled", "aborted", "failed", "succeeded")
+        ]
+    )
+
+    counts = await get_resource_job_counts(pool, "connector:o:k:c:g")
+
+    assert counts == {
+        "todo": 1,
+        "doing": 1,
+        "cancelled": 1,
+        "aborted": 1,
+        "failed": 1,
+        "succeeded": 1,
+        "pending": 1,
+        "running": 1,
+        "terminal": 4,
+        "failed_visible": 1,
+    }
+    sql = conn.fetch.await_args.args[0]
+    assert "args->>'resource_key' = $1" in sql
+    assert "aborting" not in sql


### PR DESCRIPTION
Implements SPEC-CONNECTOR-CANCEL-001: one canonical `resource_key` + fence contract for connector-scoped async jobs.

- Fixes the (confirmed dead) `_cancel_enrichment_jobs` filter: enrichment args carry only `artifact_id` since SPEC-INGEST-CONTENT-PG-001, so the old `extra_payload` WHERE clause never matched — enrichment cancellation on connector delete was a silent no-op.
- Exact-match cancellation on `args->>'resource_key'` (`todo`/`doing`, `abort=True`, `delete_job=False`) + legacy artifact-id fallback for the rollout window.
- Fence checks (fail-closed) before expensive work and fresh before irreversible writes; ≤5s cache on the crawl per-page path.
- Monitoring helper with Procrastinate 3.x status vocabulary (`aborted`, no `aborting`).
- Alembic `0013_connector_resource_fences`.

**Deploy note:** knowledge-ingest has NO auto-migrate on container start. After deploy: `docker exec klai-core-knowledge-ingest-1 alembic upgrade head` (operator action, will be run right after this deploy).

Verified: 1710 ingest + 24 connector tests pass, ruff clean, single alembic head.
Implemented by codex gpt-5.6-sol; second-pass verified by Claude.

Rollback: `git revert` of the squash commit; the fence table is additive and can stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)