### PR TITLE
feat(retrieval-api): RetrievalTrace for /retrieve (SPEC-RETRIEVAL-TRACE-001 Units 1-4)

### DIFF
--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/acceptance.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/acceptance.md
@@ -1,0 +1,140 @@
+---
+id: SPEC-RETRIEVAL-TRACE-001
+acceptance_for: spec.md
+created: 2026-05-08
+updated: 2026-05-08
+author: Mark Vletter
+---
+
+# Acceptance -- SPEC-RETRIEVAL-TRACE-001
+
+This document is the executable contract for the SPEC. Every item maps to requirements in `spec.md`.
+
+## How to run
+
+Focused local test surface:
+
+```bash
+cd klai-retrieval-api
+uv run pytest tests/test_retrieval_trace.py tests/test_api.py tests/test_confidence_band.py
+```
+
+If `tests/test_api.py` is too broad for the first implementation PR, run the existing focused retrieve tests plus the new trace tests and state the narrower command in the PR description.
+
+## Acceptance Criteria
+
+### AC-1 -- Trace object renders compatible decision record
+
+**Given** a `RetrievalTrace` populated with a normal retrieval happy path,
+**when** `to_decision_record()` is called,
+**then** the rendered dict MUST contain the current flat keys:
+
+- `coreference_rewrite` (only when telemetry level allows content)
+- `coreference_ms`
+- `embedding_ms`
+- `gate_margin`
+- `gate_bypassed`
+- `gate_ms`
+- `router`
+- `search_ms`
+- `search_candidates_count`
+- `rerank_ms`
+- `reranker_scores_top5`
+- `quality_floor_filtered`
+- `source_select`
+- `quality_boost_applied`
+- `evidence_shadow_mode`
+- `link_expand`
+- `confidence_band`
+- `total_ms`
+- `retention_class`
+
+This list mirrors REQ-3 exactly — all 19 REQ-3 keys have an explicit check here. The dict MAY also contain `trace_steps`.
+
+### AC-2 -- Step order is stable
+
+**Given** a successful non-bypassed retrieval call,
+**when** the `retrieval_decision_record` log is captured in tests,
+**then** `trace_steps[*].name` MUST follow pipeline order for all executed steps:
+
+`coreference -> embed -> gate -> router -> qdrant_search -> graph_search -> link_expand -> rerank -> quality_floor -> source_select -> quality_boost -> evidence_tier -> parent_lookup -> response_build -> confidence_band -> total`
+
+`shadow_write` and `product_event` are NOT trace steps in v1 — they execute after the `retrieval_decision_record` emission (see spec REQ-2). Skipped steps may appear in the same order with `status="skipped"`. Steps in follow-up scope (spec REQ-8 slice 4) may be absent from `trace_steps` in the first PR as long as the relative order of present steps matches this list.
+
+### AC-3 -- Gate bypass records explicit skips
+
+**Given** `gate.should_bypass(...)` returns `True`,
+**when** `/retrieve` completes,
+**then** the response behavior MUST match current behavior and the trace MUST include skipped records for downstream retrieval work with `skipped_reason="gate_bypassed"` where applicable.
+
+At minimum, `qdrant_search`, `graph_search`, `link_expand`, `rerank`, `parent_lookup`, and `response_build` MUST NOT appear as successful executed retrieval steps on a bypassed request.
+
+### AC-4 -- Privacy gating removes content outside full telemetry
+
+**Given** a trace containing raw query and resolved query content,
+**when** it is rendered with `telemetry_level="shadow"` or `telemetry_level="off"`,
+**then** the rendered decision record MUST NOT contain raw query text, resolved query text, or `coreference_rewrite`.
+
+**And when** the same trace is rendered with `telemetry_level="full"`,
+**then** current full-mode content behavior MAY be preserved and `retention_class` MUST be `content`.
+
+### AC-5 -- Fail-open graph search remains fail-open
+
+**Given** `settings.graphiti_enabled == true` and `graph_search.search(...)` raises,
+**when** `/retrieve` completes,
+**then** the endpoint MUST still return the Qdrant-based response as it does today,
+**and** the trace MUST contain a `graph_search` step with:
+
+- `status="error"`;
+- `error_type` set;
+- no raw query text;
+- no traceback string.
+
+### AC-6 -- Existing metrics are unchanged
+
+**Given** the trace migration is complete,
+**when** the focused retrieval tests run,
+**then** no existing metric import or label expectation fails.
+
+Manual review in the PR MUST confirm these names still exist:
+
+- `step_latency_seconds`
+- `retrieval_requests_total`
+- `retrieval_chunks_total`
+- `retrieval_confidence_band_total`
+- `retrieval_link_expand_top_k_total`
+- `telemetry_level_decisions_total`
+- `quality_floor_filtered_total`
+
+### AC-7 -- Trace emission failure does not fail retrieve
+
+**Given** `RetrievalTrace.to_decision_record()` is forced to raise in a test double,
+**when** `/retrieve` otherwise succeeds,
+**then** the endpoint MUST still return a normal `RetrieveResponse`,
+**and** a log event named `retrieval_trace_emit_failed` or equivalent MUST be emitted.
+
+### AC-8 -- No ranking behavior changes
+
+**Given** fixed mocks for search, rerank, quality floor, source selection, quality boost, evidence tier, and parent lookup,
+**when** the same request is run before and after trace migration,
+**then** returned chunk IDs, ordering, scores, `confidence_band`, and metadata MUST be identical.
+
+This can be implemented as a golden retrieve test or by extending an existing `test_api.py` fixture.
+
+### AC-9 -- Wrapper overhead is negligible
+
+**Given** a unit benchmark or simple local timing test around a representative trace with all initial steps,
+**when** 1,000 trace records are created and rendered,
+**then** average overhead MUST be below 1 ms per request on a developer machine.
+
+This is not a CI performance gate unless the project already has benchmark support. A PR note with local output is sufficient for v0.1.0.
+
+### AC-10 -- Developer contract is documented
+
+**Given** the SPEC implementation PR is ready,
+**then** either `retrieval_api/tracing.py` docstring or the PR description MUST document:
+
+- how to add a new step;
+- when to use metadata vs content fields;
+- allowed skipped reasons;
+- that trace wrappers must preserve existing exception behavior.

--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/plan.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/plan.md
@@ -1,0 +1,181 @@
+---
+id: SPEC-RETRIEVAL-TRACE-001
+plan_for: spec.md
+created: 2026-05-08
+updated: 2026-05-08
+author: Mark Vletter
+---
+
+# Implementation Plan -- SPEC-RETRIEVAL-TRACE-001
+
+## 0. Pre-flight
+
+1. Run the focused retrieval-api tests before changing code:
+   ```bash
+   cd klai-retrieval-api
+   uv run pytest tests/test_api.py tests/test_confidence_band.py
+   ```
+2. Capture one representative current `retrieval_decision_record` from a local happy-path test or fixture. Use it as the compatibility target for flat keys.
+3. Confirm `telemetry_level` behavior from `retrieve.py`: canonical level is resolved before pipeline work, `structlog.contextvars` is bound, and current privacy gating removes `coreference_rewrite` unless `effective_level == "full"`.
+
+## 1. Unit 1 -- Trace module with no call-site migration
+
+Add `klai-retrieval-api/retrieval_api/tracing.py`.
+
+Suggested internal types:
+
+```python
+TraceStatus = Literal["ok", "skipped", "error"]
+TelemetryLevel = Literal["off", "shadow", "full"]
+StepName = Literal[
+    "coreference",
+    "embed",
+    "gate",
+    "router",
+    "qdrant_search",
+    "graph_search",
+    "link_expand",
+    "rerank",
+    "quality_floor",
+    "source_select",
+    "quality_boost",
+    "evidence_tier",
+    "parent_lookup",
+    "response_build",
+    "confidence_band",
+    "total",
+]
+```
+
+(`shadow_write` and `product_event` are deliberately absent — they run after the
+`retrieval_decision_record` emission; see spec REQ-2.)
+
+Keep implementation lightweight: dataclasses and `time.perf_counter()`. Avoid Pydantic for internal trace objects unless tests show a need.
+
+Tests:
+
+- `klai-retrieval-api/tests/test_retrieval_trace.py`
+- construct trace, add metadata, add content, render under `full`, `shadow`, and `off`;
+- assert content is absent outside `full`;
+- assert `retention_class` follows rendered content.
+
+## 2. Unit 2 -- Compatibility renderer
+
+Implement render helpers that can produce:
+
+- `to_decision_record()` -- flat compatibility dict plus optional `trace_steps`;
+- `to_log_kwargs()` -- safe kwargs for `logger.info("retrieval_decision_record", ...)`;
+- `mark_skipped(name, reason, **metadata)`;
+- `record_ok(name, duration_ms, **metadata)`;
+- `record_error(name, exc, duration_ms, safe_message=None, **metadata)`.
+
+Before touching `/retrieve`, add golden tests that build a trace manually and assert the flat keys match current names:
+
+- `coreference_ms`;
+- `embedding_ms`;
+- `gate_margin`;
+- `gate_bypassed`;
+- `search_ms`;
+- `rerank_ms`;
+- `link_expand`;
+- `confidence_band`;
+- `total_ms`;
+- `retention_class`.
+
+## 3. Unit 3 -- Low-risk migration in retrieve.py
+
+Create `trace = RetrievalTrace(...)` after `effective_level` is resolved and `request_id` can be read from structlog contextvars or generated.
+
+Migrate only these fields first:
+
+- `coreference_rewrite`
+- `coreference_ms`
+- `embedding_ms`
+- `gate_margin`
+- `gate_bypassed`
+- `gate_ms`
+- `confidence_band`
+- `total_ms`
+- `retention_class`
+
+Keep the existing local variables (`query_resolved`, `query_vector`, `bypassed`, etc.) unchanged. The trace should replace writes to `decision_record`, not control the pipeline.
+
+Tests:
+
+- existing retrieval-api tests remain green;
+- new test asserts `retrieval_decision_record` still contains old flat keys.
+
+## 4. Unit 4 -- Optional/fail-open steps
+
+Migrate optional steps where explicit skip/error state is highest value:
+
+- `router`: skipped for `kb_slugs is not None`, router disabled, scope not org/both, gate bypassed, not enough source labels.
+- `graph_search`: skipped when `graphiti_enabled` false; `error` when graph task fails and current code logs warning.
+- `link_expand`: skipped when disabled, no raw results, no candidate URLs. Record the authority-boost application (SPEC-CRAWLER-003 R17) as metadata on this step.
+
+`shadow_write` and `product_event` are NOT wrapped: they execute after the `retrieval_decision_record` log emission and cannot appear in the emitted trace without reordering the pipeline (out of scope for an observability-only change).
+
+Preserve all existing log lines and metrics. The trace adds shape; it does not replace operational warnings yet.
+
+**This unit is the end of the first implementation PR.** Units 5 and 6 below are an explicit follow-up PR, to start only after Units 1-4 have landed and proven stable.
+
+## 5. Unit 5 -- Candidate-transform steps (FOLLOW-UP PR — not in first implementation)
+
+Wrap the remaining candidate-transform sections:
+
+- `qdrant_search`
+- `rerank`
+- `quality_floor`
+- `source_select`
+- `quality_boost`
+- `evidence_tier`
+- `parent_lookup`
+- `response_build`
+
+At this point remove duplicated timing variables only when the trace value is already proven by tests. Do not combine behavioral refactors with this unit.
+
+## 6. Unit 6 -- Metrics cleanup and docs (docs part lands with the first PR; metrics-dedup part follows Unit 5)
+
+Where a step duration is recorded in both trace and `step_latency_seconds`, use a single measured duration for both. Do not rename metrics or labels.
+
+Add a short PR note or code comment near `RetrievalTrace`:
+
+- use `trace.meta(...)` for counts, booleans, scores, durations;
+- use `trace.content(...)` for raw/resolved query text;
+- prefer stable skip reasons;
+- never put payload dumps, chunk text, credentials, URLs, or source text into error metadata.
+
+## 7. File-impact summary
+
+Expected files:
+
+```text
+klai-retrieval-api/
+  retrieval_api/
+    tracing.py                  # NEW
+    api/retrieve.py             # incremental trace writes/wrappers
+  tests/
+    test_retrieval_trace.py     # NEW
+    test_api.py                 # extend only where needed for log-shape assertions
+```
+
+No migrations, no frontend changes, no LiteLLM-hook changes, no deploy config changes.
+
+## 8. Pre-merge checklist
+
+- [ ] Existing flat `retrieval_decision_record` keys preserved.
+- [ ] `trace_steps` present and ordered in at least one happy-path log assertion.
+- [ ] Gate-bypass path marks downstream retrieval steps skipped.
+- [ ] Graph-search fail-open path records `status=error` and still returns response.
+- [ ] `telemetry_level=shadow` and `off` render no raw/resolved query text.
+- [ ] Existing Prometheus metric names and labels unchanged.
+- [ ] Focused retrieval-api tests pass.
+- [ ] PR description states this is observability-only and includes no ranking behavior change.
+
+## 9. Rollback
+
+Rollback is code-only:
+
+1. Disable use of `RetrievalTrace` in `/retrieve` and restore direct `decision_record` writes.
+2. Leave `retrieval_api/tracing.py` and tests in tree if harmless, or remove them in the rollback PR.
+3. No data rollback required; emitted `trace_steps` are additive log fields.

--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
@@ -1,0 +1,323 @@
+---
+id: SPEC-RETRIEVAL-TRACE-001
+version: "0.1.0"
+status: draft
+created: 2026-05-08
+updated: 2026-05-08
+author: Mark Vletter
+priority: high
+related:
+  - SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001
+  - SPEC-PRIVACY-QUERY-SHADOW-001
+  - SPEC-SEC-IDENTITY-ASSERT-001
+  - SPEC-RAG-PARENT-CHILD-001
+  - SPEC-KB-021
+references:
+  - docs/architecture/knowledge-retrieval-flow.md
+  - docs/knowledge-retrieval-low-confidence-abstain-2026-05-08.md
+  - .claude/rules/klai/projects/knowledge.md
+  - klai-retrieval-api/retrieval_api/api/retrieve.py
+---
+
+# HISTORY
+
+| Datum | Versie | Wijziging |
+|-------|--------|-----------|
+| 2026-05-08 | 0.1.0 | Initial draft. Introduceert `RetrievalTrace` en kleine step wrappers rond `/retrieve` als incrementele vervanging voor ad-hoc mutaties op `decision_record`, met behoud van het bestaande `retrieval_decision_record` logcontract. |
+
+---
+
+# SPEC-RETRIEVAL-TRACE-001: RetrievalTrace voor /retrieve
+
+## Summary
+
+Introduceer een typed `RetrievalTrace` object en dunne step wrappers in `klai-retrieval-api/retrieval_api/api/retrieve.py`, zodat de lange `/retrieve` pipeline haar beslissingen, timings, skips en errors consistent vastlegt zonder een volledige rewrite van de retrieval flow.
+
+De eerste versie is bewust pragmatisch:
+
+- geen nieuwe service;
+- geen schema-migratie;
+- geen verandering aan retrieval-ranking of promptgedrag;
+- geen breaking change in het bestaande `retrieval_decision_record` event;
+- wel een centrale typed trace die het huidige mutable `decision_record: dict = {}` vervangt als primaire schrijfplek.
+
+Het einddoel is niet "mooie code" op zichzelf. Het doel is dat toekomstige retrieval-wijzigingen, zoals extra chunkvelden, router-lagen, parent-expansion, privacy-gating en confidence-band tuning, niet opnieuw door de handler heen handmatig timings en dict keys hoeven te threaden.
+
+## Motivation
+
+`/retrieve` is inmiddels de drukste retrieval-pipeline van Klai. De handler doet in een enkel pad:
+
+- identity verification;
+- canonical telemetry-level resolving;
+- coreference rewrite;
+- dense + sparse embedding;
+- gate decision;
+- router source selection;
+- Qdrant search;
+- optional Graphiti search;
+- link expansion;
+- rerank;
+- link-expand score boost;
+- quality-floor filtering;
+- source-aware selection;
+- quality boost;
+- evidence-tier shadow scoring;
+- parent-child text expansion;
+- `ChunkResult` assembly;
+- confidence-band emit;
+- privacy-gated `retrieval_decision_record`;
+- shadow telemetry write;
+- `knowledge.queried` product event.
+
+De huidige observability groeit mee via een mutable `decision_record` dict die op veel plekken in de handler wordt aangepast. Dat werkt, maar het heeft drie terugkerende risico's:
+
+1. **Field threading bugs.** Klai heeft al bugs gehad waarbij een retrieval field door een van de serialisatiegrenzen wegviel. De kennisregel noemt expliciet de 7 lagen van Qdrant payload naar frontend citation.
+2. **Observability drift.** Nieuwe stappen voegen eigen timing keys, counters en logvelden toe. Daardoor is niet altijd duidelijk of een stap succesvol, skipped, disabled, bypassed of failed was.
+3. **Privacy-gating is te laat en te handmatig.** `effective_level` wordt correct bepaald en raw query content wordt nu vlak voor emit uit `decision_record` verwijderd. Nieuwe tracevelden kunnen dat per ongeluk omzeilen als ze raw content buiten de bekende keys stoppen.
+
+Deze SPEC maakt observability een first-class contract voor `/retrieve`: elke pipeline-stap registreert dezelfde shape, en compatibiliteit met het bestaande `retrieval_decision_record` blijft de migratiegrens.
+
+## Scope
+
+### In scope
+
+**Retrieval-api**
+
+- Nieuwe typed trace module, bijvoorbeeld `retrieval_api/tracing.py`.
+- `RetrievalTrace` object dat per request wordt aangemaakt in `/retrieve`.
+- `trace.step(...)` wrapper/contextmanager voor sync en async stappen.
+- Step metadata: `name`, `status`, `duration_ms`, `skipped_reason`, `error_type`, `error_message_safe`, en optionele typed details.
+- Centrale privacy/telemetry-level gating voordat trace data naar structlog of shadow-store gaat.
+- Backwards-compatible render naar het bestaande `retrieval_decision_record` event.
+- Tests rond trace shape, timing, skipped/error metadata, privacy gating en compatibiliteit.
+- Incrementele migratie van `/retrieve`: start met de stappen waar vandaag al timing/decision-record velden bestaan; laat rankinggedrag ongemoeid.
+
+**Documentation / runbook**
+
+- Korte developer-notitie in de SPEC/PR over hoe nieuwe retrieval-stappen trace data moeten toevoegen.
+- Geen brede architectuurdoc rewrite in deze SPEC.
+
+### Out of scope
+
+- Volledige opsplitsing van `retrieve.py` in een pipeline framework.
+- Nieuwe distributed tracing backend, OpenTelemetry spans, Jaeger, of vendor-integratie.
+- Nieuwe product-events of BI-schema's.
+- Verandering aan ranking, reranker, graph search, link expansion, parent expansion, confidence thresholds of prompt-injectie.
+- Wijziging van de response body van `/retrieve`, behalve als een toekomstige SPEC apart een debug-only trace response contract definieert.
+- Retentieconfiguratie in VictoriaLogs. Deze SPEC respecteert de bestaande telemetry-level en retention-class contracten.
+
+## Functional Requirements
+
+### REQ-1 -- Typed trace object
+
+**THE retrieval-api SHALL** introduce a typed `RetrievalTrace` object for one `/retrieve` request.
+
+Minimum constructor inputs:
+
+- `request_id: str`
+- `org_id: str`
+- `scope: str`
+- `telemetry_level: Literal["off", "shadow", "full"]`
+- `started_at: float` or equivalent monotonic timestamp
+
+The object SHALL own:
+
+- ordered step records;
+- top-level decision fields that are not naturally tied to one step;
+- compatibility rendering for `retrieval_decision_record`;
+- privacy-gated rendering for logs.
+
+The object MUST NOT perform retrieval work itself. It is an observability/data-collection helper, not a pipeline orchestrator.
+
+### REQ-2 -- Step wrapper records status consistently
+
+**THE retrieval-api SHALL** provide a step wrapper for retrieval pipeline sections. For every wrapped step it MUST record:
+
+- `name`;
+- `status`: `ok`, `skipped`, or `error`;
+- `duration_ms`;
+- `skipped_reason` when status is `skipped`;
+- `error_type` and safe error metadata when status is `error`;
+- optional step-specific fields.
+
+The wrapper MUST preserve existing exception semantics. If a step currently raises and aborts the request, wrapping it MUST still raise. If a step currently catches and logs a failure, wrapping it MUST record `status=error` and allow the existing fail-open behavior to continue.
+
+Initial step names:
+
+| Step | Existing code surface |
+|------|-----------------------|
+| `coreference` | `coreference.resolve` |
+| `embed` | `embed_single` + `embed_sparse` gather |
+| `gate` | `gate.should_bypass` |
+| `router` | `fetch_source_catalog` + `route_to_sources` |
+| `qdrant_search` | `search.hybrid_search` |
+| `graph_search` | `graph_search.search` |
+| `link_expand` | `search.fetch_chunks_by_urls` |
+| `rerank` | `reranker.rerank` |
+| `quality_floor` | `filter_quality_floor` |
+| `source_select` | `source_aware_select` |
+| `quality_boost` | `quality_boost` |
+| `evidence_tier` | `evidence_tier.apply` |
+| `parent_lookup` | `parent_lookup.fetch_parents` |
+| `response_build` | `ChunkResult(...)` assembly |
+| `confidence_band` | `_compute_confidence_band` |
+
+Deliberately **not** separate steps in v1:
+
+- `write_shadow` and `emit_event("knowledge.queried", ...)` run **after** the `retrieval_decision_record` log emission in the current pipeline. Including them as trace steps would require deferring the log emission until after those calls — an ordering/behavior change that does not belong in an observability-only PR. They keep their existing own log lines; a follow-up SPEC may fold them in if the emission point moves.
+- The two score-mutating micro-blocks (authority boost, SPEC-CRAWLER-003 R17, between link-expand and rerank; and `_apply_link_expand_boost`, SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-3, after rerank) are recorded as metadata fields on the adjacent named step (`link_expand` resp. `rerank`), not as separate steps — this keeps the step vocabulary bounded while still satisfying REQ-9 completeness.
+
+### REQ-3 -- Backwards-compatible retrieval_decision_record
+
+**THE trace SHALL** render a flat dict compatible with the current `retrieval_decision_record` consumers.
+
+The first implementation MUST keep existing top-level keys where dashboards, alerts, docs, or recent SPECs mention them, including at least:
+
+- `coreference_rewrite` when telemetry allows content;
+- `coreference_ms`;
+- `embedding_ms`;
+- `gate_margin`;
+- `gate_bypassed`;
+- `gate_ms`;
+- `router`;
+- `search_ms`;
+- `search_candidates_count`;
+- `rerank_ms`;
+- `reranker_scores_top5`;
+- `quality_floor_filtered`;
+- `source_select`;
+- `quality_boost_applied`;
+- `evidence_shadow_mode`;
+- `link_expand`;
+- `confidence_band`;
+- `total_ms`;
+- `retention_class`.
+
+The render MAY add a nested `trace_steps` array. It MUST NOT remove existing fields in the first migration PR.
+
+### REQ-4 -- Privacy and telemetry-level gating at trace boundary
+
+**THE trace SHALL** centralize privacy gating before any trace data is emitted.
+
+Rules:
+
+- In `telemetry_level != "full"`, raw query text and resolved query text MUST NOT be emitted in `retrieval_decision_record`.
+- In `telemetry_level == "full"`, content-bearing fields MAY be emitted exactly as today.
+- Every step detail field MUST declare whether it is content-bearing or metadata-only, either by explicit API (`trace.content(...)` vs `trace.meta(...)`) or by typed field definition.
+- The rendered record MUST set `retention_class="content"` only when content-bearing fields are present and allowed.
+- Defense-in-depth structlog processors remain in place; this SPEC does not rely on them as the primary gate.
+
+### REQ-5 -- Skipped metadata is explicit
+
+**WHEN** a step is skipped due to gate bypass, disabled config, no candidates, no candidate URLs, shadow mode, or missing verified identity, **THE trace SHALL** record a step with `status="skipped"` and a stable `skipped_reason`.
+
+Minimum skipped reasons:
+
+- `gate_bypassed`
+- `disabled_by_config`
+- `no_candidates`
+- `no_candidate_urls`
+- `reranker_disabled`
+- `shadow_mode`
+- `no_verified_identity`
+
+This replaces the current pattern where missing timing fields imply skip state.
+
+### REQ-6 -- Error metadata is safe and useful
+
+**WHEN** a wrapped fail-open step catches an exception, **THE trace SHALL** record:
+
+- `status="error"`;
+- `error_type`, e.g. `TimeoutError`;
+- `error_message_safe` only when it is known not to contain query text, credentials, source text, or payload dumps;
+- no raw traceback in the trace payload.
+
+The normal logger MAY still emit `exc_info=True` on existing warning/error logs where appropriate. The trace payload itself must remain safe for telemetry-level `shadow`.
+
+### REQ-7 -- Metrics remain stable
+
+**THE implementation SHALL NOT** remove or rename existing Prometheus metrics as part of this SPEC.
+
+Existing calls to `step_latency_seconds`, `retrieval_confidence_band_total`, `retrieval_link_expand_top_k_total`, `telemetry_level_decisions_total`, `retrieval_requests_total`, `retrieval_chunks_total`, and `quality_floor_filtered_total` may move behind helper functions only if their label cardinality and increment/observe semantics remain unchanged.
+
+Note: the Prometheus `step` label vocabulary in `metrics.py` (`coref`, `qdrant`, `graph`, `embed`, ...) intentionally differs from the trace `StepName` vocabulary (`coreference`, `qdrant_search`, `graph_search`, `embed`, ...). The two are not meant to be joined; do NOT rename the Prometheus labels to match the trace — that would break existing dashboards.
+
+### REQ-8 -- Incremental migration, no pipeline rewrite
+
+**THE implementation SHALL** migrate `/retrieve` in small slices:
+
+1. Add `RetrievalTrace` and tests without changing `/retrieve`.
+2. Wrap low-risk pure/timing-only steps first (`coreference`, `embed`, `gate`, `confidence_band`, `total`).
+3. Wrap optional/fail-open steps next (`router`, `graph_search`, `link_expand`).
+4. Wrap candidate-transform steps last (`qdrant_search`, `rerank`, `quality_floor`, `source_select`, `quality_boost`, `evidence_tier`, `parent_lookup`, `response_build`).
+
+Each slice MUST keep tests green before the next slice starts. Slices 1-3 are the scope of the first implementation PR; slice 4 is an explicit follow-up PR once slices 1-3 have proven stable (it carries the highest regression surface for the least incremental observability value).
+
+### REQ-9 -- Trace helper enforces stable step names
+
+**THE trace module SHALL** define step names as constants or a `Literal`/enum type. New ad-hoc string names in `/retrieve` are not allowed once the helper exists.
+
+This is to keep Grafana, VictoriaLogs queries, and regression tests from drifting due to spelling differences like `qdrant`, `search`, and `qdrant_search`.
+
+### REQ-10 -- Tests cover compatibility and privacy
+
+**THE implementation SHALL** add tests that prove:
+
+- existing flat `retrieval_decision_record` keys still render;
+- `trace_steps` order follows pipeline order;
+- skipped steps include stable reasons;
+- fail-open errors become `status="error"` without changing response behavior;
+- `telemetry_level="shadow"` removes raw query and resolved query text;
+- `telemetry_level="full"` keeps content-bearing fields where current behavior does;
+- gate-bypassed requests still emit total/gate metadata and mark downstream retrieval steps skipped.
+
+## Non-Functional Requirements
+
+- **Latency:** wrapper overhead MUST be below 1 ms p95 per request on local unit/benchmark coverage. The implementation should use `time.perf_counter()` and simple dataclasses/Pydantic-free internal records unless a stronger reason appears.
+- **Compatibility:** existing dashboards and VictoriaLogs queries against `retrieval_decision_record` MUST continue to work during the first release.
+- **Fail-open:** trace emission failure MUST NOT fail `/retrieve`. If rendering the trace raises unexpectedly, retrieval should return normally and log `retrieval_trace_emit_failed`.
+- **Low cardinality:** step names and skipped reasons MUST be bounded constants. No query text, chunk IDs, URLs, exception messages, or tenant-specific values in metric labels.
+- **No cross-service lockstep deploy:** LiteLLM-hook, portal-api, MCP, and frontend must not need same-day changes.
+
+## Architecture Decisions
+
+### A1. Trace object, not pipeline framework
+
+`RetrievalTrace` is intentionally a sidecar. It records what the existing handler did; it does not decide what the handler should do. That keeps the first migration small and avoids entangling observability with ranking behavior.
+
+### A2. Flat compatibility render first
+
+The current `retrieval_decision_record` event is already used by low-confidence diagnostics and privacy-level validation. The first release keeps the flat keys and adds structure beside them. A later SPEC may deprecate flat keys after dashboards and runbooks have moved.
+
+### A3. Privacy at write API boundaries
+
+Trace call sites should make content-vs-metadata explicit when writing. The final renderer still enforces policy, but the API should make it hard to accidentally store raw query text in a metadata field.
+
+### A4. Step wrappers around existing blocks
+
+The handler stays readable during migration: wrap existing blocks, do not extract every step into a new class. Once trace coverage is stable, future refactors can split the pipeline with real behavioral tests in place.
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Compatibility render accidentally changes a `retrieval_decision_record` key | medium | high | Golden tests against a representative happy-path, gate-bypass path, and graph-failure path. First PR keeps old keys top-level. |
+| Trace wrapper hides or swallows an exception | low | high | Wrapper API must default to re-raise. Fail-open behavior is opt-in and tested per step. |
+| New `trace_steps` array leaks query text in shadow/off mode | medium | high | Content-vs-metadata API plus explicit tests for shadow/off rendering. |
+| Added structure makes the already-long handler harder to read | medium | medium | Migrate in slices and remove old duplicated timing variables as each step moves. No broad extraction until after trace tests are in place. |
+| Metrics and trace disagree on timing | medium | low | Use the same measured duration for both trace record and `step_latency_seconds.observe()` where practical. |
+
+## Open Questions
+
+1. Should `trace_steps` include chunk IDs for debugging when `telemetry_level="full"`? Initial answer: no. Keep chunk IDs in shadow-store/write-shadow paths and existing response logs, not per-step trace.
+2. Should `RetrievalTrace` live under `retrieval_api/tracing.py` or `retrieval_api/services/trace.py`? Initial preference: top-level `retrieval_api/tracing.py`, because it is not a retrieval service.
+3. Should skip reasons be emitted to Prometheus as labels? Initial answer: no in v0.1. VictoriaLogs can query `trace_steps`; metrics cardinality stays unchanged.
+
+## Internal References
+
+Note on `related`: `SPEC-PRIVACY-QUERY-SHADOW-001` has no spec directory under `.moai/specs/` anymore — it was implemented and archived. Its requirements survive as code comments in `retrieve.py` and `metrics.py`; treat those as the authoritative reference.
+
+- [Knowledge Retrieval Flow](../../../docs/architecture/knowledge-retrieval-flow.md)
+- [Low-Confidence Abstain implementation notes](../../../docs/knowledge-retrieval-low-confidence-abstain-2026-05-08.md)
+- [Knowledge Domain Patterns](../../../.claude/rules/klai/projects/knowledge.md)
+- [`retrieve.py`](../../../klai-retrieval-api/retrieval_api/api/retrieve.py)

--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
@@ -23,6 +23,7 @@ references:
 
 | Datum | Versie | Wijziging |
 |-------|--------|-----------|
+| 2026-09-01 | 0.1.1 | Implementation note: op origin/main zijn de gate- en evidence-tier-stappen inmiddels uit de pipeline verwijderd (commit 2ce085277, "remove retired retrieval experiments"). De trace rendert voor die stappen compatibiliteitsdefaults / een skipped step; er is geen gate-gedrag heringevoerd. AC-3 is daardoor niet runtime-bereikbaar en geldt als vervallen zolang de gate retired is. |
 | 2026-05-08 | 0.1.0 | Initial draft. Introduceert `RetrievalTrace` en kleine step wrappers rond `/retrieve` als incrementele vervanging voor ad-hoc mutaties op `decision_record`, met behoud van het bestaande `retrieval_decision_record` logcontract. |
 
 ---

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -56,6 +56,7 @@ from retrieval_api.services.router import fetch_source_catalog, route_to_sources
 from retrieval_api.services.tei import embed_single, embed_sparse
 from retrieval_api.services.telemetry import write_shadow
 from retrieval_api.services.tenant_telemetry import get_canonical_level, resolve_effective_level
+from retrieval_api.tracing import RetrievalTrace
 from retrieval_api.util.payload import payload_list
 
 logger = structlog.get_logger(__name__)
@@ -477,6 +478,21 @@ async def retrieve(
     structlog.contextvars.bind_contextvars(telemetry_level=effective_level)
 
     t0 = time.perf_counter()
+    request_id = structlog.contextvars.get_contextvars().get("request_id") or str(uuid.uuid4())
+    trace = RetrievalTrace(
+        request_id=request_id,
+        org_id=req.org_id,
+        scope=req.scope,
+        telemetry_level=effective_level,
+        started_at=t0,
+    )
+    # Gate and evidence-tier experiments were retired in August 2026. Keep
+    # their flat compatibility fields truthful without restoring either
+    # behavior: retrieval never bypasses and evidence shadow mode is inactive.
+    trace.meta("gate_margin", None)
+    trace.meta("gate_bypassed", False)
+    trace.meta("gate_ms", 0.0)
+    trace.meta("evidence_shadow_mode", False)
     # @MX:NOTE: [AUTO] Shadow log for parameter tuning (SPEC-KB-021 Change 4).
     # decision_record accumulates timing + decision data throughout the pipeline
     # and is emitted as retrieval_decision_record at the end of the request.
@@ -499,25 +515,34 @@ async def retrieve(
         # (a 0.0 sample would skew p50/p95 toward zero). coref_ms stays 0.0 for
         # the decision_record + retrieve log.
         coref_ms = 0.0
-        decision_record["coreference_rewrite"] = {
-            "original": req.raw_query,
-            "resolved": query_resolved,
-            "source": "caller",
-        }
-        decision_record["coreference_ms"] = 0.0
+        trace.content(
+            "coreference_rewrite",
+            {
+                "original": req.raw_query,
+                "resolved": query_resolved,
+                "source": "caller",
+            },
+        )
+        trace.meta("coreference_ms", 0.0)
+        trace.record_ok("coreference", 0.0, source="caller")
     else:
         t_coref = time.perf_counter()
-        query_resolved = await coreference.resolve(
-            req.query, req.conversation_history, telemetry_level=effective_level
+        async with trace.step("coreference", started_at=t_coref) as coreference_step:
+            query_resolved = await coreference.resolve(
+                req.query, req.conversation_history, telemetry_level=effective_level
+            )
+            coreference_step.meta("source", "retrieval-api")
+        coref_ms = coreference_step.duration_ms
+        step_latency_seconds.labels(step="coref").observe(coref_ms / 1000)
+        trace.content(
+            "coreference_rewrite",
+            {
+                "original": req.query,
+                "resolved": query_resolved,
+                "source": "retrieval-api",
+            },
         )
-        coref_ms = (time.perf_counter() - t_coref) * 1000
-        step_latency_seconds.labels(step="coref").observe(time.perf_counter() - t_coref)
-        decision_record["coreference_rewrite"] = {
-            "original": req.query,
-            "resolved": query_resolved,
-            "source": "retrieval-api",
-        }
-        decision_record["coreference_ms"] = round(coref_ms, 1)
+        trace.meta("coreference_ms", round(coref_ms, 1))
 
     # 2. Embed resolved query (dense + sparse in parallel). When coreference /
     # query rewrite changed the query, also embed the user's pre-rewrite
@@ -526,18 +551,24 @@ async def retrieve(
     # name like "Salesforce" — that an over-eager rewrite would otherwise drop
     # from the candidate pool, where the reranker can no longer recover them.
     t_embed = time.perf_counter()
-    raw_query = req.raw_query if req.raw_query and req.raw_query != query_resolved else None
-    embed_coros = [embed_single(query_resolved), embed_sparse(query_resolved)]
-    if raw_query is not None:
-        embed_coros += [embed_single(raw_query), embed_sparse(raw_query)]
-    embedded = await asyncio.gather(*embed_coros)
-    query_vector, sparse_vector = embedded[0], embedded[1]
-    raw_query_vector = embedded[2] if raw_query is not None else None
-    raw_sparse_vector = embedded[3] if raw_query is not None else None
-    embed_ms = (time.perf_counter() - t_embed) * 1000
-    step_latency_seconds.labels(step="embed").observe(time.perf_counter() - t_embed)
-    decision_record["embedding_ms"] = round(embed_ms, 1)
+    async with trace.step("embed", started_at=t_embed) as embed_step:
+        raw_query = req.raw_query if req.raw_query and req.raw_query != query_resolved else None
+        embed_coros = [embed_single(query_resolved), embed_sparse(query_resolved)]
+        if raw_query is not None:
+            embed_coros += [embed_single(raw_query), embed_sparse(raw_query)]
+        embedded = await asyncio.gather(*embed_coros)
+        query_vector, sparse_vector = embedded[0], embedded[1]
+        raw_query_vector = embedded[2] if raw_query is not None else None
+        raw_sparse_vector = embedded[3] if raw_query is not None else None
+        embed_step.meta("raw_query_leg_applied", raw_query is not None)
+    embed_ms = embed_step.duration_ms
+    step_latency_seconds.labels(step="embed").observe(embed_ms / 1000)
+    trace.meta("embedding_ms", round(embed_ms, 1))
     decision_record["raw_query_leg_applied"] = raw_query is not None
+
+    # The retired gate has no runtime work. Its explicit skipped step keeps the
+    # trace vocabulary stable without reintroducing retrieval bypass behavior.
+    trace.mark_skipped("gate", "disabled_by_config")
 
     chunks_out: list[ChunkResult] = []
     candidates_retrieved = 0
@@ -564,29 +595,40 @@ async def retrieve(
     # 3b. Query router — identifies relevant sources for post-rerank selection
     router_meta: dict = {"router_decision": None, "router_layer_used": "skipped"}
     router_selected: set[str] | None = None
-    if settings.router_enabled and req.scope in ("org", "both"):
-        source_label_catalog = await fetch_source_catalog(req.org_id, req.kb_slugs)
-        if len(source_label_catalog) >= settings.router_min_source_label_count:
-            routing = await route_to_sources(
-                query_resolved=query_resolved,
-                query_vector=query_vector,
-                org_id=req.org_id,
-                source_label_catalog=source_label_catalog,
-                margin_single=settings.router_margin_single,
-                margin_dual=settings.router_margin_dual,
-                llm_fallback=settings.router_llm_fallback,
-                centroid_ttl_seconds=settings.router_centroid_ttl_seconds,
-                kb_slugs=req.kb_slugs,
-            )
-            if routing.selected_source_labels:
-                router_selected = set(routing.selected_source_labels)
-            router_meta = {
-                "router_decision": routing.selected_source_labels,
-                "router_layer_used": routing.layer_used,
-                "router_margin": routing.margin,
-                "router_centroid_cache_hit": routing.cache_hit,
-            }
-    decision_record["router"] = router_meta
+    async with trace.step("router") as router_step:
+        if not settings.router_enabled:
+            router_step.skip("disabled_by_config")
+        elif req.scope not in ("org", "both"):
+            router_step.skip("scope_not_applicable")
+        else:
+            source_label_catalog = await fetch_source_catalog(req.org_id, req.kb_slugs)
+            if len(source_label_catalog) < settings.router_min_source_label_count:
+                router_step.skip(
+                    "insufficient_source_labels",
+                    source_label_count=len(source_label_catalog),
+                )
+            else:
+                routing = await route_to_sources(
+                    query_resolved=query_resolved,
+                    query_vector=query_vector,
+                    org_id=req.org_id,
+                    source_label_catalog=source_label_catalog,
+                    margin_single=settings.router_margin_single,
+                    margin_dual=settings.router_margin_dual,
+                    llm_fallback=settings.router_llm_fallback,
+                    centroid_ttl_seconds=settings.router_centroid_ttl_seconds,
+                    kb_slugs=req.kb_slugs,
+                )
+                if routing.selected_source_labels:
+                    router_selected = set(routing.selected_source_labels)
+                router_meta = {
+                    "router_decision": routing.selected_source_labels,
+                    "router_layer_used": routing.layer_used,
+                    "router_margin": routing.margin,
+                    "router_centroid_cache_hit": routing.cache_hit,
+                }
+        router_step.meta("router_layer_used", router_meta["router_layer_used"])
+    trace.meta("router", router_meta)
 
     # 4. Search — Qdrant + Graphiti in parallel (AC-5)
     t_qdrant = time.perf_counter()
@@ -604,6 +646,8 @@ async def retrieve(
     if settings.graphiti_enabled:
         t_graph = time.perf_counter()
         graph_task = asyncio.create_task(graph_search.search(query_resolved, req.org_id, top_k=20))
+    else:
+        trace.mark_skipped("graph_search", "disabled_by_config")
 
     raw_results = await qdrant_coro
     qdrant_ms = (time.perf_counter() - t_qdrant) * 1000
@@ -612,14 +656,16 @@ async def retrieve(
 
     if graph_task is not None and t_graph is not None:
         try:
-            graph_results = await graph_task
-            graph_search_ms = (time.perf_counter() - t_graph) * 1000
-            step_latency_seconds.labels(step="graph").observe(graph_search_ms / 1000)
-            graph_results_count = len(graph_results)
-            if graph_results:
-                await _label_graph_results(graph_results, req)
-                graph_candidate_ids = {r["chunk_id"] for r in graph_results}
-                raw_results = _rrf_merge(raw_results, graph_results)
+            async with trace.step("graph_search", started_at=t_graph) as graph_step:
+                graph_results = await graph_task
+                graph_search_ms = (time.perf_counter() - t_graph) * 1000
+                step_latency_seconds.labels(step="graph").observe(graph_search_ms / 1000)
+                graph_results_count = len(graph_results)
+                graph_step.meta("candidates_returned", graph_results_count)
+                if graph_results:
+                    await _label_graph_results(graph_results, req)
+                    graph_candidate_ids = {r["chunk_id"] for r in graph_results}
+                    raw_results = _rrf_merge(raw_results, graph_results)
         except Exception:
             # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
             # traceback that the previous `error=str(exc)` dropped (TRY401).
@@ -629,41 +675,51 @@ async def retrieve(
     decision_record["search_candidates_count"] = candidates_retrieved
 
     # 4b. Link expansion (SPEC-CRAWLER-003 R14-R16)
-    if settings.link_expand_enabled and raw_results:
+    if not settings.link_expand_enabled:
+        link_expand_step = trace.mark_skipped("link_expand", "disabled_by_config")
+    elif not raw_results:
+        link_expand_step = trace.mark_skipped("link_expand", "no_candidates")
+    else:
         t_expand = time.perf_counter()
-        seed_chunks = raw_results[: settings.link_expand_seed_k]
-        candidate_urls: list[str] = []
-        seen_urls: set[str] = set()
-        for chunk in seed_chunks:
-            for url in payload_list(chunk, "links_to"):
-                if url not in seen_urls:
-                    seen_urls.add(url)
-                    candidate_urls.append(url)
+        async with trace.step("link_expand", started_at=t_expand) as link_expand_step:
+            seed_chunks = raw_results[: settings.link_expand_seed_k]
+            candidate_urls: list[str] = []
+            seen_urls: set[str] = set()
+            for chunk in seed_chunks:
+                for url in payload_list(chunk, "links_to"):
+                    if url not in seen_urls:
+                        seen_urls.add(url)
+                        candidate_urls.append(url)
+                    if len(candidate_urls) >= settings.link_expand_max_urls:
+                        break
                 if len(candidate_urls) >= settings.link_expand_max_urls:
                     break
-            if len(candidate_urls) >= settings.link_expand_max_urls:
-                break
 
-        # F3 phase 1: capture seed chunk_ids before expansion so we can
-        # measure later how many of the served top-k were original-seed
-        # vs newly-expanded vs neither.
-        link_expand_seed_chunk_ids = {c["chunk_id"] for c in seed_chunks}
-        link_expand_candidate_urls = len(candidate_urls)
+            # F3 phase 1: capture seed chunk_ids before expansion so we can
+            # measure later how many of the served top-k were original-seed
+            # vs newly-expanded vs neither.
+            link_expand_seed_chunk_ids = {c["chunk_id"] for c in seed_chunks}
+            link_expand_candidate_urls = len(candidate_urls)
+            link_expand_step.meta("seed_k", len(seed_chunks))
+            link_expand_step.meta("candidate_urls", link_expand_candidate_urls)
 
-        if candidate_urls:
-            expansion_chunks = await search.fetch_chunks_by_urls(
-                candidate_urls, req, settings.link_expand_candidates
-            )
-            existing_ids = {r["chunk_id"] for r in raw_results}
-            new_chunks = [c for c in expansion_chunks if c["chunk_id"] not in existing_ids]
-            link_expand_count = len(new_chunks)
-            # F3 phase 1: tag the expansion chunks. Underscore prefix
-            # keeps the field internal — Pydantic ChunkResult ignores
-            # unknown fields by default and the build loop only reads
-            # explicit keys, so this never leaks to the response body.
-            for c in new_chunks:
-                c["_link_expanded"] = True
-            raw_results = raw_results + new_chunks
+            if not candidate_urls:
+                link_expand_step.skip("no_candidate_urls")
+            else:
+                expansion_chunks = await search.fetch_chunks_by_urls(
+                    candidate_urls, req, settings.link_expand_candidates
+                )
+                existing_ids = {r["chunk_id"] for r in raw_results}
+                new_chunks = [c for c in expansion_chunks if c["chunk_id"] not in existing_ids]
+                link_expand_count = len(new_chunks)
+                link_expand_step.meta("expanded_added", link_expand_count)
+                # F3 phase 1: tag the expansion chunks. Underscore prefix
+                # keeps the field internal — Pydantic ChunkResult ignores
+                # unknown fields by default and the build loop only reads
+                # explicit keys, so this never leaks to the response body.
+                for c in new_chunks:
+                    c["_link_expanded"] = True
+                raw_results = raw_results + new_chunks
 
         link_expand_ms = (time.perf_counter() - t_expand) * 1000
         step_latency_seconds.labels(step="link_expand").observe(link_expand_ms / 1000)
@@ -677,11 +733,18 @@ async def retrieve(
     # 4c. Authority boost (SPEC-CRAWLER-003 R17), retained only for
     # ranking-contract shadow comparison. Active mode serves by the
     # post-rerank final_rank_score contract instead.
-    if ranking_contract_mode == "shadow" and settings.link_expand_enabled and raw_results:
+    authority_boost_enabled = (
+        ranking_contract_mode == "shadow" and settings.link_expand_enabled and bool(raw_results)
+    )
+    authority_boosted_count = 0
+    if authority_boost_enabled:
         for r in raw_results:
             incoming = r.get("incoming_link_count") or 0
             if incoming > 0:
                 r["score"] = r["score"] + settings.link_authority_boost * math.log(1 + incoming)
+                authority_boosted_count += 1
+    link_expand_step.meta("authority_boost_enabled", authority_boost_enabled)
+    link_expand_step.meta("authority_boosted_count", authority_boosted_count)
 
     raw_results, page_context_candidate_boosted = _apply_page_context_boost(
         raw_results,
@@ -927,13 +990,15 @@ async def retrieve(
 
     # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 — confidence band on the
     # served chunks so downstream consumers can decide how strongly to answer.
-    confidence_band: ConfidenceBand = _compute_confidence_band(
-        serving,
-        high_threshold=settings.confidence_band_high_threshold,
-        low_threshold=settings.confidence_band_low_threshold,
-        reranker_enabled=settings.reranker_enabled,
-    )
-    decision_record["confidence_band"] = confidence_band
+    t_confidence = time.perf_counter()
+    with trace.step("confidence_band", started_at=t_confidence):
+        confidence_band: ConfidenceBand = _compute_confidence_band(
+            serving,
+            high_threshold=settings.confidence_band_high_threshold,
+            low_threshold=settings.confidence_band_low_threshold,
+            reranker_enabled=settings.reranker_enabled,
+        )
+    trace.meta("confidence_band", confidence_band)
     retrieval_confidence_band_total.labels(band=confidence_band, org_id=req.org_id).inc()
 
     evidence_query = (
@@ -972,7 +1037,8 @@ async def retrieve(
         outcome = "hit" if graph_in_top_k_ids else "miss"
         retrieval_graph_top_k_total.labels(outcome=outcome, org_id=req.org_id).inc()
 
-    decision_record["total_ms"] = round(retrieval_ms, 1)
+    trace.meta("total_ms", round(retrieval_ms, 1))
+    trace.record_ok("total", retrieval_ms)
 
     # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-5: gate raw-query content on
     # decision_record. In off + shadow mode, strip the coreference
@@ -985,29 +1051,19 @@ async def retrieve(
     # 'content' events to a 7d-retention stream and 'metadata' events
     # to the existing 30d stream (operator-side VictoriaLogs config —
     # follow-up runbook in Unit 8).
-    if effective_level != "full" and "coreference_rewrite" in decision_record:
-        decision_record.pop("coreference_rewrite", None)
-        decision_record["retention_class"] = "metadata"
+    if effective_level != "full":
         telemetry_level_decisions_total.labels(
             level=effective_level, decision="metadata_only"
         ).inc()
     elif effective_level == "full":
-        decision_record["retention_class"] = "content"
         telemetry_level_decisions_total.labels(level="full", decision="content_emitted").inc()
-    else:
-        # off mode without coreference_rewrite already in the record.
-        decision_record["retention_class"] = "metadata"
 
     try:
-        logger.info(
-            "retrieval_decision_record",
-            org_id=req.org_id,
-            scope=req.scope,
-            telemetry_level=effective_level,
-            **decision_record,
-        )
+        for key, value in decision_record.items():
+            trace.meta(key, value)
+        logger.info("retrieval_decision_record", **trace.to_log_kwargs())
     except Exception:
-        logger.exception("decision_record_emit_failed")
+        logger.exception("retrieval_trace_emit_failed")
 
     # SPEC-PRIVACY-QUERY-SHADOW-001 REQ-7: shadow-store INSERT for shadow
     # + full modes. Fire-and-forget — failures are counted in
@@ -1020,9 +1076,7 @@ async def retrieve(
     # missing rows would silently degrade observability and bias the
     # dashboards' decision counters.
     if effective_level in ("shadow", "full"):
-        request_id_for_shadow = structlog.contextvars.get_contextvars().get("request_id") or str(
-            uuid.uuid4()
-        )
+        request_id_for_shadow = trace.request_id
         chunk_ids_for_shadow = [c.chunk_id for c in chunks_out]
         reranker_scores = [c.reranker_score for c in chunks_out if c.reranker_score is not None]
         reranker_top1 = max(reranker_scores) if reranker_scores else None

--- a/klai-retrieval-api/retrieval_api/tracing.py
+++ b/klai-retrieval-api/retrieval_api/tracing.py
@@ -1,0 +1,366 @@
+"""Lightweight, privacy-gated tracing for the retrieval pipeline.
+
+Add a step by extending ``StepName`` and wrapping the existing block with
+``trace.step(...)`` (the same context manager supports ``with`` and
+``async with``). Use ``meta`` for non-content values such as counts, booleans,
+scores, and durations. Use ``content`` for raw or resolved query text; content
+is rendered only at ``full`` telemetry. Never store payload dumps, chunk/source
+text, credentials, or URLs in error metadata.
+
+Skip reasons are intentionally bounded by ``SkippedReason``. Add a new reason
+there before using it at a call site. Wrappers preserve exceptions by default;
+``fail_open=True`` is an explicit per-step choice and is valid only where the
+existing pipeline already fails open. Error messages are omitted unless the
+caller supplies a known-safe ``safe_error_message``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Any, Literal, Self, cast, get_args, overload
+
+TraceStatus = Literal["ok", "skipped", "error"]
+TelemetryLevel = Literal["off", "shadow", "full"]
+StepName = Literal[
+    "coreference",
+    "embed",
+    "gate",
+    "router",
+    "qdrant_search",
+    "graph_search",
+    "link_expand",
+    "rerank",
+    "quality_floor",
+    "source_select",
+    "quality_boost",
+    "evidence_tier",
+    "parent_lookup",
+    "response_build",
+    "confidence_band",
+    "total",
+]
+SkippedReason = Literal[
+    "gate_bypassed",
+    "disabled_by_config",
+    "no_candidates",
+    "no_candidate_urls",
+    "reranker_disabled",
+    "shadow_mode",
+    "no_verified_identity",
+    "scope_not_applicable",
+    "insufficient_source_labels",
+]
+
+STEP_NAMES = frozenset(get_args(StepName))
+SKIPPED_REASONS = frozenset(get_args(SkippedReason))
+_STEP_RESERVED_FIELDS = frozenset(
+    {
+        "name",
+        "status",
+        "duration_ms",
+        "skipped_reason",
+        "error_type",
+        "error_message_safe",
+    }
+)
+
+
+def _validated_step_name(name: StepName) -> StepName:
+    if name not in STEP_NAMES:
+        raise ValueError(f"Unknown retrieval trace step: {name}")
+    return cast(StepName, name)
+
+
+def _validated_skip_reason(reason: SkippedReason) -> SkippedReason:
+    if reason not in SKIPPED_REASONS:
+        raise ValueError(f"Unknown retrieval trace skip reason: {reason}")
+    return cast(SkippedReason, reason)
+
+
+@dataclass(slots=True)
+class TraceStep:
+    """One ordered trace entry plus its privacy-classified details."""
+
+    name: StepName
+    status: TraceStatus = "ok"
+    duration_ms: float = 0.0
+    skipped_reason: SkippedReason | None = None
+    error_type: str | None = None
+    error_message_safe: str | None = None
+    _started_at: float | None = field(default=None, repr=False)
+    _metadata: dict[str, Any] = field(default_factory=dict, repr=False)
+    _content: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def meta(self, key: str, value: Any) -> Self:
+        """Attach a metadata-only detail and return this step."""
+        if key in _STEP_RESERVED_FIELDS:
+            raise ValueError(f"Reserved retrieval trace step field: {key}")
+        if key in self._content:
+            raise ValueError(f"Retrieval trace field already classified as content: {key}")
+        self._metadata[key] = value
+        return self
+
+    def content(self, key: str, value: Any) -> Self:
+        """Attach a content-bearing detail and return this step."""
+        if key in _STEP_RESERVED_FIELDS:
+            raise ValueError(f"Reserved retrieval trace step field: {key}")
+        if key in self._metadata:
+            raise ValueError(f"Retrieval trace field already classified as metadata: {key}")
+        self._content[key] = value
+        return self
+
+    def skip(self, reason: SkippedReason, **metadata: Any) -> Self:
+        """Mark this entered step skipped without changing control flow."""
+        self.status = "skipped"
+        self.skipped_reason = _validated_skip_reason(reason)
+        for key, value in metadata.items():
+            self.meta(key, value)
+        return self
+
+    def _finish(self, ended_at: float) -> None:
+        if self._started_at is not None:
+            self.duration_ms = (ended_at - self._started_at) * 1000
+
+    def _record_error(
+        self, exc: BaseException, ended_at: float, safe_error_message: str | None
+    ) -> None:
+        self._finish(ended_at)
+        self.status = "error"
+        self.skipped_reason = None
+        self.error_type = type(exc).__name__
+        self.error_message_safe = safe_error_message
+
+    def _render(self, *, include_content: bool) -> dict[str, Any]:
+        rendered: dict[str, Any] = {
+            "name": self.name,
+            "status": self.status,
+            "duration_ms": round(self.duration_ms, 3),
+            **self._metadata,
+        }
+        if self.skipped_reason is not None:
+            rendered["skipped_reason"] = self.skipped_reason
+        if self.error_type is not None:
+            rendered["error_type"] = self.error_type
+        if self.error_message_safe is not None:
+            rendered["error_message_safe"] = self.error_message_safe
+        if include_content:
+            rendered.update(self._content)
+        return rendered
+
+
+class _StepContext:
+    """Shared state for exception-preserving and fail-open wrappers."""
+
+    def __init__(
+        self,
+        trace: RetrievalTrace,
+        name: StepName,
+        *,
+        safe_error_message: str | None,
+        started_at: float | None,
+    ) -> None:
+        self._trace = trace
+        self._name: StepName = _validated_step_name(name)
+        self._safe_error_message = safe_error_message
+        self._started_at = started_at
+        self._record: TraceStep | None = None
+
+    def __enter__(self) -> TraceStep:
+        started_at = self._started_at if self._started_at is not None else time.perf_counter()
+        self._record = TraceStep(name=self._name, _started_at=started_at)
+        self._trace._steps.append(self._record)
+        return self._record
+
+    async def __aenter__(self) -> TraceStep:
+        return self.__enter__()
+
+    def _complete(
+        self,
+        exc: BaseException | None,
+    ) -> None:
+        assert self._record is not None
+        ended_at = time.perf_counter()
+        if exc is None:
+            self._record._finish(ended_at)
+        else:
+            self._record._record_error(exc, ended_at, self._safe_error_message)
+
+
+class _ReraisingStepContext(_StepContext):
+    """Context manager whose type guarantees exception propagation."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, traceback
+        self._complete(exc)
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.__exit__(exc_type, exc, traceback)
+
+
+class _FailOpenStepContext(_StepContext):
+    """Context manager that suppresses only an exception from its step."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        del exc_type, traceback
+        self._complete(exc)
+        return exc is not None
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return self.__exit__(exc_type, exc, traceback)
+
+
+@dataclass(slots=True)
+class RetrievalTrace:
+    """Privacy-aware decision trace for one retrieval request."""
+
+    request_id: str
+    org_id: str
+    scope: str
+    telemetry_level: TelemetryLevel
+    started_at: float
+    _steps: list[TraceStep] = field(default_factory=list, init=False, repr=False)
+    _metadata: dict[str, Any] = field(default_factory=dict, init=False, repr=False)
+    _content: dict[str, Any] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.telemetry_level not in get_args(TelemetryLevel):
+            raise ValueError(f"Unknown telemetry level: {self.telemetry_level}")
+
+    def meta(self, key: str, value: Any) -> Self:
+        """Add a metadata-only top-level compatibility field."""
+        if key in self._content:
+            raise ValueError(f"Retrieval trace field already classified as content: {key}")
+        self._metadata[key] = value
+        return self
+
+    def content(self, key: str, value: Any) -> Self:
+        """Add a content-bearing top-level compatibility field."""
+        if key in self._metadata:
+            raise ValueError(f"Retrieval trace field already classified as metadata: {key}")
+        self._content[key] = value
+        return self
+
+    @overload
+    def step(
+        self,
+        name: StepName,
+        *,
+        fail_open: Literal[False] = False,
+        safe_error_message: str | None = None,
+        started_at: float | None = None,
+    ) -> _ReraisingStepContext: ...
+
+    @overload
+    def step(
+        self,
+        name: StepName,
+        *,
+        fail_open: Literal[True],
+        safe_error_message: str | None = None,
+        started_at: float | None = None,
+    ) -> _FailOpenStepContext: ...
+
+    def step(
+        self,
+        name: StepName,
+        *,
+        fail_open: bool = False,
+        safe_error_message: str | None = None,
+        started_at: float | None = None,
+    ) -> _StepContext:
+        """Return a sync/async wrapper; exceptions re-raise unless opted out."""
+        context_type = _FailOpenStepContext if fail_open else _ReraisingStepContext
+        return context_type(
+            self,
+            name,
+            safe_error_message=safe_error_message,
+            started_at=started_at,
+        )
+
+    def mark_skipped(self, name: StepName, reason: SkippedReason, **metadata: Any) -> TraceStep:
+        """Append a zero-duration skipped step."""
+        record = TraceStep(
+            name=_validated_step_name(name),
+            status="skipped",
+            skipped_reason=_validated_skip_reason(reason),
+        )
+        for key, value in metadata.items():
+            record.meta(key, value)
+        self._steps.append(record)
+        return record
+
+    def record_ok(self, name: StepName, duration_ms: float, **metadata: Any) -> TraceStep:
+        """Append a successful step measured by existing pipeline timing."""
+        record = TraceStep(name=_validated_step_name(name), duration_ms=duration_ms)
+        for key, value in metadata.items():
+            record.meta(key, value)
+        self._steps.append(record)
+        return record
+
+    def record_error(
+        self,
+        name: StepName,
+        exc: BaseException,
+        duration_ms: float,
+        safe_message: str | None = None,
+        **metadata: Any,
+    ) -> TraceStep:
+        """Append safe error metadata for an existing fail-open boundary."""
+        record = TraceStep(
+            name=_validated_step_name(name),
+            status="error",
+            duration_ms=duration_ms,
+            error_type=type(exc).__name__,
+            error_message_safe=safe_message,
+        )
+        for key, value in metadata.items():
+            record.meta(key, value)
+        self._steps.append(record)
+        return record
+
+    def to_decision_record(self) -> dict[str, Any]:
+        """Render flat compatibility fields plus ordered, privacy-safe steps."""
+        include_content = self.telemetry_level == "full"
+        rendered = dict(self._metadata)
+        if include_content:
+            rendered.update(self._content)
+        rendered["trace_steps"] = [
+            step._render(include_content=include_content) for step in self._steps
+        ]
+        has_rendered_content = include_content and bool(
+            self._content or any(step._content for step in self._steps)
+        )
+        rendered["retention_class"] = "content" if has_rendered_content else "metadata"
+        return rendered
+
+    def to_log_kwargs(self) -> dict[str, Any]:
+        """Render logger kwargs with request identity and privacy gating."""
+        return {
+            **self.to_decision_record(),
+            "request_id": self.request_id,
+            "org_id": self.org_id,
+            "scope": self.scope,
+            "telemetry_level": cast(str, self.telemetry_level),
+        }

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -182,6 +182,41 @@ class TestRetrieveEndpoint:
         assert "top_item_chunk_ids" in decision_attrs
         assert decision_record.msg["confidence_band"] == "high"
         assert "confidence_band_corroborated" not in decision_record.msg
+        assert [
+            (chunk["chunk_id"], chunk["score"], chunk["reranker_score"]) for chunk in data["chunks"]
+        ] == [("c1", 0.9, 0.95)]
+        assert {
+            key: value
+            for key, value in data["metadata"].items()
+            if key not in {"retrieval_ms", "rerank_ms"}
+        } == {
+            "candidates_retrieved": 1,
+            "reranked_to": 1,
+            "graph_results_count": 0,
+            "graph_search_ms": None,
+        }
+        trace_steps = decision_record.msg["trace_steps"]
+        assert [step["name"] for step in trace_steps] == [
+            "coreference",
+            "embed",
+            "gate",
+            "router",
+            "graph_search",
+            "link_expand",
+            "confidence_band",
+            "total",
+        ]
+        assert trace_steps[2] == {
+            "name": "gate",
+            "status": "skipped",
+            "duration_ms": 0.0,
+            "skipped_reason": "disabled_by_config",
+        }
+        assert trace_steps[4]["status"] == "skipped"
+        assert trace_steps[4]["skipped_reason"] == "disabled_by_config"
+        assert trace_steps[5]["status"] == "skipped"
+        assert trace_steps[5]["skipped_reason"] == "no_candidate_urls"
+        assert "coreference_rewrite" not in decision_record.msg
 
     def test_retrieve_passes_effective_telemetry_level_to_coreference(
         self, client, sample_retrieve_request
@@ -767,6 +802,133 @@ class TestGraphMetadata:
                 f"Record attrs: {rec.__dict__}"
             )
         assert "graph:edge-1" in rec_attrs
+
+
+class TestRetrievalTraceEndpoint:
+    """Endpoint contracts that cannot be proven by the trace helper alone."""
+
+    def test_graph_search_error_is_safe_and_response_stays_qdrant_based(
+        self, client, sample_retrieve_request, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.INFO)
+        qdrant_chunk = {
+            "chunk_id": "qdrant-1",
+            "text": "Qdrant result",
+            "score": 0.9,
+            "artifact_id": "a1",
+            "content_type": "policy",
+            "context_prefix": None,
+            "scope": "org",
+            "valid_at": None,
+            "invalid_at": None,
+            "ingested_at": None,
+            "assertion_mode": None,
+        }
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="resolved query",
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[qdrant_chunk],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.graph_search.search",
+                new_callable=AsyncMock,
+                side_effect=TimeoutError("private query text"),
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.ranking_contract_mode = "active"
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_enabled = False
+            mock_settings.graphiti_enabled = True
+            mock_settings.link_expand_enabled = False
+            mock_settings.link_expand_score_boost = 1.0
+            mock_settings.source_quota_enabled = False
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            response = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert response.status_code == 200
+        assert [chunk["chunk_id"] for chunk in response.json()["chunks"]] == ["qdrant-1"]
+        record = next(
+            item for item in caplog.records if "retrieval_decision_record" in item.getMessage()
+        )
+        graph_step = next(
+            step for step in record.msg["trace_steps"] if step["name"] == "graph_search"
+        )
+        assert graph_step["status"] == "error"
+        assert graph_step["error_type"] == "TimeoutError"
+        assert "private query text" not in repr(graph_step)
+        assert "traceback" not in repr(graph_step).lower()
+
+    def test_trace_render_failure_does_not_fail_retrieve(
+        self, client, sample_retrieve_request, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.ERROR)
+        with (
+            patch(
+                "retrieval_api.api.retrieve.coreference.resolve",
+                new_callable=AsyncMock,
+                return_value="resolved query",
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_single",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.embed_sparse",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "retrieval_api.api.retrieve.search.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "retrieval_api.api.retrieve.RetrievalTrace.to_decision_record",
+                side_effect=RuntimeError("render failed"),
+            ),
+            patch("retrieval_api.api.retrieve.settings") as mock_settings,
+        ):
+            mock_settings.ranking_contract_mode = "active"
+            mock_settings.retrieval_candidates = 60
+            mock_settings.reranker_enabled = False
+            mock_settings.graphiti_enabled = False
+            mock_settings.link_expand_enabled = False
+            mock_settings.link_expand_score_boost = 1.0
+            mock_settings.source_quota_enabled = False
+            mock_settings.router_enabled = False
+            mock_settings.retrieval_quality_floor = 0.05
+            mock_settings.confidence_band_high_threshold = 0.60
+            mock_settings.confidence_band_low_threshold = 0.30
+            response = client.post("/retrieve", json=sample_retrieve_request)
+
+        assert response.status_code == 200
+        assert response.json()["retrieval_bypassed"] is False
+        assert any("retrieval_trace_emit_failed" in item.getMessage() for item in caplog.records)
 
 
 class TestLinkExpandInstrumentation:

--- a/klai-retrieval-api/tests/test_retrieval_trace.py
+++ b/klai-retrieval-api/tests/test_retrieval_trace.py
@@ -1,0 +1,148 @@
+"""Contract tests for retrieval decision tracing."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from retrieval_api.tracing import RetrievalTrace
+
+
+def _populated_trace(level: str = "full") -> RetrievalTrace:
+    trace = RetrievalTrace(
+        request_id="request-123",
+        org_id="org-123",
+        scope="org",
+        telemetry_level=level,
+        started_at=time.perf_counter(),
+    )
+    trace.content(
+        "coreference_rewrite",
+        {"original": "raw question", "resolved": "resolved question", "source": "test"},
+    )
+    for key, value in {
+        "coreference_ms": 1.0,
+        "embedding_ms": 2.0,
+        "gate_margin": None,
+        "gate_bypassed": False,
+        "gate_ms": 0.0,
+        "router": {"router_layer_used": "centroid"},
+        "search_ms": 3.0,
+        "search_candidates_count": 5,
+        "rerank_ms": 4.0,
+        "reranker_scores_top5": [0.9],
+        "quality_floor_filtered": 0,
+        "source_select": {"source_select_mode": "diversify"},
+        "quality_boost_applied": False,
+        "evidence_shadow_mode": False,
+        "link_expand": {"enabled": True},
+        "confidence_band": "high",
+        "total_ms": 10.0,
+    }.items():
+        trace.meta(key, value)
+    return trace
+
+
+def test_decision_record_preserves_all_flat_compatibility_fields() -> None:
+    record = _populated_trace().to_decision_record()
+
+    assert set(
+        (
+            "coreference_rewrite",
+            "coreference_ms",
+            "embedding_ms",
+            "gate_margin",
+            "gate_bypassed",
+            "gate_ms",
+            "router",
+            "search_ms",
+            "search_candidates_count",
+            "rerank_ms",
+            "reranker_scores_top5",
+            "quality_floor_filtered",
+            "source_select",
+            "quality_boost_applied",
+            "evidence_shadow_mode",
+            "link_expand",
+            "confidence_band",
+            "total_ms",
+            "retention_class",
+        )
+    ).issubset(record)
+    assert record["retention_class"] == "content"
+
+
+@pytest.mark.parametrize("level", ["shadow", "off"])
+def test_non_full_render_removes_top_level_and_step_content(level: str) -> None:
+    trace = _populated_trace(level)
+    with trace.step("coreference") as step:
+        step.content("resolved_query", "resolved question")
+        step.meta("source", "retrieval-api")
+
+    record = trace.to_decision_record()
+
+    assert "coreference_rewrite" not in record
+    assert "resolved question" not in repr(record)
+    assert record["trace_steps"][0]["source"] == "retrieval-api"
+    assert record["retention_class"] == "metadata"
+
+
+def test_steps_keep_pipeline_order_and_stable_skip_reason() -> None:
+    trace = _populated_trace("shadow")
+    trace.record_ok("coreference", 1.0, source="caller")
+    trace.record_ok("embed", 2.0)
+    trace.mark_skipped("gate", "disabled_by_config")
+    trace.mark_skipped("router", "scope_not_applicable")
+
+    steps = trace.to_decision_record()["trace_steps"]
+
+    assert [step["name"] for step in steps] == ["coreference", "embed", "gate", "router"]
+    assert steps[2]["status"] == "skipped"
+    assert steps[2]["skipped_reason"] == "disabled_by_config"
+
+
+def test_step_wrapper_records_error_and_reraises_by_default() -> None:
+    trace = _populated_trace("shadow")
+
+    with pytest.raises(TimeoutError, match="provider payload must not be rendered"):
+        with trace.step("graph_search"):
+            raise TimeoutError("provider payload must not be rendered")
+
+    step = trace.to_decision_record()["trace_steps"][0]
+    assert step["status"] == "error"
+    assert step["error_type"] == "TimeoutError"
+    assert "error_message_safe" not in step
+    assert "provider payload" not in repr(step)
+    assert "traceback" not in repr(step).lower()
+
+
+def test_fail_open_is_explicit_and_safe_message_is_opt_in() -> None:
+    trace = _populated_trace("shadow")
+
+    with trace.step("graph_search", fail_open=True, safe_error_message="upstream timeout"):
+        raise TimeoutError("private query text")
+
+    step = trace.to_decision_record()["trace_steps"][0]
+    assert step["status"] == "error"
+    assert step["error_message_safe"] == "upstream timeout"
+    assert "private query text" not in repr(step)
+
+
+def test_invalid_step_name_and_skip_reason_are_rejected() -> None:
+    trace = _populated_trace("shadow")
+
+    with pytest.raises(ValueError, match="Unknown retrieval trace step"):
+        trace.record_ok("search", 1.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Unknown retrieval trace skip reason"):
+        trace.mark_skipped("router", "not_enough_labels")  # type: ignore[arg-type]
+
+
+def test_log_kwargs_include_request_identity_and_safe_record() -> None:
+    kwargs = _populated_trace("shadow").to_log_kwargs()
+
+    assert kwargs["request_id"] == "request-123"
+    assert kwargs["org_id"] == "org-123"
+    assert kwargs["scope"] == "org"
+    assert kwargs["telemetry_level"] == "shadow"
+    assert "coreference_rewrite" not in kwargs


### PR DESCRIPTION
Observability-only: typed `RetrievalTrace` + step wrappers (coreference, embed, router, graph_search, link_expand), privacy-gated compatibility render of `retrieval_decision_record` (all 19 flat keys preserved), `trace_steps` added beside them.

- Zero ranking/behavior change — golden test asserts identical chunk IDs, order, scores, confidence band (AC-8).
- `shadow_write`/`product_event` deliberately not trace steps (they run after the log emission).
- Unit 5 (candidate-transform steps) is an explicit follow-up PR.
- Note: gate/evidence-tier were already retired on main (2ce085277); spec updated (v0.1.1), no gate behavior reintroduced.

Verified: 605 tests pass, ruff clean, wrapper overhead 0.004 ms/request.
Implemented by codex gpt-5.6-sol; second-pass verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)