### PR TITLE
fix(knowledge-ingest): keep document text out of graphiti task args + scrub content from logs

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -373,7 +373,6 @@ def _register_tasks(procrastinate_app: Any) -> None:
     )
     async def ingest_graphiti_episode(
         artifact_id: str,
-        document_text: str,
         org_id: str,
         content_type: str,
         belief_time_start: int,
@@ -381,6 +380,7 @@ def _register_tasks(procrastinate_app: Any) -> None:
         path: str = "",
         replace_stale: bool = False,
         resource_key: str | None = None,
+        document_text: str | None = None,
     ) -> None:
         """Ingest a document into the Graphiti knowledge graph.
 
@@ -395,14 +395,10 @@ def _register_tasks(procrastinate_app: Any) -> None:
         ``source_connector_id`` arg, so the artifact-presence check is the
         canonical signal here.
 
-        Supersession guard: ``document_text`` is frozen at enqueue time, so a
-        job dequeued after a newer ingest replaced its artifact would write
-        stale content. Existence alone does not catch this — superseded rows
-        are retained — and since #1152 named episodes ``doc:<kb_slug>:<path>``
-        the stale episode shares its name with the active version, so retrieval
-        resolves it and cites the live page for content that only existed in
-        the old one. ``_enrich_document`` guards the same window with
-        ``artifact_is_active``; this mirrors it.
+        SPEC-INGEST-CONTENT-PG-001: re-reads ``document_text`` from PostgreSQL
+        at execution time so document bodies never enter Procrastinate args.
+        The optional argument is accepted only for jobs queued before this
+        rollout and is deliberately ignored; remove it after one deploy window.
 
         SPEC-TI-003-FOLLOWUP-001 AC-1: opens a tenant_scoped_connection on
         ``org_id`` so artifact_exists + update_artifact_extra both run with
@@ -410,17 +406,30 @@ def _register_tasks(procrastinate_app: Any) -> None:
         """
         from knowledge_ingest import pg_store
 
+        # Rollout compatibility only: old queued jobs still contain this kwarg.
+        # Never use it, because Procrastinate persists and logs task arguments.
+        del document_text
+
         async with tenant_scoped_connection(org_id) as conn:
-            if not await pg_store.artifact_exists(conn, artifact_id):
+            artifact = await pg_store.read_artifact_for_enrichment(conn, artifact_id)
+            if artifact is None and not await pg_store.artifact_exists(conn, artifact_id):
                 logger.info(
                     "graphiti_aborted_artifact_missing",
                     artifact_id=artifact_id,
                     org_id=org_id,
                 )
                 return
-            if not await pg_store.artifact_is_active(conn, artifact_id):
+            if artifact is None:
                 logger.info(
                     "graphiti_aborted_artifact_superseded",
+                    artifact_id=artifact_id,
+                    org_id=org_id,
+                )
+                return
+            document_text = artifact["extra"].get("document_text", "") or ""
+            if not document_text:
+                logger.info(
+                    "graphiti_aborted_no_document_text",
                     artifact_id=artifact_id,
                     org_id=org_id,
                 )

--- a/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
+++ b/klai-knowledge-ingest/knowledge_ingest/graph_refresh.py
@@ -125,7 +125,6 @@ async def _refresh_stale_graph(
             queueing_lock=f"graphiti:{artifact_id}",
         ).defer_async(
             artifact_id=artifact_id,
-            document_text=indexable_content,
             org_id=org_id,
             content_type=content_type,
             belief_time_start=belief_time_start,

--- a/klai-knowledge-ingest/knowledge_ingest/logging_setup.py
+++ b/klai-knowledge-ingest/knowledge_ingest/logging_setup.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import sys
 import uuid
 
@@ -9,6 +10,60 @@ import structlog
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+
+_REDACTED = "<redacted>"
+_CONTENT_FIELD_NAMES = frozenset(
+    {
+        "body_text",
+        "content_body",
+        "document_text",
+        "page_content",
+        "raw_content",
+    }
+)
+_CONTENT_ASSIGNMENT_RE = re.compile(
+    rf"(?P<prefix>['\"]?(?:{'|'.join(sorted(_CONTENT_FIELD_NAMES))})['\"]?\s*[:=]\s*)"
+    r"(?P<quote>['\"])(?:\\.|(?!(?P=quote)).)*(?P=quote)",
+    re.DOTALL,
+)
+
+
+def _redact_content_assignments(value: str) -> str:
+    if not any(field in value for field in _CONTENT_FIELD_NAMES):
+        return value
+
+    def _replacement(match: re.Match[str]) -> str:
+        quote = match.group("quote")
+        return f"{match.group('prefix')}{quote}{_REDACTED}{quote}"
+
+    return _CONTENT_ASSIGNMENT_RE.sub(_replacement, value)
+
+
+def _redact_nested_content(value: object) -> object:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if isinstance(key, str) and key.casefold() in _CONTENT_FIELD_NAMES:
+                value[key] = _REDACTED
+            else:
+                value[key] = _redact_nested_content(nested_value)
+        return value
+    if isinstance(value, list):
+        for index, nested_value in enumerate(value):
+            value[index] = _redact_nested_content(nested_value)
+        return value
+    if isinstance(value, tuple):
+        return tuple(_redact_nested_content(item) for item in value)
+    if isinstance(value, str):
+        return _redact_content_assignments(value)
+    return value
+
+
+def redact_content_fields(
+    _logger: object, _method_name: str, event_dict: dict[str, object]
+) -> dict[str, object]:
+    """Redact document bodies from structured fields and rendered task messages."""
+    _redact_nested_content(event_dict)
+    return event_dict
 
 
 def setup_logging(service_name: str = "knowledge-ingest") -> None:
@@ -30,6 +85,7 @@ def setup_logging(service_name: str = "knowledge-ingest") -> None:
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
+        redact_content_fields,
     ]
 
     if log_format == "console":

--- a/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
+++ b/klai-knowledge-ingest/knowledge_ingest/routes/ingest.py
@@ -1006,7 +1006,6 @@ async def ingest_document(conn: asyncpg.Connection, req: IngestRequest) -> dict:
             queueing_lock=f"graphiti:{artifact_id}",
         ).defer_async(
             artifact_id=artifact_id,
-            document_text=indexable_content,
             org_id=req.org_id,
             content_type=req.content_type,
             belief_time_start=kf["belief_time_start"],

--- a/klai-knowledge-ingest/tests/test_extra_payload_contract.py
+++ b/klai-knowledge-ingest/tests/test_extra_payload_contract.py
@@ -164,12 +164,13 @@ def _build_request(
     source_connector_id: str | None = None,
     source_ref: str | None = None,
     source_domain: str | None = None,
+    content: str = "# Hello\nWorld",
 ) -> IngestRequest:
     return IngestRequest(
         org_id="org-contract",
         kb_slug="kb-contract",
         path="docs/page.md",
-        content="# Hello\nWorld",
+        content=content,
         source_type=source_type,
         content_type="kb_article",
         source_connector_id=source_connector_id,
@@ -179,7 +180,10 @@ def _build_request(
 
 
 async def _run_with_mocks(
-    req: IngestRequest, mock_proc_app: _MockProcApp
+    req: IngestRequest,
+    mock_proc_app: _MockProcApp,
+    *,
+    graphiti_enabled: bool = False,
 ) -> tuple[dict, AsyncMock]:
     """Run ``ingest_document`` with all I/O mocked so the test only
     exercises the Phase-1 extra_payload assembly.
@@ -269,7 +273,7 @@ async def _run_with_mocks(
         ),
         patch("knowledge_ingest.routes.ingest.settings") as mock_settings,
     ):
-        mock_settings.graphiti_enabled = False  # skip graphiti enqueue
+        mock_settings.graphiti_enabled = graphiti_enabled
         mock_settings.chunk_size = 1500
         mock_settings.chunk_overlap = 200
         mock_settings.enrichment_enabled = True
@@ -278,6 +282,20 @@ async def _run_with_mocks(
 
         result = await ingest_document(conn, req)
         return result, update_extra_mock
+
+
+@pytest.mark.asyncio
+async def test_graphiti_enqueue_does_not_carry_document_text():
+    document_text = "# Private connector page\n\n" + ("Customer-only body. " * 20)
+    req = _build_request(source_type="notion", content=document_text)
+    proc_app = _MockProcApp()
+
+    result, _ = await _run_with_mocks(req, proc_app, graphiti_enabled=True)
+
+    assert result["status"] == "ok"
+    assert proc_app.defer_kwargs is not None
+    assert "document_text" not in proc_app.defer_kwargs
+    assert document_text not in repr(proc_app.defer_kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
+++ b/klai-knowledge-ingest/tests/test_graph_refresh_on_stale_extraction_version.py
@@ -112,7 +112,6 @@ async def test_unchanged_content_with_legacy_graph_rules_queues_replacement() ->
     }
     app.ingest_graphiti_episode.defer_async.assert_awaited_once_with(
         artifact_id=_ARTIFACT_ID,
-        document_text=req.content,
         org_id=_ORG_ID,
         content_type="kb_article",
         belief_time_start=1_755_820_800,
@@ -120,6 +119,7 @@ async def test_unchanged_content_with_legacy_graph_rules_queues_replacement() ->
         path=_PATH,
         replace_stale=True,
     )
+    assert req.content not in repr(app.ingest_graphiti_episode.defer_async.await_args.kwargs)
 
 
 @pytest.mark.asyncio
@@ -292,6 +292,9 @@ async def _run_graphiti_task(graphiti_task: object, *, replace_stale: bool = Fal
     graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
 
     store = MagicMock()
+    store.read_artifact_for_enrichment = AsyncMock(
+        return_value={"extra": {"document_text": "Klai routes calls to the right colleague."}}
+    )
     store.artifact_exists = AsyncMock(return_value=True)
     store.artifact_is_active = AsyncMock(return_value=True)
     store.get_episode_ids_for_document_history = AsyncMock(
@@ -317,7 +320,6 @@ async def _run_graphiti_task(graphiti_task: object, *, replace_stale: bool = Fal
     ):
         await graphiti_task(
             artifact_id=_ARTIFACT_ID,
-            document_text="Klai routes calls to the right colleague.",
             org_id=_ORG_ID,
             content_type="kb_article",
             belief_time_start=1_755_820_800,

--- a/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
@@ -1,9 +1,8 @@
-"""A graphiti job for a superseded artifact must not write its frozen text.
+"""A graphiti job for a superseded artifact must not write stale text.
 
 Contract: the graph may only hold episodes for the version of a document that
-is currently active. A queued ``ingest_graphiti_episode`` carries the document
-text as a task argument, frozen at enqueue time, so a job that is dequeued
-after a newer ingest superseded its artifact would store stale content.
+is currently active. ``ingest_graphiti_episode`` therefore reloads the active
+artifact body from PostgreSQL at execution time and soft-skips superseded rows.
 
 Why this became user-visible in #1152: episodes used to be named after the
 artifact_id, so a stale episode was simply unresolvable -- a dead end. Since
@@ -87,6 +86,11 @@ async def _run(
     graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
 
     pg_store = MagicMock()
+    pg_store.read_artifact_for_enrichment = AsyncMock(
+        return_value={"extra": {"document_text": "current content from PostgreSQL"}}
+        if active
+        else None
+    )
     pg_store.artifact_exists = AsyncMock(return_value=exists)
     pg_store.artifact_is_active = AsyncMock(return_value=active)
     pg_store.update_artifact_extra = AsyncMock(return_value=None)
@@ -106,7 +110,6 @@ async def _run(
     ):
         await graphiti_task(
             artifact_id=_ARTIFACT_ID,
-            document_text="content that only existed in the superseded version",
             org_id=_ORG_ID,
             content_type="text/markdown",
             belief_time_start=0,
@@ -120,6 +123,7 @@ async def _run_active_document(
     document_text: str,
     episode_results: list[str | Exception | None],
     expected_error: type[Exception] | None = None,
+    legacy_document_text: str | None = None,
 ):
     ingest_episode = AsyncMock(side_effect=episode_results)
     graph_module = MagicMock()
@@ -128,6 +132,9 @@ async def _run_active_document(
     graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
 
     pg_store = MagicMock()
+    pg_store.read_artifact_for_enrichment = AsyncMock(
+        return_value={"extra": {"document_text": document_text}}
+    )
     pg_store.artifact_exists = AsyncMock(return_value=True)
     pg_store.artifact_is_active = AsyncMock(return_value=True)
     pg_store.update_artifact_extra = AsyncMock(return_value=None)
@@ -140,13 +147,14 @@ async def _run_active_document(
     ):
         kwargs = {
             "artifact_id": _ARTIFACT_ID,
-            "document_text": document_text,
             "org_id": _ORG_ID,
             "content_type": "text/markdown",
             "belief_time_start": 0,
             "kb_slug": "support",
             "path": "guide.md",
         }
+        if legacy_document_text is not None:
+            kwargs["document_text"] = legacy_document_text
         if expected_error is None:
             await graphiti_task(**kwargs)
         else:
@@ -215,6 +223,20 @@ async def test_short_document_creates_one_episode_and_records_both_id_keys(graph
         "graphiti_extraction_version": 2,
     }
     graph_module.flush_entity_graph_data.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_old_signature_document_text_is_ignored_in_favour_of_postgres(graphiti_task):
+    ingest_episode, _, _ = await _run_active_document(
+        graphiti_task,
+        "Current body loaded from PostgreSQL.",
+        ["episode-1"],
+        legacy_document_text="Stale body frozen in the old queued job.",
+    )
+
+    assert ingest_episode.call_args.kwargs["document_text"] == (
+        "Current body loaded from PostgreSQL."
+    )
 
 
 @pytest.mark.asyncio
@@ -290,7 +312,10 @@ async def test_deletion_between_episode_parts_aborts_before_the_next_write(graph
     graph_module.flush_entity_graph_data = AsyncMock(return_value=None)
     graph_module.delete_kb_episodes = AsyncMock(return_value=None)
     pg_store = MagicMock()
-    pg_store.artifact_exists = AsyncMock(side_effect=[True, True, True, False])
+    pg_store.read_artifact_for_enrichment = AsyncMock(
+        return_value={"extra": {"document_text": f"{paragraph}\n\n{paragraph}\n\n{paragraph}"}}
+    )
+    pg_store.artifact_exists = AsyncMock(side_effect=[True, True, False])
     pg_store.artifact_is_active = AsyncMock(return_value=True)
     pg_store.update_artifact_extra = AsyncMock(return_value=None)
     pg_store.append_graphiti_episode_id = AsyncMock(return_value=None)
@@ -302,7 +327,6 @@ async def test_deletion_between_episode_parts_aborts_before_the_next_write(graph
     ):
         await graphiti_task(
             artifact_id=_ARTIFACT_ID,
-            document_text=f"{paragraph}\n\n{paragraph}\n\n{paragraph}",
             org_id=_ORG_ID,
             content_type="text/markdown",
             belief_time_start=0,
@@ -312,7 +336,7 @@ async def test_deletion_between_episode_parts_aborts_before_the_next_write(graph
 
     assert ingest_episode.await_count == 2
     graph_module.delete_kb_episodes.assert_awaited_once_with(_ORG_ID, ["episode-2"])
-    assert pg_store.artifact_exists.await_count == 4
+    assert pg_store.artifact_exists.await_count == 3
 
 
 @pytest.mark.asyncio

--- a/klai-knowledge-ingest/tests/test_logging_setup.py
+++ b/klai-knowledge-ingest/tests/test_logging_setup.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+
+def test_procrastinate_job_message_redacts_document_text() -> None:
+    from knowledge_ingest.logging_setup import redact_content_fields
+
+    secret = "Customer-only Notion body with a 'quoted value' and\nmultiple lines."
+    call_string = (
+        "ingest_graphiti_episode[42]("
+        f"artifact_id='artifact-1', document_text={secret!r}, org_id='org-1')"
+    )
+
+    for event in (
+        f"Starting job {call_string}",
+        f"Job {call_string} ended with status: Success, lasted 1.234 s",
+    ):
+        event_dict = {
+            "event": event,
+            "job": {
+                "task_kwargs": {"artifact_id": "artifact-1", "document_text": secret},
+                "call_string": call_string,
+            },
+        }
+
+        scrubbed = redact_content_fields(None, "info", event_dict)
+
+        assert secret not in repr(scrubbed)
+        assert scrubbed["job"]["task_kwargs"]["artifact_id"] == "artifact-1"
+        assert scrubbed["job"]["task_kwargs"]["document_text"] == "<redacted>"
+        assert "document_text=" in scrubbed["event"]
+        assert "<redacted>" in scrubbed["event"]


### PR DESCRIPTION
Found during today's production smoke test of SPEC-CONNECTOR-CANCEL-001: `ingest_graphiti_episode` takes the full document body as a task argument, so procrastinate logs it verbatim on job start and end. That puts customer content (Notion/Confluence bodies, not just public web text) in the service logs for **every tenant regardless of their telemetry level** (off/shadow/full), plus in `procrastinate_jobs.args`.

`enrich_document_*` was fixed for exactly this by SPEC-INGEST-CONTENT-PG-001; the graphiti task was missed at the time. Same recipe applied:

- Task re-reads the body from PostgreSQL at execution time; both enqueue sites send IDs + metadata only.
- `document_text` kept as a deprecated, ignored kwarg for one deploy window so in-flight old-signature jobs do not crash the worker (removable in a follow-up).
- Defence-in-depth structlog processor redacts content fields from structured args **and** from procrastinate's message-embedded args. Verified against a real production log line: 6348 → 484 chars, zero content fragments, identifiers preserved.

Not retroactive: existing log entries age out with the 30-day retention; old queued args are unaffected.

Verified: 1723 tests pass, ruff clean. Implemented by codex gpt-5.6-sol; reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)