### PR TITLE
fix(security): pin the branch in the hook's push tests

### DIFF
--- a/rules/tests/test_public_issue_publication.py
+++ b/rules/tests/test_public_issue_publication.py
@@ -229,18 +229,42 @@ def test_hook_blocks_unapproved_pushes_that_can_mutate_main(command: str) -> Non
         "gh pr checks 42",
         "gh pr diff 42",
         "gh pr checkout 42",
-        "git push -u origin HEAD",
-        "git push --force origin HEAD",
         "git push origin feature/foo",
         "git push -u origin fix/publication-guard",
         "git push origin HEAD:refs/heads/fix/publication-guard",
-        "git push",
     ],
 )
-def test_hook_allows_read_only_pr_commands_and_feature_branch_pushes(
+def test_hook_allows_read_only_pr_commands_and_named_feature_branch_pushes(
     command: str,
 ) -> None:
     result = _run_hook(command)
+
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["git push -u origin HEAD", "git push --force origin HEAD", "git push"],
+)
+def test_hook_allows_head_pushes_from_a_feature_branch(
+    command: str, tmp_path: Path
+) -> None:
+    """HEAD-relative pushes depend on the checked-out branch, so pin it.
+
+    These three were asserted without controlling the branch. That passed on a
+    feature worktree and on a detached PR checkout, and failed on main -- where
+    the hook is right to block them. The test was reading its environment
+    rather than the contract. Its sibling below pins main; this one pins a
+    feature branch, so both outcomes are asserted deliberately.
+    """
+    subprocess.run(
+        ["git", "init", "--initial-branch=feature/guard-context", str(tmp_path)],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    result = _run_hook(command, cwd=tmp_path)
 
     assert result.returncode == 0
 


### PR DESCRIPTION
#1273 turned `main` red. Fixing that.

## What broke

Three cases asserted that HEAD-relative pushes are allowed, without controlling which branch is checked out — while the hook resolves the branch via `git symbolic-ref`.

On a feature worktree and on a detached PR checkout they pass. On `main` the hook correctly blocks them, so they failed the moment the merge commit landed.

**The hook is right; the test was wrong.** It read its own environment instead of the contract, and it only looked green on the PR because a PR is checked out detached. Exactly the failure mode this repo keeps rediscovering: an assertion that passes for a reason unrelated to what it claims to check.

## The fix

Its sibling already pinned the `main` case in a `tmp_path` repo. This does the same for the feature-branch case, so both outcomes are asserted deliberately rather than one of them being inherited from wherever CI happens to run.

## Verification

- `rules/tests/` — 89 passed
- still fail-proof: breaking the branch resolution in the hook turns three tests red, including the two that pin these outcomes

## Note on process

This PR was opened with `KLAI_ALLOW_PUBLIC_CODE_MUTATION=1`. The guard merged in #1273 blocks `gh pr create` without it — working as intended, on its author, within the hour. Stating the authorisation rather than leaving it implicit is the whole point of the marker.

Worth recording one rough edge for later: the hook matches the command string, so a Bash call that merely *contains* the text `git push` — a heredoc writing these very tests, for instance — trips it. Not urgent, and erring this way is the right direction, but it will annoy anyone editing this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)