### PR TITLE
fix(knowledge-ingest): drop rollout fallback + count only real cancellations

### DIFF
--- a/.moai/specs/SPEC-CONNECTOR-CANCEL-001/plan.md
+++ b/.moai/specs/SPEC-CONNECTOR-CANCEL-001/plan.md
@@ -73,7 +73,7 @@ Branch: `fix/SPEC-CONNECTOR-CANCEL-001`
 2. Add `cancel_jobs_by_resource_key(proc_app, resource_key, queues)` using `cancel_job_by_id_async(..., abort=True, delete_job=False)`.
 3. Filter `status IN ('todo', 'doing')` (Procrastinate 3.x: `aborting` is legacy/unused; abort-requested jobs stay `doing`).
 4. Replace connector cleanup's artifact-id/json-path cancellation with resource-key cancellation where payloads exist. Note: the current `_cancel_enrichment_jobs` filter on `args->'extra_payload'->>'source_connector_id'` is dead code (enrichment args carry only `artifact_id` since SPEC-INGEST-CONTENT-PG-001) — remove it, don't preserve it.
-5. Keep a compatibility fallback for old queued jobs that do not yet carry `resource_key` during rollout: match enrichment/graphiti jobs via `args->>'artifact_id' = ANY(<snapshot ids>)` using the artifact-id snapshot that purge already takes. Remove the fallback in a follow-up after one deploy window.
+5. [x] Keep a compatibility fallback for old queued jobs that do not yet carry `resource_key` during rollout: match enrichment/graphiti jobs via `args->>'artifact_id' = ANY(<snapshot ids>)` using the artifact-id snapshot that purge already takes. Removed on 2026-09-01 after production verification found zero live legacy jobs without `resource_key`.
 
 **Exit:** cancellation is exact-match on `args->>'resource_key'`, not `args::text LIKE`.
 

--- a/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/connector_cleanup.py
@@ -30,6 +30,7 @@ from knowledge_ingest import graph as graph_module
 from knowledge_ingest import pg_store, qdrant_store
 from knowledge_ingest.connector_state import mark_connector_resource_deleting
 from knowledge_ingest.db import get_pool, tenant_scoped_connection
+from knowledge_ingest.queues import CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK
 from knowledge_ingest.resource_jobs import (
     cancel_jobs_by_resource_key,
     connector_resource_key,
@@ -38,19 +39,14 @@ from knowledge_ingest.resource_jobs import (
 logger = structlog.get_logger()
 
 
-# Procrastinate task names we want to cancel on connector delete.
-# Module path is what procrastinate stores as ``task_name`` — see
-# ``enrichment_tasks._register_tasks``.
-_ENRICHMENT_TASKS = (
-    "knowledge_ingest.enrichment_tasks.enrich_document_bulk",
-    "knowledge_ingest.enrichment_tasks.enrich_document_interactive",
-)
-_GRAPHITI_TASKS = ("knowledge_ingest.enrichment_tasks.ingest_graphiti_episode",)
-
-
 @dataclass
 class CleanupReport:
-    """Per-step counts for observability + assertions in tests."""
+    """Per-step counts for observability + assertions in tests.
+
+    ``enrichment_jobs_cancelled`` counts actual cancellations from the
+    crawl-jobs and enrich-bulk queues. ``graphiti_jobs_cancelled`` counts
+    actual cancellations from the graphiti-bulk queue.
+    """
 
     enrichment_jobs_cancelled: int = 0
     graphiti_jobs_cancelled: int = 0
@@ -151,91 +147,6 @@ async def _list_resource_keys(
     return sorted(keys)
 
 
-async def _cancel_enrichment_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
-    """Cancel legacy artifact-only enrichment jobs during rollout.
-
-    New jobs are cancelled by exact resource key. This fallback intentionally
-    matches only jobs without one, using the pre-cleanup artifact-id snapshot.
-    Procrastinate cancellation is per-id, so discover the IDs once and loop.
-
-    SPEC-TI-003-FOLLOWUP-001 AC-2 exception: this query targets the
-    procrastinate_jobs table, not knowledge.*, so a raw pool acquire
-    is allowed here.
-    """
-    if not artifact_ids:
-        return 0
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id FROM procrastinate_jobs
-             WHERE task_name = ANY($1::text[])
-               AND status IN ('todo', 'doing')
-               AND args->>'resource_key' IS NULL
-               AND args->>'artifact_id' = ANY($2::text[])
-            """,
-            list(_ENRICHMENT_TASKS),
-            artifact_ids,
-        )
-    job_ids = [int(r["id"]) for r in rows]
-
-    cancelled = 0
-    for jid in job_ids:
-        try:
-            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=False)
-            cancelled += 1
-        except Exception:
-            # Job may have just transitioned from todo->doing->finished
-            # between our SELECT and the cancel call. That's a no-op for
-            # us — the existence-guard (REQ-07) catches the race anyway.
-            logger.warning(
-                "cancel_job_failed",
-                job_id=jid,
-                artifact_ids=artifact_ids,
-                exc_info=True,
-            )
-    return cancelled
-
-
-async def _cancel_graphiti_jobs(proc_app: Any, artifact_ids: list[str]) -> int:
-    """Cancel queued + in-flight ingest_graphiti_episode jobs.
-
-    The graphiti task signature does not carry ``source_connector_id``;
-    it accepts ``artifact_id`` as an arg. We pass the artifact-id set
-    captured BEFORE artifact deletion (``_list_artifact_ids``) so the
-    filter still resolves.
-
-    SPEC-TI-003-FOLLOWUP-001 AC-2 exception: this query targets the
-    procrastinate_jobs table, not knowledge.*, so a raw pool acquire
-    is allowed here.
-    """
-    if not artifact_ids:
-        return 0
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT id FROM procrastinate_jobs
-             WHERE task_name = ANY($1::text[])
-               AND status IN ('todo', 'doing')
-               AND args->>'resource_key' IS NULL
-               AND args->>'artifact_id' = ANY($2::text[])
-            """,
-            list(_GRAPHITI_TASKS),
-            artifact_ids,
-        )
-    job_ids = [int(r["id"]) for r in rows]
-
-    cancelled = 0
-    for jid in job_ids:
-        try:
-            await proc_app.job_manager.cancel_job_by_id_async(jid, abort=True, delete_job=False)
-            cancelled += 1
-        except Exception:
-            logger.warning("cancel_graphiti_job_failed", job_id=jid, exc_info=True)
-    return cancelled
-
-
 async def purge_connector(
     *,
     org_id: str,
@@ -246,10 +157,9 @@ async def purge_connector(
     """Delete every byte that belongs to a connector. Idempotent.
 
     Order matters:
-      1. Snapshot artifact-ids (needed for graphiti-cancel below).
-      2. Cancel queued + in-flight enrichment jobs — closes the regrow
-         window before we touch the data stores.
-      3. Cancel queued + in-flight graphiti jobs (by artifact-id set).
+      1. Snapshot artifact-ids (needed for cross-store cleanup below).
+      2. Cancel queued + in-flight connector writer jobs by resource key —
+         closes the regrow window before we touch the data stores.
       4. Hard-delete pg artifacts (cascades via FK to embedding_queue,
          artifact_entities, derivations + URL-set scope to crawled_pages
          and page_links — see ``pg_store.delete_connector_artifacts``).
@@ -281,24 +191,32 @@ async def purge_connector(
         resource_keys = await _list_resource_keys(conn, org_id, kb_slug, connector_id)
         log.info("connector_purge_step_artifacts_listed", count=len(artifact_ids))
 
-        # Resource keys are the primary ownership index. Artifact ids remain a
-        # one-deploy compatibility fallback for jobs queued before this contract.
+        # Resource keys are the ownership index for all connector writer jobs.
         for resource_key in resource_keys:
             await mark_connector_resource_deleting(conn, resource_key)
         pool = await get_pool()
-        resource_cancelled = 0
+        enrichment_cancelled = 0
+        graphiti_cancelled = 0
         for resource_key in resource_keys:
-            cancellation = await cancel_jobs_by_resource_key(proc_app, pool, resource_key)
-            resource_cancelled += cancellation.jobs_cancelled
+            enrichment_cancellation = await cancel_jobs_by_resource_key(
+                proc_app,
+                pool,
+                resource_key,
+                queues=(CRAWL_JOBS, ENRICH_BULK),
+            )
+            enrichment_cancelled += enrichment_cancellation.jobs_cancelled
+            graphiti_cancellation = await cancel_jobs_by_resource_key(
+                proc_app,
+                pool,
+                resource_key,
+                queues=(GRAPHITI_BULK,),
+            )
+            graphiti_cancelled += graphiti_cancellation.jobs_cancelled
 
-        enrichment_cancelled = await _cancel_enrichment_jobs(proc_app, artifact_ids)
         log.info(
             "connector_purge_step_enrichment_jobs_cancelled",
             cancelled=enrichment_cancelled,
         )
-
-        # Step 3: cancel graphiti jobs (uses artifact_id list from step 1).
-        graphiti_cancelled = await _cancel_graphiti_jobs(proc_app, artifact_ids)
         log.info(
             "connector_purge_step_graphiti_jobs_cancelled",
             cancelled=graphiti_cancelled,
@@ -454,7 +372,7 @@ async def purge_connector(
         # becomes redundant (the portal_connectors row delete cascades).
 
         report = CleanupReport(
-            enrichment_jobs_cancelled=enrichment_cancelled + resource_cancelled,
+            enrichment_jobs_cancelled=enrichment_cancelled,
             graphiti_jobs_cancelled=graphiti_cancelled,
             artifacts_deleted=artifacts_deleted,
             crawl_jobs_deleted=crawl_jobs_deleted,

--- a/klai-knowledge-ingest/knowledge_ingest/resource_jobs.py
+++ b/klai-knowledge-ingest/knowledge_ingest/resource_jobs.py
@@ -92,12 +92,15 @@ async def cancel_jobs_by_resource_key(
     failed = 0
     for job_id in job_ids:
         try:
-            await proc_app.job_manager.cancel_job_by_id_async(
+            was_cancelled = await proc_app.job_manager.cancel_job_by_id_async(
                 job_id,
                 abort=True,
                 delete_job=False,
             )
-            cancelled += 1
+            if was_cancelled:
+                cancelled += 1
+            else:
+                failed += 1
         except Exception:
             failed += 1
             logger.warning(

--- a/klai-knowledge-ingest/tests/test_connector_cleanup.py
+++ b/klai-knowledge-ingest/tests/test_connector_cleanup.py
@@ -14,7 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from knowledge_ingest.connector_cleanup import CleanupReport, _list_resource_keys, purge_connector
-from knowledge_ingest.resource_jobs import connector_resource_key
+from knowledge_ingest.queues import CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK
+from knowledge_ingest.resource_jobs import ResourceJobCancellation, connector_resource_key
 
 
 @pytest.fixture
@@ -28,19 +29,32 @@ def mocked_proc_app() -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock) -> None:
-    """Verify the canonical order: snapshot artifact-ids -> cancel enrichment ->
+    """Verify the canonical order: snapshot resource keys -> cancel enrichment ->
     cancel graphiti -> snapshot episode-ids -> delete pg artifacts ->
     delete pg crawl_jobs -> delete falkor episodes -> delete qdrant.
 
-    Failure to preserve this order = regrow bug. Specifically, snapshotting
-    artifact-ids must happen BEFORE artifacts deletion, otherwise the
-    graphiti-cancel step has no IDs to filter procrastinate-jobs by.
+    Failure to preserve this order = regrow bug. Resource-key cancellation
+    must happen before deleting connector-owned data.
     """
     call_order: list[str] = []
 
     async def fake_list_artifact_ids(*_a: object, **_kw: object) -> list[str]:
         call_order.append("list_artifact_ids")
         return ["artifact-1", "artifact-2"]
+
+    async def fake_list_resource_keys(*_a: object, **_kw: object) -> list[str]:
+        call_order.append("list_resource_keys")
+        return ["connector:org-zid:support:conn-uuid:generation-1"]
+
+    async def fake_cancel_jobs(
+        *_a: object, queues: tuple[str, ...], **_kw: object
+    ) -> ResourceJobCancellation:
+        if queues == (CRAWL_JOBS, ENRICH_BULK):
+            call_order.append("cancel_enrichment_jobs")
+            return ResourceJobCancellation(3, 2, 1)
+        assert queues == (GRAPHITI_BULK,)
+        call_order.append("cancel_graphiti_jobs")
+        return ResourceJobCancellation(1, 1, 0)
 
     async def fake_get_pool() -> MagicMock:
         # No-op pool: the cancel-jobs step uses raw SQL via the pool, but
@@ -95,6 +109,14 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
         patch(
             "knowledge_ingest.connector_cleanup._list_artifact_ids",
             side_effect=fake_list_artifact_ids,
+        ),
+        patch(
+            "knowledge_ingest.connector_cleanup._list_resource_keys",
+            side_effect=fake_list_resource_keys,
+        ),
+        patch(
+            "knowledge_ingest.connector_cleanup.cancel_jobs_by_resource_key",
+            side_effect=fake_cancel_jobs,
         ),
         patch(
             "knowledge_ingest.connector_cleanup.get_pool",
@@ -157,6 +179,9 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
     # SPEC-CONNECTOR-DELETE-LIFECYCLE-001 REQ-05 + REQ-06.
     assert call_order == [
         "list_artifact_ids",
+        "list_resource_keys",
+        "cancel_enrichment_jobs",
+        "cancel_graphiti_jobs",
         "get_connector_episode_ids",
         "get_orphan_image_keys_for_connector",
         "delete_connector_artifacts",
@@ -170,6 +195,8 @@ async def test_purge_connector_orders_steps_correctly(mocked_proc_app: MagicMock
     assert report.artifacts_deleted == 2
     assert report.crawl_jobs_deleted == 1
     assert report.falkor_episodes_deleted == 1
+    assert report.enrichment_jobs_cancelled == 2
+    assert report.graphiti_jobs_cancelled == 1
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_resource_jobs.py
+++ b/klai-knowledge-ingest/tests/test_resource_jobs.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from structlog.testing import capture_logs
 
 from knowledge_ingest.queues import CRAWL_JOBS, ENRICH_BULK, GRAPHITI_BULK
 from knowledge_ingest.resource_jobs import (
@@ -85,7 +86,7 @@ async def test_live_job_lookup_filters_exact_resource_key_and_3x_live_statuses()
 async def test_cancel_jobs_preserves_rows_and_requests_abort() -> None:
     pool, _ = _pool_with_rows([{"id": 11}])
     proc_app = MagicMock()
-    proc_app.job_manager.cancel_job_by_id_async = AsyncMock()
+    proc_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=True)
 
     report = await cancel_jobs_by_resource_key(proc_app, pool, "connector:o:k:c:g")
 
@@ -93,6 +94,22 @@ async def test_cancel_jobs_preserves_rows_and_requests_abort() -> None:
     proc_app.job_manager.cancel_job_by_id_async.assert_awaited_once_with(
         11, abort=True, delete_job=False
     )
+
+
+@pytest.mark.asyncio
+async def test_cancel_jobs_counts_false_result_as_failed_to_cancel() -> None:
+    pool, _ = _pool_with_rows([{"id": 11}])
+    proc_app = MagicMock()
+    proc_app.job_manager.cancel_job_by_id_async = AsyncMock(return_value=False)
+
+    with capture_logs() as logs:
+        report = await cancel_jobs_by_resource_key(proc_app, pool, "connector:o:k:c:g")
+
+    assert (report.jobs_found, report.jobs_cancelled, report.jobs_failed_to_cancel) == (1, 0, 1)
+    event = next(log for log in logs if log["event"] == "connector_resource_jobs_cancel_requested")
+    assert event["jobs_found"] == 1
+    assert event["jobs_cancelled"] == 0
+    assert event["jobs_failed_to_cancel"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up on today's production smoke test of SPEC-CONNECTOR-CANCEL-001 (delete fired mid-backlog on the e2e tenant; no regrow, fence held, cleanup idempotent).

Two findings from that smoke, fixed here:
1. **Rollout fallback removed** — verified zero live jobs without `resource_key` in production, so the artifact-id fallback (plan Fase 3 task 5) is dead weight.
2. **Cancel counter was lying** — `cancel_job_by_id_async` returns False when the job is no longer cancellable; the loop counted it as a cancel anyway (smoke reported 14 cancels while 0 jobs were actually cancelled). False now counts as `jobs_failed_to_cancel`; counts split per queue.

Verified: 1712 tests pass (incl. new False-return regression test), ruff clean. Implemented by codex gpt-5.6-sol; reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)