### PR TITLE
fix(meetings): stop lying about "recording", and stop losing the terminal status

### DIFF
--- a/klai-portal/backend/app/api/meetings.py
+++ b/klai-portal/backend/app/api/meetings.py
@@ -302,6 +302,13 @@ async def stop_meeting(
     if meeting.status not in ACTIVE_STATUSES:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Meeting is not active")
 
+    # Persist the stop intent before Vexa's DELETE: destroying the workload can
+    # synchronously deliver bot.failed, and a later local commit would overwrite
+    # that terminal callback with "stopping".
+    meeting.status = "stopping"
+    meeting.ended_at = datetime.now(UTC)
+    await db.commit()
+
     ref = parse_meeting_url(meeting.meeting_url)
     if ref:
         try:
@@ -311,9 +318,6 @@ async def stop_meeting(
                 "Vexa stop_bot failed, continuing", meeting_id=str(meeting.id), error=str(exc), exc_info=True
             )
 
-    meeting.status = "stopping"
-    meeting.ended_at = datetime.now(UTC)
-    await db.commit()
     # See start_meeting: no post-commit refresh — RLS tenant context is gone
     # after commit, and expire_on_commit=False keeps the mutated fields intact.
     return await _build_meeting_response(meeting, db)
@@ -831,7 +835,11 @@ async def vexa_webhook(
         meeting = await scoped_db.merge(meeting)
 
         if payload.status is not None and payload.status != "completed":
-            if portal_status and meeting.status != portal_status and meeting.status != "stopping":
+            if (
+                portal_status
+                and meeting.status != portal_status
+                and (meeting.status != "stopping" or portal_status == "failed")
+            ):
                 meeting.status = portal_status
                 await scoped_db.commit()
                 logger.info(

--- a/klai-portal/backend/app/services/bot_poller.py
+++ b/klai-portal/backend/app/services/bot_poller.py
@@ -54,25 +54,6 @@ def _snapshot(m: VexaMeeting) -> _ActiveMeetingSnapshot:
     return _ActiveMeetingSnapshot(id=m.id, org_id=m.org_id, meeting_url=m.meeting_url, status=m.status)
 
 
-async def _upgrade_joining_to_recording(meeting_id: uuid.UUID, org_id: int) -> None:
-    """Set meeting status joining→recording when the bot is confirmed active.
-
-    Runs in a tenant-scoped session so vexa_meetings' UPDATE RLS policy
-    accepts the write. Caller holds the meeting id and provides org_id.
-    """
-    async with tenant_scoped_session(org_id) as db:
-        m = await db.scalar(
-            select(VexaMeeting).where(
-                VexaMeeting.id == meeting_id,
-                VexaMeeting.status == "joining",
-            )
-        )
-        if m is not None:
-            m.status = "recording"
-            await db.commit()
-            logger.info("Bot poll: bot active, updated status joining→recording", meeting_id=str(meeting_id))
-
-
 async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
     """Bot is gone from Vexa — transition meeting to stopping and run transcription.
 
@@ -201,8 +182,6 @@ async def _poll_once() -> None:
             continue
 
         if (ref.platform, ref.native_meeting_id) in running_keys:
-            if snap.status == "joining" and snap.org_id is not None:
-                await _upgrade_joining_to_recording(snap.id, snap.org_id)
             continue  # bot is still running
 
         await _handle_meeting_ended(snap)

--- a/klai-portal/backend/tests/test_bot_poller.py
+++ b/klai-portal/backend/tests/test_bot_poller.py
@@ -181,10 +181,8 @@ async def test_poll_once_does_not_access_orm_after_session_exit(monkeypatch):
         "_fetch_running_keys_safe",
         AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
     )
-    upgrade = AsyncMock()
     handle_ended = AsyncMock()
     recover_stuck = AsyncMock()
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", upgrade)
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
 
@@ -193,15 +191,13 @@ async def test_poll_once_does_not_access_orm_after_session_exit(monkeypatch):
 
     # Bot is still running (platform/native_id in running_keys) and status is
     # "recording" — so no helper should fire.
-    upgrade.assert_not_awaited()
     handle_ended.assert_not_awaited()
     recover_stuck.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_poll_once_upgrades_joining_to_recording(monkeypatch):
-    """When the bot is running and status is 'joining', upgrade to 'recording'
-    — and pass primitives, not ORM instances, to the helper."""
+async def test_running_bot_does_not_report_recording_before_admission(monkeypatch):
+    """A running container proves liveness, not admission to the meeting."""
     post_exit = [False]
     mid = uuid.uuid4()
     meeting = _mk_meeting(post_exit_flag=post_exit, meeting_id=mid, status="joining", org_id=7)
@@ -216,14 +212,14 @@ async def test_poll_once_upgrades_joining_to_recording(monkeypatch):
         "_fetch_running_keys_safe",
         AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
     )
-    upgrade = AsyncMock()
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", upgrade)
+    tenant_session = MagicMock()
+    monkeypatch.setattr(bot_poller, "tenant_scoped_session", tenant_session)
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
 
     await bot_poller._poll_once()
 
-    upgrade.assert_awaited_once_with(mid, 7)
+    tenant_session.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -246,7 +242,6 @@ async def test_poll_once_handles_meeting_ended_when_bot_gone(monkeypatch):
     )
     handle_ended = AsyncMock()
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
 
     await bot_poller._poll_once()
@@ -274,7 +269,6 @@ async def test_poll_once_recovers_stuck_meetings(monkeypatch):
     recover_stuck = AsyncMock()
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
 
     await bot_poller._poll_once()
 
@@ -303,7 +297,6 @@ async def test_poll_once_skips_end_detection_when_running_keys_none(monkeypatch)
     recover_stuck = AsyncMock()
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", recover_stuck)
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
 
     await bot_poller._poll_once()
 
@@ -334,7 +327,6 @@ async def test_poll_once_skips_meeting_with_unparseable_url(monkeypatch):
     monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value=set()))
     handle_ended = AsyncMock()
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
-    monkeypatch.setattr(bot_poller, "_upgrade_joining_to_recording", AsyncMock())
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
 
     await bot_poller._poll_once()

--- a/klai-portal/backend/tests/test_meeting_stop_lifecycle.py
+++ b/klai-portal/backend/tests/test_meeting_stop_lifecycle.py
@@ -1,0 +1,144 @@
+"""Regression coverage for the manual meeting-stop lifecycle."""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.api.meetings import VexaWebhookPayload
+
+
+def _meeting(*, status: str) -> MagicMock:
+    meeting = MagicMock()
+    meeting.id = uuid.uuid4()
+    meeting.org_id = 42
+    meeting.status = status
+    meeting.meeting_url = "https://meet.google.com/abc-defg-hij"
+    meeting.ended_at = None
+    return meeting
+
+
+@pytest.mark.asyncio
+async def test_stop_meeting_terminal_callback_wins_during_vexa_delete(monkeypatch) -> None:
+    """A callback delivered by DELETE must not be overwritten with ``stopping``."""
+    from app.api import meetings as meetings_module
+
+    meeting = _meeting(status="recording")
+    persisted = {"status": meeting.status}
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=meeting)
+
+    async def _commit() -> None:
+        persisted["status"] = meeting.status
+
+    db.commit = AsyncMock(side_effect=_commit)
+
+    async def _stop_bot(_platform: str, _native_meeting_id: str) -> None:
+        # Vexa's DELETE synchronously destroys the workload and delivers bot.failed.
+        assert persisted["status"] == "stopping"
+        persisted["status"] = "failed"
+
+    monkeypatch.setattr(meetings_module, "can_write_meeting", AsyncMock(return_value=True))
+    monkeypatch.setattr(meetings_module.vexa, "stop_bot", _stop_bot)
+    monkeypatch.setattr(meetings_module, "_build_meeting_response", AsyncMock(return_value=MagicMock()))
+
+    await meetings_module.stop_meeting(
+        meeting.id,
+        perms=MagicMock(org_id=meeting.org_id, user_id="user-1"),
+        db=db,
+    )
+
+    assert persisted["status"] == "failed"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_meeting_is_recoverable_when_vexa_delete_fails(monkeypatch) -> None:
+    """A failed external stop still leaves a committed row for poller recovery."""
+    from app.api import meetings as meetings_module
+
+    meeting = _meeting(status="recording")
+    events: list[str] = []
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=meeting)
+    db.commit = AsyncMock(side_effect=lambda: events.append(f"commit:{meeting.status}"))
+
+    async def _stop_bot(_platform: str, _native_meeting_id: str) -> None:
+        events.append("vexa_delete")
+        raise RuntimeError("Vexa unavailable")
+
+    monkeypatch.setattr(meetings_module, "can_write_meeting", AsyncMock(return_value=True))
+    monkeypatch.setattr(meetings_module.vexa, "stop_bot", _stop_bot)
+    monkeypatch.setattr(meetings_module, "_build_meeting_response", AsyncMock(return_value=MagicMock()))
+
+    await meetings_module.stop_meeting(
+        meeting.id,
+        perms=MagicMock(org_id=meeting.org_id, user_id="user-1"),
+        db=db,
+    )
+
+    assert events == ["commit:stopping", "vexa_delete"]
+
+
+async def _deliver_status_callback(
+    monkeypatch, *, current_status: str, callback_status: str
+) -> tuple[MagicMock, MagicMock]:
+    from app.api import meetings as meetings_module
+    from app.core import database as database_module
+
+    meeting = _meeting(status=current_status)
+    lookup_db = MagicMock()
+    lookup_db.scalar = AsyncMock(return_value=meeting)
+    lookup_db.expunge = MagicMock()
+    scoped_db = MagicMock()
+    scoped_db.merge = AsyncMock(return_value=meeting)
+    scoped_db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _cross_org_session():
+        yield lookup_db
+
+    @asynccontextmanager
+    async def _tenant_session(_org_id: int):
+        yield scoped_db
+
+    monkeypatch.setattr(meetings_module, "_require_webhook_secret", lambda _request: None)
+    monkeypatch.setattr(database_module, "cross_org_session", _cross_org_session)
+    monkeypatch.setattr(database_module, "tenant_scoped_session", _tenant_session)
+
+    payload = VexaWebhookPayload(
+        platform="google_meet",
+        native_meeting_id="abc-defg-hij",
+        status=callback_status,
+    )
+    result = await meetings_module.vexa_webhook(payload, request=MagicMock(), db=AsyncMock())
+
+    assert result == {"status": "synced"}
+    return meeting, scoped_db
+
+
+@pytest.mark.asyncio
+async def test_terminal_failure_callback_advances_stopping_meeting(monkeypatch) -> None:
+    """Vexa ``bot.failed`` is terminal even after the user requested stop."""
+    meeting, scoped_db = await _deliver_status_callback(
+        monkeypatch,
+        current_status="stopping",
+        callback_status="failed",
+    )
+
+    assert meeting.status == "failed"
+    scoped_db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_nonterminal_callback_does_not_rewind_stopping_meeting(monkeypatch) -> None:
+    """A late admission callback cannot rewind a stop already in progress."""
+    meeting, scoped_db = await _deliver_status_callback(
+        monkeypatch,
+        current_status="stopping",
+        callback_status="awaiting_admission",
+    )
+
+    assert meeting.status == "stopping"
+    scoped_db.commit.assert_not_awaited()


### PR DESCRIPTION
Two Klai-side bugs, both surfaced by one meeting today where the bot never got into the call.

## First: the Vexa upgrade is exonerated for these

The Google Meet admission code is **byte-identical** between v0.12.22 and v0.12.26:

| file | sha256 (both images) |
|---|---|
| `googlemeet/admission.js` | `a462ee0982983785…` |
| `googlemeet/join.js` | `f9e61eb3ce1ceaa6…` |
| `googlemeet/selectors.js` | `747318a1a2d4aa7e…` |

`diff -rq` over the whole bundled `googlemeet` directory is clean, and the `suppressing admission` log line exists in v0.12.22 too. It showed up "once in 14 days" because no Google Meet bot had hit a lobby in that window — not because anything changed. I read that as new behaviour earlier; it was not.

What v0.12.26 *did* change is global browser stealth (`puppeteer-extra-plugin-stealth`, WebGL/`deviceMemory`/`chrome.runtime` spoofing). Whether that affects how Google surfaces an admission request is a separate question and not answerable from our side.

## "Recording" was our own claim, not Vexa's

`bot_poller` promoted `joining → recording` purely because a bot container existed. So the portal said "recording" while the bot was sitting in the lobby waiting for an admission that never came. That is exactly what the user saw.

Removed. Only the Vexa lifecycle callback confirms recording now. The poller keeps doing what it can actually observe: container disappearance and timeout recovery.

## "Stopping…" forever was a lost update

Production sequence:

```
10:41:04.706   runtime reports workload destroyed
10:41:04.758   portal processes Vexa status failed
10:41:04.760   Vexa registers bot.failed, HTTP 200
   a few ms    the stop route commits its already-loaded object as
               "stopping", overwriting the terminal failed
10:51:10       the ten-minute poller finally notices the row
10:52:45       recovery lands on done, empty transcript
```

So the user watched "Stopping…" for ten minutes and then got an empty meeting.

`stop_meeting` now commits the stop intent **before** the Vexa DELETE, because destroying the workload can deliver `bot.failed` synchronously. The webhook lets a terminal `failed` override `stopping`; non-terminal callbacks still cannot undo a stop.

## Both are pre-existing

The race needs Vexa to answer inside that window, and the poller's promotion only lies while a bot is in the lobby. Nobody had looked at a meeting in exactly that state before.

## Verification

Regression tests verified red before and green after — reverting the stop ordering fails `test_stop_meeting_terminal_callback_wins_during_vexa_delete` and `test_stop_meeting_is_recoverable_when_vexa_delete_fails`.

`ruff check` 0 · `ruff format --check` 0 · `pyright` 0 errors · backend suite **3742 passed**.

## Still open, and not ours

Whether Google actually surfaced the bot's admission request to the host. The click demonstrably landed: the X11 `buttonDown`/`buttonUp` precede the lobby-state selectors, which match post-click text like "Asking to be let in" rather than the pre-join button. The screenshot that would settle it was written to the container's writable layer with no volume mount, so it died with the container — worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)