### PR TITLE
fix(vexa): give bots a narrow path to STT again — transcription has been dead since 17 Aug

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -77,6 +77,7 @@ jobs:
           bash deploy/scripts/tests/docker-orphan-audit-caddy-routes.test.sh
           bash deploy/scripts/tests/docker-orphan-audit-hand-edits.test.sh
           bash deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+          bash deploy/scripts/tests/vexa12-transcription-path.test.sh
 
       - name: Sync docker-compose.yml + config + run smoke-test
         uses: appleboy/ssh-action@v1

--- a/deploy/VERSIONS.md
+++ b/deploy/VERSIONS.md
@@ -68,7 +68,7 @@ GPU production image pins are intentionally not listed in this public repo becau
 | Service | Image | Rationale |
 |---|---|---|
 | `docker-socket-proxy` | `tecnativa/docker-socket-proxy:v0.5.0` | Limits portal-api to specific Docker API verbs (CONTAINERS, NETWORKS, POST, DELETE). Stable; rare releases. |
-| `runtime-api-socket-proxy` | `alpine/socat:1.8.1.3` | Bridges Vexa runtime-api's Unix Docker socket expectation to docker-socket-proxy TCP. Keep current with Alpine socat releases because old tags carry many fixed base-package CVEs. |
+| `runtime-api-socket-proxy`, `vexa12-transcription-proxy` | `alpine/socat:1.8.1.3` | Bridges the two deliberately narrow TCP capabilities: Vexa runtime's Unix Docker socket expectation, and bot-network STT traffic to the host tunnel. Keep current with Alpine socat releases because old tags carry many fixed base-package CVEs. |
 | `garage` | `dxflrs/garage:v2.3.0` | S3-compatible object storage. Config field names change between minor releases — re-verify `garage.toml` after each bump. See `.claude/rules/klai/platform/garage.md`. |
 | `listmonk` | `listmonk/listmonk:v6.2.0` | Self-hosted mailing platform at `mailing.getklai.com` for campaign templates, lists, and Twenty-selected audiences. Upgrade after checking listmonk release notes and database migrations. |
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -72,17 +72,18 @@ networks:
     driver: bridge
     # Split the address space so the firewall can tell a service from a bot.
     #
-    # Bots and vexa12-meeting-api share this network by design — the runtime's
-    # DOCKER_NETWORK puts each bot alongside redis and meeting-api, which is the
-    # name a bot dials for its callback. But meeting-api also reaches the
-    # transcription endpoint on the host, and bots must not. With one flat /16 of
-    # dynamic addresses there was no way to express that: the INPUT exception for
-    # tcp/8000 had to cover the whole subnet, every ephemeral bot included
-    # (SPEC-SEC-022 REQ-2).
+    # Bots and the trusted Vexa services share this network by design — the
+    # runtime's DOCKER_NETWORK puts each bot alongside redis and meeting-api,
+    # which is the name a bot dials for its callback. The bot process also sends
+    # captured PCM to STT itself, but bots must not reach host ports directly.
+    # A fixed-address TCP proxy below exposes only host tcp/8000; the INPUT
+    # exception is scoped to that proxy. With one flat /16 of dynamic addresses
+    # there would be no way to distinguish it from an ephemeral bot.
     #
     # ip_range confines dynamic allocation to the upper half, so a bot can never
-    # be handed an address out of the lower half. meeting-api is pinned there and
-    # the firewall exception narrows from ~65k addresses to one.
+    # be handed an address out of the lower half. Trusted services are pinned
+    # there and the firewall exception narrows from ~65k addresses to the STT
+    # proxy's single address.
     ipam:
       config:
         - subnet: 172.29.0.0/16
@@ -1702,6 +1703,31 @@ services:
       timeout: 5s
       retries: 3
 
+  # The bot process performs the STT POST itself. Bots cannot use the host-bound
+  # GPU tunnel directly: harden-docker-user.sh default-denies the whole dynamic
+  # bot address pool. This byte-only proxy is the narrow capability they need —
+  # one listener, one fixed destination, no environment or secret surface. Its
+  # fixed address is the sole tcp/8000 exception in the host INPUT firewall.
+  vexa12-transcription-proxy:
+    image: alpine/socat:1.8.1.3
+    restart: unless-stopped
+    command: >
+      TCP-LISTEN:8000,fork,reuseaddr
+      TCP:172.18.0.1:8000,connect-timeout=5
+    init: true
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      vexa12-bots:
+        ipv4_address: 172.29.0.11
+    deploy:
+      resources:
+        limits:
+          memory: 32M
+
   # ─── Vexa 0.12 admin-api (schema owner) ─────────────────────────────────
   # Klai calls none of its endpoints. It runs because ensure_schema() lives here
   # and converges vexa_v012 to the SQLAlchemy metadata at boot (create_all in FK
@@ -1804,7 +1830,9 @@ services:
       RECORDING_ENABLED: "false"
       TRANSCRIBE_ENABLED: "true"
       BOT_AUTHENTICATED: "false"
-      TRANSCRIPTION_SERVICE_URL: http://172.18.0.1:8000/v1/audio/transcriptions
+      # The bot itself performs this POST. Use the single-destination proxy;
+      # direct host access from the dynamic bot pool is denied by INPUT policy.
+      TRANSCRIPTION_SERVICE_URL: http://vexa12-transcription-proxy:8000/v1/audio/transcriptions
       TRANSCRIPTION_SERVICE_TOKEN: ${WHISPER_SERVICE_TOKEN:-internal}
       # Storage backend: Garage speaks S3. Unused while RECORDING_ENABLED=false,
       # but the service still wants the config to boot (same as 0.10).
@@ -1846,6 +1874,8 @@ services:
         condition: service_healthy   # schema owner — tables must exist first
       vexa12-runtime:
         condition: service_started
+      vexa12-transcription-proxy:
+        condition: service_started
     networks:
       # NOT klai-net — see the vexa12-portal network comment. meeting-api's network
       # membership is its only authorization boundary.
@@ -1854,9 +1884,8 @@ services:
       vexa12-internal: {} # reaches vexa12-admin-api without exposing it to bots
       vexa12-storage: {}  # reaches garage for the S3 config it boots with
       vexa12-bots:
-        # Outside the ip_range on this network, so no bot can ever receive this
-        # address. harden-docker-user.sh allows only this IP to reach the host's
-        # transcription port (SPEC-SEC-022 REQ-2).
+        # Trusted control-plane address outside the dynamic bot pool. Only the
+        # transcription proxy's separate .11 address may reach host tcp/8000.
         ipv4_address: 172.29.0.10
         aliases:
           - meeting-api   # the name a spawned 0.12 bot dials for its callback

--- a/deploy/scripts/harden-docker-user.sh
+++ b/deploy/scripts/harden-docker-user.sh
@@ -64,18 +64,18 @@ iptables -L DOCKER-USER -n --line-numbers
 # a new host port later is covered without anyone remembering to add it.
 #
 # The exception is tcp/8000, the transcription endpoint, and it is scoped to one
-# address. vexa12-meeting-api carries TRANSCRIPTION_SERVICE_URL pointing there
-# and shares this network with the bots by design — the runtime puts each bot
-# alongside redis and meeting-api, which is the name it dials for its callback.
+# address: vexa12-transcription-proxy. Vexa bots POST their captured PCM to STT
+# themselves, so meeting-api passes them the proxy's in-network URL. The proxy
+# has one fixed TCP destination and no environment or secret surface.
 #
 # So the boundary cannot be drawn per network; it is drawn inside it. The compose
 # file confines dynamic allocation on vexa12-bots to 172.29.128.0/17 and pins
-# meeting-api at 172.29.0.10, outside that pool. A bot can never be handed that
-# address, so allowing it grants nothing to a compromised browser.
+# the transcription proxy at 172.29.0.11, outside that pool. A bot can never be
+# handed that address, so allowing it grants nothing to a compromised browser.
 #
 # Read the pinned address from Docker rather than repeating the literal — if the
-# compose pin is ever dropped, MEETING_API_IP comes back empty and the exception
-# is simply not installed, which fails closed.
+# compose pin is ever dropped, TRANSCRIPTION_PROXY_IP comes back empty and the
+# exception is simply not installed, which fails closed.
 #
 # The subnet is read from Docker rather than hardcoded: 172.29.0.0/16 today, but
 # the SPEC was written against 172.27.0.0/16 and that range now belongs to a
@@ -95,7 +95,7 @@ fi
 echo ""
 echo "Restricting $BOTS_NET ($BOTS_CIDR) → host ..."
 
-MEETING_API_IP="$(docker inspect klai-core-vexa12-meeting-api-1 \
+TRANSCRIPTION_PROXY_IP="$(docker inspect klai-core-vexa12-transcription-proxy-1 \
     --format '{{range $k,$v := .NetworkSettings.Networks}}{{if eq $k "vexa12-bots"}}{{$v.IPAddress}}{{end}}{{end}}' \
     2>/dev/null || true)"
 
@@ -103,21 +103,21 @@ MEETING_API_IP="$(docker inspect klai-core-vexa12-meeting-api-1 \
 # whole-subnet form too — it is what this script installed before the pin
 # existed, and leaving it behind would keep every bot excepted.
 while iptables -D INPUT -s "$BOTS_CIDR" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
-[ -n "$MEETING_API_IP" ] && \
-    while iptables -D INPUT -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
+[ -n "$TRANSCRIPTION_PROXY_IP" ] && \
+    while iptables -D INPUT -s "$TRANSCRIPTION_PROXY_IP" -p tcp --dport 8000 -j ACCEPT 2>/dev/null; do :; done
 while iptables -D INPUT -s "$BOTS_CIDR" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; do :; done
 while iptables -D INPUT -s "$BOTS_CIDR" -j DROP 2>/dev/null; do :; done
 
 # Rules are inserted at position 1, so later inserts land above earlier ones.
 iptables -I INPUT 1 -s "$BOTS_CIDR" -j DROP
 iptables -I INPUT 1 -s "$BOTS_CIDR" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-if [ -z "$MEETING_API_IP" ]; then
-    echo "  WARNING: vexa12-meeting-api has no vexa12-bots address — transcription" >&2
+if [ -z "$TRANSCRIPTION_PROXY_IP" ]; then
+    echo "  WARNING: vexa12-transcription-proxy has no vexa12-bots address — transcription" >&2
     echo "           exception NOT installed. Meetings will fail until this resolves." >&2
     exit 1
 fi
-iptables -I INPUT 1 -s "$MEETING_API_IP" -p tcp --dport 8000 -j ACCEPT
-echo "  transcription exception: $MEETING_API_IP only"
+iptables -I INPUT 1 -s "$TRANSCRIPTION_PROXY_IP" -p tcp --dport 8000 -j ACCEPT
+echo "  transcription exception: $TRANSCRIPTION_PROXY_IP only"
 
 echo "Done. INPUT rules for $BOTS_CIDR:"
 iptables -L INPUT -n --line-numbers | grep -E "^(num|[0-9]+ .*${BOTS_CIDR//./\\.})" || true

--- a/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
+++ b/deploy/scripts/tests/harden-docker-user-bot-isolation.test.sh
@@ -29,16 +29,16 @@ FAIL=0
 
 run_script() {
     # $1 = subnet the docker stub reports ("" = network not found)
-    # $2 = meeting-api's address on that network ("" = pin missing)
+    # $2 = transcription proxy's address on that network ("" = pin missing)
     local subnet="$1"
-    local MEETING_IP="${2-172.29.0.10}"
+    local PROXY_IP="${2-172.29.0.11}"
     local tmp; tmp="$(mktemp -d)"
 
     cat > "$tmp/docker" <<STUB
 #!/usr/bin/env bash
 case "\$*" in
   *IPAM*)      [ -n "$subnet" ] && echo "$subnet" ;;
-  *meeting-api*) [ -n "$MEETING_IP" ] && echo "$MEETING_IP" ;;
+  *transcription-proxy*) [ -n "$PROXY_IP" ] && echo "$PROXY_IP" ;;
 esac
 exit 0
 STUB
@@ -91,8 +91,8 @@ check "the SPEC's stale 172.27.0.0/16 is not used" \
 check "a default DROP is installed for the bot subnet" \
     bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP"' "$LAST_CALLS"
 
-check "transcription (8000) is excepted for the pinned address only" \
-    bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.10 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
+check "transcription (8000) is excepted for the pinned proxy only" \
+    bash -c 'echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.11 -p tcp --dport 8000 -j ACCEPT"' "$LAST_CALLS"
 
 check "the whole subnet is NOT excepted — that would cover every bot" \
     bash -c '! echo "$0" | grep -q -- "-I INPUT 1 -s 172.29.0.0/16 -p tcp --dport 8000"' "$LAST_CALLS"
@@ -105,7 +105,7 @@ check "the old whole-subnet exception is cleared on re-run" \
 check "the exception is inserted after the DROP, so it lands above it" \
     bash -c '
       drop=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.0/16 -j DROP" | tail -1 | cut -d: -f1)
-      acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.10 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
+      acc=$(echo "$0" | grep -n -- "-I INPUT 1 -s 172.29.0.11 -p tcp --dport 8000" | tail -1 | cut -d: -f1)
       [ -n "$drop" ] && [ -n "$acc" ] && [ "$acc" -gt "$drop" ]' "$LAST_CALLS"
 
 check "established host-initiated connections are accepted above the DROP" \

--- a/deploy/scripts/tests/vexa12-transcription-path.test.sh
+++ b/deploy/scripts/tests/vexa12-transcription-path.test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Regression guard for the Vexa bot -> STT network path.
+#
+# Vexa meeting-api passes TRANSCRIPTION_SERVICE_URL into each spawned bot, and
+# the bot itself POSTs captured PCM to that URL. Bots are deliberately blocked
+# from every host-bound port by harden-docker-user.sh, so the URL must name a
+# narrow in-network proxy. The proxy may reach only the host's transcription
+# tunnel; it must not weaken the bot-subnet INPUT deny.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE="$REPO_ROOT/deploy/docker-compose.yml"
+FAIL=0
+
+service_block() {
+    local service="$1"
+    awk -v service="$service" '
+        $0 == "  " service ":" { capture=1; next }
+        capture && /^  [a-zA-Z0-9_-]+:$/ { exit }
+        capture { print }
+    ' "$COMPOSE"
+}
+
+check() {
+    local description="$1"
+    shift
+    if "$@"; then
+        echo "OK:   $description"
+    else
+        echo "FAIL: $description" >&2
+        FAIL=1
+    fi
+}
+
+echo "-- Vexa 0.12 bot transcription path --"
+
+MEETING_API_BLOCK="$(service_block vexa12-meeting-api)"
+PROXY_BLOCK="$(service_block vexa12-transcription-proxy)"
+
+check "meeting-api passes bots the network-local transcription proxy URL" \
+    grep -Fq 'TRANSCRIPTION_SERVICE_URL: http://vexa12-transcription-proxy:8000/v1/audio/transcriptions' \
+    <<<"$MEETING_API_BLOCK"
+
+check "meeting-api no longer passes bots the host bridge address" \
+    bash -c '! grep -Fq "TRANSCRIPTION_SERVICE_URL: http://172.18.0.1:8000" <<<"$0"' \
+    "$MEETING_API_BLOCK"
+
+check "the proxy exposes only a TCP listener for STT" \
+    grep -Fq 'TCP-LISTEN:8000,fork,reuseaddr' <<<"$PROXY_BLOCK"
+
+check "the proxy forwards only to the host transcription tunnel" \
+    grep -Fq 'TCP:172.18.0.1:8000' <<<"$PROXY_BLOCK"
+
+check "the proxy is reachable from spawned bots" \
+    grep -Fq 'vexa12-bots:' <<<"$PROXY_BLOCK"
+
+check "the proxy has a trusted address outside the dynamic bot pool" \
+    grep -Fq 'ipv4_address: 172.29.0.11' <<<"$PROXY_BLOCK"
+
+check "the proxy does not bridge bots onto klai-net" \
+    bash -c '! grep -Fq -- "- klai-net" <<<"$0"' "$PROXY_BLOCK"
+
+check "the proxy has no environment or env_file secret surface" \
+    bash -c '! grep -Eq "^[[:space:]]+(environment|env_file):" <<<"$0"' \
+    "$PROXY_BLOCK"
+
+check "the proxy drops Linux capabilities" \
+    grep -Fq -- '- ALL' <<<"$PROXY_BLOCK"
+
+check "the proxy filesystem is read-only" \
+    grep -Fq 'read_only: true' <<<"$PROXY_BLOCK"
+
+echo "----------------------------------------"
+if [ "$FAIL" -eq 0 ]; then
+    echo "Vexa 0.12 bot transcription path: OK"
+else
+    echo "Vexa 0.12 bot transcription path: FAILED" >&2
+fi
+exit "$FAIL"

--- a/deploy/tests/test_transcription_contract.py
+++ b/deploy/tests/test_transcription_contract.py
@@ -54,7 +54,22 @@ def test_scribe_and_vexa_share_transcription_backend_origin():
     meeting_endpoint = urlparse(meeting_env["TRANSCRIPTION_SERVICE_URL"])
 
     assert meeting_endpoint.path == "/v1/audio/transcriptions"
-    assert (meeting_endpoint.scheme, meeting_endpoint.hostname, meeting_endpoint.port) == (
+
+    # Vexa reaches the backend through vexa12-transcription-proxy: bots are
+    # default-denied to host ports (SPEC-SEC-022 REQ-2) and the bot process
+    # makes the STT call itself, so a fixed-address socat hop is the only way
+    # in. The contract is still "the same backend as scribe" -- it just has to
+    # be followed one hop, which also pins the proxy at the right destination.
+    proxy = compose["services"].get(meeting_endpoint.hostname)
+    if proxy is not None:
+        destination = str(proxy["command"]).split("TCP:", 1)[1].split(",", 1)[0]
+        proxy_host, _, proxy_port = destination.rpartition(":")
+        effective_host, effective_port = proxy_host, int(proxy_port)
+        assert meeting_endpoint.port == 8000, "the proxy listener is tcp/8000"
+    else:
+        effective_host, effective_port = meeting_endpoint.hostname, meeting_endpoint.port
+
+    assert (meeting_endpoint.scheme, effective_host, effective_port) == (
         scribe_base.scheme,
         scribe_base.hostname,
         scribe_base.port,


### PR DESCRIPTION
**Every Klai recording since 2026-08-17 has silently produced an empty transcript.**

Not since today's v0.12.26 upgrade. The Teams meeting of 2026-08-28, on the old v0.12.22, fails identically — `stt unavailable: fetch failed`, 0 transcript rows. The upgrade is exonerated; the timing was a coincidence.

## Audio capture was never the problem

Today's bot recorded 59 frames past the 0.005 silence gate: **241,664 samples, 15.1 seconds of PCM at 16 kHz**, RMS 0.000437–0.209792, speaker 0 named for the participant, three connected tracks.

It started eight transcription jobs. **All eight died after ~48s with `stt unavailable: fetch failed`**, taking 11 seconds of audio with them.

## The cause is our own firewall

#1029 narrowed the tcp/8000 INPUT exception from the whole bot subnet to meeting-api's single pinned address, on the premise that meeting-api is what reaches the transcription endpoint.

**The bot process makes that POST itself.** Dynamic bots land in `172.29.128.0/17` and hit the default DROP, so the STT endpoint became unreachable for the one component that actually calls it.

## The fix keeps the security property

Reopening the /16 would undo SPEC-SEC-022 REQ-2, which exists to keep ephemeral bots off host ports.

Instead: a fixed-address socat proxy at `172.29.0.11` inside the bot network. Bots reach the proxy in-network, and the proxy is the **sole** address the host INPUT rule admits to tcp/8000. It carries bytes and nothing else — read-only rootfs, all capabilities dropped, `no-new-privileges`, 32M, no environment or secret surface. The bot keeps its default deny to the host.

## A red herring worth naming

`0 csrc / 0 captions / 0 observations` are sidecar counters for lanes Google Meet does not use — it binds names per channel in the `gmeet` lane. `mainAudioProvedSilent` never fired and no `MAIN-AUDIO ABSENT` appears in the bot log.

Reading those zeros as "no audio" sends you to the wrong half of the system. That is where I went first, and it cost time.

## Guard

`deploy/scripts/tests/vexa12-transcription-path.test.sh` asserts the proxy exists, is pinned, and stays byte-only, and runs in `deploy-compose.yml` before the core-01 sync. Verified to fail when the service is removed:

```
FAIL: the proxy filesystem is read-only
Vexa 0.12 bot transcription path: FAILED
```

The existing bot-isolation guard still passes, so the deny it protects is intact. `check-image-tags`, `check-image-pullable`, `env-scope-guard` and `test-audit-compose` all pass.

## After merge

This needs a real meeting to confirm end to end — the failure mode is silent by construction, which is how it survived two weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)