### PR TITLE
chore(deps): bump the three Docker images that can be verified, and unhide the Vexa bot pin

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -853,7 +853,7 @@ services:
   # compose file once the team is in. Admin token in SOPS (env-first per
   # validator-env-parity).
   vaultwarden:
-    image: vaultwarden/server:1.37.1
+    image: vaultwarden/server:1.37.2
     restart: unless-stopped
     environment:
       DOMAIN: "https://vault.getklai.com"
@@ -1278,7 +1278,7 @@ services:
       - monitoring
 
   alloy:
-    image: grafana/alloy:v1.18.1
+    image: grafana/alloy:v1.19.0
     restart: unless-stopped
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
@@ -1894,7 +1894,7 @@ services:
   # The previous /data mount was cosmetic and caused total graph loss on 2026-04-19
   # when the container was recreated during the falkordb:latest -> v4.18.1 pin (5d12587e).
   falkordb:
-    image: falkordb/falkordb:v4.20.3
+    image: falkordb/falkordb:v4.20.4
     restart: unless-stopped
     # SPEC-GRAPH-SCALE-001 REQ-2: the image bakes FALKORDB_ARGS="MAX_QUEUED_QUERIES 25
     # TIMEOUT 1000 RESULTSET_SIZE 10000" into its own Dockerfile (FalkorDB/FalkorDB#1826),

--- a/renovate.json5
+++ b/renovate.json5
@@ -110,6 +110,32 @@
     commitMessageAction: 'Refresh lock files',
   },
 
+  // Renovate's docker-compose manager only reads `image:` keys. The Vexa bot
+  // is pinned in an ENV value instead — `BROWSER_IMAGE: vexaai/vexa-bot:<v>` on
+  // vexa12-runtime — because the runtime spawns bot containers itself rather
+  // than Compose starting them. So Renovate moved the three vexa `image:` refs
+  // and silently left the bot behind, which is how PR #1240 came to propose a
+  // 0.12.23 runtime driving a 0.12.22 bot. Vexa is pre-1.0 and publishes no
+  // changelog, so a patch-level protocol change between the two is not
+  // something a reviewer can rule out.
+  //
+  // This makes the pin visible so the whole set moves as one PR. It does NOT
+  // make the upgrade automatic: deploy/docker-compose.yml documents that the
+  // bot image must be pulled on core-01 BEFORE the first spawn, because
+  // docker-socket-proxy has IMAGES disabled (SPEC-SEC-024) and `compose up`
+  // never fetches an env-valued image. Nothing in the pipeline enforces that,
+  // so a Vexa bump stays a deliberate operation with a manual step.
+  customManagers: [
+    {
+      customType: 'regex',
+      managerFilePatterns: ['/^deploy/docker-compose\\.yml$/'],
+      matchStrings: [
+        'BROWSER_IMAGE:\\s+(?<depName>vexaai/vexa-bot):(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: 'docker',
+    },
+  ],
+
   packageRules: [
     {
       description:


### PR DESCRIPTION
Takes over the reviewable part of Renovate's grouped #1240, and fixes the reason the rest is not reviewable.

## Landing

| image | | |
|---|---|---|
| `vaultwarden/server` | 1.37.1 → 1.37.2 | patch |
| `grafana/alloy` | v1.18.1 → v1.19.0 | minor |
| `falkordb/falkordb` | v4.20.3 → v4.20.4 | patch |

Both prescribed guards pass on the full set: `deploy/check-image-tags.sh` (all pinned) and `deploy/check-image-pullable.sh` (14 public manifests verified, 1 locally-built ref accepted).

Alloy carries the log pipeline, so it got a second look rather than a version-number glance: `deploy/alloy/config.alloy` uses only long-stable core components — `discovery.docker`, `loki.source.docker`, `loki.process`, `loki.write`, `prometheus.*` — none of which changed shape in 1.19.

## Not landing, and why

The three `vexaai/v012-*` images. Renovate's docker-compose manager only reads `image:` keys, and the bot is pinned in an **environment value**:

```yaml
vexa12-runtime:
  image: vexaai/v012-runtime:v0.12.22
  environment:
    BROWSER_IMAGE: vexaai/vexa-bot:v0.12.22   # <- invisible to Renovate
```

The runtime spawns bot containers itself instead of Compose starting them. So #1240 would move the three APIs to 0.12.23 and leave the bot on 0.12.22 — a skew nobody chose.

Vexa is pre-1.0 and publishes no changelog, so whether a patch changes the bot/runtime protocol is not something a reviewer can establish. A silent recording failure is worse than a deferred upgrade. The bump is superseded anyway: upstream is at **v0.12.26**, which Renovate's own table flags as `+2`.

Bumping `BROWSER_IMAGE` alongside them is not the quick fix either. The compose file documents why: `docker-socket-proxy` has IMAGES disabled (SPEC-SEC-024) so the runtime cannot pull, and `compose up` never fetches an env-valued image. The image must be pulled on core-01 **before** the first spawn or `POST /containers/create` fails with "No such image". Nothing in the pipeline enforces that — `scripts/check-vexa12-deploy-preconditions.sh` is an operator command run by hand.

## The durable fix

Stop the pin being invisible. A `customManager` now tracks it, so the whole Vexa set moves as one reviewable PR instead of three-quarters of it moving silently.

It deliberately does **not** make the upgrade automatic. The manual pull keeps a Vexa bump a chosen operation with a known prerequisite, which is what the compose comments have been asking for all along.

Verified the manager actually matches, because one that silently matches nothing is the failure mode this repo keeps rediscovering:

```
matches: 1
  depName=vexaai/vexa-bot  currentValue=v0.12.22
filePattern matches deploy/docker-compose.yml: True
filePattern matches the gpu variant:           False
```

`sh scripts/test-renovate-config.sh` PASS · `renovate-config-validator` OK · pre-commit image-tag, pullable and env-scope guards all passed on commit.

## After this merges

#1240 conflicts and Renovate regenerates it with the Vexa images alone — now including the bot pin, at whatever version is current. That PR is then a single deliberate decision plus one documented `docker pull` on core-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)