### PR TITLE
fix(mcp): say that browser-direct MCP is out of scope, instead of implying it

### DIFF
--- a/klai-knowledge-mcp/main.py
+++ b/klai-knowledge-mcp/main.py
@@ -828,6 +828,13 @@ _TRANSPORT_SECURITY = TransportSecuritySettings(
         "127.0.0.1",
         "127.0.0.1:8080",
     ],
+    # Browser-direct MCP clients are intentionally out of scope. The public
+    # clients are native/server-side MCP hosts; OAuth opens the portal in a
+    # browser for consent, then redirects back to the MCP client. LibreChat is
+    # server-side too. Keep this explicit: an empty list rejects every request
+    # that carries Origin while preserving origin-less clients. Adding even the
+    # resource's own origin is a product-surface expansion, not a config fix.
+    allowed_origins=[],
 )
 _TRANSPORT_SECURITY_VALIDATOR = TransportSecurityMiddleware(_TRANSPORT_SECURITY)
 

--- a/klai-knowledge-mcp/tests/test_mcp_hygiene.py
+++ b/klai-knowledge-mcp/tests/test_mcp_hygiene.py
@@ -191,16 +191,31 @@ def test_rejected_foreign_hosts_do_not_consume_mcp_sessions(mcp_client: TestClie
     assert len(session_manager._server_instances) == sessions_before
 
 
-def test_rejected_foreign_origins_do_not_consume_mcp_sessions(mcp_client: TestClient) -> None:
-    """The adjacent Origin rejection must happen before session allocation too."""
+@pytest.mark.parametrize(
+    "origin",
+    (
+        "https://mcp.getklai.com",
+        "https://my.getklai.com",
+        "https://evil.example.com",
+    ),
+    ids=("resource-origin", "portal-origin", "foreign-origin"),
+)
+def test_browser_origins_are_deliberately_rejected_without_consuming_mcp_sessions(
+    mcp_client: TestClient,
+    origin: str,
+) -> None:
+    """Browser-direct MCP is out of scope, so every present Origin is rejected."""
     import main
+
+    assert main._TRANSPORT_SECURITY.allowed_origins == []
+    assert "allowed_origins" in main._TRANSPORT_SECURITY.model_fields_set
 
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
         "Authorization": "Bearer klai_mcp_test-token-never-verified",
         "Host": "mcp.getklai.com",
-        "Origin": "https://evil.example.com",
+        "Origin": origin,
     }
     body = {"jsonrpc": "2.0", "id": 1, "method": "ping"}
 


### PR DESCRIPTION
Closes #1206.

## What looked wrong

`allowed_origins` sat at its default empty list while `enable_dns_rebinding_protection` was on. The SDK accepts an *absent* Origin and otherwise requires an exact match, so every request carrying one was refused — including our own:

| Origin | |
|---|---|
| `https://mcp.getklai.com` | 403 |
| `https://my.getklai.com` | 403 |
| `https://evil.example.com` | 403 |
| *(no Origin header)* | reaches the transport |

That reads like an oversight in either direction, which is the actual defect. **The behaviour is right; nothing said so.**

## Why it is right

Browser-direct MCP is not a surface we have:

- Caddy describes the public `/mcp` route as the endpoint for native MCP hosts.
- LibreChat reaches the container server-to-server over the Docker network, with no OAuth at all.
- The browser's only part is OAuth consent on `my.getklai.com`, after which the authorization code goes back to the registered MCP client. **A redirect host is not a request Origin.**
- The portal frontend shows the MCP URL but calls only `/api/me/mcp-tokens`.
- The widget has no `/mcp` consumer, and SPEC-SHIELD-001 keeps MCP clients and the browser extension as separate surfaces.

So adding even the resource's own origin would not fix a bug — it would open a product surface. The list stays empty and now says why.

## The test was weaker than it looked

It asserted that a foreign origin gets 403, which cannot distinguish *"foreign origin rejected"* from *"every origin rejected"* while both are true.

It now parametrises the resource origin, the portal origin and a foreign one, so the blanket rejection is asserted as the intent rather than inferred from a single case.

It also asserts `model_fields_set`, and that is what makes the guard real: deleting the explicit `allowed_origins=[]` leaves behaviour *identical*, because the SDK default is also empty — a behavioural assertion alone would stay green forever. Verified that removing the line turns three cases red.

## Verification

`ruff check` 0 · `ruff format --check` 0 · `pyright` 0 errors · `pytest` **207 passed**. Fail-proof reproduced independently during review.

`allowed_hosts` and `enable_dns_rebinding_protection` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)