### PR TITLE
chore(knowledge-ingest): drop deprecated document_text kwarg from graphiti task

### DIFF
--- a/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
+++ b/klai-knowledge-ingest/knowledge_ingest/enrichment_tasks.py
@@ -380,7 +380,6 @@ def _register_tasks(procrastinate_app: Any) -> None:
         path: str = "",
         replace_stale: bool = False,
         resource_key: str | None = None,
-        document_text: str | None = None,
     ) -> None:
         """Ingest a document into the Graphiti knowledge graph.
 
@@ -397,18 +396,12 @@ def _register_tasks(procrastinate_app: Any) -> None:
 
         SPEC-INGEST-CONTENT-PG-001: re-reads ``document_text`` from PostgreSQL
         at execution time so document bodies never enter Procrastinate args.
-        The optional argument is accepted only for jobs queued before this
-        rollout and is deliberately ignored; remove it after one deploy window.
 
         SPEC-TI-003-FOLLOWUP-001 AC-1: opens a tenant_scoped_connection on
         ``org_id`` so artifact_exists + update_artifact_extra both run with
         the RLS GUC pinned to this tenant.
         """
         from knowledge_ingest import pg_store
-
-        # Rollout compatibility only: old queued jobs still contain this kwarg.
-        # Never use it, because Procrastinate persists and logs task arguments.
-        del document_text
 
         async with tenant_scoped_connection(org_id) as conn:
             artifact = await pg_store.read_artifact_for_enrichment(conn, artifact_id)

--- a/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
+++ b/klai-knowledge-ingest/tests/test_graphiti_skips_superseded_artifact.py
@@ -123,7 +123,6 @@ async def _run_active_document(
     document_text: str,
     episode_results: list[str | Exception | None],
     expected_error: type[Exception] | None = None,
-    legacy_document_text: str | None = None,
 ):
     ingest_episode = AsyncMock(side_effect=episode_results)
     graph_module = MagicMock()
@@ -153,8 +152,6 @@ async def _run_active_document(
             "kb_slug": "support",
             "path": "guide.md",
         }
-        if legacy_document_text is not None:
-            kwargs["document_text"] = legacy_document_text
         if expected_error is None:
             await graphiti_task(**kwargs)
         else:
@@ -223,20 +220,6 @@ async def test_short_document_creates_one_episode_and_records_both_id_keys(graph
         "graphiti_extraction_version": 2,
     }
     graph_module.flush_entity_graph_data.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_old_signature_document_text_is_ignored_in_favour_of_postgres(graphiti_task):
-    ingest_episode, _, _ = await _run_active_document(
-        graphiti_task,
-        "Current body loaded from PostgreSQL.",
-        ["episode-1"],
-        legacy_document_text="Stale body frozen in the old queued job.",
-    )
-
-    assert ingest_episode.call_args.kwargs["document_text"] == (
-        "Current body loaded from PostgreSQL."
-    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the deploy window opened by #1282. `ingest_graphiti_episode` kept `document_text` as a deprecated, ignored kwarg so in-flight old-signature jobs would not crash the worker. Verified in production before and after this change: **0** live `ingest_graphiti_episode` jobs (todo/doing), **0** carrying `document_text` — so the compatibility shim is dead weight.

The logging scrubber in `logging_setup.py` is deliberately untouched: it stays as defence-in-depth for every task type.

Verified: 1722 tests pass, ruff clean, 2 files / 24 deletions. Implemented by codex gpt-5.6-sol; reviewed by Claude (remaining `document_text` references confirmed to be PostgreSQL reads, not task args).

🤖 Generated with [Claude Code](https://claude.com/claude-code)