### PR TITLE
feat(knowledge-mcp): ActionSpec convention Phase 1 + search_knowledge pilot (SPEC-ACTION-CONTRACT-001)

### DIFF
--- a/.moai/specs/SPEC-ACTION-CONTRACT-001/acceptance.md
+++ b/.moai/specs/SPEC-ACTION-CONTRACT-001/acceptance.md
@@ -1,0 +1,106 @@
+# Acceptance Criteria: SPEC-ACTION-CONTRACT-001
+
+Given/When/Then scenarios that must pass before this SPEC is considered useful
+as an engineering convention.
+
+---
+
+## AC-1: New MCP tool includes ActionSpec metadata
+
+**Given** a PR adds a new `@mcp.tool` to `klai-knowledge-mcp`
+**When** the PR is reviewed
+**Then** the action has an `ActionSpec` with `action_id`, `kind`,
+`input.schema`, `auth.mode`, `auth.tenant_identity`, `effects`,
+`execution.timeout_ms`, `failure.mode`, `telemetry`, `result_policy`, `tests`,
+and `docs`
+**And** the tests cover input bounds, auth/identity failure, timeout behaviour,
+and result-size policy where applicable
+
+## AC-2: New Procrastinate task declares lane and effects
+
+**Given** a PR adds a new Procrastinate task or queue in
+`klai-knowledge-ingest`
+**When** the task is added
+**Then** its `ActionSpec` declares `kind=procrastinate_task`
+**And** `execution.concurrency_class` maps to either `IO_QUEUES` or
+`LLM_QUEUES`
+**And** the lane partition test fails if the queue is in neither lane or both
+lanes
+**And** write/destructive behaviour is explicit
+
+## AC-3: New service-boundary HTTP action declares tenant identity source
+
+**Given** a PR adds a service-to-service HTTP call that carries `user_id`,
+`org_id`, `org_slug`, `kb_slug`, or `connector_id`
+**When** the ActionSpec is inspected
+**Then** `auth.tenant_identity.source` names where the value comes from
+**And** `auth.tenant_identity.verified_by` names the verifier or says
+`derived_from_signed_token`
+**And** caller-supplied tenant identity is not accepted on the strength of an
+internal secret alone
+
+## AC-4: Failure mode is deliberate and tested
+
+**Given** an action depends on portal-api, retrieval-api, a model provider, or
+an external connector
+**When** the dependency times out or returns 5xx in tests
+**Then** the observed behaviour matches `failure.mode`
+**And** `fail_open` actions log/telemetry the degradation
+**And** `fail_closed` actions return a safe generic error
+**And** `fail_loud_degraded` actions explicitly surface the degradation to the
+model/user
+
+## AC-5: Model-facing results are capped
+
+**Given** an action returns data to a model host
+**When** the upstream returns too many items or oversized text fields
+**Then** the action enforces the `result_policy` caps before returning
+**And** the returned shape contains only fields allowed by the policy
+**And** cross-tenant leakage is covered by either RLS, verified identity,
+post-filtering, or a named combination
+
+## AC-6: Telemetry policy is explicit
+
+**Given** an action succeeds
+**When** telemetry is inspected
+**Then** all events listed in `telemetry.events` are emitted or deliberately
+fire-and-forget
+**And** telemetry failure does not change the action result unless the
+ActionSpec explicitly says telemetry is part of the critical path
+**And** privacy-sensitive raw content is gated by the action's telemetry/data
+policy
+
+## AC-7: Legacy actions are not forced into a mass migration
+
+**Given** an existing action is untouched by a PR
+**When** CI runs after SPEC-ACTION-CONTRACT-001 phase 1
+**Then** CI does not fail solely because that legacy action lacks ActionSpec
+metadata
+**And** CI may fail when the PR materially changes that action without adding
+or updating the metadata
+
+## AC-8: Review can find action contracts by action_id
+
+**Given** an engineer searches the repo for an `action_id`
+**When** they search for e.g. `knowledge-mcp.search_knowledge`
+**Then** they find the metadata block or owning SPEC
+**And** the block points to the entrypoint and relevant tests
+
+## AC-9: No production behaviour changes from adopting the convention
+
+**Given** phase 1 lands validation helpers and metadata for one pilot action
+**When** the service is deployed
+**Then** request/response behaviour, auth decisions, queue execution, and
+telemetry payloads remain unchanged except for optional metadata-only logs if
+explicitly added
+
+## AC-10: First pilot backfill is reviewable
+
+**Given** `search_knowledge` or the LiteLLM retrieval call is chosen as the
+first pilot
+**When** its ActionSpec is added
+**Then** the diff is small enough to review without re-reading unrelated hook
+logic
+**And** existing tests for that action still pass
+**And** the metadata captures the existing behaviour rather than changing it
+

--- a/.moai/specs/SPEC-ACTION-CONTRACT-001/plan.md
+++ b/.moai/specs/SPEC-ACTION-CONTRACT-001/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: SPEC-ACTION-CONTRACT-001
+
+**Status:** draft
+**Methodology:** documentation-first, then characterization tests for the first
+adopters. This SPEC is a convention; implementation should avoid broad
+cross-service refactors.
+**Estimated effort:** 1-2 focused backend sessions for phase 1, then
+incremental adoption in future action PRs.
+
+---
+
+## Phase ordering
+
+| Phase | Title | Blocker | Owner |
+|---|---|---|---|
+| 0 | Ratify metadata vocabulary | SPEC review | Backend |
+| 1 | Add lightweight local type/checker | Phase 0 | Backend |
+| 2 | Adopt on new actions only | Phase 1 | All feature owners |
+| 3 | Backfill high-risk existing actions | Phase 2 | Backend/security |
+| 4 | Optional shared registry | Real need proven | Backend |
+
+---
+
+## Phase 0 - Ratify vocabulary
+
+Review and freeze the initial enum values from `spec.md`:
+
+- `kind`
+- `auth.mode`
+- `effects.access`
+- `execution.concurrency_class`
+- `failure.mode`
+
+Output of this phase:
+
+- Update `spec.md` if review finds missing values.
+- No code changes required.
+
+---
+
+## Phase 1 - Add lightweight validation
+
+Goal: make missing metadata visible in review without forcing a runtime
+framework.
+
+Recommended implementation:
+
+- Add a small test helper or lint script that can validate ActionSpec dicts.
+- Prefer a local Python dataclass/Pydantic model only in services that already
+  have a natural place for it.
+- Do not make every service import a new shared package in this phase.
+
+Candidate files:
+
+- `klai-knowledge-mcp/tests/` for MCP examples
+- `deploy/litellm/tests/` for hook sub-action examples
+- `klai-knowledge-ingest/tests/test_queues_constants.py` for queue/lane mapping
+
+Validation should check:
+
+- required fields exist,
+- enum values are valid,
+- `timeout_ms` is present for HTTP/model calls,
+- destructive actions have explicit `destructive: true`,
+- model-facing actions have a `result_policy`.
+
+---
+
+## Phase 2 - Adopt on new actions
+
+Every new action in scope adds metadata in the same PR that adds the action.
+
+Review checklist:
+
+1. Does `action_id` uniquely identify the callable boundary?
+2. Are auth and tenant/user identity source explicit?
+3. Is read/write/destructive behaviour explicit?
+4. Does the concurrency class match the actual workload?
+5. Is timeout explicit and tested?
+6. Is failure mode deliberate?
+7. Are telemetry events and privacy policy named?
+8. Is model-facing output capped and leak-guarded?
+9. Are tests/acceptance cases listed?
+
+This phase is the main value of the SPEC. It prevents new drift while avoiding
+a disruptive old-code migration.
+
+---
+
+## Phase 3 - Backfill high-risk existing actions
+
+Backfill only actions that are security-sensitive, model-facing, destructive,
+or likely to be copied.
+
+Initial candidates:
+
+- `klai-knowledge-mcp/main.py::search_knowledge`
+- `klai-knowledge-mcp/main.py::save_personal_knowledge`
+- `klai-knowledge-mcp/main.py::save_org_knowledge`
+- `klai-knowledge-mcp/main.py::save_to_docs`
+- `deploy/litellm/klai_knowledge.py` retrieval call inside
+  `KlaiKnowledgeHook.async_pre_call_hook`
+- `deploy/litellm/klai_knowledge.py::_get_templates`
+- `deploy/litellm/klai_knowledge.py::_rewrite_and_classify`
+- destructive connector-delete / purge actions
+- new or recently changed Procrastinate task queues
+
+Do not backfill every helper in one PR. Tie metadata backfill to a nearby
+change or a focused security hardening pass.
+
+---
+
+## Phase 4 - Optional shared registry
+
+Only add a shared registry if at least two concrete needs appear, for example:
+
+- docs generation from ActionSpecs,
+- automated Grafana dashboard labels,
+- policy checks in CI across multiple services,
+- runtime action discovery for an admin UI.
+
+Until then, duplication of a small metadata block is cheaper than another
+cross-service dependency.
+
+---
+
+## Rollout safety
+
+- Phase 1 is test-only/docs-only; no production behaviour changes.
+- Phase 2 applies to new actions only.
+- Phase 3 is incremental and can be skipped for untouched legacy actions.
+- Existing action behaviour remains governed by the owning SPECs listed in
+  `related`.
+

--- a/.moai/specs/SPEC-ACTION-CONTRACT-001/spec.md
+++ b/.moai/specs/SPEC-ACTION-CONTRACT-001/spec.md
@@ -1,0 +1,366 @@
+---
+id: SPEC-ACTION-CONTRACT-001
+version: "0.1.0"
+status: draft
+created: 2026-05-08
+updated: 2026-05-08
+author: Mark Vletter
+priority: high
+issue_number: null
+related:
+  - SPEC-MCP-RETRIEVAL-001
+  - SPEC-MCP-AUTH-001
+  - SPEC-SEC-IDENTITY-ASSERT-001
+  - SPEC-SEC-SERVICE-AUTH-001
+  - SPEC-WORKER-LANES-001
+---
+
+# SPEC-ACTION-CONTRACT-001: ActionSpec convention for model-facing and service-boundary actions
+
+## HISTORY
+
+| Datum | Versie | Wijziging |
+|-------|--------|-----------|
+| 2026-05-08 | 0.1.0 | Initial draft. Introduces a pragmatic `ActionSpec` convention for new Klai actions that are model-facing or cross a service boundary: MCP tools, connector actions, retrieval stages, Procrastinate tasks, and LiteLLM hook actions. This is a documentation/test convention first, not a broad framework rewrite. |
+
+---
+
+## Summary
+
+Klai now has several places where code exposes "actions" to a model or
+crosses an internal service boundary:
+
+- MCP tools in `klai-knowledge-mcp/main.py` (`save_*`, `search_knowledge`)
+- LiteLLM hook actions in `deploy/litellm/klai_knowledge.py` (feature lookup,
+  query rewrite, taxonomy classify, retrieval, telemetry)
+- retrieval-api stages reached by `/retrieve`
+- connector and ingest operations that enqueue Procrastinate tasks
+- worker queue/lane assignments in `klai-knowledge-ingest/knowledge_ingest/queues.py`
+
+Those actions already carry implicit contracts: identity source, auth mode,
+read/write semantics, timeout, fail-open/fail-closed behaviour, telemetry, and
+result-shape. Today those contracts are spread across docstrings, comments,
+tests, and service-specific specs. That makes new action additions easy to
+under-specify, especially when the caller is an LLM or when a service acts on
+behalf of a tenant/user.
+
+This SPEC defines a lightweight `ActionSpec` convention. New model-facing and
+service-boundary actions must declare a small metadata block next to the action
+entrypoint or in the owning SPEC. The convention is intentionally boring:
+structured metadata, local tests, and checklist enforcement. It does **not**
+require refactoring existing services into one common action framework.
+
+---
+
+## Problem
+
+Klai has learned the same boundary lesson in multiple areas:
+
+- `SPEC-SEC-IDENTITY-ASSERT-001` showed that a shared service secret proves
+  network identity, not tenant identity.
+- `SPEC-MCP-RETRIEVAL-001` needed explicit tool result shape, `top_k` bounds,
+  timeout, telemetry, and `ToolError` behaviour.
+- `SPEC-WORKER-LANES-001` made queue lane/concurrency an explicit contract
+  because "just add a task" silently starved user-triggered work.
+- The LiteLLM hook has several deliberate fail-open/fail-loud decisions. Some
+  are user-protective, some are availability-protective, and they are easy to
+  miscopy into the wrong surface.
+
+The missing abstraction is not "one executor for everything". The missing
+abstraction is a small action contract that forces engineers and review agents
+to answer the same safety questions before adding a callable boundary.
+
+---
+
+## Scope
+
+In scope:
+
+- Define the `ActionSpec` metadata schema and naming convention.
+- Require the convention for **new** actions that are model-facing or cross a
+  service boundary.
+- Add a migration path for high-risk existing actions without blocking feature
+  work.
+- Define minimal validation/test expectations.
+- Cover Python services first, because the current action surfaces are mostly
+  Python (`klai-knowledge-mcp`, `deploy/litellm`, `klai-knowledge-ingest`,
+  `klai-retrieval-api`, `klai-connector`).
+
+Out of scope:
+
+- Refactoring all existing MCP tools, LiteLLM helpers, retrieval stages, and
+  Procrastinate tasks in one PR.
+- Introducing a runtime registry that all services must import.
+- Changing auth semantics, retrieval semantics, or queue lane assignments.
+- Replacing Procrastinate, FastMCP, LiteLLM hooks, connector clients, or
+  retrieval-api route structure.
+
+---
+
+## Definition: Action
+
+An **Action** is any callable unit that one of these actors can trigger:
+
+1. a model or model host (MCP tool, LiteLLM tool/hook, agent connector action),
+2. another Klai service over HTTP/RPC,
+3. an async worker queue, or
+4. a retrieval/ingest pipeline stage that changes data visibility, makes an
+   external call, emits telemetry, or affects user-facing answers.
+
+Pure internal helper functions are not actions unless they are the boundary
+where one of the properties above becomes true.
+
+---
+
+## ActionSpec metadata
+
+Every new action in scope SHALL have an `ActionSpec` metadata block with these
+fields. The preferred representation is a typed Python dataclass or Pydantic
+model when a service already has a local pattern for configuration models; a
+YAML-ish comment block in the owning SPEC is acceptable for the first phase.
+
+```yaml
+action_id: knowledge-mcp.search_knowledge
+owner_service: klai-knowledge-mcp
+entrypoint: klai-knowledge-mcp/main.py::search_knowledge
+kind: mcp_tool
+
+input:
+  schema: search_knowledge(query: str, top_k: int = 8)  # function signature; no request model exists
+  validation:
+    query.max_chars: 2000
+    top_k: clamp[1,15]
+
+auth:
+  mode: oauth_or_internal_secret
+  caller_identity: oauth_client | librechat_internal
+  tenant_identity:
+    requires_user_id: true
+    requires_org_id: true
+    source: _identify_request(ctx)
+    verified_by: portal-api /internal/mcp-token/verify or /internal/identity/verify
+
+effects:
+  access: read
+  destructive: false
+  external_calls:
+    - retrieval-api /retrieve
+
+execution:
+  concurrency_class: interactive_io
+  timeout_ms: 3000
+  retry_policy: none
+  idempotency: read_only
+
+failure:
+  mode: fail_closed
+  user_surface: ToolError generic bilingual message
+  log_fields:
+    - action_id
+    - status_code
+    - elapsed_ms
+
+telemetry:
+  events:
+    - retrieval_log
+    - product_events.knowledge.queried
+    - gap_event
+  correlation:
+    - request_id
+    - org_id
+    - user_id
+    - caller_client_id
+
+result_policy:
+  max_items: 15
+  max_text_chars_per_item: service-local cap
+  secret_redaction: required
+  cross_tenant_leak_guard: retrieval-api RLS + verified identity
+
+tests:
+  unit:
+    - input bounds
+    - auth/identity failure
+    - timeout/failure mode
+    - telemetry fire-and-forget
+  integration:
+    - cross-tenant isolation where data is tenant-scoped
+
+docs:
+  spec: .moai/specs/SPEC-MCP-RETRIEVAL-001/spec.md
+  runbook: optional
+```
+
+### Required fields
+
+**REQ-1.** `action_id` SHALL be stable, globally searchable, and lower-case:
+`{service_or_domain}.{action_name}`. Examples:
+`knowledge-mcp.search_knowledge`, `litellm.knowledge_retrieve`,
+`knowledge-ingest.run_crawl`, `connector.delete_connector`.
+
+**REQ-2.** `kind` SHALL use one of:
+`mcp_tool`, `connector_action`, `retrieval_stage`, `procrastinate_task`,
+`litellm_hook_action`, `http_endpoint`, `scheduled_task`, or
+`internal_boundary`.
+
+**REQ-3.** `input.schema` SHALL name the request model, function signature, or
+typed payload contract. Free-form `dict` payloads are allowed only when the
+field-level validation rules are listed in `input.validation`.
+
+**REQ-4.** `auth.mode` SHALL state how the caller is authenticated. Valid
+initial values:
+`oauth_user`, `oauth_client`, `internal_secret`, `service_jwt`,
+`oauth_or_internal_secret`, `public_none`, `worker_internal`.
+
+**REQ-5.** `auth.tenant_identity` SHALL state whether `user_id`, `org_id`,
+`org_slug`, `kb_slug`, `connector_id`, or equivalent scope fields are required,
+where they come from, and how they are verified. If the action carries a
+caller-supplied tenant/user value across a service boundary, the verification
+mechanism must be named.
+
+**REQ-6.** `effects.access` SHALL be one of `read`, `write`, `read_write`, or
+`none`. `effects.destructive` SHALL be explicit `true` or `false`.
+
+**REQ-7.** `execution.concurrency_class` SHALL be one of:
+`interactive_io`, `bulk_io`, `llm`, `cpu`, `operator`, or `unknown`.
+For Procrastinate tasks this maps to the queue lane (`IO_QUEUES` or
+`LLM_QUEUES`). For non-worker actions it documents expected latency and
+upstream pressure.
+
+**REQ-8.** `execution.timeout_ms` SHALL be explicit for every action that makes
+HTTP calls, model calls, queue waits, file/garage access, or database operations
+outside the local request transaction. "Uses default timeout" is not an
+acceptable value.
+
+**REQ-9.** `failure.mode` SHALL be `fail_open`, `fail_closed`, or
+`fail_loud_degraded`.
+
+- `fail_open`: continue without the optional action result, log/telemetry only.
+- `fail_closed`: abort the action and return a safe error.
+- `fail_loud_degraded`: continue with degraded answer/data but explicitly tell
+  the model/user that the protected dependency failed.
+
+**REQ-10.** `telemetry.events` SHALL list emitted events/log streams or state
+`none` with a reason. Model-facing and tenant-scoped actions should default to
+at least one structured event unless the action is too low-volume or
+privacy-sensitive.
+
+**REQ-11.** `result_policy` SHALL state result-size caps and data-leak guards
+for any model-facing result. Tool results must not rely on "the model will be
+careful" as the only leak guard.
+
+**REQ-12.** `tests` SHALL include at least one test or acceptance scenario for
+auth/identity, input bounds, failure mode, and result policy when those fields
+are nontrivial.
+
+**REQ-13.** `docs.spec` SHALL point to the owning SPEC or local markdown file.
+If an action is added without a SPEC, the metadata block in code is the
+documentation source of truth.
+
+---
+
+## Placement
+
+**REQ-14.** For new actions, the ActionSpec SHALL live adjacent to the
+entrypoint when practical:
+
+- MCP tool: directly above the `@mcp.tool` function or in
+  `klai-knowledge-mcp/action_specs.py` imported by tests.
+- LiteLLM hook sub-action: near the helper that performs the boundary call
+  (`_get_kb_feature`, `_rewrite_and_classify`, retrieval call, telemetry emit).
+- Procrastinate task: near the task registration and queue constant.
+- Connector action: near the HTTP client method and route handler.
+- Retrieval stage: near the request/response model or route handler.
+
+**REQ-15.** If a service cannot yet import a shared `ActionSpec` type without
+creating deployment churn, it MAY use a `# ACTION_SPEC:` comment block in
+phase 1. The block must still contain the required fields.
+
+**REQ-16.** Existing actions do not need immediate metadata unless they are
+being materially changed. Material changes include auth semantics, identity
+source, write/destructive behaviour, result shape, timeout, retry policy,
+queue/lane, or telemetry shape.
+
+---
+
+## Baseline classifications for known surfaces
+
+These are not implementation mandates; they are the initial classification
+targets for future incremental metadata additions.
+
+| Surface | Example | Kind | Access | Failure mode | Concurrency |
+|---|---|---|---|---|---|
+| MCP save personal/org/docs | `save_personal_knowledge`, `save_org_knowledge`, `save_to_docs` | `mcp_tool` | write | fail_closed | interactive_io |
+| MCP search | `search_knowledge` | `mcp_tool` | read | fail_closed | interactive_io |
+| LiteLLM feature gate | `_get_kb_feature` | `litellm_hook_action` | read | fail_closed for entitlement | interactive_io |
+| LiteLLM templates | `_get_templates` | `litellm_hook_action` | read | fail_open | interactive_io |
+| LiteLLM query rewrite | `_rewrite_and_classify` | `litellm_hook_action` | read | fail_open | llm |
+| LiteLLM retrieval | `/retrieve` call in hook | `litellm_hook_action` | read | fail_loud_degraded | interactive_io |
+| Ingest queue task | `run_crawl`, enrichment tasks | `procrastinate_task` | write/read_write | task-specific | `IO_QUEUES` or `LLM_QUEUES` |
+| Connector delete/purge | connector purge task | `procrastinate_task` / `connector_action` | read_write | fail_closed where destructive | bulk_io |
+
+---
+
+## Design decisions
+
+### A1. Convention before framework
+
+The first version is a contract convention plus tests. A shared Python package
+is allowed later, but not required now. The current services deploy
+independently; forcing every surface to import one registry would create more
+risk than value.
+
+### A2. ActionSpec documents model risk and service-boundary risk together
+
+MCP tools and LiteLLM hook actions are model-facing. Procrastinate tasks and
+connector actions are service-boundary operations. The same metadata catches
+both classes: identity, effects, concurrency, timeout, failure mode, telemetry,
+and result policy.
+
+### A3. Failure mode is first-class
+
+Klai intentionally uses different behaviours:
+
+- templates fail open because missing style guidance should not break chat,
+- entitlement and identity fail closed,
+- retrieval failure in LibreChat fails loud/degraded so the model warns the
+  user instead of pretending the KB was empty,
+- MCP retrieval failure raises `ToolError`.
+
+Those choices must be named per action. Copying one surface's failure mode into
+another is a bug unless the ActionSpec says it is intended.
+
+### A4. Concurrency class is part of the action contract
+
+`SPEC-WORKER-LANES-001` showed that latency profile and queue lane are
+architecture, not tuning. Every new queued or long-running action must say
+whether it is I/O, LLM, CPU, or operator work before it lands.
+
+### A5. Result policy belongs beside model-facing output
+
+Actions that return data to a model must cap output size and state leak guards.
+The model may format or cite the result, but the action owns the data boundary.
+
+---
+
+## Non-goals
+
+1. No mass migration of every existing helper in `deploy/litellm/klai_knowledge.py`.
+2. No single `ActionExecutor` abstraction.
+3. No central permission system replacement.
+4. No new database tables.
+5. No runtime discovery API for actions in v0.1.0.
+6. No change to customer-visible behaviour.
+
+---
+
+## Implementation plan
+
+See `plan.md`.
+
+---
+
+## Acceptance criteria
+
+See `acceptance.md`.
+

--- a/klai-knowledge-mcp/action_specs.py
+++ b/klai-knowledge-mcp/action_specs.py
@@ -1,0 +1,201 @@
+"""Local ActionSpec convention for klai-knowledge-mcp actions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+ACTION_KINDS = frozenset(
+    {
+        "mcp_tool",
+        "connector_action",
+        "retrieval_stage",
+        "procrastinate_task",
+        "litellm_hook_action",
+        "http_endpoint",
+        "scheduled_task",
+        "internal_boundary",
+    }
+)
+AUTH_MODES = frozenset(
+    {
+        "oauth_user",
+        "oauth_client",
+        "internal_secret",
+        "service_jwt",
+        "oauth_or_internal_secret",
+        "public_none",
+        "worker_internal",
+    }
+)
+ACCESS_MODES = frozenset({"read", "write", "read_write", "none"})
+CONCURRENCY_CLASSES = frozenset({"interactive_io", "bulk_io", "llm", "cpu", "operator", "unknown"})
+FAILURE_MODES = frozenset({"fail_open", "fail_closed", "fail_loud_degraded"})
+MODEL_FACING_KINDS = frozenset({"mcp_tool", "connector_action", "litellm_hook_action"})
+
+
+@dataclass(frozen=True, slots=True)
+class ActionSpec:
+    """Metadata describing an action boundary without changing its execution."""
+
+    action_id: str
+    owner_service: str
+    entrypoint: str
+    kind: str
+    input: dict[str, Any]
+    auth: dict[str, Any]
+    effects: dict[str, Any]
+    execution: dict[str, Any]
+    failure: dict[str, Any]
+    telemetry: dict[str, Any]
+    result_policy: dict[str, Any] | None
+    tests: dict[str, Any]
+    docs: dict[str, Any]
+
+
+_REQUIRED_FIELDS = (
+    "action_id",
+    "owner_service",
+    "entrypoint",
+    "kind",
+    "input",
+    "auth",
+    "effects",
+    "execution",
+    "failure",
+    "telemetry",
+    "tests",
+    "docs",
+)
+
+
+def _required_mapping(payload: Mapping[str, Any], field: str) -> Mapping[str, Any]:
+    value = payload[field]
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a mapping")
+    return value
+
+
+def _require_key(payload: Mapping[str, Any], path: str, key: str) -> Any:
+    if key not in payload or payload[key] is None or payload[key] == "":
+        raise ValueError(f"missing required field: {path}.{key}")
+    return payload[key]
+
+
+def _validate_enum(path: str, value: Any, allowed: frozenset[str]) -> None:
+    if value not in allowed:
+        raise ValueError(f"invalid {path}: {value!r}")
+
+
+def validate_action_spec(spec: ActionSpec | Mapping[str, Any]) -> None:
+    """Raise ``ValueError`` when an ActionSpec does not satisfy Phase 1 rules."""
+
+    payload: Mapping[str, Any] = asdict(spec) if isinstance(spec, ActionSpec) else spec
+    missing = [field for field in _REQUIRED_FIELDS if field not in payload or not payload[field]]
+    if missing:
+        raise ValueError(f"missing required fields: {', '.join(missing)}")
+
+    input_spec = _required_mapping(payload, "input")
+    auth = _required_mapping(payload, "auth")
+    effects = _required_mapping(payload, "effects")
+    execution = _required_mapping(payload, "execution")
+    failure = _required_mapping(payload, "failure")
+    telemetry = _required_mapping(payload, "telemetry")
+    docs = _required_mapping(payload, "docs")
+
+    _require_key(input_spec, "input", "schema")
+    _require_key(auth, "auth", "tenant_identity")
+    _require_key(telemetry, "telemetry", "events")
+    _require_key(docs, "docs", "spec")
+
+    _validate_enum("kind", payload["kind"], ACTION_KINDS)
+    _validate_enum("auth.mode", _require_key(auth, "auth", "mode"), AUTH_MODES)
+    _validate_enum("effects.access", _require_key(effects, "effects", "access"), ACCESS_MODES)
+    _validate_enum(
+        "execution.concurrency_class",
+        _require_key(execution, "execution", "concurrency_class"),
+        CONCURRENCY_CLASSES,
+    )
+    _validate_enum("failure.mode", _require_key(failure, "failure", "mode"), FAILURE_MODES)
+
+    if "destructive" not in effects or not isinstance(effects["destructive"], bool):
+        raise ValueError("effects.destructive must be an explicit boolean")
+
+    if effects.get("external_calls"):
+        timeout_ms = execution.get("timeout_ms")
+        if not isinstance(timeout_ms, int) or isinstance(timeout_ms, bool) or timeout_ms <= 0:
+            raise ValueError("execution.timeout_ms must be explicit for HTTP-calling actions")
+
+    if payload["kind"] in MODEL_FACING_KINDS and not payload.get("result_policy"):
+        raise ValueError("result_policy is required for model-facing actions")
+
+
+SEARCH_KNOWLEDGE_SPEC = ActionSpec(
+    action_id="knowledge-mcp.search_knowledge",
+    owner_service="klai-knowledge-mcp",
+    entrypoint="klai-knowledge-mcp/main.py::search_knowledge",
+    kind="mcp_tool",
+    input={
+        "schema": (
+            "search_knowledge(query: str, ctx: Context, top_k: int = 8, "
+            "scope: Literal['org', 'personal', 'both'] = 'both', "
+            "kb_slugs: list[str] | None = None)"
+        ),
+        "validation": {
+            "query.max_chars": 2000,
+            "top_k": "clamp[1,15]",
+            "scope": ["org", "personal", "both"],
+            "kb_slugs": "truncate to 20; ignored for personal scope",
+        },
+    },
+    auth={
+        "mode": "oauth_or_internal_secret",
+        "caller_identity": "oauth_client | librechat_internal",
+        "tenant_identity": {
+            "requires_user_id": True,
+            "requires_org_id": True,
+            "source": "_identify_request(ctx)",
+            "verified_by": ("portal-api /internal/mcp-token/verify or /internal/identity/verify"),
+        },
+    },
+    effects={
+        "access": "read",
+        "destructive": False,
+        "external_calls": ["retrieval-api /retrieve"],
+    },
+    execution={
+        "concurrency_class": "interactive_io",
+        "timeout_ms": 3000,
+        "retry_policy": "none",
+        "idempotency": "read_only",
+    },
+    failure={
+        "mode": "fail_closed",
+        "user_surface": "ToolError generic bilingual message for retrieval failures",
+        "log_fields": ["failure_type", "status_code", "client_id"],
+    },
+    telemetry={
+        "events": [
+            "retrieval_log",
+            "retrieval-api product_events.knowledge.queried",
+            "gap_event when classified",
+        ],
+        "delivery": "retrieval_log and gap_event are fire-and-forget",
+        "correlation": ["org_id", "user_id", "caller_client_id"],
+    },
+    result_policy={
+        "max_items": 15,
+        "allowed_fields": ["title", "source_url", "text", "artifact_id", "score", "scope"],
+        "text_cap": "retrieval-api policy; MCP does not apply an additional cap",
+        "cross_tenant_leak_guard": "retrieval-api RLS plus verified identity",
+    },
+    tests={
+        "unit": [
+            "tests/test_search_knowledge.py",
+            "tests/test_action_specs.py",
+        ],
+        "integration": "cross-tenant isolation is owned by retrieval-api tests",
+    },
+    docs={"spec": ".moai/specs/SPEC-ACTION-CONTRACT-001/spec.md"},
+)

--- a/klai-knowledge-mcp/tests/test_action_specs.py
+++ b/klai-knowledge-mcp/tests/test_action_specs.py
@@ -1,0 +1,90 @@
+"""Phase 1 validation tests for SPEC-ACTION-CONTRACT-001."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict
+
+import pytest
+
+from action_specs import SEARCH_KNOWLEDGE_SPEC, validate_action_spec
+
+
+def _pilot_payload() -> dict:
+    return asdict(SEARCH_KNOWLEDGE_SPEC)
+
+
+def test_validator_accepts_search_knowledge_pilot() -> None:
+    validate_action_spec(SEARCH_KNOWLEDGE_SPEC)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "action_id",
+        "owner_service",
+        "entrypoint",
+        "kind",
+        "input",
+        "auth",
+        "effects",
+        "execution",
+        "failure",
+        "telemetry",
+        "tests",
+        "docs",
+    ],
+)
+def test_validator_rejects_missing_required_fields(field: str) -> None:
+    payload = _pilot_payload()
+    payload.pop(field)
+
+    with pytest.raises(ValueError, match="missing required field"):
+        validate_action_spec(payload)
+
+
+@pytest.mark.parametrize(
+    ("section", "field"),
+    [
+        (None, "kind"),
+        ("auth", "mode"),
+        ("effects", "access"),
+        ("execution", "concurrency_class"),
+        ("failure", "mode"),
+    ],
+)
+def test_validator_rejects_invalid_enum_values(section: str | None, field: str) -> None:
+    payload = _pilot_payload()
+    target = payload if section is None else payload[section]
+    target[field] = "invalid"
+
+    with pytest.raises(ValueError, match="invalid"):
+        validate_action_spec(payload)
+
+
+def test_validator_rejects_http_action_without_timeout() -> None:
+    payload = _pilot_payload()
+    payload["execution"].pop("timeout_ms")
+
+    with pytest.raises(ValueError, match="timeout_ms"):
+        validate_action_spec(payload)
+
+
+@pytest.mark.parametrize("destructive", [None, "false"])
+def test_validator_requires_explicit_destructive_boolean(destructive: object) -> None:
+    payload = _pilot_payload()
+    if destructive is None:
+        payload["effects"].pop("destructive")
+    else:
+        payload["effects"]["destructive"] = destructive
+
+    with pytest.raises(ValueError, match="destructive"):
+        validate_action_spec(payload)
+
+
+def test_validator_rejects_model_facing_action_without_result_policy() -> None:
+    payload = deepcopy(_pilot_payload())
+    payload.pop("result_policy")
+
+    with pytest.raises(ValueError, match="result_policy"):
+        validate_action_spec(payload)


### PR DESCRIPTION
Phase 1 of the ActionSpec convention: `ActionSpec` dataclass + validator + one pilot (`SEARCH_KNOWLEDGE_SPEC` describing existing `search_knowledge` behavior). Test-only/metadata-only — `main.py` untouched, zero production behavior change (AC-9).

Verified: 205 tests pass, ruff clean, 291 LOC.
Implemented by codex gpt-5.6-sol; second-pass verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)