### PR TITLE
docs(renovate): make the eslint ceiling say when it can be lifted

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -296,15 +296,29 @@
     },
     {
       description:
-        'eslint (klai-docs only): pinned below 10 — eslint-config-next 16.3.1 \
-        pulls in eslint-plugin-react 7.37.5, whose lib/util/version.js still \
-        calls context.getFilename(). ESLint 10 removed that method, so \
-        `eslint .` throws "contextOrFilename.getFilename is not a function" \
-        while loading the very first React rule and the quality-docs job never \
-        gets as far as linting (proven by PR #1161). 7.37.5 is the latest \
-        release, so there is nothing to bump to and nothing in klai-docs to \
-        edit around it. klai-portal/frontend is already on eslint 10 and is \
-        unaffected — it does not use eslint-config-next. \
+        'eslint (klai-docs only): pinned below 10 — eslint-config-next pulls \
+        in eslint-plugin-react, whose lib/util/version.js still calls \
+        context.getFilename(). ESLint 10 removed that method, so `eslint .` \
+        throws "contextOrFilename.getFilename is not a function" while loading \
+        the very first React rule and quality-docs never gets as far as \
+        linting. klai-portal/frontend is already on eslint 10 and is \
+        unaffected — it does not use eslint-config-next, which is why this \
+        rule is scoped by matchFileNames rather than applied repo-wide. \
+        \
+        Re-verified 2026-09-01 against the current chain, not inferred from \
+        peer ranges: eslint 10.9.1 + eslint-config-next 16.3.4 reproduces the \
+        same crash. eslint-plugin-react is still 7.37.5 (April 2025) and its \
+        `next` dist-tag is a 2018 release candidate, so there is no \
+        prerelease route either. \
+        \
+        Do not reach for a fork or a patch step to get around this: it is a \
+        dev-only linter and the upstream fixes already exist as PRs. Lift the \
+        ceiling — delete this entry, do not raise the number — once all four \
+        hold: (1) eslint-plugin-react publishes a stable release carrying \
+        upstream #4022 with an eslint-10 peer, (2) eslint-plugin-import \
+        publishes its already-merged #3230, (3) eslint-plugin-jsx-a11y \
+        declares ^10 support, and (4) a plain `npm ci` without forcing plus \
+        `npm run lint` in klai-docs both pass. \
         Tracking: GetKlai/klai#1184',
       matchManagers: ['npm'],
       matchPackageNames: ['eslint'],


### PR DESCRIPTION
The ceiling comment named `eslint-config-next 16.3.1` and asserted *"7.37.5 is the latest release, so there is nothing to bump to"*. Both were true when written, and neither told a reader whether they still held — so the only way to find out was to redo the whole investigation. Someone did, today.

## Re-verified, not inferred

Against the current chain rather than from peer ranges: **eslint 10.9.1 with eslint-config-next 16.3.4 reproduces the identical crash** in `eslint-plugin-react/lib/util/version.js`.

The plugin is still 7.37.5 from April 2025, and its `next` dist-tag turns out to be a release candidate from **2018** — so the prerelease route people reach for first does not exist here.

## The useful part is the exit condition

Waiting on upstream is now four checkable facts instead of a feeling, with the upstream PR numbers, so the next recheck is a few minutes rather than an afternoon:

1. `eslint-plugin-react` publishes a stable release carrying upstream #4022 with an eslint-10 peer
2. `eslint-plugin-import` publishes its already-merged #3230
3. `eslint-plugin-jsx-a11y` declares `^10` support
4. a plain `npm ci` without forcing, plus `npm run lint` in `klai-docs`, both pass

It also records the conclusion that was reached and would otherwise be rediscovered: **do not fork or patch around this.** It is a dev-only linter and the fixes exist upstream; carrying a fork would cost more than staying on 9.

## Scoping

The `matchFileNames` scoping was verified empirically while re-checking, not assumed:

```
klai-docs/package.json            [ { allowedVersions: '<10.0.0', matchFileNames: [...] } ]
klai-portal/frontend/package.json []
```

So the frontend keeps receiving 10.x — it is on `^10.6.0` and can go to 10.9.1.

Comment-only change. `sh scripts/test-renovate-config.sh` PASS · `renovate-config-validator` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)