### PR TITLE
fix(renovate): re-check a branch when its quality run finishes, not an hour later

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,15 @@ on:
     # ready-to-merge for up to seven days. A run is ~2 minutes and does
     # nothing when there is nothing to do.
     - cron: '7 * * * *'
+  # A branch update and Renovate's check-run query can be only seconds apart.
+  # GitHub Actions may not have published any check-runs yet, so that run
+  # correctly leaves the PR yellow. Nudge Renovate again once the required
+  # workflow has completed; the normal branch-status gate still decides
+  # whether quality passed and the PR may merge.
+  workflow_run:
+    workflows: ['Required quality']
+    types: [completed]
+    branches: ['renovate/**']
   workflow_dispatch:
     inputs:
       logLevel:
@@ -21,8 +30,21 @@ on:
         default: info
         required: false
 
+# A batch can complete quality for several Renovate branches together. Keep
+# one run active and coalesce completion nudges behind it so two app instances
+# never update the same branch concurrently. Do not cancel a run mid-update.
+concurrency:
+  group: renovate-automerge
+  cancel-in-progress: false
+
 jobs:
   renovate:
+    # workflow_run carries secrets even when the triggering workflow came from
+    # a fork. This job only checks out main, but do not let an untrusted fork
+    # trigger the privileged app-token flow at all.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       # Only what the token-minting step needs. Renovate itself acts as the

--- a/scripts/test-renovate-config.sh
+++ b/scripts/test-renovate-config.sh
@@ -37,6 +37,39 @@ assert_contains "$workflow" \
   "RENOVATE_X_GITHUB_HOST_RULES: 'true'" \
   'Renovate must pass its GitHub App token to GitHub Packages lookups'
 
+# Renovate checks a newly written branch before GitHub Actions has necessarily
+# published its check-runs. Its GitHub check-run cache is process-local, so a
+# fresh Renovate process after the required workflow completes is the safe
+# nudge: failed quality still blocks the merge, while successful quality gets
+# observed without waiting for (or racing) the next cron run.
+assert_line "$quality_workflow" \
+  'name: Required quality' \
+  'the quality workflow name must stay aligned with the Renovate completion trigger'
+assert_line "$workflow" \
+  '  workflow_run:' \
+  'Renovate must be nudged after the required quality workflow completes'
+assert_line "$workflow" \
+  "    workflows: ['Required quality']" \
+  'the Renovate nudge must follow the required quality workflow'
+assert_line "$workflow" \
+  '    types: [completed]' \
+  'the Renovate nudge must wait until the required quality workflow is complete'
+assert_line "$workflow" \
+  "    branches: ['renovate/**']" \
+  'quality completions must only nudge Renovate for Renovate branches'
+assert_line "$workflow" \
+  '  group: renovate-automerge' \
+  'Renovate runs must be serialized so completion nudges cannot race each other'
+assert_line "$workflow" \
+  '  cancel-in-progress: false' \
+  'a completion nudge must not interrupt a Renovate run that is already updating branches'
+assert_line "$workflow" \
+  "      github.event_name != 'workflow_run' ||" \
+  'scheduled and manual Renovate runs must remain enabled'
+assert_line "$workflow" \
+  '      github.event.workflow_run.head_repository.full_name == github.repository' \
+  'fork quality runs must not trigger a privileged Renovate nudge'
+
 assert_contains "$config" \
   "matchPackageNames: ['ghcr.io/getklai/librechat']" \
   'the digest-only Klai LibreChat image must have an explicit Renovate policy'


### PR DESCRIPTION
Renovate force-pushes a branch and then reads its check-runs seconds later. GitHub has often published none yet, so the run correctly sees an empty list, calls the branch yellow, and declines to merge. Nothing then re-evaluates until the next hourly cron.

## Measured

| PR | rewritten | first check | Renovate looked | outcome |
|---|---|---|---|---|
| #1255 | 12:38:17 | 12:38:28 | 12:38:32 | 2 in-progress |
| #1256 | 12:48:36 | 12:48:45 | 12:54:57 | green — merged 12:56:52 |
| #1258 | 12:57:38 | 12:57:49 | **12:57:43** | six seconds early, zero checks |
| #1259 | 12:57:49 | 12:58:00 | 12:58:00.4 | 2 queued, correctly yellow |

The window is seconds wide, which is why **38 PRs have automerged fine**: their SHA sat still until a later run, or a check already existed before Renovate looked.

## Not a cache artifact

That was my first hypothesis and it is wrong. Renovate's check-run cache is process-local and keyed on the URL, a fresh process cannot inherit it, and the run reported `hit: 0`. The `http cache: saving` line means a fresh 200 — reuse would log `Using cached response`.

## The fix

Not to make Renovate believe an empty list is green — that would merge on an unproven gate. Instead, look again at the moment there is something to see: a `workflow_run` trigger on the required quality workflow, scoped to `renovate/**`. The ordinary branch-status gate still decides whether `quality` passed.

Two things that trigger needs:

**A concurrency group.** One quality batch can finish for several branches at once, and two Renovate instances must not update the same branch concurrently. `cancel-in-progress: false` so a run is never killed mid-update.

**A fork guard.** `workflow_run` carries secrets even when the triggering run came from a fork. The job refuses to mint the app token unless `head_repository` is this repository.

## Guard

`scripts/test-renovate-config.sh`, verified to fail when the trigger is removed:

```
FAIL: Renovate must be nudged after the required quality workflow completes
exit=1
```

`sh scripts/test-renovate-config.sh` PASS · `renovate-config-validator` OK · YAML parses.

## Note on the investigation

My repeated `workflow_dispatch` debug runs were themselves force-pushing those branches and resetting the CI clock each time — so part of the "stuck since 07:40" appearance was self-inflicted. Worth knowing before anyone debugs this the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)