### PR TITLE
fix(meetings): promote to recording on Vexa's admitted state, not on a container

### DIFF
--- a/klai-portal/backend/app/services/bot_poller.py
+++ b/klai-portal/backend/app/services/bot_poller.py
@@ -1,11 +1,11 @@
 """
 Background task: poll Vexa for active meetings and trigger transcription when done.
 
-Two responsibilities:
-1. Detect meetings that ended naturally (host closed Google Meet) — Vexa doesn't
-   send a webhook in that case. Polls GET /bots/status every POLL_INTERVAL seconds
-   and triggers transcription when a meeting's native_meeting_id is no longer present.
-2. Recover meetings stuck in "stopping" — if the "completed" webhook from Vexa
+Three responsibilities:
+1. Reconcile Vexa's lifecycle state from GET /bots/status. An `active` meeting is
+   the admission-backed signal that recording has started; container liveness alone is not.
+2. Detect meetings whose bot disappeared and trigger transcription as a webhook backstop.
+3. Recover meetings stuck in "stopping" — if the "completed" webhook from Vexa
    never arrives after stop_bot(), the meeting would stay in "stopping" forever.
    After PROCESSING_TIMEOUT_MINUTES, the poller tries to transcribe directly.
 
@@ -30,12 +30,16 @@ from app.api.meetings import ACTIVE_STATUSES, run_transcription
 from app.core.database import cross_org_session, set_tenant, tenant_scoped_session
 from app.models.meetings import VexaMeeting
 from app.services.recording_cleanup import cleanup_recording
-from app.services.vexa import parse_meeting_url, vexa
+from app.services.vexa import MAX_WAIT_FOR_ADMISSION_MS, MeetingRef, parse_meeting_url, vexa
 
 logger = structlog.get_logger()
 
 POLL_INTERVAL = 10  # seconds — Vexa's own documented polling interval
 PROCESSING_TIMEOUT_MINUTES = 10  # retry transcription after this many minutes stuck in "processing"
+JOINING_CALLBACK_GRACE_SECONDS = 60
+JOINING_TIMEOUT_SECONDS = MAX_WAIT_FOR_ADMISSION_MS // 1000 + JOINING_CALLBACK_GRACE_SECONDS
+_PREACTIVE_VEXA_STATUSES = frozenset({"requested", "joining", "awaiting_admission"})
+_VEXA_LIFECYCLE_STATUSES = _PREACTIVE_VEXA_STATUSES | {"active", "stopping", "completed", "failed"}
 
 
 @dataclass(frozen=True)
@@ -48,14 +52,21 @@ class _ActiveMeetingSnapshot:
     org_id: int | None
     meeting_url: str
     status: str
+    started_at: datetime | None = None
 
 
 def _snapshot(m: VexaMeeting) -> _ActiveMeetingSnapshot:
-    return _ActiveMeetingSnapshot(id=m.id, org_id=m.org_id, meeting_url=m.meeting_url, status=m.status)
+    return _ActiveMeetingSnapshot(
+        id=m.id,
+        org_id=m.org_id,
+        meeting_url=m.meeting_url,
+        status=m.status,
+        started_at=m.started_at or m.created_at,
+    )
 
 
 async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
-    """Bot is gone from Vexa — transition meeting to stopping and run transcription.
+    """Reconcile a bot that is no longer present in Vexa's non-terminal list.
 
     Tenant-scoped: uses snap.org_id to satisfy vexa_meetings UPDATE RLS.
     """
@@ -73,6 +84,13 @@ async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
         if m is None:
             return  # webhook already handled it
 
+        if m.status in {"pending", "joining"}:
+            m.status = "failed"
+            m.ended_at = m.ended_at or datetime.now(UTC)
+            m.error_message = "Bot ended before recording was confirmed"
+            await db.commit()
+            return
+
         m.status = "stopping"
         m.ended_at = m.ended_at or datetime.now(UTC)
         await db.commit()
@@ -86,22 +104,91 @@ async def _handle_meeting_ended(snap: _ActiveMeetingSnapshot) -> None:
 
 async def _fetch_running_keys_safe(
     active: list[_ActiveMeetingSnapshot],
-) -> set[tuple[str, str]] | None:
-    """Return the set of (platform, native_meeting_id) for all running Vexa bots.
+) -> dict[tuple[str, str], str | None] | None:
+    """Return each running Vexa meeting's admission-backed lifecycle status.
 
     Returns None if the Vexa API call fails (caller must skip end-detection that cycle).
+    Legacy responses without a meeting lifecycle status retain the key with a None value:
+    they prove liveness, but not admission.
     """
     if not active:
         return None
     try:
         running_bots = await vexa.get_running_bots()
-        return {(b["platform"], b["native_meeting_id"]) for b in running_bots}
+        statuses: dict[tuple[str, str], str | None] = {}
+        for bot in running_bots:
+            raw_status = bot.get("meeting_status") or bot.get("status")
+            lifecycle_status = raw_status if raw_status in _VEXA_LIFECYCLE_STATUSES else None
+            statuses[(bot["platform"], bot["native_meeting_id"])] = lifecycle_status
+        return statuses
     except Exception:
         logger.warning(
             "Bot status poll failed — skipping end detection this cycle",
             exc_info=True,
         )
         return None
+
+
+async def _confirm_recording(snap: _ActiveMeetingSnapshot) -> None:
+    """Promote joining only after Vexa reports its admitted `active` lifecycle state."""
+    if snap.org_id is None:
+        logger.warning("recording_confirmation_skipped_missing_org_id", meeting_id=str(snap.id))
+        return
+    async with tenant_scoped_session(snap.org_id) as db:
+        meeting = await db.scalar(
+            select(VexaMeeting).where(
+                VexaMeeting.id == snap.id,
+                VexaMeeting.status == "joining",
+            )
+        )
+        if meeting is None:
+            return
+        meeting.status = "recording"
+        await db.commit()
+        logger.info("Bot poll: Vexa confirmed meeting active", meeting_id=str(snap.id))
+
+
+def _joining_timed_out(snap: _ActiveMeetingSnapshot) -> bool:
+    return bool(
+        snap.status == "joining"
+        and snap.started_at is not None
+        and datetime.now(UTC) - snap.started_at >= timedelta(seconds=JOINING_TIMEOUT_SECONDS)
+    )
+
+
+async def _fail_joining_timeout(snap: _ActiveMeetingSnapshot, ref: MeetingRef) -> None:
+    """Stop and fail a bot that stayed pre-active beyond its admission budget plus callback grace."""
+    logger.warning(
+        "Bot poll: meeting did not reach active before admission deadline",
+        meeting_id=str(snap.id),
+        timeout_seconds=JOINING_TIMEOUT_SECONDS,
+    )
+    try:
+        await vexa.stop_bot(ref.platform, ref.native_meeting_id)
+    except Exception:
+        logger.warning(
+            "Bot poll: failed to stop meeting after admission deadline",
+            meeting_id=str(snap.id),
+            exc_info=True,
+        )
+        return
+
+    if snap.org_id is None:
+        logger.warning("joining_timeout_skipped_missing_org_id", meeting_id=str(snap.id))
+        return
+    async with tenant_scoped_session(snap.org_id) as db:
+        meeting = await db.scalar(
+            select(VexaMeeting).where(
+                VexaMeeting.id == snap.id,
+                VexaMeeting.status == "joining",
+            )
+        )
+        if meeting is None:
+            return
+        meeting.status = "failed"
+        meeting.ended_at = meeting.ended_at or datetime.now(UTC)
+        meeting.error_message = f"Bot was not admitted within {JOINING_TIMEOUT_SECONDS // 60} minutes"
+        await db.commit()
 
 
 async def _recover_stuck_meeting(snap: _ActiveMeetingSnapshot) -> None:
@@ -169,22 +256,28 @@ async def _poll_once() -> None:
     """
     active, stuck = await _load_cycle_snapshots()
 
-    # Fetch running bots once per cycle — a meeting has ended when its
-    # (platform, native_meeting_id) is absent from this list.
-    running_keys = await _fetch_running_keys_safe(active)
+    # Fetch running bots once per cycle. Presence proves workload liveness;
+    # only the Vexa lifecycle state `active` proves meeting admission.
+    running_statuses = await _fetch_running_keys_safe(active)
 
     for snap in active:
-        if running_keys is None:
+        if running_statuses is None:
             continue  # poll failed; don't trigger transcription based on missing data
 
         ref = parse_meeting_url(snap.meeting_url)
         if ref is None:
             continue
 
-        if (ref.platform, ref.native_meeting_id) in running_keys:
-            continue  # bot is still running
+        key = (ref.platform, ref.native_meeting_id)
+        if key not in running_statuses:
+            await _handle_meeting_ended(snap)
+            continue
 
-        await _handle_meeting_ended(snap)
+        vexa_status = running_statuses[key]
+        if snap.status == "joining" and vexa_status == "active":
+            await _confirm_recording(snap)
+        elif _joining_timed_out(snap):
+            await _fail_joining_timeout(snap, ref)
 
     for snap in stuck:
         await _recover_stuck_meeting(snap)

--- a/klai-portal/backend/app/services/vexa.py
+++ b/klai-portal/backend/app/services/vexa.py
@@ -18,6 +18,10 @@ from app.trace import get_trace_headers
 
 logger = structlog.get_logger()
 
+MAX_WAIT_FOR_ADMISSION_MS = 120_000
+NO_ONE_JOINED_TIMEOUT_MS = 120_000
+MAX_TIME_LEFT_ALONE_MS = 60_000
+
 
 class MeetingRef(NamedTuple):
     platform: str
@@ -108,9 +112,9 @@ class VexaClient:
             "recording_enabled": False,
             "bot_name": "Klai",
             "automatic_leave": {
-                "max_time_left_alone": 30000,  # 30s after everyone leaves
-                "no_one_joined_timeout": 120000,  # 2 min if no one joins
-                "max_wait_for_admission": 120000,  # 2 min in waiting room
+                "max_time_left_alone": MAX_TIME_LEFT_ALONE_MS,
+                "no_one_joined_timeout": NO_ONE_JOINED_TIMEOUT_MS,
+                "max_wait_for_admission": MAX_WAIT_FOR_ADMISSION_MS,
             },
         }
         if meeting_url:
@@ -133,11 +137,11 @@ class VexaClient:
         resp.raise_for_status()
 
     async def get_running_bots(self) -> list[dict]:
-        """Return the list of currently running bot containers from Vexa.
+        """Return Vexa's non-terminal meetings and their lifecycle status.
 
         Uses GET /bots/status which returns {"running_bots": [...]}.
-        Each entry has: platform, native_meeting_id, status, normalized_status, container_id.
-        Returns an empty list if the call fails — treated as "unknown, assume still running".
+        Vexa 0.12 entries expose the meeting FSM in `status`; older gateways may
+        only expose container-oriented `status` / `normalized_status` fields.
         """
         resp = await self._http.get("/bots/status", headers={**get_trace_headers()})
         resp.raise_for_status()

--- a/klai-portal/backend/tests/test_bot_poller.py
+++ b/klai-portal/backend/tests/test_bot_poller.py
@@ -37,7 +37,9 @@ class _TrackedMeeting:
     session is gone.
     """
 
-    _COLUMN_ATTRS = frozenset({"id", "org_id", "meeting_url", "status", "ended_at", "vexa_meeting_id"})
+    _COLUMN_ATTRS = frozenset(
+        {"id", "org_id", "meeting_url", "status", "ended_at", "started_at", "created_at", "vexa_meeting_id"}
+    )
 
     def __init__(self, *, post_exit_flag: list[bool], **columns: object) -> None:
         # Use object.__setattr__ so __getattr__ doesn't trip on our init.
@@ -63,7 +65,9 @@ def _mk_meeting(
     platform: str = "google_meet",
     native_id: str = "abc-def-ghi",
     status: str = "recording",
+    started_at: datetime | None = None,
 ) -> _TrackedMeeting:
+    started_at = started_at or datetime.now(UTC)
     return _TrackedMeeting(
         post_exit_flag=post_exit_flag,
         id=meeting_id or uuid.uuid4(),
@@ -71,6 +75,8 @@ def _mk_meeting(
         meeting_url=f"https://meet.google.com/{native_id}",
         status=status,
         ended_at=None,
+        started_at=started_at,
+        created_at=started_at,
         vexa_meeting_id=42,
     )
 
@@ -109,6 +115,55 @@ def test_stuck_meetings_stmt_includes_rows_without_vexa_meeting_id() -> None:
     assert "vexa_meetings.vexa_meeting_id IS NOT NULL" not in compiled
     assert "vexa_meetings.ended_at <" in compiled
     assert "vexa_meetings.created_at <" in compiled
+
+
+@pytest.mark.asyncio
+async def test_vexa_lifecycle_status_is_preserved_for_reconciliation(monkeypatch) -> None:
+    """The poller must retain Vexa's meeting FSM status instead of reducing it to container liveness."""
+    post_exit = [False]
+    active = [_mk_meeting(post_exit_flag=post_exit, status="joining")]
+    monkeypatch.setattr(
+        bot_poller.vexa,
+        "get_running_bots",
+        AsyncMock(
+            return_value=[
+                {
+                    "platform": "google_meet",
+                    "native_meeting_id": "abc-def-ghi",
+                    "status": "active",
+                }
+            ]
+        ),
+    )
+
+    result = await bot_poller._fetch_running_keys_safe(active)
+
+    assert result == {("google_meet", "abc-def-ghi"): "active"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_runtime_status_does_not_confirm_recording(monkeypatch) -> None:
+    """A legacy container-only status proves liveness but cannot prove meeting admission."""
+    post_exit = [False]
+    active = [_mk_meeting(post_exit_flag=post_exit, status="joining")]
+    monkeypatch.setattr(
+        bot_poller.vexa,
+        "get_running_bots",
+        AsyncMock(
+            return_value=[
+                {
+                    "platform": "google_meet",
+                    "native_meeting_id": "abc-def-ghi",
+                    "status": "Up 3 minutes",
+                    "normalized_status": "active",
+                }
+            ]
+        ),
+    )
+
+    result = await bot_poller._fetch_running_keys_safe(active)
+
+    assert result == {("google_meet", "abc-def-ghi"): None}
 
 
 @pytest.mark.asyncio
@@ -152,6 +207,41 @@ async def test_handle_meeting_ended_rearms_tenant_context_after_stopping_commit(
     assert events == ["commit", "set_tenant", "run_transcription", "commit"]
 
 
+@pytest.mark.asyncio
+async def test_disappeared_unadmitted_bot_fails_without_transcription(monkeypatch) -> None:
+    """A bot that vanished before any active signal did not produce a confirmed recording."""
+    meeting_id = uuid.uuid4()
+    meeting = MagicMock(status="joining", ended_at=None, error_message=None)
+    db = MagicMock()
+    db.scalar = AsyncMock(return_value=meeting)
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _tenant_session(_org_id):
+        yield db
+
+    run_transcription = AsyncMock()
+    monkeypatch.setattr(bot_poller, "tenant_scoped_session", _tenant_session)
+    monkeypatch.setattr(bot_poller, "set_tenant", AsyncMock())
+    monkeypatch.setattr(bot_poller, "run_transcription", run_transcription)
+    monkeypatch.setattr(bot_poller, "cleanup_recording", AsyncMock())
+
+    snap = bot_poller._ActiveMeetingSnapshot(
+        id=meeting_id,
+        org_id=42,
+        meeting_url="https://meet.google.com/abc-def-ghi",
+        status="joining",
+    )
+
+    await bot_poller._handle_meeting_ended(snap)
+
+    assert meeting.status == "failed"
+    assert meeting.ended_at is not None
+    assert meeting.error_message == "Bot ended before recording was confirmed"
+    db.commit.assert_awaited_once()
+    run_transcription.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -179,7 +269,7 @@ async def test_poll_once_does_not_access_orm_after_session_exit(monkeypatch):
     monkeypatch.setattr(
         bot_poller,
         "_fetch_running_keys_safe",
-        AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
+        AsyncMock(return_value={("google_meet", "abc-def-ghi"): "awaiting_admission"}),
     )
     handle_ended = AsyncMock()
     recover_stuck = AsyncMock()
@@ -210,7 +300,7 @@ async def test_running_bot_does_not_report_recording_before_admission(monkeypatc
     monkeypatch.setattr(
         bot_poller,
         "_fetch_running_keys_safe",
-        AsyncMock(return_value={("google_meet", "abc-def-ghi")}),
+        AsyncMock(return_value={("google_meet", "abc-def-ghi"): "awaiting_admission"}),
     )
     tenant_session = MagicMock()
     monkeypatch.setattr(bot_poller, "tenant_scoped_session", tenant_session)
@@ -220,6 +310,104 @@ async def test_running_bot_does_not_report_recording_before_admission(monkeypatc
     await bot_poller._poll_once()
 
     tenant_session.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_vexa_status_reports_recording_after_admission(monkeypatch) -> None:
+    """Only Vexa's active lifecycle state proves that the bot reached the meeting."""
+    post_exit = [False]
+    meeting = _mk_meeting(post_exit_flag=post_exit, status="joining", org_id=7)
+    scoped_meeting = MagicMock(status="joining")
+    scoped_db = MagicMock()
+    scoped_db.scalar = AsyncMock(return_value=scoped_meeting)
+    scoped_db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _tenant_session(_org_id):
+        yield scoped_db
+
+    monkeypatch.setattr(bot_poller, "cross_org_session", _mk_cross_org_session([meeting], [], post_exit))
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value={("google_meet", "abc-def-ghi"): "active"}),
+    )
+    monkeypatch.setattr(bot_poller, "tenant_scoped_session", _tenant_session)
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    assert scoped_meeting.status == "recording"
+    scoped_db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("vexa_status", ["awaiting_admission", None])
+async def test_joining_meeting_times_out_even_while_vexa_bot_is_still_running(monkeypatch, vexa_status) -> None:
+    """A live bot container must not keep an unadmitted meeting active forever."""
+    post_exit = [False]
+    started_at = datetime.now(UTC) - timedelta(seconds=181)
+    meeting = _mk_meeting(post_exit_flag=post_exit, status="joining", org_id=7, started_at=started_at)
+    scoped_meeting = MagicMock(status="joining", ended_at=None, error_message=None)
+    scoped_db = MagicMock()
+    scoped_db.scalar = AsyncMock(return_value=scoped_meeting)
+    scoped_db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _tenant_session(_org_id):
+        yield scoped_db
+
+    stop_bot = AsyncMock()
+    monkeypatch.setattr(bot_poller, "cross_org_session", _mk_cross_org_session([meeting], [], post_exit))
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value={("google_meet", "abc-def-ghi"): vexa_status}),
+    )
+    monkeypatch.setattr(bot_poller, "tenant_scoped_session", _tenant_session)
+    monkeypatch.setattr(bot_poller.vexa, "stop_bot", stop_bot)
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    assert scoped_meeting.status == "failed"
+    assert scoped_meeting.ended_at is not None
+    assert scoped_meeting.error_message == "Bot was not admitted within 3 minutes"
+    stop_bot.assert_awaited_once_with("google_meet", "abc-def-ghi")
+
+
+@pytest.mark.asyncio
+async def test_joining_timeout_retries_when_vexa_stop_fails(monkeypatch) -> None:
+    """Do not report a terminal timeout while the overdue upstream workload could still be running."""
+    post_exit = [False]
+    started_at = datetime.now(UTC) - timedelta(seconds=181)
+    meeting = _mk_meeting(post_exit_flag=post_exit, status="joining", org_id=7, started_at=started_at)
+    scoped_meeting = MagicMock(status="joining")
+    scoped_db = MagicMock()
+    scoped_db.scalar = AsyncMock(return_value=scoped_meeting)
+    scoped_db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _tenant_session(_org_id):
+        yield scoped_db
+
+    monkeypatch.setattr(bot_poller, "cross_org_session", _mk_cross_org_session([meeting], [], post_exit))
+    monkeypatch.setattr(
+        bot_poller,
+        "_fetch_running_keys_safe",
+        AsyncMock(return_value={("google_meet", "abc-def-ghi"): "awaiting_admission"}),
+    )
+    monkeypatch.setattr(bot_poller, "tenant_scoped_session", _tenant_session)
+    monkeypatch.setattr(bot_poller.vexa, "stop_bot", AsyncMock(side_effect=RuntimeError("upstream unavailable")))
+    monkeypatch.setattr(bot_poller, "_handle_meeting_ended", AsyncMock())
+    monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())
+
+    await bot_poller._poll_once()
+
+    assert scoped_meeting.status == "joining"
+    scoped_db.commit.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -238,7 +426,7 @@ async def test_poll_once_handles_meeting_ended_when_bot_gone(monkeypatch):
     monkeypatch.setattr(
         bot_poller,
         "_fetch_running_keys_safe",
-        AsyncMock(return_value=set()),  # empty → bot has ended
+        AsyncMock(return_value={}),  # empty → bot has ended
     )
     handle_ended = AsyncMock()
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
@@ -316,6 +504,8 @@ async def test_poll_once_skips_meeting_with_unparseable_url(monkeypatch):
         meeting_url="not-a-valid-meeting-url",
         status="recording",
         ended_at=None,
+        started_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
         vexa_meeting_id=None,
     )
 
@@ -324,7 +514,7 @@ async def test_poll_once_skips_meeting_with_unparseable_url(monkeypatch):
         "cross_org_session",
         _mk_cross_org_session([meeting], [], post_exit),
     )
-    monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value=set()))
+    monkeypatch.setattr(bot_poller, "_fetch_running_keys_safe", AsyncMock(return_value={}))
     handle_ended = AsyncMock()
     monkeypatch.setattr(bot_poller, "_handle_meeting_ended", handle_ended)
     monkeypatch.setattr(bot_poller, "_recover_stuck_meeting", AsyncMock())

--- a/klai-portal/backend/tests/test_vexa_client.py
+++ b/klai-portal/backend/tests/test_vexa_client.py
@@ -79,3 +79,25 @@ async def test_client_sends_x_user_id() -> None:
     """0.12 rejects a spawn without X-User-Id (401 Invalid user identity)."""
     client = VexaClient()
     assert client._http.headers.get("X-User-Id") == VexaClient.VEXA_USER_ID
+
+
+@pytest.mark.anyio
+async def test_bot_leave_deadlines_match_the_portal_lifecycle_contract() -> None:
+    """Unadmitted bots get 2 minutes; admitted empty meetings get the promised 60-second grace."""
+    client = VexaClient()
+    response = httpx.Response(
+        201,
+        json={"id": 9},
+        request=httpx.Request("POST", "http://meeting-api:8080/bots"),
+    )
+    with patch.object(client, "_http") as http:
+        http.post = AsyncMock(return_value=response)
+
+        await client.start_bot("google_meet", "abc-def-ghi")
+
+    payload = http.post.await_args.kwargs["json"]
+    assert payload["automatic_leave"] == {
+        "max_time_left_alone": 60_000,
+        "no_one_joined_timeout": 120_000,
+        "max_wait_for_admission": 120_000,
+    }


### PR DESCRIPTION
Follow-up to #1286, which I got half right.

#1286 removed the poller's `joining → recording` promotion because it fired on *container existence*, so the portal claimed "recording" while the bot sat in a lobby. That part was correct. But it assumed a callback path that does not exist, and left meetings stuck on **"Joining…"** instead.

## The callback chain that shows why

```
11:29:45   bot -> Vexa: joining
11:29:55   bot -> Vexa: awaiting_admission
11:30:04   bot -> Vexa: active          <- admitted, and Klai never hears it
11:32:26   bot leaves: left_alone
11:32:36   Vexa: completed
```

Klai *does* translate `active → recording`. But **Vexa's operator webhook only emits terminal `meeting.completed` and `bot.failed`.** The `active` transition never arrives, so nothing could move the meeting off `joining`.

## The fix

The poller now reads Vexa's own lifecycle status from `GET /bots/status` and promotes only on `active` — admission-backed, which is the signal the old promotion was pretending to have.

A legacy gateway that reports no lifecycle status keeps its entry with a `None` value: it proves liveness, not admission, and deliberately does not promote.

A bot that disappears while still `pending` or `joining` is now marked `failed` with *"Bot ended before recording was confirmed"*, instead of running transcription over a meeting that was never recorded and calling it done. **That is what produced an empty transcript presented as a finished meeting.**

## Two smaller corrections found on the way

`max_time_left_alone` was 30s while the UI has always promised 60 — *"we wait 60 seconds, in case anyone comes back"*. The code now matches the promise.

And there is a 180s backstop for a meeting that never leaves `joining`: the 120s admission budget Vexa is given, plus 60s of callback grace.

## The lobby wait was already bounded

`max_wait_for_admission` becomes `waitingRoomTimeout` upstream; expiry yields `awaiting_admission_timeout` and `bot.failed`, and production confirms that terminal webhook reaches Klai with HTTP 200. "Polling up to 120000ms" does not become an unbounded wait.

## Verification

Red before, green after: neutralising the active promotion fails `test_active_vexa_status_reports_recording_after_admission`.

`ruff check` 0 · `ruff format --check` 0 · `pyright` 0 errors · backend suite **3750 passed**.

## Explicitly not addressed here

Why that admitted bot captured **0 transcript rows, 0 captions, 0 csrc** across ~2.5 minutes in the meeting. That is a separate failure under investigation on its own branch — this PR only stops us misreporting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)