### PR TITLE
feat(deploy): gpu-01 transcription compose + push-health + runbook

### DIFF
--- a/deploy/docker-compose.gpu.yml
+++ b/deploy/docker-compose.gpu.yml
@@ -1,0 +1,209 @@
+# gpu-01 GPU Inference Services
+# SPEC-GPU-001 — Phase 1
+# Alle services gebonden aan 127.0.0.1 (NOOIT 0.0.0.0) — toegang alleen via SSH tunnel van core-01
+
+services:
+
+  # ─── TEI: dense embeddings (BAAI/bge-m3) ──────────────────────────────
+  # HuggingFace Text Embeddings Inference — vervangt Infinity voor dense embeddings
+  # Gebruikt lokaal gecachede model uit infinity-models volume (snapshot met safetensors)
+  # VRAM: ~4-5GB
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:1.9
+    restart: unless-stopped
+    command: --model-id /data/huggingface/hub/models--BAAI--bge-m3/snapshots/5617a9f61b028005a4858fdac845db406aefb181 --port 7997 --max-client-batch-size 256
+    volumes:
+      - infinity-models:/data
+    ports:
+      - "127.0.0.1:7997:7997"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      # TEI is a Rust binary — no python3 available. Use curl instead.
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:7997/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+
+  # ─── Infinity: reranker (BAAI/bge-reranker-v2-m3) ─────────────────────
+  # Infinity alleen voor reranking — dense embeddings verhuisd naar TEI
+  # VRAM: ~3-4GB
+  infinity:
+    image: michaelf34/infinity:0.0.77
+    restart: unless-stopped
+    command: >
+      v2
+      --model-id BAAI/bge-reranker-v2-m3
+      --device cuda
+      --engine torch
+      --url-prefix /v1
+      --port 7998
+    volumes:
+      - infinity-models:/app/.cache
+    ports:
+      - "127.0.0.1:7998:7998"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:7998/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+
+  # ─── BGE-M3 sparse sidecar ─────────────────────────────────────────────
+  # Sparse embeddings (SPLADE-stijl) voor hybride retrieval.
+  # Op GPU — BGE-M3 CPU inference duurt 30s+, wat altijd tot timeout leidt in knowledge-ingest.
+  # RTX 4000 Ada heeft 20GB VRAM; met TEI+Infinity+Whisper is er ~14GB vrij.
+  bge-m3-sparse:
+    build: ./bge-m3-sparse
+    restart: unless-stopped
+    environment:
+      MODEL_NAME: BAAI/bge-m3
+      HF_HOME: /models
+    volumes:
+      - bge-models:/models
+    ports:
+      - "127.0.0.1:8001:8001"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
+  # ─── Vexa transcription workers (SPEC-VEXA-003 — replaces whisper-server) ────
+  # Nginx LB + 2 faster-whisper CUDA workers (least-connections) with two-tier
+  # admission (realtime/deferred), hallucination detection, VAD, temperature
+  # fallback. API is OpenAI-compatible (POST /v1/audio/transcriptions) on the
+  # SAME host port 8000 as the legacy whisper-server so gpu-tunnel.service
+  # and all consumer URLs (meeting-api TRANSCRIPTION_SERVICE_URL, scribe-api
+  # WhisperHttpProvider) stay unchanged. See SPEC-VEXA-003 plan.md §3.4.
+  #
+  # VRAM budget (RTX 4000 Ada 20GB):
+  #   TEI bge-m3       ~4-5 GB
+  #   Infinity rerank  ~3-4 GB
+  #   bge-m3-sparse    ~3 GB
+  #   2x worker int8   ~4 GB (~2 GB each, large-v3-turbo int8)
+  #   headroom         ~4-6 GB
+  # If Phase 7.7 OOMs or latency spikes, drop to 1 worker and/or tune
+  # MAX_ACTIVE_REQUESTS / REALTIME_RESERVED_SLOTS. See plan.md R8.
+
+  transcription-worker-1:
+    # NOTE: vexaai/transcription-service is NOT published to Docker Hub.
+    # Built locally on gpu-01 from upstream Vexa-ai/vexa source (CUDA 12.3.2 +
+    # cuDNN 9, faster-whisper). Tag convention `<semver>-local-YYMMDD-HHMM`
+    # is recognised by `deploy/check-image-pullable.sh` as locally-built and
+    # skipped from the registry-manifest check. Bumping = `git clone v0.10.x`
+    # + `docker build` on gpu-01; runbook in `docs/runbooks/transcription-service-bump.md`.
+    image: vexaai/transcription-service:0.10.6-local-260503-0858
+    restart: unless-stopped
+    environment:
+      WORKER_ID: "1"
+      MODEL_SIZE: large-v3-turbo
+      DEVICE: cuda
+      COMPUTE_TYPE: int8
+      MAX_ACTIVE_REQUESTS: "20"
+      REALTIME_RESERVED_SLOTS: "1"
+      FAIL_FAST_WHEN_BUSY: "true"
+      BUSY_RETRY_AFTER_S: "1"
+    volumes:
+      - vexa-transcription-models:/app/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    networks:
+      - transcription-net
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+
+  transcription-worker-2:
+    # See note on transcription-worker-1 — locally-built, not on Docker Hub.
+    image: vexaai/transcription-service:0.10.6-local-260503-0858
+    restart: unless-stopped
+    environment:
+      WORKER_ID: "2"
+      MODEL_SIZE: large-v3-turbo
+      DEVICE: cuda
+      COMPUTE_TYPE: int8
+      MAX_ACTIVE_REQUESTS: "20"
+      REALTIME_RESERVED_SLOTS: "1"
+      FAIL_FAST_WHEN_BUSY: "true"
+      BUSY_RETRY_AFTER_S: "1"
+    volumes:
+      - vexa-transcription-models:/app/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    networks:
+      - transcription-net
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8081/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+
+  # Nginx least-connections load balancer. Listens on host :8000 to retain
+  # the legacy gpu-tunnel.service + consumer URLs. Config lives on-server at
+  # /opt/klai/vexa-transcription/nginx.conf (not in git — rendered during
+  # Phase 6 deploy). Template is at deploy/vexa-transcription/nginx.conf.
+  transcription-api:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:80"
+    volumes:
+      - /opt/klai/vexa-transcription/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      transcription-worker-1:
+        condition: service_healthy
+      transcription-worker-2:
+        condition: service_healthy
+    networks:
+      - transcription-net
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  transcription-net:
+    driver: bridge
+
+volumes:
+  infinity-models:
+  bge-models:
+  vexa-transcription-models:

--- a/deploy/scripts/push-health.sh
+++ b/deploy/scripts/push-health.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# push-health.sh — Push container health to Uptime Kuma
+#
+# Runs every minute via cron (klai user).
+# Two check methods:
+#   push_healthcheck — reads Docker-native healthcheck status (docker inspect)
+#   push_exec        — tests connectivity via docker exec from a container on the same network
+#
+# To add a new service:
+#   1. Create a push monitor in Uptime Kuma, copy the token
+#   2. Add KUMA_TOKEN_<NAME>=<token> to your config.env and redeploy (deploy.sh main)
+#   3. Add push_healthcheck or push_exec line below using the variable
+#   4. Run: crontab -e  (entry is already present — no change needed)
+#
+# NOTE: CI does NOT sync this file to the server. deploy-compose.yml triggers on
+# deploy/scripts/** but only installs compose-up.sh + audit scripts. After editing,
+# manually: scp deploy/scripts/push-health.sh core-01:/opt/klai/scripts/push-health.sh
+#
+# All KUMA_TOKEN_* references use ${VAR:-} defaults — set -u would otherwise abort
+# the whole run (and every later push) on a single missing token.
+set -uo pipefail
+
+# Load push tokens from main env (deployed from config.sops.env)
+# shellcheck source=/dev/null
+[ -f /opt/klai/.env ] && source /opt/klai/.env
+
+KUMA="${UPTIME_KUMA_PUSH_URL:-https://status.${DOMAIN}/api/push}"
+LOG=/opt/klai/logs/health.log
+
+mkdir -p /opt/klai/logs
+
+# Resolve container name by compose project + service label.
+# Coolify may prefix container names with a hash after redeploy; this finds
+# the actual running container regardless of name prefix.
+resolve_container() {
+    docker ps \
+        --filter "label=com.docker.compose.project=klai-core" \
+        --filter "label=com.docker.compose.service=$1" \
+        --format "{{.Names}}" | head -1
+}
+
+# Resolve exec proxy and healthcheck containers once at startup
+PORTAL_API=$(resolve_container portal-api)
+LIBRECHAT=$(resolve_container librechat-klai)
+LITELLM=$(resolve_container litellm)
+MONGODB=$(resolve_container mongodb)
+POSTGRES=$(resolve_container postgres)
+REDIS=$(resolve_container redis)
+VEXA=$(resolve_container vexa-bot-manager)
+
+# Push based on Docker-native healthcheck status (requires healthcheck: in compose)
+push_healthcheck() {
+    local container="$1" token="$2" label="$3"
+    local health
+    health=$(docker inspect --format='{{.State.Health.Status}}' "$container" 2>/dev/null || echo "missing")
+    if [ "$health" = "healthy" ]; then
+        curl -sf "${KUMA}/${token}?status=up&msg=OK" -o /dev/null
+    else
+        curl -sf "${KUMA}/${token}?status=down&msg=${health}" -o /dev/null
+        echo "$(date -Iseconds) WARN ${label}: ${health}" >> "$LOG"
+    fi
+}
+
+# Push based on connectivity test via docker exec (for services on isolated networks)
+push_exec() {
+    local container="$1" cmd="$2" token="$3" label="$4"
+    if [ -z "$container" ]; then
+        curl -sf "${KUMA}/${token}?status=down&msg=container-not-found" -o /dev/null
+        echo "$(date -Iseconds) WARN ${label}: container not found" >> "$LOG"
+        return
+    fi
+    if docker exec "$container" sh -c "$cmd" &>/dev/null; then
+        curl -sf "${KUMA}/${token}?status=up&msg=OK" -o /dev/null
+    else
+        curl -sf "${KUMA}/${token}?status=down&msg=unreachable" -o /dev/null
+        echo "$(date -Iseconds) WARN ${label}: exec check failed" >> "$LOG"
+    fi
+}
+
+# ── Products ──────────────────────────────────────────────────────────────────
+
+# Chat: LibreChat health endpoint
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://librechat-klai:3080/health')\"" \
+    "${KUMA_TOKEN_CHAT:-}" "Chat"
+
+# Scribe: scribe-api receives audio, calls whisper-server internally
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://scribe-api:8020/health')\"" \
+    "${KUMA_TOKEN_SCRIBE:-}" "Scribe"
+
+# Docs: Next.js app — check TCP reachability (no /health route)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import socket; s=socket.create_connection(('docs-app',3010),timeout=5); s.close()\"" \
+    "${KUMA_TOKEN_DOCS:-}" "Docs"
+
+# Knowledge: knowledge-ingest product-level (RAG ingestion pipeline)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://knowledge-ingest:8000/health')\"" \
+    "${KUMA_TOKEN_KNOWLEDGE:-}" "Knowledge"
+
+# ── Infrastructure ────────────────────────────────────────────────────────────
+
+# Portal API: tenant provisioning + auth gateway
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8010/health')\"" \
+    "${KUMA_TOKEN_PORTAL_API:-}" "Portal API"
+
+# MongoDB: conversation store (Chat)
+push_healthcheck "$MONGODB"  "${KUMA_TOKEN_MONGODB:-}"  "Conversations Database"
+
+# PostgreSQL: accounts, meetings, knowledge (shared)
+push_healthcheck "$POSTGRES" "${KUMA_TOKEN_POSTGRES:-}" "Account Database"
+
+# Redis: LLM request cache + LibreChat session store
+push_healthcheck "$REDIS"    "${KUMA_TOKEN_REDIS:-}"    "AI Request Cache"
+
+# Meilisearch: LibreChat message search index
+push_exec "$LIBRECHAT" \
+    "wget -qO- http://meilisearch:7700/health 2>/dev/null | grep -q available" \
+    "${KUMA_TOKEN_MEILI:-}" "Message Search"
+
+# Ollama: local fallback LLM (backup for LiteLLM)
+push_exec "$LITELLM" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://ollama:11434/')\"" \
+    "${KUMA_TOKEN_OLLAMA:-}" "Backup Language Model"
+
+# Whisper: transcription engine on gpu-01, reached via SSH-tunnel bridge IP
+# (no `whisper-server` compose service on core-01 — see WHISPER_SERVER_URL in compose)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://172.18.0.1:8000/health')\"" \
+    "${KUMA_TOKEN_WHISPER:-}" "Transcription Engine"
+
+# Docling: document-to-markdown conversion (knowledge-ingest only since SPEC-PORTAL-UNIFY-KB-001)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://docling-serve:5001/health')\"" \
+    "${KUMA_TOKEN_DOCLING:-}" "Document Processing"
+
+# Gitea: docs content store (Docs product, Knowledge webhook source)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://gitea:3000/api/healthz')\"" \
+    "${KUMA_TOKEN_GITEA:-}" "Docs Storage"
+
+# Qdrant: vector store for Knowledge retrieval
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://qdrant:6333/healthz')\"" \
+    "${KUMA_TOKEN_QDRANT:-}" "Vector Database"
+
+# TEI: text embeddings on gpu-01 via SSH-tunnel bridge IP (TEI_URL in compose)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://172.18.0.1:7997/health')\"" \
+    "${KUMA_TOKEN_TEI:-}" "Embeddings"
+
+# Reranker: cross-encoder reranking on gpu-01 via SSH-tunnel bridge IP
+# (TEI_RERANKER_URL in compose — port 7998, not TEI's 7997)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://172.18.0.1:7998/health')\"" \
+    "${KUMA_TOKEN_RERANKER:-}" "Reranker"
+
+# Firecrawl: web content fetcher (Chat web mode)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://firecrawl-api:3002/')\"" \
+    "${KUMA_TOKEN_FIRECRAWL:-}" "Web Content Fetcher"
+
+# SearXNG: privacy-preserving web search (Chat + Focus)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://searxng:8080/')\"" \
+    "${KUMA_TOKEN_SEARXNG:-}" "Web Search"
+
+# Mailer: transactional email service
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://klai-mailer:8000/health')\"" \
+    "${KUMA_TOKEN_MAILER:-}" "Email Service"
+
+# Vexa bot manager: meeting bot lifecycle (Docker-native healthcheck)
+push_healthcheck "$VEXA" "${KUMA_TOKEN_VEXA:-}" "Meeting Bot Manager"
+
+# ── Knowledge layer (service-level) ──────────────────────────────────────────
+
+# Knowledge Ingestion: RAG pipeline service (separate from Products "Knowledge")
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://knowledge-ingest:8000/health')\"" \
+    "${KUMA_TOKEN_KNOWLEDGE_INGEST:-}" "Knowledge Ingestion"
+
+# External Source Sync: klai-connector syncs GitHub → knowledge-ingest
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://klai-connector:8200/health')\"" \
+    "${KUMA_TOKEN_CONNECTOR:-}" "External Source Sync"
+
+# Knowledge MCP: bridge between Chat (LibreChat) and Knowledge layer
+push_exec "$PORTAL_API" \
+    "python3 -c \"import socket; s=socket.create_connection(('klai-knowledge-mcp',8080),timeout=5); s.close()\"" \
+    "${KUMA_TOKEN_KNOWLEDGE_MCP:-}" "Knowledge MCP"
+
+# FalkorDB: graph database (Knowledge graph store — Graphiti)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import socket; s=socket.create_connection(('falkordb',6379),timeout=5); s.close()\"" \
+    "${KUMA_TOKEN_FALKORDB:-}" "Graph Database"
+
+# Retrieval API: hybrid vector + graph search (Knowledge product)
+push_exec "$PORTAL_API" \
+    "python3 -c \"import urllib.request; urllib.request.urlopen('http://retrieval-api:8040/health')\"" \
+    "${KUMA_TOKEN_RETRIEVAL_API:-}" "Retrieval API"

--- a/deploy/vexa-transcription/nginx.conf
+++ b/deploy/vexa-transcription/nginx.conf
@@ -1,0 +1,79 @@
+# Nginx least-connections load balancer for Vexa transcription-service workers.
+# SPEC-VEXA-003 — replaces the custom 146-line Python whisper-server on gpu-01.
+#
+# Deploy path on gpu-01: /opt/klai/vexa-transcription/nginx.conf
+# Reload: `docker compose -f docker-compose.gpu.yml exec transcription-api nginx -s reload`
+
+worker_processes auto;
+error_log /dev/stderr warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+    use epoll;
+    multi_accept on;
+}
+
+http {
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    sendfile on;
+    keepalive_timeout 75s;
+
+    # Large file uploads (audio blobs) — Scribe may send multi-minute WAVs.
+    client_max_body_size 100m;
+    client_body_timeout 300s;
+    send_timeout 300s;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+
+    upstream transcription_workers {
+        # least_conn directs to the worker with the fewest active connections.
+        # Both workers publish their OpenAI-compatible API on port 8081 inside
+        # the transcription-net Docker network.
+        least_conn;
+        server transcription-worker-1:8081 max_fails=3 fail_timeout=30s;
+        server transcription-worker-2:8081 max_fails=3 fail_timeout=30s;
+        keepalive 16;
+    }
+
+    server {
+        listen 80 default_server;
+        server_name _;
+
+        # Cheap liveness probe for the LB itself.
+        location = /health {
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+        }
+
+        # OpenAI-compatible transcription endpoint — consumers target this.
+        # tier=realtime vs tier=deferred is passed through as a form field and
+        # interpreted by the worker's admission controller.
+        location /v1/audio/transcriptions {
+            proxy_pass http://transcription_workers;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            # When all workers return 503 (backpressure), nginx surfaces it as-is.
+            # Consumers (meeting-api, scribe-api) honour Retry-After per REQ-E-005.
+            proxy_next_upstream error timeout;
+            proxy_next_upstream_tries 2;
+        }
+
+        # Capacity endpoint — acceptance §M.4 polls this during load tests.
+        location = /capacity {
+            proxy_pass http://transcription_workers;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+        }
+
+        # Reject anything else so misrouted calls fail loudly.
+        location / {
+            return 404;
+        }
+    }
+}

--- a/docs/runbooks/transcription-service-bump.md
+++ b/docs/runbooks/transcription-service-bump.md
@@ -1,0 +1,120 @@
+# Runbook — Bumping `vexaai/transcription-service`
+
+The Vexa transcription-service is the one Vexa image we cannot pull from
+Docker Hub. It ships only as upstream source (CUDA build, multi-GB image),
+so every bump requires a manual `docker build` on `gpu-01`.
+
+This runbook is the canonical procedure. Diverge at your own risk.
+
+## When to bump
+
+- Upstream Vexa-ai/vexa ships a transcription-relevant fix (admission
+  control, hallucination filter, VAD, faster-whisper version, CUDA
+  compatibility).
+- A regression is observed in the workers (CUDA OOM, transcript drift,
+  latency spike).
+
+Do **not** bump in lock-step with the core stack (`admin-api`,
+`api-gateway`, `meeting-api`, `runtime-api`, `vexa-bot`) just for tidiness.
+The HTTP contract between meeting-api and the transcription LB is stable
+across upstream minor versions; mixed-version is fine.
+
+## Pre-flight (no changes yet)
+
+```bash
+# 1. Verify upstream has the tag with the service.
+gh api repos/Vexa-ai/vexa/contents/services/transcription-service?ref=v0.10.6 --jq '.[] | .name'
+# Expect: Dockerfile, main.py, nginx.conf, requirements.txt, …
+
+# 2. Verify gpu-01 has headroom.
+ssh core-01 "ssh -i /opt/klai/gpu-tunnel-key root@5.9.10.215 '
+  df -h / | tail -1                                   # need >20G free
+  nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader
+  docker images vexaai/transcription-service --format \"{{.Tag}}\\t{{.Size}}\"
+'"
+
+# 3. Confirm the rollback image is still on disk (do NOT prune it).
+```
+
+## Build (gpu-01, leaves running workers untouched)
+
+```bash
+TAG="0.10.6-local-$(date +%y%m%d-%H%M)"   # local convention; check-image-pullable.sh accepts this
+
+ssh core-01 "ssh -i /opt/klai/gpu-tunnel-key root@5.9.10.215 '
+  set -e
+  cd /opt
+  [ -d vexa-src ] && rm -rf vexa-src
+  git clone --depth 1 --branch v0.10.6 https://github.com/Vexa-ai/vexa.git vexa-src
+  cd vexa-src/services/transcription-service
+  docker build -t vexaai/transcription-service:$TAG .
+  docker images vexaai/transcription-service
+'"
+```
+
+The build is ~10–15 min on gpu-01 (CUDA base layer caches across runs).
+Old image tag stays on disk for rollback.
+
+## Recreate workers (canary, then full)
+
+`/opt/klai-gpu/docker-compose.yml` is hand-edited on gpu-01 (no CI sync).
+Repo file at `deploy/docker-compose.gpu.yml` is the audit copy.
+
+```bash
+# Canary: worker-1 first.
+ssh core-01 "ssh -i /opt/klai/gpu-tunnel-key root@5.9.10.215 '
+  cd /opt/klai-gpu
+  sed -i.bak \"s|image: vexaai/transcription-service:[A-Za-z0-9._-]\\+|image: vexaai/transcription-service:$TAG|\" docker-compose.yml
+  # Verify only worker-1 changed (sed targets first match if you scope it).
+  # If both workers should canary independently, edit by line number instead.
+  docker compose up -d transcription-worker-1
+'"
+
+# Observe for 5–10 min during a real meeting.
+# Healthcheck:
+ssh core-01 "ssh -i /opt/klai/gpu-tunnel-key root@5.9.10.215 '
+  docker ps --format \"{{.Names}}\\t{{.Image}}\\t{{.Status}}\" | grep transcription
+'"
+
+# If healthy: bring worker-2 over with the same sed + up -d.
+```
+
+## Repo alignment
+
+After the live image runs, sync the repo:
+
+1. Update `deploy/docker-compose.gpu.yml` — both `transcription-worker-{1,2}`
+   image refs to the new tag.
+2. Update `deploy/VERSIONS.md` — the locally-built note + table row.
+3. Run `sh deploy/check-image-pullable.sh` — must say `OK: … N locally-built ref(s) accepted.`
+4. Run `sh deploy/check-image-tags.sh` — same.
+5. Open PR, merge.
+
+## Rollback
+
+```bash
+ssh core-01 "ssh -i /opt/klai/gpu-tunnel-key root@5.9.10.215 '
+  cd /opt/klai-gpu
+  mv docker-compose.yml.bak docker-compose.yml   # if .bak still exists
+  # OR sed it back to the previous tag, which is still on disk.
+  docker compose up -d transcription-worker-1 transcription-worker-2
+'"
+```
+
+Old images remain on disk (do not `docker image prune` until the new
+build has soaked for at least a week of real meetings).
+
+## What can NOT go wrong this way
+
+The forcing function `deploy/check-image-pullable.sh` runs in
+pre-commit and in the `deploy-compose.yml` workflow. If a future PR
+bumps a `vexaai/*` ref to a tag that does not exist on Docker Hub
+**and** does not match the locally-built tag pattern
+(`<semver>-local-YYMMDD-HHMM` or legacy `<semver>-YYMMDD-HHMM`), the
+commit is rejected. PR #269 would have failed this check.
+
+## See also
+
+- `.claude/rules/klai/pitfalls/process-rules.md` — `verify-image-pullable-before-pin` pitfall.
+- `deploy/VERSIONS.md` — the canonical pin table.
+- SPEC-VEXA-003 deploy-notes — original local-build context.


### PR DESCRIPTION
Session deliverables for the transcription-service work: `deploy/docker-compose.gpu.yml` (gpu-01, hand-synced — not in CI paths), `deploy/vexa-transcription/nginx.conf`, `docs/runbooks/transcription-service-bump.md`, and `deploy/scripts/push-health.sh`.

push-health.sh was reviewed against the live topology and fixed before landing: 10 missing `${KUMA_TOKEN_*:-}` defaults restored (a regression of the documented set -u crash fix) and the TEI/reranker/whisper checks now target `172.18.0.1:7997/7998/8000` (the compose hostnames `tei`/`infinity-reranker`/`whisper-server` no longer exist on core-01; the old reranker check also used TEI's port). Will be scp'd to core-01 after merge (CI does not sync this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)