### PR TITLE
feat(retrieval-api): complete RetrievalTrace — Unit 5+6 (SPEC-RETRIEVAL-TRACE-001)

### DIFF
--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/plan.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/plan.md
@@ -2,7 +2,7 @@
 id: SPEC-RETRIEVAL-TRACE-001
 plan_for: spec.md
 created: 2026-05-08
-updated: 2026-05-08
+updated: 2026-09-01
 author: Mark Vletter
 ---
 
@@ -117,26 +117,25 @@ Migrate optional steps where explicit skip/error state is highest value:
 
 Preserve all existing log lines and metrics. The trace adds shape; it does not replace operational warnings yet.
 
-**This unit is the end of the first implementation PR.** Units 5 and 6 below are an explicit follow-up PR, to start only after Units 1-4 have landed and proven stable.
+**This unit was the end of the first implementation PR.** Units 5 and the metrics part of Unit 6 were completed after Units 1-4 landed and proved stable.
 
-## 5. Unit 5 -- Candidate-transform steps (FOLLOW-UP PR — not in first implementation)
+## 5. Unit 5 -- Candidate-transform steps (DONE)
 
-Wrap the remaining candidate-transform sections:
+Wrapped the remaining live candidate-transform sections:
 
 - `qdrant_search`
 - `rerank`
 - `quality_floor`
 - `source_select`
 - `quality_boost`
-- `evidence_tier`
 - `parent_lookup`
 - `response_build`
 
-At this point remove duplicated timing variables only when the trace value is already proven by tests. Do not combine behavioral refactors with this unit.
+The retired `evidence_tier` experiment was not reintroduced. Duplicated timing variables were removed only where tests prove the trace and metric use the same measured duration. No behavioral refactor was combined with this unit.
 
-## 6. Unit 6 -- Metrics cleanup and docs (docs part lands with the first PR; metrics-dedup part follows Unit 5)
+## 6. Unit 6 -- Metrics cleanup and docs (DONE)
 
-Where a step duration is recorded in both trace and `step_latency_seconds`, use a single measured duration for both. Do not rename metrics or labels.
+Where a step duration is recorded in both trace and `step_latency_seconds`, the implementation now uses a single measured duration for both. No metrics or labels were renamed.
 
 Add a short PR note or code comment near `RetrievalTrace`:
 
@@ -163,14 +162,14 @@ No migrations, no frontend changes, no LiteLLM-hook changes, no deploy config ch
 
 ## 8. Pre-merge checklist
 
-- [ ] Existing flat `retrieval_decision_record` keys preserved.
-- [ ] `trace_steps` present and ordered in at least one happy-path log assertion.
+- [x] Existing flat `retrieval_decision_record` keys preserved.
+- [x] `trace_steps` present and ordered in at least one happy-path log assertion.
 - [ ] Gate-bypass path marks downstream retrieval steps skipped.
-- [ ] Graph-search fail-open path records `status=error` and still returns response.
-- [ ] `telemetry_level=shadow` and `off` render no raw/resolved query text.
-- [ ] Existing Prometheus metric names and labels unchanged.
-- [ ] Focused retrieval-api tests pass.
-- [ ] PR description states this is observability-only and includes no ranking behavior change.
+- [x] Graph-search fail-open path records `status=error` and still returns response.
+- [x] `telemetry_level=shadow` and `off` render no raw/resolved query text.
+- [x] Existing Prometheus metric names and labels unchanged.
+- [x] Focused retrieval-api tests pass.
+- [x] PR description states this is observability-only and includes no ranking behavior change.
 
 ## 9. Rollback
 

--- a/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
+++ b/.moai/specs/SPEC-RETRIEVAL-TRACE-001/spec.md
@@ -1,9 +1,9 @@
 ---
 id: SPEC-RETRIEVAL-TRACE-001
-version: "0.1.0"
+version: "0.2.0"
 status: draft
 created: 2026-05-08
-updated: 2026-05-08
+updated: 2026-09-01
 author: Mark Vletter
 priority: high
 related:
@@ -23,6 +23,7 @@ references:
 
 | Datum | Versie | Wijziging |
 |-------|--------|-----------|
+| 2026-09-01 | 0.2.0 | De trace is compleet voor alle live `/retrieve`-pipelinestappen. De kandidaattransformaties zijn gewrapt en gedeelde Prometheus-/trace-duren worden eenmaal gemeten; retired gate/evidence-tier-gedrag is niet heringevoerd. |
 | 2026-09-01 | 0.1.1 | Implementation note: op origin/main zijn de gate- en evidence-tier-stappen inmiddels uit de pipeline verwijderd (commit 2ce085277, "remove retired retrieval experiments"). De trace rendert voor die stappen compatibiliteitsdefaults / een skipped step; er is geen gate-gedrag heringevoerd. AC-3 is daardoor niet runtime-bereikbaar en geldt als vervallen zolang de gate retired is. |
 | 2026-05-08 | 0.1.0 | Initial draft. Introduceert `RetrievalTrace` en kleine step wrappers rond `/retrieve` als incrementele vervanging voor ad-hoc mutaties op `decision_record`, met behoud van het bestaande `retrieval_decision_record` logcontract. |
 

--- a/klai-retrieval-api/retrieval_api/api/retrieve.py
+++ b/klai-retrieval-api/retrieval_api/api/retrieve.py
@@ -646,30 +646,32 @@ async def retrieve(
     if settings.graphiti_enabled:
         t_graph = time.perf_counter()
         graph_task = asyncio.create_task(graph_search.search(query_resolved, req.org_id, top_k=20))
-    else:
-        trace.mark_skipped("graph_search", "disabled_by_config")
 
-    raw_results = await qdrant_coro
-    qdrant_ms = (time.perf_counter() - t_qdrant) * 1000
-    step_latency_seconds.labels(step="qdrant").observe(time.perf_counter() - t_qdrant)
+    async with trace.step("qdrant_search", started_at=t_qdrant) as qdrant_step:
+        raw_results = await qdrant_coro
+        qdrant_step.meta("candidates_returned", len(raw_results))
+    qdrant_ms = qdrant_step.duration_ms
+    step_latency_seconds.labels(step="qdrant").observe(qdrant_ms / 1000)
     decision_record["search_ms"] = round(qdrant_ms, 1)
 
     if graph_task is not None and t_graph is not None:
         try:
             async with trace.step("graph_search", started_at=t_graph) as graph_step:
                 graph_results = await graph_task
-                graph_search_ms = (time.perf_counter() - t_graph) * 1000
-                step_latency_seconds.labels(step="graph").observe(graph_search_ms / 1000)
                 graph_results_count = len(graph_results)
                 graph_step.meta("candidates_returned", graph_results_count)
                 if graph_results:
                     await _label_graph_results(graph_results, req)
                     graph_candidate_ids = {r["chunk_id"] for r in graph_results}
                     raw_results = _rrf_merge(raw_results, graph_results)
+            graph_search_ms = graph_step.duration_ms
+            step_latency_seconds.labels(step="graph").observe(graph_search_ms / 1000)
         except Exception:
             # SPEC-SEC-HYGIENE-001 REQ-43.3: exc_info=True preserves the
             # traceback that the previous `error=str(exc)` dropped (TRY401).
             logger.warning("Graph search task failed", exc_info=True)
+    else:
+        trace.mark_skipped("graph_search", "disabled_by_config")
 
     candidates_retrieved = len(raw_results)
     decision_record["search_candidates_count"] = candidates_retrieved
@@ -721,7 +723,7 @@ async def retrieve(
                     c["_link_expanded"] = True
                 raw_results = raw_results + new_chunks
 
-        link_expand_ms = (time.perf_counter() - t_expand) * 1000
+        link_expand_ms = link_expand_step.duration_ms
         step_latency_seconds.labels(step="link_expand").observe(link_expand_ms / 1000)
         logger.debug(
             "link_expand",
@@ -758,8 +760,11 @@ async def retrieve(
         t_rerank = time.perf_counter()
         rerank_input = raw_results[: settings.reranker_candidates]
         rerank_top_n = min(len(rerank_input), max(req.top_k, req.top_k * 3))
-        reranked = await reranker.rerank(query_resolved, rerank_input, rerank_top_n)
-        rerank_ms = (time.perf_counter() - t_rerank) * 1000
+        async with trace.step("rerank", started_at=t_rerank) as rerank_step:
+            rerank_step.meta("candidates_in", len(rerank_input))
+            reranked = await reranker.rerank(query_resolved, rerank_input, rerank_top_n)
+            rerank_step.meta("candidates_out", len(reranked))
+        rerank_ms = rerank_step.duration_ms
         step_latency_seconds.labels(step="rerank").observe(rerank_ms / 1000)
         reranked_to = len(reranked)
         decision_record["rerank_ms"] = round(rerank_ms, 1)
@@ -769,6 +774,12 @@ async def retrieve(
     else:
         reranked = raw_results[: req.top_k]
         reranked_to = len(reranked)
+        rerank_step = trace.mark_skipped(
+            "rerank",
+            "no_candidates" if not raw_results else "reranker_disabled",
+            candidates_in=len(raw_results),
+            candidates_out=reranked_to,
+        )
 
     # REQ-RANK-01/04: in active mode every serving chunk gets the single
     # ranking truth; in shadow mode the field stays ABSENT on serving
@@ -787,11 +798,27 @@ async def retrieve(
     # reranker boost. Applied AFTER rerank and BEFORE quality-floor so
     # expanded chunks get a fair shot at surviving source-aware-select.
     # Default boost=1.00 is a no-op until operator tunes the env var.
+    link_expand_boost_enabled = (
+        settings.link_expand_enabled and settings.link_expand_score_boost > 1.0
+    )
+    link_expand_boosted_count = sum(
+        1
+        for chunk in reranked
+        if link_expand_boost_enabled
+        and chunk.get("_link_expanded")
+        and (
+            isinstance(chunk.get("final_rank_score"), (int, float))
+            or isinstance(chunk.get("reranker_score"), (int, float))
+        )
+    )
     reranked = _apply_link_expand_boost(
         reranked,
         boost=settings.link_expand_score_boost,
         enabled=settings.link_expand_enabled,
     )
+    rerank_step.meta("link_expand_boost_enabled", link_expand_boost_enabled)
+    rerank_step.meta("link_expand_boost_factor", settings.link_expand_score_boost)
+    rerank_step.meta("link_expand_boosted_count", link_expand_boosted_count)
     if settings.reranker_enabled:
         reranked, page_context_boosted = _apply_page_context_boost(
             reranked,
@@ -807,9 +834,13 @@ async def retrieve(
     # could burn a diversity slot. The default floor (0.05) cannot
     # accidentally filter neutral 0.5 chunks; an operator must set the
     # threshold > 0.5 explicitly.
-    reranked, quality_floor_filtered = filter_quality_floor(
-        reranked, floor=settings.retrieval_quality_floor
-    )
+    with trace.step("quality_floor") as quality_floor_step:
+        quality_floor_step.meta("candidates_in", len(reranked))
+        reranked, quality_floor_filtered = filter_quality_floor(
+            reranked, floor=settings.retrieval_quality_floor
+        )
+        quality_floor_step.meta("candidates_out", len(reranked))
+        quality_floor_step.meta("filtered_count", quality_floor_filtered)
     decision_record["quality_floor_filtered"] = quality_floor_filtered
     if quality_floor_filtered > 0:
         # SPEC-INGEST-LOGIN-WALL-DETECT-001 REQ-08 — labelled by org_id so
@@ -826,34 +857,51 @@ async def retrieve(
     excluded_preferred_kb_slugs = (
         {personal_kb_slug(req.user_id)} if req.scope == "both" and req.user_id else None
     )
-    if settings.source_quota_enabled:
-        reranked, source_meta = source_aware_select(
-            reranked,
-            top_n=req.top_k,
-            max_per_source=settings.source_quota_max_per_source,
-            preferred_labels=router_selected,
-            preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
-            excluded_preferred_kb_slugs=excluded_preferred_kb_slugs,
-            source_preference_boost=settings.source_preference_boost,
-        )
-    else:
-        source_meta = {
-            "source_select_mode": "disabled",
-            "source_counts": {},
-            "preference_applied": False,
-            "preferred_labels": [],
-            "boost": settings.source_preference_boost,
-            "pack_without_preference": [],
-            "suppressed_count": 0,
-            "max_score_inversion": 0.0,
-        }
+    with trace.step("source_select") as source_select_step:
+        source_select_step.meta("candidates_in", len(reranked))
+        if settings.source_quota_enabled:
+            reranked, source_meta = source_aware_select(
+                reranked,
+                top_n=req.top_k,
+                max_per_source=settings.source_quota_max_per_source,
+                preferred_labels=router_selected,
+                preferred_kb_slugs=set(req.kb_slugs) if req.kb_slugs else None,
+                excluded_preferred_kb_slugs=excluded_preferred_kb_slugs,
+                source_preference_boost=settings.source_preference_boost,
+            )
+        else:
+            source_select_step.skip("disabled_by_config")
+            source_meta = {
+                "source_select_mode": "disabled",
+                "source_counts": {},
+                "preference_applied": False,
+                "preferred_labels": [],
+                "boost": settings.source_preference_boost,
+                "pack_without_preference": [],
+                "suppressed_count": 0,
+                "max_score_inversion": 0.0,
+            }
+        source_select_step.meta("candidates_out", len(reranked))
+        source_select_step.meta("mode", source_meta["source_select_mode"])
+        source_select_step.meta("preference_applied", source_meta["preference_applied"])
+        source_select_step.meta("suppressed_count", source_meta["suppressed_count"])
+        source_select_step.meta("max_score_inversion", source_meta["max_score_inversion"])
     decision_record["source_select"] = source_meta
 
     # 5c. Quality score boost (SPEC-KB-015 REQ-KB-015-19,20,21)
-    reranked = quality_boost(reranked, contract_active=ranking_contract_mode == "active")
-    decision_record["quality_boost_applied"] = any(
-        r.get("feedback_count", 0) >= 3 for r in reranked
-    )
+    with trace.step("quality_boost") as quality_boost_step:
+        quality_boost_step.meta("candidates_in", len(reranked))
+        reranked = quality_boost(reranked, contract_active=ranking_contract_mode == "active")
+        quality_boost_applied = any(r.get("feedback_count", 0) >= 3 for r in reranked)
+        quality_boosted_count = sum(
+            1
+            for chunk in reranked
+            if isinstance(chunk.get("feedback_count", 0), (int, float))
+            and chunk.get("feedback_count", 0) >= 3
+        )
+        quality_boost_step.meta("candidates_out", len(reranked))
+        quality_boost_step.meta("boosted_count", quality_boosted_count)
+    decision_record["quality_boost_applied"] = quality_boost_applied
     if ranking_shadow_preview is not None:
         # REQ-RANK-04 shadow diff: replay the FULL post-rerank pipeline
         # (same steps, same settings) on the preview so "new" is what
@@ -939,49 +987,56 @@ async def retrieve(
     from retrieval_api.services import parent_lookup
 
     parent_id_per_serving: list[int | None] = [r.get("parent_chunk_id") for r in serving]
-    parent_text_by_id = await parent_lookup.fetch_parents(
-        pid for pid in parent_id_per_serving if pid is not None
-    )
+    parent_ids_requested = [pid for pid in parent_id_per_serving if pid is not None]
+    async with trace.step("parent_lookup") as parent_lookup_step:
+        parent_text_by_id = await parent_lookup.fetch_parents(parent_ids_requested)
+        parent_lookup_step.meta("parent_ids_requested", len(parent_ids_requested))
+        parent_lookup_step.meta("parents_found", len(parent_text_by_id))
 
     # 7. Build ChunkResult objects (with parent-text swap when available)
     chunks_out = []
-    for r in serving:
-        pid = r.get("parent_chunk_id")
-        if pid is not None and pid in parent_text_by_id:
-            display_text = parent_text_by_id[pid]
-            is_parent = True
-        else:
-            display_text = r["text"]
-            is_parent = False
-        chunks_out.append(
-            ChunkResult(
-                chunk_id=r["chunk_id"],
-                artifact_id=r.get("artifact_id"),
-                content_type=r.get("content_type"),
-                text=display_text,
-                context_prefix=r.get("context_prefix"),
-                heading_path=r.get("heading_path"),
-                score=r.get("final_rank_score", r["score"])
-                if ranking_contract_mode == "active"
-                else r["score"],
-                reranker_score=r.get("reranker_score"),
-                scope=r.get("scope"),
-                valid_at=r.get("valid_at"),
-                invalid_at=r.get("invalid_at"),
-                ingested_at=r.get("ingested_at"),
-                assertion_mode=r.get("assertion_mode"),
-                source_ref=r.get("source_ref"),
-                source_connector_id=r.get("source_connector_id"),
-                source_url=r.get("source_url"),
-                kb_slug=r.get("kb_slug"),
-                source_label=r.get("source_label"),
-                title=r.get("title"),
-                original_filename=r.get("original_filename"),
-                image_urls=payload_list(r, "image_urls") or None,
-                entity_names=payload_list(r, "entity_names") or None,
-                is_parent_text=is_parent,
+    parent_text_chunks = 0
+    with trace.step("response_build") as response_build_step:
+        for r in serving:
+            pid = r.get("parent_chunk_id")
+            if pid is not None and pid in parent_text_by_id:
+                display_text = parent_text_by_id[pid]
+                is_parent = True
+                parent_text_chunks += 1
+            else:
+                display_text = r["text"]
+                is_parent = False
+            chunks_out.append(
+                ChunkResult(
+                    chunk_id=r["chunk_id"],
+                    artifact_id=r.get("artifact_id"),
+                    content_type=r.get("content_type"),
+                    text=display_text,
+                    context_prefix=r.get("context_prefix"),
+                    heading_path=r.get("heading_path"),
+                    score=r.get("final_rank_score", r["score"])
+                    if ranking_contract_mode == "active"
+                    else r["score"],
+                    reranker_score=r.get("reranker_score"),
+                    scope=r.get("scope"),
+                    valid_at=r.get("valid_at"),
+                    invalid_at=r.get("invalid_at"),
+                    ingested_at=r.get("ingested_at"),
+                    assertion_mode=r.get("assertion_mode"),
+                    source_ref=r.get("source_ref"),
+                    source_connector_id=r.get("source_connector_id"),
+                    source_url=r.get("source_url"),
+                    kb_slug=r.get("kb_slug"),
+                    source_label=r.get("source_label"),
+                    title=r.get("title"),
+                    original_filename=r.get("original_filename"),
+                    image_urls=payload_list(r, "image_urls") or None,
+                    entity_names=payload_list(r, "entity_names") or None,
+                    is_parent_text=is_parent,
+                )
             )
-        )
+        response_build_step.meta("chunks_built", len(chunks_out))
+        response_build_step.meta("parent_text_chunks", parent_text_chunks)
 
     retrieval_ms = (time.perf_counter() - t0) * 1000
     step_latency_seconds.labels(step="total").observe(retrieval_ms / 1000)

--- a/klai-retrieval-api/tests/test_api.py
+++ b/klai-retrieval-api/tests/test_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -49,6 +49,14 @@ class TestRetrieveEndpoint:
         import logging
 
         caplog.set_level(logging.INFO)
+        observed_step_latencies: dict[str, list[float]] = {}
+
+        def capture_step_metric(*, step: str) -> MagicMock:
+            metric = MagicMock()
+            metric.observe.side_effect = lambda value: observed_step_latencies.setdefault(
+                step, []
+            ).append(value)
+            return metric
 
         with (
             patch(
@@ -118,6 +126,10 @@ class TestRetrieveEndpoint:
                 "retrieval_api.api.retrieve.build_evidence_pack",
                 wraps=build_evidence_pack,
             ) as mock_evidence_pack,
+            patch(
+                "retrieval_api.api.retrieve.step_latency_seconds.labels",
+                side_effect=capture_step_metric,
+            ),
         ):
             # Enable reranker so the rerank mock is actually called
             mock_settings.reranker_enabled = True
@@ -201,8 +213,15 @@ class TestRetrieveEndpoint:
             "embed",
             "gate",
             "router",
+            "qdrant_search",
             "graph_search",
             "link_expand",
+            "rerank",
+            "quality_floor",
+            "source_select",
+            "quality_boost",
+            "parent_lookup",
+            "response_build",
             "confidence_band",
             "total",
         ]
@@ -212,10 +231,28 @@ class TestRetrieveEndpoint:
             "duration_ms": 0.0,
             "skipped_reason": "disabled_by_config",
         }
-        assert trace_steps[4]["status"] == "skipped"
-        assert trace_steps[4]["skipped_reason"] == "disabled_by_config"
         assert trace_steps[5]["status"] == "skipped"
-        assert trace_steps[5]["skipped_reason"] == "no_candidate_urls"
+        assert trace_steps[5]["skipped_reason"] == "disabled_by_config"
+        assert trace_steps[6]["status"] == "skipped"
+        assert trace_steps[6]["skipped_reason"] == "no_candidate_urls"
+        rerank_step = trace_steps[7]
+        assert rerank_step["candidates_in"] == 1
+        assert rerank_step["candidates_out"] == 1
+        assert rerank_step["link_expand_boost_enabled"] is False
+        assert rerank_step["link_expand_boost_factor"] == 1.0
+        assert rerank_step["link_expand_boosted_count"] == 0
+        steps_by_name = {step["name"]: step for step in trace_steps}
+        for trace_name, metric_name in (
+            ("coreference", "coref"),
+            ("embed", "embed"),
+            ("qdrant_search", "qdrant"),
+            ("link_expand", "link_expand"),
+            ("rerank", "rerank"),
+            ("total", "total"),
+        ):
+            assert observed_step_latencies[metric_name] == [
+                pytest.approx(steps_by_name[trace_name]["duration_ms"] / 1000, abs=6e-7)
+            ]
         assert "coreference_rewrite" not in decision_record.msg
 
     def test_retrieve_passes_effective_telemetry_level_to_coreference(
@@ -733,6 +770,15 @@ class TestGraphMetadata:
         import logging
 
         caplog.set_level(logging.INFO)
+        observed_step_latencies: dict[str, list[float]] = {}
+
+        def capture_step_metric(*, step: str) -> MagicMock:
+            metric = MagicMock()
+            metric.observe.side_effect = lambda value: observed_step_latencies.setdefault(
+                step, []
+            ).append(value)
+            return metric
+
         graph_chunk = {
             "chunk_id": "graph:edge-1",
             "text": "Graph edge fact",
@@ -771,6 +817,10 @@ class TestGraphMetadata:
                 new_callable=AsyncMock,
                 return_value=[graph_chunk],
             ),
+            patch(
+                "retrieval_api.api.retrieve.step_latency_seconds.labels",
+                side_effect=capture_step_metric,
+            ),
             patch("retrieval_api.api.retrieve.settings") as mock_settings,
         ):
             mock_settings.retrieval_candidates = 60
@@ -802,6 +852,10 @@ class TestGraphMetadata:
                 f"Record attrs: {rec.__dict__}"
             )
         assert "graph:edge-1" in rec_attrs
+        graph_step = next(step for step in rec.msg["trace_steps"] if step["name"] == "graph_search")
+        assert observed_step_latencies["graph"] == [
+            pytest.approx(graph_step["duration_ms"] / 1000, abs=6e-7)
+        ]
 
 
 class TestRetrievalTraceEndpoint:
@@ -937,13 +991,18 @@ class TestLinkExpandInstrumentation:
     internal state into the response.
     """
 
-    def test_link_expanded_flag_does_not_leak_to_response(self, client, sample_retrieve_request):
+    def test_link_expanded_flag_does_not_leak_and_boost_is_traced(
+        self, client, sample_retrieve_request, caplog
+    ):
         """Internal `_link_expanded` flag MUST NOT appear in any ChunkResult field.
 
         ChunkResult is a Pydantic model with explicit fields. The build loop in
         retrieve.py:325-360 reads only listed keys, so the underscore-prefixed
         flag stays internal. This test pins that contract.
         """
+        import logging
+
+        caplog.set_level(logging.INFO)
         seed_chunk = {
             "chunk_id": "seed-1",
             "text": "Seed text",
@@ -1034,7 +1093,7 @@ class TestLinkExpandInstrumentation:
             # SPEC-RAG-LOW-CONFIDENCE-ABSTAIN-001 REQ-1 / REQ-3
             mock_settings.confidence_band_high_threshold = 0.60
             mock_settings.confidence_band_low_threshold = 0.30
-            mock_settings.link_expand_score_boost = 1.00
+            mock_settings.link_expand_score_boost = 1.20
             resp = client.post("/retrieve", json=sample_retrieve_request)
 
         assert resp.status_code == 200
@@ -1046,6 +1105,11 @@ class TestLinkExpandInstrumentation:
                 f"Internal flag leaked into response: {chunk}. "
                 "F3 phase 1 contract: instrumentation MUST stay internal."
             )
+        record = next(r for r in caplog.records if "retrieval_decision_record" in r.getMessage())
+        rerank_step = next(step for step in record.msg["trace_steps"] if step["name"] == "rerank")
+        assert rerank_step["link_expand_boost_enabled"] is True
+        assert rerank_step["link_expand_boost_factor"] == 1.2
+        assert rerank_step["link_expand_boosted_count"] == 1
 
     def test_decision_record_link_expand_block_emitted(
         self, client, sample_retrieve_request, caplog

--- a/klai-retrieval-api/tests/test_retrieval_trace.py
+++ b/klai-retrieval-api/tests/test_retrieval_trace.py
@@ -88,6 +88,53 @@ def test_non_full_render_removes_top_level_and_step_content(level: str) -> None:
     assert record["retention_class"] == "metadata"
 
 
+@pytest.mark.parametrize(
+    ("level", "expected_retention", "content_expected"),
+    [
+        ("off", "metadata", False),
+        ("shadow", "metadata", False),
+        ("full", "content", True),
+    ],
+)
+def test_all_candidate_transform_steps_render_safely_at_every_telemetry_level(
+    level: str,
+    expected_retention: str,
+    content_expected: bool,
+) -> None:
+    trace = _populated_trace(level)
+    trace.content("query_text", "private raw query")
+    safe_details = {
+        "qdrant_search": {"candidates_returned": 4},
+        "rerank": {
+            "candidates_in": 4,
+            "candidates_out": 3,
+            "link_expand_boost_enabled": True,
+            "link_expand_boost_factor": 1.2,
+            "link_expand_boosted_count": 1,
+        },
+        "quality_floor": {"candidates_in": 3, "candidates_out": 2, "filtered_count": 1},
+        "source_select": {"candidates_in": 2, "candidates_out": 2, "mode": "diversify"},
+        "quality_boost": {"candidates_in": 2, "candidates_out": 2, "boosted_count": 1},
+        "parent_lookup": {"parent_ids_requested": 1, "parents_found": 1},
+        "response_build": {"chunks_built": 2, "parent_text_chunks": 1},
+    }
+    for name, details in safe_details.items():
+        trace.record_ok(name, 1.0, **details)
+
+    record = trace.to_decision_record()
+
+    assert [step["name"] for step in record["trace_steps"]] == list(safe_details)
+    assert record["retention_class"] == expected_retention
+    assert ("query_text" in record) is content_expected
+    assert ("coreference_rewrite" in record) is content_expected
+    for content_value in ("private raw query", "raw question", "resolved question"):
+        assert (content_value in repr(record)) is content_expected
+    for step in record["trace_steps"]:
+        assert "private raw query" not in repr(step)
+        assert "chunk_id" not in repr(step)
+        assert "https://" not in repr(step)
+
+
 def test_steps_keep_pipeline_order_and_stable_skip_reason() -> None:
     trace = _populated_trace("shadow")
     trace.record_ok("coreference", 1.0, source="caller")


### PR DESCRIPTION
Completes the trace announced as follow-up in #1265: all live candidate-transform steps (`qdrant_search`, `rerank`, `quality_floor`, `source_select`, `quality_boost`, `parent_lookup`, `response_build`) now emit trace steps; the post-rerank link-expand boost is rerank metadata. Metric dedup per Unit 6 (one measured duration for trace + `step_latency_seconds`, no name/label changes).

Per-tenant telemetry levels (off/shadow/full) are enforced and tested for every new step: zero content-bearing fields outside `full`, `retention_class` stays correct. Golden test proves identical chunk IDs/order/scores (AC-8).

Verified: 609 tests pass, ruff clean. Implemented by codex gpt-5.6-sol; second-pass verified by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)