### PR TITLE
fix(audit): drop stale pre-vexa12 hostnames from Caddy-upstream whitelists

### DIFF
--- a/deploy/scripts/docker-orphan-audit.sh
+++ b/deploy/scripts/docker-orphan-audit.sh
@@ -271,7 +271,7 @@ if [[ -n "$CADDY_TENANTS_OK" ]]; then
         local h="$1"
         case "$h" in
             localhost|127.0.0.1) return 0 ;;
-            api-gateway|admin-api|meeting-api|runtime-api|transcription-api) return 0 ;;
+            transcription-api) return 0 ;;  # gpu-01 tunnel upstream, no local compose service
             h2c|http|https|h2|h3) return 0 ;;
         esac
         # Caddy named matchers start with @


### PR DESCRIPTION
Follow-up of the stale-name audit: the two orphan-audit scripts whitelisted Caddy upstreams (api-gateway/admin-api/meeting-api/runtime-api) that SPEC-VEXA-004 removed. Dead entries would mask a future stale route. transcription-api stays whitelisted (gpu-01 tunnel upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)