### PR TITLE
Design system: rules beside the code, and text you can read

### DIFF
--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -215,15 +215,15 @@ adjust the page container width instead of adding local offsets.
 ### Description length and `PageIntro`
 
 The `description` is a SHORT subtitle: a count or a single line. It sits below
-the title and is muted (`text-gray-400`). When a primary action is present,
+the title and uses the secondary text colour (`text-gray-600`). When a primary action is present,
 `PageHeader` caps it at `sm:max-w-[60%]` of the header width so the subtitle
 never runs under the right-aligned action — keep it short and this cap is
 never reached.
 
 When a list/overview page needs to actually explain the feature before the
 list, do NOT stretch the subtitle. Put the explanation in a `PageIntro` block
-below the header — plain text, no card, slightly more readable
-(`text-gray-600`) than the subtitle, with `space-y-3` between paragraphs. This
+below the header — plain text, no card, using the same readable secondary
+colour (`text-gray-600`), with `space-y-3` between paragraphs. This
 is the `/app/instructions` pattern: title + short subtitle + action, then an
 intro body.
 
@@ -252,7 +252,7 @@ page title.
     <h1 className="page-title text-[26px] font-display-bold text-gray-900">
       {title}
     </h1>
-    <p className="mt-1 text-sm text-gray-400">{description}</p>
+    <p className="mt-1 text-sm text-gray-600">{description}</p>
   </div>
   <Button type="button" variant="outline" size="sm" onClick={onBack}>
     <ArrowLeft className="h-4 w-4 mr-2" />
@@ -902,9 +902,10 @@ The live render is the `/dev/ui` "Conversation" section.
 
 Use:
 
-- `text-gray-900` for primary text.
-- `text-gray-600` for explanatory body copy below a header (`PageIntro`).
-- `text-gray-400` for muted descriptions/metadata (the `PageHeader` subtitle).
+- `text-gray-900` — primary text — 16.85:1.
+- `text-gray-600` — muted / secondary text; the default — 7.18:1.
+- `text-gray-500` — icons and other non-text; clears the 3:1 non-text bar — 4.39:1.
+- `text-gray-400` — decorative and disabled only — 2.41:1.
 - `border-gray-200` for borders.
 - `klai-hover` for interactive hover states.
 - `var(--color-success)`, `var(--color-warning)`, `var(--color-destructive)`

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -1050,11 +1050,7 @@ These patterns must not be copied:
 
 This table catalogues the normative rules above, each with a stable ID, an
 RFC 2119 level, and a declared verification mode. It answers "how much of this
-document is actually checked?" — a question the prose could not answer before,
-because nothing counted it.
-
-Be exact about what the ledger guarantees, because a ledger that overstates
-itself is the defect it exists to catch.
+document is actually checked?"
 
 **Machine-checked** by `tests/design/rules-ledger.test.ts`, which fails the
 build: that every `automated` row names a check that exists and is switched on
@@ -1063,13 +1059,10 @@ that every design check in the repo has a row; that active IDs are not retired;
 that the counts in What Is Enforced match these rows. Coverage cannot be
 claimed where it does not exist, in either direction.
 
-**Maintained by hand**, and worth knowing before you trust a count:
-
-- *Completeness against the prose.* Extracting normative sentences from prose
-  is not mechanically decidable, so a rule added to a section without a row
-  here goes unnoticed. Add the row in the same change.
-- *Retiring IDs.* When a row is deleted, add its ID to Retired IDs below. The
-  check then prevents that number from returning to the active table.
+Component guideline rows inside the generated markers come from the matching
+`src/components/ui/` header comments. The other rows and completeness against
+the prose remain maintained by hand. When a row is retired, add its ID to
+Retired IDs below so the number cannot return.
 
 Verification modes use the vocabulary from the Design System Doc Spec
 (`automated` / `assisted` / `manual`), plus one of our own:
@@ -1084,6 +1077,8 @@ Verification modes use the vocabulary from the Design System Doc Spec
 The Current Deprecated Patterns list above is the negative
 restatement of these rules, not a separate set.
 
+<!-- generated:component-guidelines -->
+<!-- generated:component-guideline-ids KLAI-UI-007 KLAI-UI-008 KLAI-UI-011 KLAI-UI-012 KLAI-UI-013 KLAI-UI-015 KLAI-UI-017 KLAI-UI-018 KLAI-UI-019 KLAI-UI-024 KLAI-UI-025 KLAI-UI-026 KLAI-UI-027 KLAI-UI-028 KLAI-UI-031 KLAI-UI-034 KLAI-UI-035 KLAI-UI-037 KLAI-UI-038 KLAI-UI-041 KLAI-UI-044 -->
 | ID | Rule | Level | Verification | Check / reason |
 |---|---|---|---|---|
 | KLAI-UI-001 | A hex literal in `className` that equals a token in `index.css` is a defect; reference the token instead | must-not | automated | `klai/no-hardcoded-brand-color` |
@@ -1137,6 +1132,7 @@ restatement of these rules, not a separate set.
 | KLAI-UI-049 | A raw `<textarea>` outside `src/components/ui/` is forbidden | must-not | automated | `klai/no-raw-textarea` |
 | KLAI-UI-050 | The portal type scale is rem-based on a 110% root, so text, padding, control heights and column widths scale together; an absolute px font size does not scale and is a defect | must | manual | Reviewer step. Nothing yet stops a new `text-[Npx]` or a px `font-size` in `index.css` from being added |
 | KLAI-UI-051 | Foreground colours documented in the Colors section meet WCAG AA on both portal surfaces or carry a current, reasoned exception | must | automated | `tests/design/documented-contrast.test.ts` |
+<!-- /generated:component-guidelines -->
 
 ### Retired IDs
 

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -23,8 +23,8 @@ catalog and be described here in the same change.
 
 The normative rules in this document are catalogued in the Rules Ledger at the
 end of this file, each with an ID, an RFC 2119 level and a declared
-verification mode. The count today: **51 rules — 9 automated, 4 assisted,
-34 manual, 4 deliberately unchecked.**
+verification mode. The count today: **52 rules — 9 automated, 4 assisted,
+35 manual, 4 deliberately unchecked.**
 
 The catalogue is maintained by hand. The ledger's own preamble says which of
 its guarantees a test backs and which rely on you adding the row — read that
@@ -444,8 +444,8 @@ needs a different semantic.
 | `neutral` | `text-gray-400/500` | Utility, navigation, low-risk | rename, configure, open, view, copy, more, cancel |
 | `primary` | `var(--color-primary)` | Primary create / submit / send | add, send |
 | `info` | `var(--color-info-text)` | Information, progress, system context | info |
-| `success` | `var(--color-success)` | Positive status change or recovery | sync, save, reactivate |
-| `warning` | `var(--color-warning)` | Caution / reversible risky action | edit, retry, suspend |
+| `success` | `var(--color-success-text)` | Positive status change or recovery | sync, save, reactivate |
+| `warning` | `var(--color-warning-text)` | Caution / reversible risky action | edit, retry, suspend |
 | `danger` | `var(--color-destructive)` | Destructive or high-impact | delete, stop, leave, offboard |
 
 Note: `edit` is tone `warning` (amber) — editing is a reversible change that
@@ -908,8 +908,11 @@ Use:
 - `text-gray-400` — decorative and disabled only — 2.41:1.
 - `border-gray-200` for borders.
 - `klai-hover` for interactive hover states.
-- `var(--color-success)`, `var(--color-warning)`, `var(--color-destructive)`
-  for semantic states.
+- Semantic base tokens are for fills and borders. On a light surface, foregrounds
+  use the matching `-text` token: `var(--color-success-text)` (7.30:1),
+  `var(--color-warning-text)` (6.73:1), and `var(--color-destructive-text)`
+  (6.15:1). Existing `var(--color-destructive)` foregrounds remain valid because
+  the base token itself clears AA at 5.17:1.
 
 Do not use raw Tailwind semantic colors such as `text-green-*`, `text-red-*`,
 `bg-amber-*`, or `hover:bg-gray-50` in new portal UI.
@@ -922,13 +925,13 @@ system (see Row Actions And Action Tones).
 Status badges use the `Badge` component with a semantic variant. The semantic
 variants (`info`, `success`, `warning`, `destructive`) derive from the SAME
 primary tokens as the action tones — same hue, same meaning — kept soft via a
-10% tint background with the solid token as text:
+10% tint background with the darker `-text` token as foreground:
 
 ```
-success  → bg var(--color-success)/10   text var(--color-success)
-warning  → bg var(--color-warning)/10   text var(--color-warning)
-destructive → bg var(--color-destructive)/10 text var(--color-destructive)
-info     → bg var(--color-info)/10      text var(--color-info)
+success  → bg var(--color-success)/10   text var(--color-success-text)
+warning  → bg var(--color-warning)/10   text var(--color-warning-text)
+destructive → bg var(--color-destructive)/10 text var(--color-destructive-text)
+info     → bg var(--color-info)/10      text var(--color-info-text)
 ```
 
 So a green status badge and a green sync icon are the same green, just softer.
@@ -1133,6 +1136,7 @@ restatement of these rules, not a separate set.
 | KLAI-UI-049 | A raw `<textarea>` outside `src/components/ui/` is forbidden | must-not | automated | `klai/no-raw-textarea` |
 | KLAI-UI-050 | The portal type scale is rem-based on a 110% root, so text, padding, control heights and column widths scale together; an absolute px font size does not scale and is a defect | must | manual | Reviewer step. Nothing yet stops a new `text-[Npx]` or a px `font-size` in `index.css` from being added |
 | KLAI-UI-051 | Foreground colours documented in the Colors section meet WCAG AA on both portal surfaces or carry a current, reasoned exception | must | automated | `tests/design/documented-contrast.test.ts` |
+| KLAI-UI-052 | Semantic base colour tokens are used for fills and borders; foregrounds on light portal surfaces use the matching `-text` token, while the passing destructive base foreground remains valid | must | manual | The documented contrast check covers only colours named in the Colors section, so it does not catch a base token used as a foreground elsewhere |
 <!-- /generated:component-guidelines -->
 
 ### Retired IDs

--- a/klai-portal/frontend/scripts/generate-component-reference.mjs
+++ b/klai-portal/frontend/scripts/generate-component-reference.mjs
@@ -10,7 +10,16 @@ const UI_DIR = path.join(FRONTEND_ROOT, 'src', 'components', 'ui')
 const STANDARDS = path.join(FRONTEND_ROOT, 'docs', 'ui-standards.md')
 const START_MARKER = '<!-- generated:component-reference -->'
 const END_MARKER = '<!-- /generated:component-reference -->'
+const GUIDELINES_START_MARKER = '<!-- generated:component-guidelines -->'
+const GUIDELINES_END_MARKER = '<!-- /generated:component-guidelines -->'
+const GUIDELINE_IDS_PREFIX = '<!-- generated:component-guideline-ids '
 const VALID_CANONICAL = new Set(['yes', 'restricted', 'feature'])
+const VALID_GUIDELINE_LEVELS = new Set([
+  'must',
+  'must-not',
+  'should',
+  'should-not',
+])
 
 const args = process.argv.slice(2)
 if (args.some((arg) => arg !== '--check') || args.length > 1) {
@@ -18,19 +27,74 @@ if (args.some((arg) => arg !== '--check') || args.length > 1) {
   process.exit(2)
 }
 
-function tagValue(comment, tag) {
+function commentTags(comment) {
   const lines = comment
     .split('\n')
     .map((line) => line.replace(/^\s*\* ?/, '').trim())
-  const start = lines.findIndex((line) => line.startsWith(`@${tag} `))
-  if (start < 0) return null
+  const tags = []
+  let current = null
 
-  const value = [lines[start].slice(tag.length + 2)]
-  for (let index = start + 1; index < lines.length; index += 1) {
-    if (!lines[index] || lines[index].startsWith('@')) break
-    value.push(lines[index])
+  for (const line of lines) {
+    const match = /^@(\S+)(?:\s+(.*))?$/.exec(line)
+    if (match) {
+      current = { tag: match[1], value: match[2] ?? '' }
+      tags.push(current)
+    } else if (current && line) {
+      current.value += ` ${line}`
+    } else {
+      current = null
+    }
   }
-  return value.join(' ').replace(/\s+/g, ' ').trim()
+
+  return tags.map(({ tag, value }) => ({
+    tag,
+    value: value.replace(/\s+/g, ' ').trim(),
+  }))
+}
+
+function tagValue(comment, tag) {
+  return commentTags(comment).find((entry) => entry.tag === tag)?.value ?? null
+}
+
+function guidelineMetadata(comment, file) {
+  const guidelines = []
+  let current = null
+
+  for (const entry of commentTags(comment)) {
+    if (entry.tag === 'guideline') {
+      const match = /^(KLAI-UI-\d{3})\s+(\S+)\s+(.+)$/.exec(entry.value)
+      if (!match) {
+        throw new Error(
+          `${file} has invalid @guideline ${JSON.stringify(entry.value)}; ` +
+            'expected <KLAI-UI-NNN> <level> <rule>',
+        )
+      }
+
+      const [, id, level, rule] = match
+      if (!VALID_GUIDELINE_LEVELS.has(level)) {
+        throw new Error(
+          `${file} has invalid guideline level ${JSON.stringify(level)}; ` +
+            'expected must, must-not, should, or should-not',
+        )
+      }
+
+      current = { id, level, rule, rationale: null }
+      guidelines.push(current)
+    } else if (entry.tag === 'rationale') {
+      if (!current) {
+        throw new Error(`${file} has @rationale without a preceding @guideline`)
+      }
+      if (current.rationale) {
+        throw new Error(`${file} has more than one @rationale for ${current.id}`)
+      }
+      if (!entry.value) {
+        throw new Error(`${file} has an empty @rationale for ${current.id}`)
+      }
+      current.rationale = entry.value
+    }
+  }
+
+  return guidelines
 }
 
 function componentMetadata(file) {
@@ -53,6 +117,7 @@ function componentMetadata(file) {
     name: file.replace(/\.tsx?$/, ''),
     purpose,
     canonical,
+    guidelines: guidelineMetadata(header[1], file),
     source,
   }
 }
@@ -184,8 +249,8 @@ function escapeCell(value) {
   return value.replaceAll('|', '\\|')
 }
 
-function generatedTable() {
-  const files = fs
+function componentFiles() {
+  return fs
     .readdirSync(UI_DIR, { withFileTypes: true })
     .filter(
       (entry) =>
@@ -194,9 +259,10 @@ function generatedTable() {
     )
     .map((entry) => entry.name)
     .sort((left, right) => left.localeCompare(right, 'en'))
+}
 
-  const rows = files.map((file) => {
-    const component = componentMetadata(file)
+function generatedTable(components) {
+  const rows = components.map((component) => {
     const axes = cvaAxes(component.source)
     const variants = [...axes]
       .map(([axis, values]) => `${axisLabel(axis)}: ${values.join('/')}`)
@@ -217,19 +283,165 @@ function generatedTable() {
   ].join('\n')
 }
 
-function generatedRange(doc) {
-  const start = doc.indexOf(START_MARKER)
-  const end = doc.indexOf(END_MARKER)
+function markedRange(doc, startMarker, endMarker, label) {
+  const start = doc.indexOf(startMarker)
+  const end = doc.indexOf(endMarker)
   if (start < 0 || end < 0 || end < start) {
-    throw new Error('docs/ui-standards.md is missing component-reference markers')
+    throw new Error(`docs/ui-standards.md is missing ${label} markers`)
   }
 
   return {
     start,
-    end: end + END_MARKER.length,
-    tableStart: start + START_MARKER.length + 1,
+    end: end + endMarker.length,
+    tableStart: start + startMarker.length + 1,
     tableEnd: end - 1,
   }
+}
+
+function parseLedgerRows(doc) {
+  const ledgerStart = doc.indexOf('## Rules Ledger')
+  const retiredStart = doc.indexOf('### Retired IDs', ledgerStart)
+  if (ledgerStart < 0 || retiredStart < 0) {
+    throw new Error('docs/ui-standards.md is missing its Rules Ledger')
+  }
+
+  return doc
+    .slice(ledgerStart, retiredStart)
+    .split('\n')
+    .filter((line) => line.startsWith('| KLAI-UI-'))
+    .map((line) => {
+      const [id, rule, level, verification, check] = line
+        .split('|')
+        .slice(1, -1)
+        .map((cell) => cell.trim())
+      return { id, rule, level, verification, check }
+    })
+}
+
+function previousGuidelineIds(doc) {
+  const start = doc.indexOf(GUIDELINES_START_MARKER)
+  if (start < 0) return new Set()
+
+  const lineStart = doc.indexOf(GUIDELINE_IDS_PREFIX, start)
+  const lineEnd = doc.indexOf(' -->', lineStart)
+  if (lineStart < 0 || lineEnd < 0) {
+    throw new Error('component-guidelines block is missing its generated ID list')
+  }
+
+  return new Set(
+    doc
+      .slice(lineStart + GUIDELINE_IDS_PREFIX.length, lineEnd)
+      .split(' ')
+      .filter(Boolean),
+  )
+}
+
+function componentGuidelines(components) {
+  const byId = new Map()
+
+  for (const component of components) {
+    for (const guideline of component.guidelines) {
+      const existing = byId.get(guideline.id)
+      if (existing) {
+        const fields = ['level', 'rule', 'rationale']
+        const conflict = fields.find((field) => existing[field] !== guideline[field])
+        if (conflict) {
+          throw new Error(
+            `${guideline.id} differs between ${existing.file} and ` +
+              `${component.name} at ${conflict}`,
+          )
+        }
+        existing.files.push(component.name)
+      } else {
+        byId.set(guideline.id, {
+          ...guideline,
+          file: component.name,
+          files: [component.name],
+        })
+      }
+    }
+  }
+
+  return byId
+}
+
+function ledgerTable(doc, components) {
+  const currentRows = parseLedgerRows(doc)
+  const currentById = new Map(currentRows.map((row) => [row.id, row]))
+  const guidelines = componentGuidelines(components)
+  const generatedIds = new Set([
+    ...previousGuidelineIds(doc),
+    ...guidelines.keys(),
+  ])
+  const rows = currentRows.filter((row) => !generatedIds.has(row.id))
+
+  for (const guideline of guidelines.values()) {
+    const current = currentById.get(guideline.id)
+    if (!current) {
+      throw new Error(
+        `${guideline.id} has no ledger row supplying its verification mode`,
+      )
+    }
+    rows.push({
+      id: guideline.id,
+      rule: guideline.rule,
+      level: guideline.level,
+      verification: current.verification,
+      check: current.check,
+    })
+  }
+
+  rows.sort((left, right) => left.id.localeCompare(right.id, 'en'))
+  const ids = [...guidelines.keys()].sort((left, right) => left.localeCompare(right, 'en'))
+  const renderedRows = rows.map(
+    (row) =>
+      `| ${row.id} | ${escapeCell(row.rule)} | ${row.level} | ` +
+      `${row.verification} | ${escapeCell(row.check)} |`,
+  )
+
+  return [
+    `${GUIDELINE_IDS_PREFIX}${ids.join(' ')} -->`,
+    '| ID | Rule | Level | Verification | Check / reason |',
+    '|---|---|---|---|---|',
+    ...renderedRows,
+  ].join('\n')
+}
+
+function guidelineRange(doc) {
+  if (doc.includes(GUIDELINES_START_MARKER)) {
+    return markedRange(
+      doc,
+      GUIDELINES_START_MARKER,
+      GUIDELINES_END_MARKER,
+      'component-guidelines',
+    )
+  }
+
+  const ledgerStart = doc.indexOf('## Rules Ledger')
+  const tableStart = doc.indexOf('| ID | Rule | Level | Verification | Check / reason |', ledgerStart)
+  const retiredStart = doc.indexOf('### Retired IDs', tableStart)
+  if (ledgerStart < 0 || tableStart < 0 || retiredStart < 0) {
+    throw new Error('docs/ui-standards.md is missing its Rules Ledger table')
+  }
+
+  let tableEnd = retiredStart
+  while (doc[tableEnd - 1] === '\n') tableEnd -= 1
+  return { start: tableStart, end: tableEnd }
+}
+
+function updateEnforcementCounts(doc) {
+  const rows = parseLedgerRows(doc)
+  const count = (mode) => rows.filter((row) => row.verification === mode).length
+  const replacement =
+    `The count today: **${rows.length} rules — ${count('automated')} automated, ` +
+    `${count('assisted')} assisted,\n${count('manual')} manual, ` +
+    `${count('none')} deliberately unchecked.**`
+  const pattern =
+    /The count today: \*\*\d+ rules — \d+ automated, \d+ assisted,\s*\d+ manual, \d+ deliberately unchecked\.\*\*/
+  if (!pattern.test(doc)) {
+    throw new Error('docs/ui-standards.md is missing its enforcement count line')
+  }
+  return doc.replace(pattern, replacement)
 }
 
 function diffSummary(actual, expected) {
@@ -266,23 +478,38 @@ function diffSummary(actual, expected) {
 }
 
 const doc = fs.readFileSync(STANDARDS, 'utf8')
-const range = generatedRange(doc)
-const expected = generatedTable()
-const actual = doc.slice(range.tableStart, range.tableEnd)
+const components = componentFiles().map((file) => componentMetadata(file))
+const componentRange = markedRange(
+  doc,
+  START_MARKER,
+  END_MARKER,
+  'component-reference',
+)
+const componentTable = generatedTable(components)
+let expectedDoc =
+  `${doc.slice(0, componentRange.tableStart)}${componentTable}` +
+  `${doc.slice(componentRange.tableEnd)}`
+const rulesRange = guidelineRange(expectedDoc)
+const rulesTable = ledgerTable(expectedDoc, components)
+const rulesBlock =
+  `${GUIDELINES_START_MARKER}\n${rulesTable}\n${GUIDELINES_END_MARKER}`
+expectedDoc =
+  `${expectedDoc.slice(0, rulesRange.start)}${rulesBlock}` +
+  `${expectedDoc.slice(rulesRange.end)}`
+expectedDoc = updateEnforcementCounts(expectedDoc)
 
 if (args[0] === '--check') {
-  if (actual !== expected) {
-    console.error('Component Library Reference is stale:')
-    console.error(diffSummary(actual, expected))
+  if (doc !== expectedDoc) {
+    console.error('Generated component documentation is stale:')
+    console.error(diffSummary(doc, expectedDoc))
     console.error('\nRun `npm run docs:components` to regenerate it.')
     process.exit(1)
   }
-  console.log('Component Library Reference is up to date.')
+  console.log('Component reference and guidelines are up to date.')
 } else {
-  const block = `${START_MARKER}\n${expected}\n${END_MARKER}`
-  fs.writeFileSync(
-    STANDARDS,
-    `${doc.slice(0, range.start)}${block}${doc.slice(range.end)}`,
+  fs.writeFileSync(STANDARDS, expectedDoc)
+  console.log(
+    `Generated ${components.length} component rows and ` +
+      `${componentGuidelines(components).size} guideline rows.`,
   )
-  console.log(`Generated ${expected.split('\n').length - 2} component rows.`)
 }

--- a/klai-portal/frontend/src/components/admin/offboard-wizard.tsx
+++ b/klai-portal/frontend/src/components/admin/offboard-wizard.tsx
@@ -382,7 +382,7 @@ export function OffboardWizard({
                       className="flex items-start gap-2 border-y border-gray-200 py-3"
                       data-test-id="offboard-token-banner"
                     >
-                      <KeyRound className="mt-0.5 h-4 w-4 text-gray-400" />
+                      <KeyRound className="mt-0.5 h-4 w-4 text-gray-500" />
                       <div className="space-y-1">
                         <p className="font-medium text-gray-900">
                           {m.admin_users_wizard_tokens_title()}
@@ -421,7 +421,7 @@ export function OffboardWizard({
                             <p className="truncate font-medium text-gray-900">
                               {kb.name}
                             </p>
-                            <p className="truncate text-xs text-gray-400">
+                            <p className="truncate text-xs text-gray-600">
                               {kb.slug}
                             </p>
                           </div>

--- a/klai-portal/frontend/src/components/help/HelpButton.tsx
+++ b/klai-portal/frontend/src/components/help/HelpButton.tsx
@@ -18,13 +18,13 @@ export function HelpButton() {
             </h3>
             <button
               onClick={dismissIntro}
-              className="ml-2 text-gray-400 hover:text-gray-900"
+              className="ml-2 text-gray-500 hover:text-gray-900"
               aria-label="Sluiten"
             >
               <X className="h-4 w-4" />
             </button>
           </div>
-          <p className="px-4 pb-3 text-sm text-gray-400">
+          <p className="px-4 pb-3 text-sm text-gray-600">
             {introContent.description()}
           </p>
           <div className="border-t border-gray-200 px-4 py-3">

--- a/klai-portal/frontend/src/components/kb-editor/AccessControlPanel.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/AccessControlPanel.tsx
@@ -38,7 +38,7 @@ export function AccessControlPanel({
           </span>
         </div>
         <button
-          className="text-xs text-gray-400 hover:text-gray-900"
+          className="text-xs text-gray-600 hover:text-gray-900"
           onClick={onClose}
         >
           {m.docs_access_close()}
@@ -131,7 +131,7 @@ export function AccessControlPanel({
             )}
           </Button>
           {accessSaveStatus === 'saved' && (
-            <span className="flex items-center gap-1 text-xs text-gray-400">
+            <span className="flex items-center gap-1 text-xs text-gray-600">
               <Check size={11} />{m.docs_access_saved()}
             </span>
           )}

--- a/klai-portal/frontend/src/components/kb-editor/EditorHeader.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/EditorHeader.tsx
@@ -101,19 +101,19 @@ export function EditorHeader({
       />
       <div className="flex items-center gap-2 shrink-0">
         {saveStatus === 'saving' && (
-          <span className="flex items-center gap-1 text-xs text-gray-400">
+          <span className="flex items-center gap-1 text-xs text-gray-600">
             <Loader2 size={12} className="animate-spin" />
             {m.docs_editor_saving()}
           </span>
         )}
         {saveStatus === 'saved' && (
-          <span className="flex items-center gap-1 text-xs text-gray-400">
+          <span className="flex items-center gap-1 text-xs text-gray-600">
             <Check size={12} />
             {m.docs_editor_save()}
           </span>
         )}
         {saveStatus === 'renamed' && (
-          <span className="flex items-center gap-1 text-xs text-gray-400">
+          <span className="flex items-center gap-1 text-xs text-gray-600">
             <Check size={12} />
             {m.docs_editor_url_updated()}
           </span>
@@ -132,7 +132,7 @@ export function EditorHeader({
           </Button>
           {showMenu && (
             <div className="absolute right-0 top-8 z-10 w-48 rounded-lg border border-gray-200 bg-[var(--color-card)] shadow-md py-1">
-              <p className="px-3 py-1.5 text-xs text-gray-400">
+              <p className="px-3 py-1.5 text-xs text-gray-600">
                 Paginainstellingen
               </p>
               <button

--- a/klai-portal/frontend/src/components/kb-editor/SidebarFooter.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/SidebarFooter.tsx
@@ -54,7 +54,7 @@ export function SidebarFooter({
               {m.docs_kb_create()}
             </button>
             <button
-              className="h-7 px-2 flex items-center justify-center rounded-md text-gray-400 hover:bg-[var(--color-foreground)]/[0.04] transition-colors"
+              className="h-7 px-2 flex items-center justify-center rounded-md text-gray-500 hover:bg-[var(--color-foreground)]/[0.04] transition-colors"
               onClick={onNewPageCancel}
             >
               <X size={11} />
@@ -63,7 +63,7 @@ export function SidebarFooter({
         </div>
       ) : (
         <button
-          className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-400 hover:bg-[var(--color-foreground)]/[0.04] hover:text-gray-900 rounded-md transition-colors"
+          className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-600 hover:bg-[var(--color-foreground)]/[0.04] hover:text-gray-900 rounded-md transition-colors"
           onClick={onShowNewPage}
         >
           <Plus size={14} strokeWidth={1.5} />
@@ -82,7 +82,7 @@ export function SidebarFooter({
         }}
       />
       <button
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-400 hover:bg-[var(--color-foreground)]/[0.04] hover:text-gray-900 rounded-md transition-colors"
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-sm text-gray-600 hover:bg-[var(--color-foreground)]/[0.04] hover:text-gray-900 rounded-md transition-colors"
         onClick={() => fileInputRef.current?.click()}
       >
         <Upload size={14} strokeWidth={1.5} />

--- a/klai-portal/frontend/src/components/kb-editor/SidebarPanel.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/SidebarPanel.tsx
@@ -47,7 +47,7 @@ export function SidebarPanel({
       <div className="px-4 py-3">
         <Link
           to="/app/docs"
-          className="flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+          className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-gray-900 transition-colors"
         >
           <ArrowLeft size={11} strokeWidth={1.5} />
           {m.docs_editor_back()}
@@ -55,7 +55,7 @@ export function SidebarPanel({
       </div>
       <div className="flex-1 overflow-y-auto px-1 py-1">
         {displayTree.length === 0 ? (
-          <p className="px-3 py-2 text-xs text-gray-400">
+          <p className="px-3 py-2 text-xs text-gray-600">
             {m.docs_pages_empty()}
           </p>
         ) : (

--- a/klai-portal/frontend/src/components/kb-editor/TreeItem.tsx
+++ b/klai-portal/frontend/src/components/kb-editor/TreeItem.tsx
@@ -129,7 +129,7 @@ export function TreeItem({
         </button>
         <button
           type="button"
-          className="shrink-0 text-gray-400 hover:opacity-70"
+          className="shrink-0 text-gray-500 hover:opacity-70"
           onClick={onNewPageCancel}
           aria-label={m.docs_tree_cancel()}
         >
@@ -177,7 +177,7 @@ export function TreeItem({
               <ChevronRight
                 size={12}
                 strokeWidth={1.5}
-                className={`text-gray-400 transition-transform duration-150 ${isCollapsed ? '' : 'rotate-90'}`}
+                className={`text-gray-500 transition-transform duration-150 ${isCollapsed ? '' : 'rotate-90'}`}
               />
             </button>
           ) : (
@@ -202,7 +202,7 @@ export function TreeItem({
             <>
               <button
                 type="button"
-                className="flex items-center justify-center w-5 h-5 rounded hover:bg-[var(--color-foreground)]/[0.06] text-gray-400 hover:text-gray-900 transition-colors"
+                className="flex items-center justify-center w-5 h-5 rounded hover:bg-[var(--color-foreground)]/[0.06] text-gray-500 hover:text-gray-900 transition-colors"
                 onClick={() => onAddSubpage(nodePath)}
                 title={m.docs_pages_add_subpage()}
                 aria-label={m.docs_pages_add_subpage()}
@@ -213,7 +213,7 @@ export function TreeItem({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className="flex items-center justify-center w-5 h-5 rounded hover:bg-[var(--color-foreground)]/[0.06] text-gray-400 hover:text-gray-900 transition-colors"
+                    className="flex items-center justify-center w-5 h-5 rounded hover:bg-[var(--color-foreground)]/[0.06] text-gray-500 hover:text-gray-900 transition-colors"
                     aria-label={m.docs_tree_more_options()}
                   >
                     <MoreHorizontal size={12} strokeWidth={1.5} />
@@ -251,7 +251,7 @@ export function TreeItem({
           )}
           {(hovered || menuOpen) && !isDraggingActive && (
             <span className="cursor-grab touch-none" {...attributes} {...listeners}>
-              <GripVertical size={12} strokeWidth={1.5} className="text-gray-400 opacity-30" />
+              <GripVertical size={12} strokeWidth={1.5} className="text-gray-500" />
             </span>
           )}
         </div>

--- a/klai-portal/frontend/src/components/knowledge/CookieRowsInput.tsx
+++ b/klai-portal/frontend/src/components/knowledge/CookieRowsInput.tsx
@@ -119,7 +119,7 @@ export function CookieRowsInput({
         <Plus className="h-3.5 w-3.5 mr-1" />
         Add another cookie
       </Button>
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-gray-600">
         Open the site in your browser, log in, then read the cookie name and
         value from DevTools &rarr; Application &rarr; Cookies. Type or paste
         each separately - no need to format anything.

--- a/klai-portal/frontend/src/components/knowledge/SaveToKnowledgeModal.tsx
+++ b/klai-portal/frontend/src/components/knowledge/SaveToKnowledgeModal.tsx
@@ -115,7 +115,7 @@ export function SaveToKnowledgeModal({
 
         {savedSlug ? (
           <div className="space-y-3">
-            <p className="text-sm text-[var(--color-success)]">{m.knowledge_save_success()}</p>
+            <p className="text-sm text-[var(--color-success-text)]">{m.knowledge_save_success()}</p>
             <a
               href="/app/docs"
               className="inline-flex items-center gap-1 text-sm text-[var(--color-accent)] hover:underline"

--- a/klai-portal/frontend/src/components/layout/AccountMenu.tsx
+++ b/klai-portal/frontend/src/components/layout/AccountMenu.tsx
@@ -78,7 +78,7 @@ export function AccountMenu() {
           <>
             <DropdownMenuLabel className="font-normal">
               {name && <p className="truncate text-sm font-medium text-gray-900">{name}</p>}
-              {email && <p className="truncate text-xs text-gray-400">{email}</p>}
+              {email && <p className="truncate text-xs text-gray-600">{email}</p>}
             </DropdownMenuLabel>
             <DropdownMenuSeparator />
           </>

--- a/klai-portal/frontend/src/components/layout/LockedPanel.tsx
+++ b/klai-portal/frontend/src/components/layout/LockedPanel.tsx
@@ -19,14 +19,14 @@ export function LockedPanel({ message, cta }: LockedPanelProps) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
       <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-muted)]">
-        <Lock className="h-6 w-6 text-gray-400" />
+        <Lock className="h-6 w-6 text-gray-500" />
       </div>
       <div className="space-y-1">
         {message && (
-          <p className="text-sm text-gray-400">{message}</p>
+          <p className="text-sm text-gray-600">{message}</p>
         )}
       </div>
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-gray-600">
         {cta ?? m.product_guard_cta()}
       </p>
     </div>

--- a/klai-portal/frontend/src/components/layout/ProductUpdatesPopover.tsx
+++ b/klai-portal/frontend/src/components/layout/ProductUpdatesPopover.tsx
@@ -103,7 +103,7 @@ export function ProductUpdatesPopover() {
             <div className="flex items-start justify-between gap-3 border-b border-gray-200 px-4 py-3">
               <div className="min-w-0">
                 <h2 className="text-sm font-medium text-gray-900">{m.product_updates_title()}</h2>
-                <p className="mt-1 text-xs text-gray-400">
+                <p className="mt-1 text-xs text-gray-600">
                   {unreadCount > 0 ? m.product_updates_unread_count({ count: String(unreadCount) }) : m.product_updates_all_read()}
                 </p>
               </div>
@@ -130,7 +130,7 @@ export function ProductUpdatesPopover() {
               <ListLoadingState label={m.admin_shared_loading()} className="py-8" />
             ) : updatesQuery.error ? (
               updatesQuery.error instanceof ApiError && updatesQuery.error.status === 404 ? (
-                <div className="px-4 py-8 text-center text-sm text-gray-400">
+                <div className="px-4 py-8 text-center text-sm text-gray-600">
                   {m.product_updates_not_available()}
                 </div>
               ) : (
@@ -189,7 +189,7 @@ function ProductUpdateRow({
             <ListRowTitle className="text-sm">{update.title}</ListRowTitle>
           </div>
           <ListRowDescription>{update.body}</ListRowDescription>
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-1 text-xs text-gray-600">
             {formatProductUpdateDate(update.created_at, locale)}
           </p>
         </ListRowContent>
@@ -217,7 +217,7 @@ function ProductUpdateDetail({
 
       <div className="mt-4 border-b border-gray-200 pb-4">
         <h2 className="text-base font-display-bold text-gray-900">{update.title}</h2>
-        <p className="mt-1 text-xs text-gray-400">{formatProductUpdateDate(update.created_at, locale)}</p>
+        <p className="mt-1 text-xs text-gray-600">{formatProductUpdateDate(update.created_at, locale)}</p>
       </div>
 
       <p className="mt-4 whitespace-pre-wrap text-sm leading-relaxed text-gray-700">{update.body}</p>

--- a/klai-portal/frontend/src/components/ui/alert-dialog.tsx
+++ b/klai-portal/frontend/src/components/ui/alert-dialog.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Centered confirm dialog for destructive actions outside rows
+ * @guideline KLAI-UI-027 must A destructive action outside a row uses
+ * `alert-dialog`
  */
 import * as React from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'

--- a/klai-portal/frontend/src/components/ui/badge.tsx
+++ b/klai-portal/frontend/src/components/ui/badge.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Inline status labels
+ * @guideline KLAI-UI-044 must Status pills use `Badge` semantic variants,
+ * never ad-hoc tinted pills
  */
 import * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'

--- a/klai-portal/frontend/src/components/ui/button.tsx
+++ b/klai-portal/frontend/src/components/ui/button.tsx
@@ -1,6 +1,12 @@
 /**
  * @purpose All buttons. Use for an action; a clickable row or toggle is an
  * interactive surface and uses a raw `button` instead.
+ * @guideline KLAI-UI-008 must `Button` is for an action; a raw `button` is for
+ * an interactive surface (clickable row, toggle, tree item), plus the
+ * documented avatar, vendor SSO and unsupported-size editor controls
+ * @rationale Measured and rejected: 96 of 100 raw `button` elements outside
+ * `components/ui/` are the prescribed pattern. A rule here would flag 96
+ * correct decisions
  *
  * Portal v1 spine (SPEC-PORTAL-REDESIGN-002):
  * - rounded-full (pill), sentence-case (no uppercase, no tracking-wider)

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -4,6 +4,8 @@
  * separators, quiet system lines, Cmd/Enter send, inline edit of own messages,
  * back-right header. Shared by account "Mijn meldingen" + "Berichten" and the
  * platform-admin messages tab
+ * @guideline KLAI-UI-041 must Any user-to-Klai back-and-forth uses the
+ * `conversation` component; status changes are quiet system lines
  */
 import * as React from 'react'
 import { ArrowLeft, Check, Loader2, Pencil, Send, X } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -169,7 +169,7 @@ export function ConversationTimeline({
 
   if (loading) {
     return (
-      <div className="flex min-h-[200px] items-center justify-center gap-2 text-sm text-gray-400">
+      <div className="flex min-h-[200px] items-center justify-center gap-2 text-sm text-gray-600">
         <Loader2 className="h-4 w-4 animate-spin" />
         {m.admin_shared_loading()}
       </div>
@@ -178,7 +178,7 @@ export function ConversationTimeline({
 
   if (count === 0) {
     return (
-      <div className="flex min-h-[160px] items-center justify-center px-4 text-center text-sm text-gray-400">
+      <div className="flex min-h-[160px] items-center justify-center px-4 text-center text-sm text-gray-600">
         {emptyLabel ?? ''}
       </div>
     )
@@ -190,7 +190,7 @@ export function ConversationTimeline({
     <div className={cn('space-y-5', className)}>
       {days.map((bucket) => (
         <div key={bucket.day} className="space-y-4">
-          <p className="text-center text-xs text-gray-400">
+          <p className="text-center text-xs text-gray-600">
             {formatDaySeparator(bucket.at, locale)}
           </p>
 
@@ -322,7 +322,7 @@ function MessageGroupView({
   const isMe = group.side === 'me'
   return (
     <div className={cn('flex flex-col gap-1', isMe ? 'items-end' : 'items-start')}>
-      <p className="px-1 text-xs text-gray-400">
+      <p className="px-1 text-xs text-gray-600">
         {group.author} · {formatTime(group.at, locale)}
       </p>
       {group.bodies.map((message) => {
@@ -409,7 +409,7 @@ export function ConversationComposer({
         onKeyDown={handleKeyDown}
       />
       <div className="flex items-center justify-between gap-3">
-        <span className="text-xs text-gray-400">{m.account_conversation_send_hint()}</span>
+        <span className="text-xs text-gray-600">{m.account_conversation_send_hint()}</span>
         <Button type="button" disabled={!canSend} onClick={onSubmit}>
           {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
           {sendLabel}
@@ -470,7 +470,7 @@ export function ConversationPanel({
             <h2 className="truncate text-base font-display-bold text-gray-900">{title}</h2>
             {badge}
           </div>
-          {subtitle && <p className="mt-1 text-xs text-gray-400">{subtitle}</p>}
+          {subtitle && <p className="mt-1 text-xs text-gray-600">{subtitle}</p>}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {headerActions}

--- a/klai-portal/frontend/src/components/ui/data-table.tsx
+++ b/klai-portal/frontend/src/components/ui/data-table.tsx
@@ -2,6 +2,9 @@
  * @purpose Admin table primitives: `DataTable`, `DataTableHeader`,
  * `DataTableBody`, `DataTableRow` (`interactive`/`confirming`),
  * `DataTableHead`, `DataTableCell` (`align`)
+ * @guideline KLAI-UI-017 must-not Admin tables use the `data-table` primitives,
+ * right-align the action column, and stop click propagation on that cell when
+ * the row itself is clickable
  */
 import * as React from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/data-table.tsx
+++ b/klai-portal/frontend/src/components/ui/data-table.tsx
@@ -63,7 +63,7 @@ function DataTableHead({ align = 'left', className, ...props }: DataTableHeadPro
   return (
     <th
       className={cn(
-        'px-4 py-3 text-left text-xs font-medium text-gray-400',
+        'px-4 py-3 text-left text-xs font-medium text-gray-600',
         align === 'right' && 'text-right',
         align === 'center' && 'text-center',
         className,

--- a/klai-portal/frontend/src/components/ui/inline-delete-confirm.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-delete-confirm.tsx
@@ -1,5 +1,8 @@
 /**
  * @purpose Inline destructive confirmation inside a row (no layout shift)
+ * @guideline KLAI-UI-026 must A row-level destructive confirm uses
+ * `InlineDeleteConfirm`, and the row is tinted while confirming
+ * @rationale An untinted row shows a hard seam under the overlay
  */
 import { Loader2, Trash2, X } from 'lucide-react'
 import { InlineRowButton } from '@/components/ui/inline-row-button'

--- a/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
@@ -165,7 +165,7 @@ export function InlineEditRow({
           <div className="relative mt-1">
             <p
               className={cn(
-                'block truncate text-sm text-gray-400',
+                'block truncate text-sm text-gray-600',
                 isEditing && withDescription && 'invisible',
               )}
             >

--- a/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-edit-row.tsx
@@ -1,6 +1,10 @@
 /**
  * @purpose Canonical inline edit for a list row (`InlineEditRow`): name +
  * optional description, zero layout shift, owns Save/Cancel
+ * @guideline KLAI-UI-024 must Editing a row's name in place uses
+ * `InlineEditRow` and keeps zero layout shift
+ * @rationale The ghost-and-overlay technique keeps the row from shifting; see
+ * Inline Edit
  */
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import { Check, Loader2, X } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/inline-row-button.tsx
+++ b/klai-portal/frontend/src/components/ui/inline-row-button.tsx
@@ -2,6 +2,8 @@
  * @purpose The single source for small inline-row action pills
  * (`InlineRowButton`): Save/Cancel, Delete/Cancel, Approve/Deny. Tones:
  * success/destructive/neutral
+ * @guideline KLAI-UI-025 must Every small inline-row action pill renders
+ * through `InlineRowButton`
  */
 import { Button, type ButtonProps } from '@/components/ui/button'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/input.tsx
+++ b/klai-portal/frontend/src/components/ui/input.tsx
@@ -1,5 +1,8 @@
 /**
  * @purpose Form controls
+ * @guideline KLAI-UI-007 must-not Pages are built from
+ * `src/components/ui/`; a raw `input`, `select`, list row or delete
+ * confirmation with inline Tailwind is a defect
  */
 import * as React from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/input.tsx
+++ b/klai-portal/frontend/src/components/ui/input.tsx
@@ -20,7 +20,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           'w-full rounded-lg border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 outline-none transition-colors',
-          'placeholder:text-gray-400',
+          'placeholder:text-gray-600',
           'focus:ring-2 focus:ring-[var(--color-ring)]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           className

--- a/klai-portal/frontend/src/components/ui/label.tsx
+++ b/klai-portal/frontend/src/components/ui/label.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Form controls
+ * @guideline KLAI-UI-034 must Every form field has a `Label` with matching id
+ * and htmlFor
  */
 import * as React from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/list-state.tsx
+++ b/klai-portal/frontend/src/components/ui/list-state.tsx
@@ -15,7 +15,7 @@ function ListState({ className, ...props }: ListStateProps) {
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center py-12 text-center text-sm text-gray-400',
+        'flex flex-col items-center justify-center py-12 text-center text-sm text-gray-600',
         className,
       )}
       {...props}

--- a/klai-portal/frontend/src/components/ui/list-state.tsx
+++ b/klai-portal/frontend/src/components/ui/list-state.tsx
@@ -1,6 +1,9 @@
 /**
  * @purpose List/table loading and empty states: `ListLoadingState`,
  * `ListEmptyState`
+ * @guideline KLAI-UI-018 must Collection loading and empty states use
+ * `list-state`; a failed query uses `QueryErrorState` with an explicit retry
+ * where one is available
  */
 import type { ElementType, HTMLAttributes, ReactNode } from 'react'
 import { Loader2 } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/list-state.tsx
+++ b/klai-portal/frontend/src/components/ui/list-state.tsx
@@ -55,7 +55,7 @@ interface ListEmptyStateProps extends Omit<ListStateProps, 'title'> {
 function ListEmptyState({ icon: Icon, title, description, className, ...props }: ListEmptyStateProps) {
   return (
     <ListState className={className} {...props}>
-      {Icon && <Icon className="mb-3 h-8 w-8 text-gray-400" aria-hidden="true" />}
+      {Icon && <Icon className="mb-3 h-8 w-8 text-gray-500" aria-hidden="true" />}
       <p>{title}</p>
       {description && (
         <p className="mt-1 max-w-sm text-xs text-[var(--color-muted-foreground)]">

--- a/klai-portal/frontend/src/components/ui/list.tsx
+++ b/klai-portal/frontend/src/components/ui/list.tsx
@@ -27,7 +27,7 @@ interface ListHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
 function ListHeader({ className, ...props }: ListHeaderProps) {
   return (
     <div
-      className={cn('grid items-center gap-4 px-4 py-3 text-xs font-medium text-gray-400', className)}
+      className={cn('grid items-center gap-4 px-4 py-3 text-xs font-medium text-gray-600', className)}
       {...props}
     />
   )
@@ -63,7 +63,7 @@ interface ListRowIconProps extends React.HTMLAttributes<HTMLDivElement> {}
 function ListRowIcon({ className, ...props }: ListRowIconProps) {
   return (
     <div
-      className={cn('flex h-8 w-8 shrink-0 items-center justify-center text-gray-400', className)}
+      className={cn('flex h-8 w-8 shrink-0 items-center justify-center text-gray-500', className)}
       {...props}
     />
   )
@@ -89,7 +89,7 @@ function ListRowTitle({ className, ...props }: ListRowTitleProps) {
 interface ListRowDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 function ListRowDescription({ className, ...props }: ListRowDescriptionProps) {
-  return <p className={cn('mt-1 truncate text-sm text-gray-400', className)} {...props} />
+  return <p className={cn('mt-1 truncate text-sm text-gray-600', className)} {...props} />
 }
 
 interface ListRowActionsProps extends React.HTMLAttributes<HTMLDivElement> {}

--- a/klai-portal/frontend/src/components/ui/list.tsx
+++ b/klai-portal/frontend/src/components/ui/list.tsx
@@ -2,6 +2,9 @@
  * @purpose List primitives: `ListFrame`, `ListHeader`, `ListRow`,
  * `ListRowContent`, `ListRowTitle`, `ListRowDescription`, `ListRowActions`,
  * `ListRowIcon`, `ListRowChevron`
+ * @guideline KLAI-UI-015 must A divider list gets `ListHeader` only when its
+ * rows carry two or more metadata columns beyond the title, and the header
+ * shares the row grid and padding at `lg` only
  */
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'

--- a/klai-portal/frontend/src/components/ui/page-header.tsx
+++ b/klai-portal/frontend/src/components/ui/page-header.tsx
@@ -1,6 +1,12 @@
 /**
  * @purpose Page title, short subtitle/count, and right-aligned page action
  * (`PageHeader`); longer explanatory copy below the header uses `PageIntro`
+ * @guideline KLAI-UI-011 must List and overview pages use `PageHeader`;
+ * hand-roll a title/action row only for a genuinely custom layout
+ * @guideline KLAI-UI-012 must The `PageHeader` description is a short
+ * subtitle; longer explanation goes in `PageIntro`
+ * @guideline KLAI-UI-013 must-not Back and cancel actions are an outline small
+ * Button in the page header, never a loose link above the title
  */
 import type { HTMLAttributes, ReactNode } from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/page-header.tsx
+++ b/klai-portal/frontend/src/components/ui/page-header.tsx
@@ -44,7 +44,7 @@ function PageHeader({ title, count, description, actions, className, ...props }:
         // When a primary action sits on the title row, cap the description so
         // it never runs under the action. ~60% of the header width clears the
         // right-aligned action with margin to spare. Full width when no action.
-        <p className={cn('text-sm text-gray-400', actions ? 'sm:max-w-[60%]' : undefined)}>
+        <p className={cn('text-sm text-gray-600', actions ? 'sm:max-w-[60%]' : undefined)}>
           {description}
         </p>
       ) : null}
@@ -56,8 +56,8 @@ function PageHeader({ title, count, description, actions, className, ...props }:
 // `description` subtitle. Plain text, no card. Use this when a list/overview
 // page needs to explain the feature before the list (the /app/instructions
 // pattern). Keep the PageHeader `description` to a short subtitle and move the
-// real explanation here. Body text is `text-gray-600` (more readable than the
-// gray-400 subtitle); paragraphs are separated with `space-y-3`.
+// real explanation here. Body text uses the shared `text-gray-600` secondary
+// text colour; paragraphs are separated with `space-y-3`.
 function PageIntro({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('space-y-3 text-sm text-gray-600', className)} {...props} />
 }

--- a/klai-portal/frontend/src/components/ui/page-header.tsx
+++ b/klai-portal/frontend/src/components/ui/page-header.tsx
@@ -31,7 +31,7 @@ function PageHeader({ title, count, description, actions, className, ...props }:
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           {title}
           {count != null ? (
-            <span className="ml-2 font-display text-gray-400">({count})</span>
+            <span className="ml-2 font-display text-gray-600">({count})</span>
           ) : null}
         </h1>
         {actions ? (

--- a/klai-portal/frontend/src/components/ui/pagination.tsx
+++ b/klai-portal/frontend/src/components/ui/pagination.tsx
@@ -147,7 +147,7 @@ function Pagination({
           <span
             key={slot}
             aria-hidden="true"
-            className="inline-flex h-8 w-8 items-center justify-center text-sm text-gray-400"
+            className="inline-flex h-8 w-8 items-center justify-center text-sm text-gray-600"
           >
             …
           </span>

--- a/klai-portal/frontend/src/components/ui/radio-card-group.tsx
+++ b/klai-portal/frontend/src/components/ui/radio-card-group.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Selectable radio option cards (`RadioCardGroup`)
+ * @guideline KLAI-UI-037 must A single-choice list whose options each need a
+ * label and a description uses `RadioCardGroup`
  */
 import { useId } from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/radio-card-group.tsx
+++ b/klai-portal/frontend/src/components/ui/radio-card-group.tsx
@@ -78,7 +78,7 @@ export function RadioCardGroup({
             <div className="space-y-0.5">
               <p className="text-sm font-medium text-gray-900">{option.label}</p>
               {!compact && option.description && (
-                <p className="text-xs text-gray-400">{option.description}</p>
+                <p className="text-xs text-gray-600">{option.description}</p>
               )}
             </div>
           </label>

--- a/klai-portal/frontend/src/components/ui/row-action.tsx
+++ b/klai-portal/frontend/src/components/ui/row-action.tsx
@@ -115,8 +115,8 @@ const rowActionIconButtonVariants = cva(
         primary: 'text-[var(--color-primary)]',
         info: 'text-[var(--color-info-text)]',
         danger: 'text-[var(--color-destructive)]',
-        success: 'text-[var(--color-success)]',
-        warning: 'text-[var(--color-warning)]',
+        success: 'text-[var(--color-success-text)]',
+        warning: 'text-[var(--color-warning-text)]',
       },
     },
     defaultVariants: {
@@ -134,8 +134,8 @@ const rowActionButtonVariants = cva(
         primary: 'text-[var(--color-primary)]',
         info: 'text-[var(--color-info-text)]',
         danger: 'text-[var(--color-destructive)]',
-        success: 'text-[var(--color-success)]',
-        warning: 'text-[var(--color-warning)]',
+        success: 'text-[var(--color-success-text)]',
+        warning: 'text-[var(--color-warning-text)]',
       },
     },
     defaultVariants: {

--- a/klai-portal/frontend/src/components/ui/row-action.tsx
+++ b/klai-portal/frontend/src/components/ui/row-action.tsx
@@ -111,7 +111,7 @@ const rowActionIconButtonVariants = cva(
   {
     variants: {
       tone: {
-        neutral: 'text-gray-400',
+        neutral: 'text-gray-500',
         primary: 'text-[var(--color-primary)]',
         info: 'text-[var(--color-info-text)]',
         danger: 'text-[var(--color-destructive)]',

--- a/klai-portal/frontend/src/components/ui/row-action.tsx
+++ b/klai-portal/frontend/src/components/ui/row-action.tsx
@@ -3,6 +3,8 @@
  * bordered hitbox — the default for row icon actions), `RowActionButton`,
  * `RowActionGroup` + the action→tone system. `RowActionIconButton` is the
  * low-level unbordered base, not the list/table default.
+ * @guideline KLAI-UI-019 must-not Row actions render through the `row-action`
+ * components, never a raw icon button
  */
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'

--- a/klai-portal/frontend/src/components/ui/search-input.tsx
+++ b/klai-portal/frontend/src/components/ui/search-input.tsx
@@ -20,7 +20,7 @@ const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
     return (
       <div className="relative w-full">
         <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
           aria-hidden="true"
         />
         <Input ref={ref} type={type} className={cn('pl-10', className)} {...props} />

--- a/klai-portal/frontend/src/components/ui/search-input.tsx
+++ b/klai-portal/frontend/src/components/ui/search-input.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Text input with a leading search icon (`SearchInput`)
+ * @guideline KLAI-UI-035 must Search fields use `SearchInput`, never an
+ * `Input` with a hand-placed icon
  */
 import * as React from 'react'
 import { Search } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/select.tsx
+++ b/klai-portal/frontend/src/components/ui/select.tsx
@@ -1,5 +1,8 @@
 /**
  * @purpose Form controls
+ * @guideline KLAI-UI-007 must-not Pages are built from
+ * `src/components/ui/`; a raw `input`, `select`, list row or delete
+ * confirmation with inline Tailwind is a defect
  */
 import * as React from 'react'
 import { ChevronDown } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/select.tsx
+++ b/klai-portal/frontend/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           {children}
         </select>
         <ChevronDown
-          className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
           aria-hidden="true"
         />
       </div>

--- a/klai-portal/frontend/src/components/ui/stat-card.tsx
+++ b/klai-portal/frontend/src/components/ui/stat-card.tsx
@@ -63,7 +63,7 @@ function StatCard({
   )
   const body = (
     <>
-      <p className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+      <p className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
         {label}
       </p>
       <p
@@ -81,7 +81,7 @@ function StatCard({
           value
         )}
       </p>
-      {sub && <p className="mt-1 text-xs text-gray-400">{sub}</p>}
+      {sub && <p className="mt-1 text-xs text-gray-600">{sub}</p>}
     </>
   )
   if (onClick) {

--- a/klai-portal/frontend/src/components/ui/stat-card.tsx
+++ b/klai-portal/frontend/src/components/ui/stat-card.tsx
@@ -2,6 +2,8 @@
  * @purpose Metric tile (`StatCard`): uppercase label + large tabular value +
  * optional sub. Sizes default/sm, `tone` (default/warning/destructive), `alert`
  * frame, optional `onClick` to navigate
+ * @guideline KLAI-UI-038 must Metric tiles use `StatCard`; ordinary detail
+ * sections are not wrapped in decorative cards
  */
 import * as React from 'react'
 import { Loader2 } from 'lucide-react'

--- a/klai-portal/frontend/src/components/ui/stat-card.tsx
+++ b/klai-portal/frontend/src/components/ui/stat-card.tsx
@@ -13,7 +13,7 @@ export type StatCardTone = 'default' | 'warning' | 'destructive'
 
 const toneTextClass: Record<StatCardTone, string> = {
   default: 'text-gray-900',
-  warning: 'text-[var(--color-warning)]',
+  warning: 'text-[var(--color-warning-text)]',
   destructive: 'text-[var(--color-destructive)]',
 }
 

--- a/klai-portal/frontend/src/components/ui/step-indicator.tsx
+++ b/klai-portal/frontend/src/components/ui/step-indicator.tsx
@@ -1,5 +1,7 @@
 /**
  * @purpose Wizard step progress (`StepIndicator`)
+ * @guideline KLAI-UI-028 must Multi-step flows show progress with
+ * `StepIndicator`
  */
 import { Check } from 'lucide-react'
 

--- a/klai-portal/frontend/src/components/ui/tabs.tsx
+++ b/klai-portal/frontend/src/components/ui/tabs.tsx
@@ -3,6 +3,9 @@
  * `border-gray-900` active underline. For state/search-param tabs.
  * Router-navigation tab bars (real sub-route links) use `Link` directly with
  * the same look.
+ * @guideline KLAI-UI-031 must A tab bar whose tabs are real sub-routes uses
+ * router links, not `Tabs`
+ * @rationale Router links preserve anchor semantics
  */
 import * as React from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/tabs.tsx
+++ b/klai-portal/frontend/src/components/ui/tabs.tsx
@@ -141,7 +141,7 @@ function Tabs<T extends string>({ tabs, value, onValueChange, className, ...prop
               'flex shrink-0 items-center gap-1.5 whitespace-nowrap border-b-2 pb-2 text-sm font-medium transition-colors',
               isActive
                 ? 'border-gray-900 text-gray-900'
-                : 'border-transparent text-gray-400 hover:text-gray-900',
+                : 'border-transparent text-gray-600 hover:text-gray-900',
             )}
           >
             {Icon && <Icon className="h-4 w-4" />}

--- a/klai-portal/frontend/src/components/ui/textarea.tsx
+++ b/klai-portal/frontend/src/components/ui/textarea.tsx
@@ -1,5 +1,8 @@
 /**
  * @purpose Form controls
+ * @guideline KLAI-UI-007 must-not Pages are built from
+ * `src/components/ui/`; a raw `input`, `select`, list row or delete
+ * confirmation with inline Tailwind is a defect
  */
 import * as React from 'react'
 import { cn } from '@/lib/utils'

--- a/klai-portal/frontend/src/components/ui/textarea.tsx
+++ b/klai-portal/frontend/src/components/ui/textarea.tsx
@@ -16,7 +16,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           'w-full rounded-lg border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-900 outline-none transition-colors',
-          'placeholder:text-gray-400',
+          'placeholder:text-gray-600',
           'focus:ring-2 focus:ring-[var(--color-ring)]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           className,

--- a/klai-portal/frontend/src/features/klai-assistant/KlaiAssistantLauncher.tsx
+++ b/klai-portal/frontend/src/features/klai-assistant/KlaiAssistantLauncher.tsx
@@ -402,7 +402,7 @@ function IntakeForm<TPayload extends IntakePayload>({
   if (state === 'submitted') {
     return (
       <div className="flex min-h-72 flex-col items-center justify-center text-center">
-        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-success)]/10 text-[var(--color-success)]">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--color-success)]/10 text-[var(--color-success-text)]">
           <CheckCircle2 className="h-6 w-6" />
         </div>
         <h3 className="mt-4 text-base font-semibold text-gray-900">

--- a/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
+++ b/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
@@ -325,7 +325,7 @@ export function WidgetChatSurface({
           </div>
           <div className="min-w-0">
             <h2 className={`truncate text-sm font-display-medium leading-none ${isDark ? 'text-[var(--color-rl-bg)]' : 'text-gray-900'}`}>{botName}</h2>
-            <p className={`mt-0.5 flex items-center gap-1 text-[0.6875rem] leading-none ${isDark ? 'text-[var(--color-rl-bg)]/50' : 'text-gray-400'}`}>
+            <p className={`mt-0.5 flex items-center gap-1 text-[0.6875rem] leading-none ${isDark ? 'text-[var(--color-rl-bg)]/50' : 'text-gray-600'}`}>
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-[var(--color-success)]" />
               {m.widget_chat_status_online()}
             </p>
@@ -363,7 +363,7 @@ export function WidgetChatSurface({
               size="icon"
               onClick={onClose}
               aria-label={m.widget_chat_close()}
-              className={`ml-1 h-8 w-8 ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-400'}`}
+              className={`ml-1 h-8 w-8 ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-500'}`}
             >
               <X className="h-4 w-4" />
             </Button>
@@ -427,7 +427,7 @@ export function WidgetChatSurface({
         <div className="mx-auto max-w-3xl px-4 pb-4 pt-2 sm:px-6">
           {collectUserInfo && (
             <div className="mb-3">
-              <p className={`mb-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-400'}`}>
+              <p className={`mb-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/55' : 'text-gray-600'}`}>
                 {m.widget_chat_user_info_help()}
               </p>
               <div className="grid gap-2 sm:grid-cols-2">
@@ -437,7 +437,7 @@ export function WidgetChatSurface({
                   value={visitorName}
                   onChange={(e) => setVisitorName(e.target.value)}
                   placeholder={m.widget_chat_user_info_name()}
-                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
+                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-600'}`}
                 />
                 <input
                   type="email"
@@ -445,7 +445,7 @@ export function WidgetChatSurface({
                   value={visitorEmail}
                   onChange={(e) => setVisitorEmail(e.target.value)}
                   placeholder={m.widget_chat_user_info_email()}
-                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-400'}`}
+                  className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-600'}`}
                 />
               </div>
             </div>
@@ -486,7 +486,7 @@ export function WidgetChatSurface({
             </Button>
           </form>
           {!hideDisclaimer && (
-            <p className={`mt-2.5 text-center text-[0.6875rem] ${isDark ? 'text-[var(--color-rl-bg)]/45' : 'text-gray-400'}`}>
+            <p className={`mt-2.5 text-center text-[0.6875rem] ${isDark ? 'text-[var(--color-rl-bg)]/45' : 'text-gray-600'}`}>
               {m.widget_ai_disclaimer()}
             </p>
           )}
@@ -602,7 +602,7 @@ function SourceDetails({
           <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/60 hover:text-[var(--color-rl-bg)]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 -rotate-90 transition-transform group-open:rotate-0" strokeWidth={2} />
             <span className="min-w-0 flex-1 font-medium">{m.widget_chat_sources_label()}</span>
-            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-400'}>{sourceCountLabel}</span>
+            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-600'}>{sourceCountLabel}</span>
           </summary>
           <ol className="space-y-1 px-3 pb-3">
             {sources.map((source) => (
@@ -643,7 +643,7 @@ function SourceDetails({
           <summary className={`flex min-h-9 cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs ${isDark ? 'text-[var(--color-rl-bg)]/55 hover:text-[var(--color-rl-bg)]' : 'text-gray-500 hover:text-gray-900'} [&::-webkit-details-marker]:hidden`}>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 -rotate-90 transition-transform group-open:rotate-0" strokeWidth={2} />
             <span className="min-w-0 flex-1 font-medium">Agent activiteit</span>
-            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-400'}>
+            <span className={isDark ? 'text-[var(--color-rl-bg)]/40' : 'text-gray-600'}>
               {activity.length > 0 ? activityCountLabel : sourceCountLabel}
             </span>
           </summary>

--- a/klai-portal/frontend/src/features/widgets/components/WidgetToggleCard.tsx
+++ b/klai-portal/frontend/src/features/widgets/components/WidgetToggleCard.tsx
@@ -24,7 +24,7 @@ export function WidgetToggleCard({
         <label htmlFor={id} className="block cursor-pointer text-sm font-medium text-gray-900">
           {label}
         </label>
-        <p className="text-xs text-gray-400">{help}</p>
+        <p className="text-xs text-gray-600">{help}</p>
       </div>
     </div>
   )

--- a/klai-portal/frontend/src/routes/$locale/password/forgot.tsx
+++ b/klai-portal/frontend/src/routes/$locale/password/forgot.tsx
@@ -68,7 +68,7 @@ function ForgotPasswordPage() {
           <p className="text-xl font-semibold text-gray-900">
             {m.forgot_done_heading()}
           </p>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.forgot_done_body()}
           </p>
           <a href="/" className="block text-xs text-[var(--color-rl-accent-dark)] hover:underline pt-2">
@@ -81,7 +81,7 @@ function ForgotPasswordPage() {
             <h2 className="text-xl font-semibold text-gray-900">
               {m.forgot_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.forgot_subheading()}
             </p>
           </div>
@@ -112,7 +112,7 @@ function ForgotPasswordPage() {
             </Button>
           </form>
 
-          <p className="text-center text-xs text-gray-400">
+          <p className="text-center text-xs text-gray-600">
             <a href="/" className="text-[var(--color-rl-accent-dark)] hover:underline">
               {m.forgot_back()}
             </a>

--- a/klai-portal/frontend/src/routes/$locale/signup/index.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/index.tsx
@@ -224,12 +224,12 @@ function SignupPage() {
           <p className="text-xl font-semibold text-gray-900">
             {m.signup_confirm_heading()}
           </p>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {joinPending
               ? m.signup_join_confirm_body({ email: form.email })
               : m.signup_confirm_body({ email: form.email })}
           </p>
-          <p className="text-xs text-gray-400 opacity-70">
+          <p className="text-xs text-gray-600">
             {m.signup_confirm_hint()}
           </p>
           <Link
@@ -252,7 +252,7 @@ function SignupPage() {
           <h2 className="text-xl font-semibold text-gray-900">
             {m.signup_domain_match_heading()}
           </h2>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.signup_domain_match_body({ domain: domainMatch })}
           </p>
         </div>
@@ -282,7 +282,7 @@ function SignupPage() {
           </Button>
         </div>
 
-        <p className="text-center text-xs text-gray-400">
+        <p className="text-center text-xs text-gray-600">
           <button
             type="button"
             onClick={() => { setDomainMatch(null); setError(null) }}
@@ -301,7 +301,7 @@ function SignupPage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.signup_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.signup_existing_account()}{' '}
           <Link to="/" className="font-medium text-[var(--color-rl-accent-dark)] underline">
             {m.signup_login_link()}
@@ -346,7 +346,7 @@ function SignupPage() {
 
       <div className="relative flex items-center gap-3">
         <div className="h-px flex-1 bg-gray-200" />
-        <span className="text-xs text-gray-400">{m.signup_or_continue_with()}</span>
+        <span className="text-xs text-gray-600">{m.signup_or_continue_with()}</span>
         <div className="h-px flex-1 bg-gray-200" />
       </div>
 
@@ -416,7 +416,7 @@ function SignupPage() {
             />
             <span>
               {m.signup_auto_accept_label({ domain: emailDomain })}
-              <span className="block text-xs text-gray-400">{m.signup_auto_accept_hint()}</span>
+              <span className="block text-xs text-gray-600">{m.signup_auto_accept_hint()}</span>
             </span>
           </label>
         )}
@@ -431,7 +431,7 @@ function SignupPage() {
         </Button>
       </form>
 
-      <p className="text-center text-xs text-gray-400">
+      <p className="text-center text-xs text-gray-600">
         {m.signup_privacy_text()}{' '}
         <a href="https://getklai.com/docs/legal/privacy" className="text-[var(--color-rl-accent-dark)] underline">
           {m.signup_privacy_link()}
@@ -490,7 +490,7 @@ function Field({
         required={required}
         className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
       />
-      {hint && <p className="text-xs text-gray-400">{hint}</p>}
+      {hint && <p className="text-xs text-gray-600">{hint}</p>}
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/$locale/signup/social.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/social.tsx
@@ -144,7 +144,7 @@ function SocialSignupPage() {
           <h2 className="text-xl font-semibold text-gray-900">
             {m.social_domain_match_heading()}
           </h2>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.social_domain_match_body({ domain: domainMatch.domain })}
           </p>
         </div>
@@ -157,7 +157,7 @@ function SocialSignupPage() {
             >
               <div>
                 <span className="block font-medium text-gray-900">{org.name}</span>
-                <span className="block text-xs text-gray-400">
+                <span className="block text-xs text-gray-600">
                   {org.auto_accept
                     ? m.select_workspace_join_auto_hint()
                     : m.select_workspace_request_hint()}
@@ -176,7 +176,7 @@ function SocialSignupPage() {
           </p>
         )}
 
-        <p className="text-center text-xs text-gray-400">
+        <p className="text-center text-xs text-gray-600">
           <button
             type="button"
             onClick={() => {
@@ -199,19 +199,19 @@ function SocialSignupPage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.signup_social_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.signup_social_subheading()}
         </p>
       </div>
 
       {/* Identity confirmation - read-only */}
       <div className="rounded-lg border border-gray-200 bg-[var(--color-muted)] px-3 py-2.5">
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {m.signup_social_identity_label()}
         </p>
         <p className="text-sm font-medium text-gray-900">{displayName}</p>
         {displayName !== email && (
-          <p className="text-xs text-gray-400">{email}</p>
+          <p className="text-xs text-gray-600">{email}</p>
         )}
       </div>
 
@@ -246,7 +246,7 @@ function SocialSignupPage() {
             />
             <span>
               {m.signup_auto_accept_label({ domain: emailDomain })}
-              <span className="block text-xs text-gray-400">{m.signup_auto_accept_hint()}</span>
+              <span className="block text-xs text-gray-600">{m.signup_auto_accept_hint()}</span>
             </span>
           </label>
         )}
@@ -274,7 +274,7 @@ function SocialSignupPage() {
         </Button>
       </form>
 
-      <p className="text-center text-xs text-gray-400">
+      <p className="text-center text-xs text-gray-600">
         {m.signup_privacy_text()}{' '}
         <a
           href="https://getklai.com/docs/legal/privacy"

--- a/klai-portal/frontend/src/routes/admin/_components/-BillingBreakdownSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-BillingBreakdownSection.tsx
@@ -121,7 +121,7 @@ export function BillingBreakdownSection() {
         )}
         {state.data && (
           <div className="space-y-2">
-            <div className="grid grid-cols-[1fr_auto_auto] gap-x-6 text-xs uppercase tracking-wide text-gray-400">
+            <div className="grid grid-cols-[1fr_auto_auto] gap-x-6 text-xs uppercase tracking-wide text-gray-600">
               <span>{m.admin_billing_breakdown_col_account_type()}</span>
               <span className="text-right">{m.admin_billing_breakdown_col_count()}</span>
               <span className="text-right">{m.admin_billing_breakdown_col_monthly()}</span>

--- a/klai-portal/frontend/src/routes/admin/_components/-BillingField.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-BillingField.tsx
@@ -28,7 +28,7 @@ export function BillingField({
       <Label htmlFor={name}>
         {label}
         {!required && (
-          <span className="ml-1 text-xs text-gray-400 font-normal">{m.admin_billing_field_optional()}</span>
+          <span className="ml-1 text-xs text-gray-600 font-normal">{m.admin_billing_field_optional()}</span>
         )}
       </Label>
       <Input
@@ -40,7 +40,7 @@ export function BillingField({
         required={required}
         placeholder={placeholder}
       />
-      {hint && <p className="text-xs text-gray-400">{hint}</p>}
+      {hint && <p className="text-xs text-gray-600">{hint}</p>}
     </div>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/_components/-ExtensionsSettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-ExtensionsSettingsSection.tsx
@@ -60,7 +60,7 @@ export function ExtensionsSettingsSection() {
         <h2 className="text-base font-display-bold text-gray-900">
           {m.admin_settings_extensions_title()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {isPlatformAdmin
             ? m.admin_settings_extensions_description_platform()
             : m.admin_settings_extensions_description_tenant()}
@@ -68,7 +68,7 @@ export function ExtensionsSettingsSection() {
       </div>
       <form onSubmit={handleSubmit} className="space-y-4">
         {extensionsLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : extensionsError ? (
           <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
         ) : !extensions ? null : (
@@ -80,7 +80,7 @@ export function ExtensionsSettingsSection() {
                   <li key={item.key} className="flex items-center justify-between gap-4 px-2 py-3">
                     <div className="min-w-0 flex-1">
                       <p className="text-[0.9375rem] font-display text-gray-900">{extensionLabel(item.key)}</p>
-                      <p className="text-xs text-gray-400 mt-0.5">{extensionDescription(item.key)}</p>
+                      <p className="text-xs text-gray-600 mt-0.5">{extensionDescription(item.key)}</p>
                     </div>
                     {item.manageable_by_caller ? (
                       <Checkbox
@@ -95,7 +95,7 @@ export function ExtensionsSettingsSection() {
                           'shrink-0 rounded-full px-3 py-0.5 text-xs font-medium',
                           item.enabled
                             ? 'bg-[var(--color-rl-cream)] text-[var(--color-rl-accent-dark)]'
-                            : 'bg-gray-100 text-gray-400',
+                            : 'bg-gray-100 text-gray-600',
                         ].join(' ')}
                       >
                         {item.enabled
@@ -108,7 +108,7 @@ export function ExtensionsSettingsSection() {
               })}
             </ul>
             {!isPlatformAdmin && (
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-gray-600">
                 {m.admin_settings_extensions_managed_by_klai()}
               </p>
             )}

--- a/klai-portal/frontend/src/routes/admin/_components/-LanguageSettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-LanguageSettingsSection.tsx
@@ -43,7 +43,7 @@ export function LanguageSettingsSection({
       </div>
       <form onSubmit={handleSubmit} className="space-y-4">
         {isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : error ? (
           <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
         ) : (

--- a/klai-portal/frontend/src/routes/admin/_components/-OrganizationSettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-OrganizationSettingsSection.tsx
@@ -21,13 +21,13 @@ export function OrganizationSettingsSection({
       </div>
       <div>
         {isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : error ? (
           <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
         ) : (
           <dl className="grid gap-4 sm:grid-cols-2">
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-gray-400">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-600">
                 {m.admin_settings_org_name_label()}
               </dt>
               <dd className="mt-1 text-sm font-medium text-gray-900">
@@ -35,7 +35,7 @@ export function OrganizationSettingsSection({
               </dd>
             </div>
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-gray-400">
+              <dt className="text-xs font-medium uppercase tracking-wide text-gray-600">
                 {m.admin_settings_org_domain_label()}
               </dt>
               <dd className="mt-1 text-sm font-medium text-gray-900">

--- a/klai-portal/frontend/src/routes/admin/_components/-PiiPolicySettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-PiiPolicySettingsSection.tsx
@@ -176,7 +176,7 @@ export function PiiPolicySettingsSection({
       </div>
       <div className="space-y-4">
         {isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : error ? (
           <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
         ) : (
@@ -210,7 +210,7 @@ export function PiiPolicySettingsSection({
                       {group.entities.length > 1 && (
                         <button
                           type="button"
-                          className="shrink-0 self-center rounded-md p-1.5 text-gray-400 hover:bg-[var(--color-muted)]/60 hover:text-gray-900"
+                          className="shrink-0 self-center rounded-md p-1.5 text-gray-500 hover:bg-[var(--color-muted)]/60 hover:text-gray-900"
                           aria-expanded={expanded}
                           aria-label={
                             expanded
@@ -250,12 +250,12 @@ export function PiiPolicySettingsSection({
                 <ListRowContent>
                   <ListRowTitle>{m.admin_settings_pii_locked_title()}</ListRowTitle>
                   <ListRowDescription>{m.admin_settings_pii_locked_description()}</ListRowDescription>
-                  <p className="mt-1 text-xs text-gray-400">{m.admin_settings_pii_locked_reason()}</p>
+                  <p className="mt-1 text-xs text-gray-600">{m.admin_settings_pii_locked_reason()}</p>
                 </ListRowContent>
               </ListRow>
             </ListFrame>
             {!isTenantAdmin && (
-              <p className="text-xs text-gray-400">{m.admin_settings_pii_readonly_hint()}</p>
+              <p className="text-xs text-gray-600">{m.admin_settings_pii_readonly_hint()}</p>
             )}
           </>
         )}

--- a/klai-portal/frontend/src/routes/admin/_components/-SecuritySettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-SecuritySettingsSection.tsx
@@ -57,7 +57,7 @@ export function SecuritySettingsSection({
       </div>
       <form onSubmit={handleSubmit} className="space-y-6">
         {isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : error ? (
           <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
         ) : (
@@ -76,7 +76,7 @@ export function SecuritySettingsSection({
                 <option value="recommended">{m.admin_settings_mfa_recommended()}</option>
                 <option value="required">{m.admin_settings_mfa_required()}</option>
               </Select>
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-gray-600">
                 {selectedMfa === 'optional' && m.admin_settings_mfa_optional_hint()}
                 {selectedMfa === 'recommended' && m.admin_settings_mfa_recommended_hint()}
                 {selectedMfa === 'required' && m.admin_settings_mfa_required_hint()}
@@ -92,7 +92,7 @@ export function SecuritySettingsSection({
                   onChange={(event) => setAutoAcceptSameDomain(event.target.checked)}
                   label={m.admin_settings_auto_accept_label({ domain: settings.primary_domain })}
                 />
-                <p className="pl-7 text-xs text-gray-400">
+                <p className="pl-7 text-xs text-gray-600">
                   {autoAcceptSameDomain
                     ? m.admin_settings_auto_accept_hint_on()
                     : m.admin_settings_auto_accept_hint_off()}

--- a/klai-portal/frontend/src/routes/admin/_components/-TelemetrySettingsSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/-TelemetrySettingsSection.tsx
@@ -28,7 +28,7 @@ export function TelemetrySettingsSection({
         </h2>
       </div>
       {isLoading ? (
-        <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+        <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
       ) : error ? (
         <p className="text-sm text-[var(--color-destructive)]">{m.admin_settings_error_fetch()}</p>
       ) : (
@@ -47,7 +47,7 @@ export function TelemetrySettingsSection({
             <option value="shadow">{m.admin_settings_telemetry_shadow_name()}</option>
             <option value="full">{m.admin_settings_telemetry_full_name()}</option>
           </Select>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.admin_settings_telemetry_help()}{' '}
             <a href="/app/docs/klai-help/8b57605d-675c-48cd-b33b-3ee1705c33a6" className="underline">
               {m.admin_settings_telemetry_privacy_link()}

--- a/klai-portal/frontend/src/routes/admin/_components/ProfilePicker.tsx
+++ b/klai-portal/frontend/src/routes/admin/_components/ProfilePicker.tsx
@@ -23,7 +23,7 @@ interface ProfilePickerProps {
  * - border-gray-200 unselected, border-gray-900 selected (no amber accent -
  *   "Amber NOT applied to active states in v1")
  * - bg-black/[0.06] selected layer, hover bg-black/5
- * - text-gray-900 prose, text-gray-400 muted
+ * - text-gray-900 prose, text-gray-600 muted
  */
 export function ProfilePicker({
   value,
@@ -72,7 +72,7 @@ export function ProfilePicker({
                   {labelFn ? labelFn() : role}
                 </p>
                 {!compact && (
-                  <p className="text-xs text-gray-400">
+                  <p className="text-xs text-gray-600">
                     {descFn ? descFn() : ''}
                   </p>
                 )}
@@ -82,7 +82,7 @@ export function ProfilePicker({
         })}
       </div>
       {disabled && disabledMessage && (
-        <p className="text-xs text-gray-400">{disabledMessage}</p>
+        <p className="text-xs text-gray-600">{disabledMessage}</p>
       )}
     </div>
   )

--- a/klai-portal/frontend/src/routes/admin/api-keys/$id.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/$id.tsx
@@ -41,7 +41,7 @@ function ApiKeyDetailPage() {
   if (isLoading) {
     return (
       <div className="p-6">
-        <p className="py-8 text-sm text-gray-400">
+        <p className="py-8 text-sm text-gray-600">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           {m.admin_api_keys_loading()}
         </p>
@@ -86,7 +86,7 @@ function ApiKeyDetailPage() {
             {apiKey.name}
           </h1>
           {apiKey.description && (
-            <p className="text-sm text-gray-400 mt-1">
+            <p className="text-sm text-gray-600 mt-1">
               {apiKey.description}
             </p>
           )}

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/CreatedKeyModal.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/CreatedKeyModal.tsx
@@ -66,7 +66,7 @@ export function CreatedKeyModal({
             className="shrink-0"
           >
             {copied ? (
-              <Check className="h-4 w-4 text-[var(--color-success)]" />
+              <Check className="h-4 w-4 text-[var(--color-success-text)]" />
             ) : (
               <Copy className="h-4 w-4" />
             )}

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/DangerTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/DangerTab.tsx
@@ -32,7 +32,7 @@ export function DangerTab({ apiKey }: Props) {
         <h2 className="text-sm font-medium text-[var(--color-destructive)] mb-2">
           {m.admin_api_keys_delete_section_title()}
         </h2>
-        <p className="text-sm text-gray-400 mb-4">
+        <p className="text-sm text-gray-600 mb-4">
           {m.admin_api_keys_delete_section_description()}
         </p>
         <InlineDeleteConfirm

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/DetailsTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/DetailsTab.tsx
@@ -61,7 +61,7 @@ export function DetailsTab({ apiKey }: Props) {
         </div>
         <div className="space-y-1.5">
           <Label>{m.admin_api_keys_col_key_prefix()}</Label>
-          <code className="block text-xs font-mono text-gray-400 py-2">
+          <code className="block text-xs font-mono text-gray-600 py-2">
             {apiKey.key_prefix}...
           </code>
         </div>

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/KnowledgeBasesTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/KnowledgeBasesTab.tsx
@@ -42,7 +42,7 @@ export function KnowledgeBasesTab({ apiKey }: Props) {
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <section className="space-y-4">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_api_keys_wizard_kb_access_intro_api()}
         </p>
         <KbAccessEditor

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/PermissionsTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/PermissionsTab.tsx
@@ -54,7 +54,7 @@ export function PermissionsTab({ apiKey }: Props) {
             />
             <div>
               <span className="font-medium">{m.admin_api_keys_perm_chat()}</span>
-              <p className="text-xs text-gray-400 mt-0.5">
+              <p className="text-xs text-gray-600 mt-0.5">
                 {m.admin_api_keys_perm_chat_description()}
               </p>
             </div>
@@ -68,7 +68,7 @@ export function PermissionsTab({ apiKey }: Props) {
             />
             <div>
               <span className="font-medium">{m.admin_api_keys_perm_feedback()}</span>
-              <p className="text-xs text-gray-400 mt-0.5">
+              <p className="text-xs text-gray-600 mt-0.5">
                 {m.admin_api_keys_perm_feedback_description()}
               </p>
             </div>
@@ -82,7 +82,7 @@ export function PermissionsTab({ apiKey }: Props) {
             />
             <div>
               <span className="font-medium">{m.admin_api_keys_perm_knowledge_append()}</span>
-              <p className="text-xs text-gray-400 mt-0.5">
+              <p className="text-xs text-gray-600 mt-0.5">
                 {m.admin_api_keys_perm_knowledge_append_description()}
               </p>
             </div>
@@ -96,7 +96,7 @@ export function PermissionsTab({ apiKey }: Props) {
             />
             <div>
               <span className="font-medium">{m.admin_api_keys_perm_general_chat()}</span>
-              <p className="text-xs text-gray-400 mt-0.5">
+              <p className="text-xs text-gray-600 mt-0.5">
                 {m.admin_api_keys_perm_general_chat_description()}
               </p>
             </div>

--- a/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/RotationTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/_components/tabs/RotationTab.tsx
@@ -43,7 +43,7 @@ export function RotationTab({ apiKey }: Props) {
         <h2 className="text-sm font-medium text-gray-900 mb-2">
           {m.admin_api_keys_rotate_section_title()}
         </h2>
-        <p className="text-sm text-gray-400 mb-4">
+        <p className="text-sm text-gray-600 mb-4">
           {apiKey.rotated_to_key_id
             ? m.admin_api_keys_rotate_pending_description()
             : m.admin_api_keys_rotate_section_description()}
@@ -72,7 +72,7 @@ export function RotationTab({ apiKey }: Props) {
       </div>
 
       {apiKey.rotated_from_key_id && (
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_api_keys_rotated_from_notice()}
         </p>
       )}

--- a/klai-portal/frontend/src/routes/admin/api-keys/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/index.tsx
@@ -78,7 +78,7 @@ function ApiKeysPage() {
     columnHelper.accessor('key_prefix', {
       header: () => m.admin_api_keys_col_key_prefix(),
       cell: (info) => (
-        <code className="font-mono text-xs text-gray-400">
+        <code className="font-mono text-xs text-gray-600">
           {info.getValue()}...
         </code>
       ),
@@ -92,7 +92,7 @@ function ApiKeysPage() {
     columnHelper.accessor('last_used_at', {
       header: () => m.admin_api_keys_col_last_used(),
       cell: (info) => (
-        <span className="whitespace-nowrap tabular-nums text-gray-400">
+        <span className="whitespace-nowrap tabular-nums text-gray-600">
           {formatRelativeTime(info.getValue())}
         </span>
       ),

--- a/klai-portal/frontend/src/routes/admin/api-keys/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/api-keys/new.tsx
@@ -160,7 +160,7 @@ function NewApiKeyPage() {
       <form onSubmit={handleSubmit} className="space-y-6">
         {step === 'details' && (
           <section className="space-y-4">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.admin_shared_wizard_details_intro()}
             </p>
             <div className="space-y-1.5">
@@ -202,7 +202,7 @@ function NewApiKeyPage() {
                 />
                 <div>
                   <span className="font-medium">{m.admin_api_keys_perm_chat()}</span>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {m.admin_api_keys_perm_chat_description()}
                   </p>
                 </div>
@@ -216,7 +216,7 @@ function NewApiKeyPage() {
                 />
                 <div>
                   <span className="font-medium">{m.admin_api_keys_perm_feedback()}</span>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {m.admin_api_keys_perm_feedback_description()}
                   </p>
                 </div>
@@ -230,7 +230,7 @@ function NewApiKeyPage() {
                 />
                 <div>
                   <span className="font-medium">{m.admin_api_keys_perm_knowledge_append()}</span>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {m.admin_api_keys_perm_knowledge_append_description()}
                   </p>
                 </div>
@@ -244,7 +244,7 @@ function NewApiKeyPage() {
                 />
                 <div>
                   <span className="font-medium">{m.admin_api_keys_perm_general_chat()}</span>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {m.admin_api_keys_perm_general_chat_description()}
                   </p>
                 </div>
@@ -255,7 +255,7 @@ function NewApiKeyPage() {
 
         {step === 'kbs' && (
           <section className="space-y-4">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.admin_api_keys_wizard_kb_access_intro_api()}
             </p>
             <KbAccessEditor

--- a/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
+++ b/klai-portal/frontend/src/routes/admin/billing.lazy.tsx
@@ -12,7 +12,7 @@ function BillingPage() {
     <PageContainer width="3xl" gap="6" data-help-id="admin-billing-overview">
       <div className="space-y-1">
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">{m.admin_billing_heading()}</h1>
-        <p className="text-sm text-gray-400">{m.admin_billing_subtitle()}</p>
+        <p className="text-sm text-gray-600">{m.admin_billing_subtitle()}</p>
       </div>
 
       <BillingBreakdownSection />

--- a/klai-portal/frontend/src/routes/admin/danger-zone.tsx
+++ b/klai-portal/frontend/src/routes/admin/danger-zone.tsx
@@ -59,7 +59,7 @@ function DangerZonePage() {
           {m.danger_zone_back()}
         </Button>
       </div>
-      <p className="text-sm text-gray-400 -mt-4">{m.danger_zone_subtitle()}</p>
+      <p className="text-sm text-gray-600 -mt-4">{m.danger_zone_subtitle()}</p>
 
       <Card className="border-[var(--color-destructive)]/30">
         <CardHeader>

--- a/klai-portal/frontend/src/routes/admin/deprovisioning-status.tsx
+++ b/klai-portal/frontend/src/routes/admin/deprovisioning-status.tsx
@@ -121,7 +121,7 @@ function PollingView({ isTimeout }: { isTimeout: boolean }) {
         <p className="text-xl font-semibold text-gray-900">
           {m.deprovisioning_status_heading()}
         </p>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {isTimeout
             ? m.deprovisioning_status_timeout()
             : m.deprovisioning_status_subtitle()}
@@ -148,7 +148,7 @@ function FailedView({ step }: { step?: string }) {
           {m.deprovisioning_status_failed_heading()}
         </p>
         {step && (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.deprovisioning_status_failed_step({ step })}
           </p>
         )}
@@ -171,7 +171,7 @@ function ErrorView() {
         <p className="text-xl font-semibold text-gray-900">
           {m.deprovisioning_status_failed_heading()}
         </p>
-        <p className="text-sm text-gray-400">{m.error_generic()}</p>
+        <p className="text-sm text-gray-600">{m.error_generic()}</p>
         <Button variant="link" size="sm" onClick={() => window.location.reload()}>
           {m.provisioning_error_retry()}
         </Button>

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/add-member.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/add-member.tsx
@@ -153,7 +153,7 @@ function AddMemberPage() {
                               }}
                             >
                               <span>{label}</span>
-                              <span className="ml-auto text-xs text-gray-400">
+                              <span className="ml-auto text-xs text-gray-600">
                                 {u.email}
                               </span>
                             </CommandItem>

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/edit.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/edit.tsx
@@ -155,7 +155,7 @@ function EditGroupPage() {
   if (groupLoading) {
     return (
       <div className="p-6">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           Loading...
         </p>
@@ -222,7 +222,7 @@ function EditGroupPage() {
               <Label className="mb-2 block">{m.admin_groups_members_title()}</Label>
 
               {currentMembers.length === 0 ? (
-                <p className="text-sm text-gray-400 mb-3">
+                <p className="text-sm text-gray-600 mb-3">
                   {m.admin_groups_members_empty()}
                 </p>
               ) : (
@@ -233,7 +233,7 @@ function EditGroupPage() {
                         <span className="text-sm text-gray-900">
                           {displayName(user)}
                         </span>
-                        <span className="text-xs text-gray-400 ml-2">
+                        <span className="text-xs text-gray-600 ml-2">
                           {user.email}
                         </span>
                       </div>

--- a/klai-portal/frontend/src/routes/admin/groups/$groupId/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/$groupId/index.tsx
@@ -165,7 +165,7 @@ function AdminGroupDetail() {
             {groupData.name}
           </h1>
           {groupData.description && (
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {groupData.description}
             </p>
           )}
@@ -240,7 +240,7 @@ function AdminGroupDetail() {
                   return (
                     <DataTableRow key={member.zitadel_user_id} confirming={isConfirming}>
                       <DataTableCell>{displayName(user, member)}</DataTableCell>
-                      <DataTableCell className="text-gray-400">
+                      <DataTableCell className="text-gray-600">
                         {displayEmail(user)}
                       </DataTableCell>
                       <DataTableCell className="whitespace-nowrap tabular-nums">

--- a/klai-portal/frontend/src/routes/admin/groups/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/groups/index.tsx
@@ -59,7 +59,7 @@ function MemberAvatars({
   const visible = userIds.slice(0, 4)
   const extra = userIds.length - visible.length
   if (userIds.length === 0) {
-    return <span className="text-xs text-gray-400">-</span>
+    return <span className="text-xs text-gray-600">-</span>
   }
   return (
     <div className="flex items-center gap-1.5">
@@ -79,7 +79,7 @@ function MemberAvatars({
             <div
               key={uid}
               title={uid}
-              className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-muted)] text-xs font-medium text-gray-400"
+              className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--color-muted)] text-xs font-medium text-gray-600"
             >
               ??
             </div>
@@ -87,7 +87,7 @@ function MemberAvatars({
         )
       })}
       {extra > 0 && (
-        <div className="h-7 w-7 rounded-full flex items-center justify-center text-xs font-medium bg-[var(--color-muted)] text-gray-400">
+        <div className="h-7 w-7 rounded-full flex items-center justify-center text-xs font-medium bg-[var(--color-muted)] text-gray-600">
           +{extra}
         </div>
       )}
@@ -175,7 +175,7 @@ function AdminGroups() {
           <div className="flex items-center gap-2">
             <MemberAvatars userIds={memberIds} usersMap={usersMap} />
             {memberIds.length > 0 && (
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-gray-600">
                 {memberIds.length}
               </span>
             )}

--- a/klai-portal/frontend/src/routes/admin/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/index.tsx
@@ -38,7 +38,7 @@ function AdminHome() {
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           {m.admin_home_heading()}
         </h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_home_subtitle()}
         </p>
       </div>
@@ -50,14 +50,14 @@ function AdminHome() {
             href={section.to}
             className="group flex items-center gap-3 px-2 py-3.5 klai-hover"
           >
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center text-gray-400">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center text-gray-500">
               <section.icon className="h-4 w-4" />
             </div>
             <div className="min-w-0 flex-1">
               <span className="text-[0.9375rem] font-display text-gray-900">
                 {section.label}
               </span>
-              <p className="text-xs text-gray-400 mt-0.5">
+              <p className="text-xs text-gray-600 mt-0.5">
                 {section.overviewDescription}
               </p>
             </div>

--- a/klai-portal/frontend/src/routes/admin/mcps/$serverId.tsx
+++ b/klai-portal/frontend/src/routes/admin/mcps/$serverId.tsx
@@ -72,8 +72,8 @@ function McpTestButton({ serverId }: { serverId: string }) {
         <span className="flex items-center gap-1 text-sm">
           {result.status === 'ok' ? (
             <>
-              <CheckCircle className="h-4 w-4 text-[var(--color-success)]" />
-              <span className="text-[var(--color-success)]">
+              <CheckCircle className="h-4 w-4 text-[var(--color-success-text)]" />
+              <span className="text-[var(--color-success-text)]">
                 {m.admin_mcps_test_ok()}
                 {result.response_time_ms != null && ` (${result.response_time_ms}ms)`}
               </span>
@@ -252,7 +252,7 @@ function McpEditPage() {
           )
         })}
 
-        {successMsg && <p className="text-sm text-[var(--color-success)]">{successMsg}</p>}
+        {successMsg && <p className="text-sm text-[var(--color-success-text)]">{successMsg}</p>}
         {errorMsg && <p className="text-sm text-[var(--color-destructive)]">{errorMsg}</p>}
 
         <p className="text-xs text-gray-600">

--- a/klai-portal/frontend/src/routes/admin/mcps/$serverId.tsx
+++ b/klai-portal/frontend/src/routes/admin/mcps/$serverId.tsx
@@ -185,7 +185,7 @@ function McpEditPage() {
   if (isLoading) {
     return (
       <div className="p-6 max-w-lg">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_mcps_loading()}
         </p>
       </div>
@@ -219,7 +219,7 @@ function McpEditPage() {
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {server.display_name || server.id}
           </h1>
-          <p className="text-sm text-gray-400">{server.description}</p>
+          <p className="text-sm text-gray-600">{server.description}</p>
         </div>
         <Button type="button" variant="outline" size="sm" onClick={handleBack}>
           <ArrowLeft className="h-4 w-4 mr-2" />
@@ -255,7 +255,7 @@ function McpEditPage() {
         {successMsg && <p className="text-sm text-[var(--color-success)]">{successMsg}</p>}
         {errorMsg && <p className="text-sm text-[var(--color-destructive)]">{errorMsg}</p>}
 
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {m.admin_mcps_restart_notice()}
         </p>
 

--- a/klai-portal/frontend/src/routes/admin/mcps/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/mcps/index.tsx
@@ -147,7 +147,7 @@ function McpsListPage() {
                       )}
                     </div>
                   </DataTableCell>
-                  <DataTableCell className="text-gray-400">
+                  <DataTableCell className="text-gray-600">
                     {server.description}
                   </DataTableCell>
                   <DataTableCell

--- a/klai-portal/frontend/src/routes/admin/mcps/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/mcps/new.tsx
@@ -38,7 +38,7 @@ function McpsNewPage() {
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {m.admin_mcps_new_title()}
           </h1>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.admin_mcps_new_subtitle()}
           </p>
         </div>
@@ -72,7 +72,7 @@ function McpsNewPage() {
                 <DataTableCell>
                   <span className="font-medium">{server.display_name || server.id}</span>
                 </DataTableCell>
-                <DataTableCell className="text-gray-400">{server.description}</DataTableCell>
+                <DataTableCell className="text-gray-600">{server.description}</DataTableCell>
                 <DataTableCell align="right">
                   <RowActionGroup>
                     <BorderedRowActionIconButton

--- a/klai-portal/frontend/src/routes/admin/platform/-components/OrgDetailSections.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/OrgDetailSections.tsx
@@ -138,14 +138,14 @@ export function TenantFeaturesSection({
         <h2 className="text-base font-display-bold text-gray-900">
           {m.admin_settings_extensions_title()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_settings_extensions_description_platform()}
         </p>
       </div>
 
       <form onSubmit={handleFeatureSubmit} className="space-y-4">
         {unlocks.isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_users_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_users_loading()}</p>
         ) : unlocks.error ? (
           <p className="text-sm text-[var(--color-destructive)]">
             {m.admin_settings_error_fetch()}
@@ -164,7 +164,7 @@ export function TenantFeaturesSection({
                       <p className="text-[0.9375rem] font-display text-gray-900">
                         {extensionLabel(feature.key)}
                       </p>
-                      <p className="text-xs text-gray-400 mt-0.5">
+                      <p className="text-xs text-gray-600 mt-0.5">
                         {extensionDescription(feature.key)}
                       </p>
                     </div>
@@ -287,7 +287,7 @@ export function TenantDangerZone({ org }: { org: PlatformOrg }) {
                 setOpen(false)
                 setConfirmText('')
               }}
-              className="h-auto p-0 text-sm text-gray-400 no-underline hover:text-gray-900 hover:no-underline"
+              className="h-auto p-0 text-sm text-gray-600 no-underline hover:text-gray-900 hover:no-underline"
             >
               {m.admin_users_cancel()}
             </Button>
@@ -315,7 +315,7 @@ export function UsersSection({
   return (
     <section>
       <div className="mb-3 flex items-center justify-between">
-        <h2 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+        <h2 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
           {m.platform_section_users({ count: users.length })}
         </h2>
         <Button
@@ -369,7 +369,7 @@ export function UsersSection({
                       {u.display_name || u.email || u.zitadel_user_id}
                     </span>
                     {u.email && (
-                      <p className="text-xs text-gray-400">{u.email}</p>
+                      <p className="text-xs text-gray-600">{u.email}</p>
                     )}
                   </DataTableCell>
                   <DataTableCell>
@@ -546,7 +546,7 @@ export function BotsSection({
 }) {
   return (
     <section>
-      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
         {m.platform_section_bots({ count: bots.length })}
       </h2>
       {bots.length === 0 ? (
@@ -577,7 +577,7 @@ export function BotsSection({
                   <span className="font-medium">{b.name}</span>
                 </DataTableCell>
                 <DataTableCell className="tabular-nums">{b.kb_count}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(b.created_at)}
                 </DataTableCell>
               </DataTableRow>
@@ -598,7 +598,7 @@ export function KnowledgeBasesSection({
 }) {
   return (
     <section>
-      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
         {m.platform_section_knowledge_bases({
           count: knowledgeBases.length,
         })}
@@ -620,7 +620,7 @@ export function KnowledgeBasesSection({
               <DataTableRow key={kb.id}>
                 <DataTableCell>
                   <span className="font-medium">{kb.name}</span>
-                  <p className="font-mono text-xs text-gray-400">{kb.slug}</p>
+                  <p className="font-mono text-xs text-gray-600">{kb.slug}</p>
                 </DataTableCell>
                 <DataTableCell>
                   <Badge variant="outline">
@@ -630,7 +630,7 @@ export function KnowledgeBasesSection({
                   </Badge>
                 </DataTableCell>
                 <DataTableCell>{kb.visibility}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(kb.created_at)}
                 </DataTableCell>
               </DataTableRow>
@@ -651,7 +651,7 @@ export function TemplatesSection({
 }) {
   return (
     <section>
-      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+      <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
         {m.platform_section_templates({ count: templates.length })}
       </h2>
       {templates.length === 0 ? (
@@ -676,7 +676,7 @@ export function TemplatesSection({
                       <Badge variant="outline">{m.platform_inactive()}</Badge>
                     )}
                   </div>
-                  <p className="font-mono text-xs text-gray-400">{t.slug}</p>
+                  <p className="font-mono text-xs text-gray-600">{t.slug}</p>
                 </DataTableCell>
                 <DataTableCell>
                   <Badge variant={t.scope === 'org' ? 'success' : 'outline'}>
@@ -686,7 +686,7 @@ export function TemplatesSection({
                   </Badge>
                 </DataTableCell>
                 <DataTableCell>{t.created_by_name ?? t.created_by}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(t.created_at)}
                 </DataTableCell>
               </DataTableRow>
@@ -795,7 +795,7 @@ function InviteForm({
           type="button"
           variant="link"
           onClick={onClose}
-          className="h-auto p-0 text-sm text-gray-400 no-underline hover:text-gray-900 hover:no-underline"
+          className="h-auto p-0 text-sm text-gray-600 no-underline hover:text-gray-900 hover:no-underline"
         >
           {m.admin_users_cancel()}
         </Button>

--- a/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/PlatformDashboardTabs.tsx
@@ -108,7 +108,7 @@ export function SubdomainsTab({ search }: { search: string }) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-16 text-sm text-gray-400">
+      <div className="flex items-center justify-center py-16 text-sm text-gray-600">
         <ListLoadingState label={m.platform_subdomains_loading()} />
       </div>
     )
@@ -121,7 +121,7 @@ export function SubdomainsTab({ search }: { search: string }) {
     )
   }
   if (filtered.length === 0) {
-    return <p className="py-16 text-center text-sm text-gray-400">{m.platform_subdomains_empty()}</p>
+    return <p className="py-16 text-center text-sm text-gray-600">{m.platform_subdomains_empty()}</p>
   }
 
   return (
@@ -133,7 +133,7 @@ export function SubdomainsTab({ search }: { search: string }) {
           <section key={section.category} className="space-y-3">
             <div>
               <h2 className="text-[0.9375rem] font-display-bold text-gray-900">{section.title()}</h2>
-              <p className="text-sm text-gray-400">{section.description()}</p>
+              <p className="text-sm text-gray-600">{section.description()}</p>
             </div>
             <DataTable>
               <DataTableHeader>
@@ -151,13 +151,13 @@ export function SubdomainsTab({ search }: { search: string }) {
                   <DataTableRow key={item.url}>
                     <DataTableCell>
                       <p className="font-mono text-xs text-gray-900">{item.subdomain || '(apex)'}</p>
-                      <p className="mt-1 text-xs text-gray-400">{item.description}</p>
+                      <p className="mt-1 text-xs text-gray-600">{item.description}</p>
                     </DataTableCell>
                     <DataTableCell>
                       <span className="text-sm">{item.label}</span>
                     </DataTableCell>
                     <DataTableCell>
-                      <span className="text-xs font-mono text-gray-400">{item.host}</span>
+                      <span className="text-xs font-mono text-gray-600">{item.host}</span>
                     </DataTableCell>
                     <DataTableCell>
                       <span className="text-sm text-gray-700">{item.owner}</span>
@@ -195,12 +195,12 @@ export function StatusTab() {
       <div className="rounded-xl border border-gray-200 bg-white px-5 py-5">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Activity className="h-5 w-5 shrink-0 text-gray-400" />
+            <Activity className="h-5 w-5 shrink-0 text-gray-500" />
             <div>
               <p className="text-[0.9375rem] font-display text-gray-900">
                 {m.platform_status_portal_api()}
               </p>
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-gray-600">
                 {m.platform_status_portal_api_description()}
               </p>
             </div>
@@ -218,12 +218,12 @@ export function StatusTab() {
       <div className="rounded-xl border border-gray-200 bg-white px-5 py-5">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <Bug className="h-5 w-5 shrink-0 text-gray-400" />
+            <Bug className="h-5 w-5 shrink-0 text-gray-500" />
             <div>
               <p className="text-[0.9375rem] font-display text-gray-900">
                 {m.platform_user_errors()}
               </p>
-              <p className="mt-0.5 text-sm text-gray-400">
+              <p className="mt-0.5 text-sm text-gray-600">
                 {m.platform_user_errors_description()}
               </p>
             </div>
@@ -246,7 +246,7 @@ export function StatusTab() {
             <p className="text-[0.9375rem] font-display text-gray-900">
               {m.platform_full_service_status()}
             </p>
-            <p className="mt-0.5 text-sm text-gray-400">
+            <p className="mt-0.5 text-sm text-gray-600">
               {m.platform_full_service_status_description()}
             </p>
           </div>
@@ -312,7 +312,7 @@ export function UsersTab({
                   <Badge variant="secondary">{m.platform_admin()}</Badge>
                 )}
               </div>
-              {u.email && <p className="text-xs text-gray-400">{u.email}</p>}
+              {u.email && <p className="text-xs text-gray-600">{u.email}</p>}
             </DataTableCell>
             <DataTableCell>
               <div className="flex flex-wrap items-center gap-2">
@@ -325,7 +325,7 @@ export function UsersTab({
             <DataTableCell>
               <Badge variant="outline">{u.org_plan}</Badge>
             </DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(u.created_at)}
             </DataTableCell>
             <DataTableCell align="right">
@@ -462,13 +462,13 @@ export function MessagesTab({
                     )}
                     <span className="font-medium">{thread.subject}</span>
                   </div>
-                  <p className="line-clamp-1 text-xs text-gray-400">
+                  <p className="line-clamp-1 text-xs text-gray-600">
                     {thread.latest_message_body}
                   </p>
                 </DataTableCell>
                 <DataTableCell>{thread.org_name ?? thread.org_slug ?? '-'}</DataTableCell>
                 <DataTableCell className="tabular-nums">{thread.recipient_count}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(thread.latest_message_at)}
                 </DataTableCell>
               </DataTableRow>
@@ -523,7 +523,7 @@ export function OrgsTab({
           >
             <DataTableCell>
               <span className="font-medium">{o.name}</span>
-              <p className="font-mono text-xs text-gray-400">{o.slug}</p>
+              <p className="font-mono text-xs text-gray-600">{o.slug}</p>
             </DataTableCell>
             <DataTableCell>
               <Badge variant="outline">{o.plan}</Badge>
@@ -540,7 +540,7 @@ export function OrgsTab({
                 {o.provisioning_status}
               </Badge>
             </DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(o.created_at)}
             </DataTableCell>
           </DataTableRow>
@@ -637,7 +637,7 @@ export function KbTab({
           >
             <DataTableCell>
               <span className="font-medium">{kb.name}</span>
-              <p className="font-mono text-xs text-gray-400">{kb.slug}</p>
+              <p className="font-mono text-xs text-gray-600">{kb.slug}</p>
             </DataTableCell>
             <DataTableCell>{kb.org_name}</DataTableCell>
             <DataTableCell>
@@ -648,7 +648,7 @@ export function KbTab({
               </Badge>
             </DataTableCell>
             <DataTableCell>{kb.visibility}</DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(kb.created_at)}
             </DataTableCell>
           </DataTableRow>
@@ -703,7 +703,7 @@ export function TemplatesTab({
                   <Badge variant="outline">{m.platform_inactive()}</Badge>
                 )}
               </div>
-              <p className="font-mono text-xs text-gray-400">{t.slug}</p>
+              <p className="font-mono text-xs text-gray-600">{t.slug}</p>
             </DataTableCell>
             <DataTableCell>{t.org_name}</DataTableCell>
             <DataTableCell>
@@ -714,7 +714,7 @@ export function TemplatesTab({
               </Badge>
             </DataTableCell>
             <DataTableCell>{t.created_by_name ?? t.created_by}</DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(t.created_at)}
             </DataTableCell>
           </DataTableRow>
@@ -766,7 +766,7 @@ export function BotsTab({
             </DataTableCell>
             <DataTableCell>{b.org_name}</DataTableCell>
             <DataTableCell className="tabular-nums">{b.kb_count}</DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(b.created_at)}
             </DataTableCell>
           </DataTableRow>
@@ -805,10 +805,10 @@ export function ChatErrorsTab({
               <Badge variant="destructive">{e.event_type}</Badge>
             </DataTableCell>
             <DataTableCell>{e.org_name ?? `#${e.org_id}`}</DataTableCell>
-            <DataTableCell className="max-w-md truncate text-gray-400">
+            <DataTableCell className="max-w-md truncate text-gray-600">
               {e.detail ?? '-'}
             </DataTableCell>
-            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+            <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
               {fmtDate(e.created_at)}
             </DataTableCell>
           </DataTableRow>

--- a/klai-portal/frontend/src/routes/admin/platform/-components/PlatformMessageComposer.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/PlatformMessageComposer.tsx
@@ -87,7 +87,7 @@ export function PlatformMessageComposerPanel({
         <h2 className="text-sm font-display-bold text-gray-900">
           {m.platform_messages_compose_title()}
         </h2>
-        <p className="mt-1 text-sm text-gray-400">
+        <p className="mt-1 text-sm text-gray-600">
           {m.platform_messages_compose_description({ recipient: target.recipient })}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/-feedback-helpers.tsx
@@ -229,7 +229,7 @@ export function FeedbackMetaRow({
 }) {
   return (
     <div className="space-y-1">
-      <p className="text-xs font-medium text-gray-400">{label}</p>
+      <p className="text-xs font-medium text-gray-600">{label}</p>
       <div className="text-sm text-gray-900">{value || '-'}</div>
     </div>
   )

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackItemDetailPanel.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackItemDetailPanel.tsx
@@ -410,7 +410,7 @@ function FeedbackItemDetailForm({
           {fmtDate(item.updated_at)}
         </p>
         {updateItem.isSuccess && !isEditing && (
-          <p className="text-sm text-[var(--color-success)]">
+          <p className="text-sm text-[var(--color-success-text)]">
             {m.platform_feedback_item_saved()}
           </p>
         )}
@@ -515,7 +515,7 @@ function FeedbackItemDetailForm({
               {llmPromptLabel.button}
             </Button>
             {copyNotice && (
-              <p className="text-sm text-[var(--color-success)]">
+              <p className="text-sm text-[var(--color-success-text)]">
                 {copyNotice}
               </p>
             )}
@@ -598,13 +598,13 @@ function FeedbackItemDetailForm({
                   : resolveLabel.button}
           </Button>
           {resolveNotice && (
-            <p className="text-sm text-[var(--color-success)]">{resolveNotice}</p>
+            <p className="text-sm text-[var(--color-success-text)]">{resolveNotice}</p>
           )}
           {resolveError && (
             <p className="text-sm text-[var(--color-destructive)]">{resolveError}</p>
           )}
           {updateItem.isSuccess && status !== 'resolved' && (
-            <p className="text-sm text-[var(--color-success)]">
+            <p className="text-sm text-[var(--color-success-text)]">
               {m.platform_feedback_item_saved()}
             </p>
           )}

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackItemDetailPanel.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackItemDetailPanel.tsx
@@ -96,7 +96,7 @@ export function FeedbackItemDetailPanel({
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {m.platform_feedback_item_title()}
           </h1>
-          <p className="mt-1 text-sm text-gray-400">
+          <p className="mt-1 text-sm text-gray-600">
             {m.platform_feedback_item_description()}
           </p>
         </div>
@@ -392,7 +392,7 @@ function FeedbackItemDetailForm({
           </p>
         )}
 
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {[
             feedbackItemKindLabel(item.kind),
             item.area,
@@ -405,7 +405,7 @@ function FeedbackItemDetailForm({
             .filter(Boolean)
             .join(' · ')}
         </p>
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {m.platform_col_created()} {fmtDate(item.created_at)} · {m.platform_feedback_col_updated()}{' '}
           {fmtDate(item.updated_at)}
         </p>
@@ -420,7 +420,7 @@ function FeedbackItemDetailForm({
         <section className="space-y-3 rounded-xl border border-gray-200 bg-white px-5 py-4">
           <div>
             <h3 className="text-sm font-medium text-gray-900">{m.platform_feedback_ask_info_title()}</h3>
-            <p className="mt-1 text-sm text-gray-400">{m.platform_feedback_ask_info_description()}</p>
+            <p className="mt-1 text-sm text-gray-600">{m.platform_feedback_ask_info_description()}</p>
           </div>
           <Textarea
             id={`feedback-item-ask-${item.id}`}
@@ -466,7 +466,7 @@ function FeedbackItemDetailForm({
       ) : (
         <details className="group rounded-xl border border-gray-200 bg-white">
           <summary className="flex min-h-12 cursor-pointer list-none items-center gap-3 px-4 py-3 text-sm text-gray-700 [&::-webkit-details-marker]:hidden">
-            <ChevronRight className="h-4 w-4 shrink-0 text-gray-400 transition-transform group-open:rotate-90" />
+            <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 transition-transform group-open:rotate-90" />
             <span className="min-w-0 flex-1 font-medium">
               {m.platform_feedback_linked_feedback({ count: String(submissions.length) })}
             </span>
@@ -477,12 +477,12 @@ function FeedbackItemDetailForm({
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="outline">{feedbackKindLabel(submission.event_type)}</Badge>
                   <Badge variant="secondary">{feedbackLinkTypeLabel(submission.link_type)}</Badge>
-                  <span className="text-xs text-gray-400">{fmtDate(submission.created_at)}</span>
+                  <span className="text-xs text-gray-600">{fmtDate(submission.created_at)}</span>
                 </div>
                 <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-gray-900">
                   {submission.raw_text}
                 </p>
-                <div className="mt-2 grid gap-2 text-xs text-gray-400 sm:grid-cols-2">
+                <div className="mt-2 grid gap-2 text-xs text-gray-600 sm:grid-cols-2">
                   <span>
                     {submission.org_name ?? submission.org_slug ?? m.platform_feedback_unknown_organization()}
                     {feedbackSubmissionReporterLabel(submission)

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackSubmissionDetailPanel.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackSubmissionDetailPanel.tsx
@@ -75,7 +75,7 @@ function TriageChoice({
       <Icon className="h-4 w-4 shrink-0" />
       <span className="flex min-w-0 flex-col">
         <span className="text-sm font-medium">{label}</span>
-        <span className="text-xs font-normal text-gray-400">{hint}</span>
+        <span className="text-xs font-normal text-gray-600">{hint}</span>
       </span>
     </Button>
   )
@@ -176,7 +176,7 @@ export function FeedbackSubmissionDetailPanel({
             ? m.platform_feedback_triage_title()
             : m.platform_feedback_submission_detail_title()}
         </h1>
-        <p className="mt-1 text-sm text-gray-400">
+        <p className="mt-1 text-sm text-gray-600">
           {item.org_name ?? item.org_slug ?? m.platform_feedback_unknown_organization()}
           {reporter ? ` · ${reporter}` : ''} · {fmtDate(item.created_at)}
         </p>
@@ -192,7 +192,7 @@ export function FeedbackSubmissionDetailPanel({
     <section className="space-y-2">
       <p className="whitespace-pre-wrap text-[0.9375rem] leading-7 text-gray-900">{reportText}</p>
       {item.page_url && (
-        <p className="truncate font-mono text-xs text-gray-400">{item.page_url}</p>
+        <p className="truncate font-mono text-xs text-gray-600">{item.page_url}</p>
       )}
     </section>
   )
@@ -251,14 +251,14 @@ export function FeedbackSubmissionDetailPanel({
             className="flex w-full items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white px-5 py-4 text-left klai-hover"
           >
             <span className="min-w-0">
-              <span className="block text-xs font-medium text-gray-400">
+              <span className="block text-xs font-medium text-gray-600">
                 {m.platform_feedback_belongs_to_item()}
               </span>
               <span className="mt-0.5 block truncate text-sm font-medium text-gray-900">
                 #{item.linked_item_id}
                 {item.linked_item_title ? ` · ${item.linked_item_title}` : ''}
               </span>
-              <span className="mt-0.5 block text-xs text-gray-400">
+              <span className="mt-0.5 block text-xs text-gray-600">
                 {feedbackStatusLabel(item.status)}
               </span>
             </span>
@@ -266,7 +266,7 @@ export function FeedbackSubmissionDetailPanel({
           </button>
         ) : (
           <section className="rounded-xl border border-gray-200 bg-white px-5 py-4">
-            <p className="text-xs font-medium text-gray-400">{m.platform_col_status()}</p>
+            <p className="text-xs font-medium text-gray-600">{m.platform_col_status()}</p>
             <p className="mt-1 text-sm font-medium text-gray-900">
               {feedbackStatusLabel(item.status)}
             </p>
@@ -345,7 +345,7 @@ export function FeedbackSubmissionDetailPanel({
           </div>
 
           <span className="relative block">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
             <Input
               value={search}
               onChange={(event) => setSearch(event.target.value)}
@@ -369,7 +369,7 @@ export function FeedbackSubmissionDetailPanel({
                         </span>
                       )}
                       <p className="truncate text-sm font-medium text-gray-900">{row.title}</p>
-                      {row.meta && <p className="truncate text-xs text-gray-400">{row.meta}</p>}
+                      {row.meta && <p className="truncate text-xs text-gray-600">{row.meta}</p>}
                       {isClosedItem && (
                         <div className="mt-2">
                           <Checkbox
@@ -516,7 +516,7 @@ export function FeedbackSubmissionDetailPanel({
         </div>
         <button
           type="button"
-          className="text-xs text-gray-400 underline-offset-2 hover:text-gray-600 hover:underline"
+          className="text-xs text-gray-600 underline-offset-2 hover:text-gray-900 hover:underline"
           onClick={() => setMode('status')}
         >
           {m.platform_feedback_choice_status()}

--- a/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/feedback/FeedbackTab.tsx
@@ -197,7 +197,7 @@ function FeedbackSubmissionRow({
             {feedbackKindLabel(item.event_type)}
           </Badge>
           {feedbackSignalLabel(item) && (
-            <span className="text-xs text-gray-400">{feedbackSignalLabel(item)}</span>
+            <span className="text-xs text-gray-600">{feedbackSignalLabel(item)}</span>
           )}
         </div>
       </DataTableCell>
@@ -211,10 +211,10 @@ function FeedbackSubmissionRow({
           {item.org_name ?? (item.org_id ? `#${item.org_id}` : '-')}
         </span>
         {item.org_slug && (
-          <p className="font-mono text-xs text-gray-400">{item.org_slug}</p>
+          <p className="font-mono text-xs text-gray-600">{item.org_slug}</p>
         )}
         {feedbackSubmissionReporterLabel(item) && (
-          <p className="mt-1 max-w-[180px] truncate text-xs text-gray-400">
+          <p className="mt-1 max-w-[180px] truncate text-xs text-gray-600">
             {feedbackSubmissionReporterLabel(item)}
           </p>
         )}
@@ -224,7 +224,7 @@ function FeedbackSubmissionRow({
           {item.raw_text ?? '-'}
         </p>
       </DataTableCell>
-      <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+      <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
         {fmtDate(item.created_at)}
       </DataTableCell>
       <DataTableCell align="right">
@@ -285,7 +285,7 @@ function OpenItemsPanel({
         </div>
       </div>
       {items.isFetching && !items.isLoading && (
-        <p className="mb-2 text-xs text-gray-400">
+        <p className="mb-2 text-xs text-gray-600">
           <Loader2 className="mr-2 inline h-3 w-3 animate-spin" />
           {m.platform_feedback_items_refreshing()}
         </p>
@@ -321,7 +321,7 @@ function OpenItemsPanel({
                   <span className="block truncate font-medium text-gray-900">
                     {item.title}
                   </span>
-                  <span className="mt-1 block truncate text-xs text-gray-400">
+                  <span className="mt-1 block truncate text-xs text-gray-600">
                     {item.area}
                   </span>
                 </DataTableCell>
@@ -329,7 +329,7 @@ function OpenItemsPanel({
                   <span className="block truncate text-sm text-gray-900">
                     {feedbackItemReporterSummary(item)}
                   </span>
-                  <span className="mt-1 block text-xs text-gray-400">
+                  <span className="mt-1 block text-xs text-gray-600">
                     {m.platform_feedback_reporter_counts({
                       orgs: item.org_count,
                       users: item.user_count,
@@ -340,7 +340,7 @@ function OpenItemsPanel({
                   <Badge variant="outline">{feedbackItemStatusLabel(item.status)}</Badge>
                 </DataTableCell>
                 <DataTableCell>{feedbackItemKindLabel(item.kind)}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap text-gray-400">
+                <DataTableCell className="whitespace-nowrap text-gray-600">
                   {fmtDate(item.updated_at)}
                 </DataTableCell>
                 <DataTableCell align="right">

--- a/klai-portal/frontend/src/routes/admin/platform/-components/stats/StatsTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/stats/StatsTab.tsx
@@ -141,7 +141,7 @@ export function StatsTab({
           ))}
         </div>
         {data && (
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.platform_usage_window({
               start: fmtWindowDate(data.start),
               end: fmtWindowDate(data.end, true),
@@ -208,7 +208,7 @@ export function StatsTab({
               >
                 <DataTableCell>
                   <span className="font-medium">{row.name}</span>
-                  <p className="font-mono text-xs text-gray-400">{row.slug}</p>
+                  <p className="font-mono text-xs text-gray-600">{row.slug}</p>
                   <div className="mt-1 flex gap-1">
                     <Badge variant="outline">{row.plan}</Badge>
                     <Badge variant="outline">{row.billing_status}</Badge>
@@ -221,7 +221,7 @@ export function StatsTab({
                 <DataTableCell className="tabular-nums text-[var(--color-destructive)]">{fmtNumber(row.failed_requests)}</DataTableCell>
                 <DataTableCell className="tabular-nums">{fmtCompact(row.total_tokens)}</DataTableCell>
                 <DataTableCell className="tabular-nums">{fmtSpend(row.spend_usd)}</DataTableCell>
-                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-400">
+                <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(row.last_activity_at)}
                 </DataTableCell>
               </DataTableRow>

--- a/klai-portal/frontend/src/routes/admin/platform/-components/stats/UsageSection.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/stats/UsageSection.tsx
@@ -204,7 +204,7 @@ export function UsageSection({
               ? m.platform_usage_daily_trend()
               : m.platform_usage_weekly_trend()}
           </h2>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.platform_usage_last_activity()}: {fmtDate(data.last_activity_at)}
           </p>
         </div>
@@ -311,7 +311,7 @@ function UsageBars({
                   style={{ height: barHeight(point.failed_requests) }}
                 />
               </div>
-              <span className="max-w-full truncate text-[0.625rem] text-gray-400">
+              <span className="max-w-full truncate text-[0.625rem] text-gray-600">
                 {point.label}
               </span>
             </div>

--- a/klai-portal/frontend/src/routes/admin/platform/feedback.submissions.$submissionId.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/feedback.submissions.$submissionId.tsx
@@ -37,7 +37,7 @@ function PlatformFeedbackSubmissionPage() {
   return (
     <PageContainer width="4xl" gap="8">
       {detail.isLoading && (
-        <p className="py-8 text-sm text-gray-400">
+        <p className="py-8 text-sm text-gray-600">
           <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
           {m.admin_shared_loading()}
         </p>

--- a/klai-portal/frontend/src/routes/admin/platform/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/index.tsx
@@ -209,7 +209,7 @@ function PlatformConsole() {
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {m.platform_title()}
           </h1>
-          <p className="mt-1 text-sm text-gray-400">
+          <p className="mt-1 text-sm text-gray-600">
             {m.platform_description()}
           </p>
         </div>
@@ -313,7 +313,7 @@ function PlatformConsole() {
             stats ? (
               <>
                 {stats.new_feedback_count}{' '}
-                <span className="font-display text-gray-400">
+                <span className="font-display text-gray-600">
                   {m.platform_stat_new_feedback_unit()}
                 </span>
               </>
@@ -352,7 +352,7 @@ function PlatformConsole() {
 
       <div className="flex items-center gap-3">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
           <Input
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/klai-portal/frontend/src/routes/admin/platform/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/new.tsx
@@ -69,7 +69,7 @@ function NewTenantPage() {
           {m.admin_users_cancel()}
         </Button>
       </div>
-      <p className="text-sm text-gray-400 mb-6">
+      <p className="text-sm text-gray-600 mb-6">
         {m.platform_new_tenant_description()}
       </p>
 

--- a/klai-portal/frontend/src/routes/admin/platform/onboarding-howto.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/onboarding-howto.tsx
@@ -95,7 +95,7 @@ function OnboardingHowtoPage() {
           {m.platform_back_to_platform()}
         </Button>
       </div>
-      <p className="mb-6 text-sm text-gray-400">
+      <p className="mb-6 text-sm text-gray-600">
         {m.platform_onboarding_description()}
       </p>
 

--- a/klai-portal/frontend/src/routes/admin/platform/orgs.$orgId.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/orgs.$orgId.tsx
@@ -83,7 +83,7 @@ function PlatformOrgDetailPage() {
   if (isLoading) {
     return (
       <PageContainer width="4xl">
-        <p className="py-8 text-sm text-gray-400">
+        <p className="py-8 text-sm text-gray-600">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           {m.admin_shared_loading()}
         </p>
@@ -161,7 +161,7 @@ function PlatformOrgDetailPage() {
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {data.org.name}
           </h1>
-          <div className="mt-2 flex items-center gap-2 flex-wrap text-sm text-gray-400">
+          <div className="mt-2 flex items-center gap-2 flex-wrap text-sm text-gray-600">
             <span className="font-mono">{data.org.slug}</span>
             <span>·</span>
             <Badge variant="outline">{data.org.plan}</Badge>

--- a/klai-portal/frontend/src/routes/admin/profiles/$profile/add-member.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/$profile/add-member.tsx
@@ -115,7 +115,7 @@ function AddProfileMemberPage() {
 
       <Card>
         <CardContent className="pt-6">
-          <p className="mb-4 text-sm text-gray-400">
+          <p className="mb-4 text-sm text-gray-600">
             {profileLabel}
           </p>
           <form onSubmit={handleSubmit} className="space-y-4">
@@ -154,7 +154,7 @@ function AddProfileMemberPage() {
                               }}
                             >
                               <span>{label}</span>
-                              <span className="ml-auto text-xs text-gray-400">
+                              <span className="ml-auto text-xs text-gray-600">
                                 {u.email}
                               </span>
                             </CommandItem>

--- a/klai-portal/frontend/src/routes/admin/profiles/$profile/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/$profile/index.tsx
@@ -101,7 +101,7 @@ function AdminProfileDetail() {
             {profileLabel}
           </h1>
           {profileDescription && (
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {profileDescription}
             </p>
           )}
@@ -177,14 +177,14 @@ function AdminProfileDetail() {
                       />
                     </DataTableCell>
                     <DataTableCell>{displayName(user)}</DataTableCell>
-                    <DataTableCell className="text-gray-400">{user.email}</DataTableCell>
+                    <DataTableCell className="text-gray-600">{user.email}</DataTableCell>
                     <DataTableCell className="w-28 whitespace-nowrap tabular-nums">
                       {formatDate(user.created_at)}
                     </DataTableCell>
                     <DataTableCell align="right" className="w-16">
                       {alreadyPersonal ? (
                         // No demote target on the lowest rung.
-                        <span className="text-xs text-gray-400">-</span>
+                        <span className="text-xs text-gray-600">-</span>
                       ) : (
                         <InlineDeleteConfirm
                           isConfirming={isConfirming}

--- a/klai-portal/frontend/src/routes/admin/profiles/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/profiles/index.tsx
@@ -74,7 +74,7 @@ function AdminProfiles() {
           <div className="font-medium text-gray-900">
             {info.getValue()}
           </div>
-          <div className="text-xs text-gray-400">
+          <div className="text-xs text-gray-600">
             {info.row.original.description}
           </div>
         </div>

--- a/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/$userId/edit.tsx
@@ -136,7 +136,7 @@ function EditUserPage() {
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
             {m.admin_users_edit_heading()}
           </h1>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.admin_users_edit_subtitle()}
           </p>
         </div>

--- a/klai-portal/frontend/src/routes/admin/users/_components/UserActions.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/_components/UserActions.tsx
@@ -139,7 +139,7 @@ export function UserActions({
                       >
                         {profileLabel(targetRole)}
                         {user.role === targetRole && (
-                          <span className="ml-2 text-xs text-gray-400">
+                          <span className="ml-2 text-xs text-gray-600">
                             ({m.admin_settings_saved()})
                           </span>
                         )}

--- a/klai-portal/frontend/src/routes/admin/users/index.tsx
+++ b/klai-portal/frontend/src/routes/admin/users/index.tsx
@@ -122,15 +122,15 @@ function UsersPage() {
           )}
 
           {usersQuery.isLoading ? (
-            <p className="py-8 text-sm text-gray-400">
+            <p className="py-8 text-sm text-gray-600">
               {m.admin_users_loading()}
             </p>
           ) : users.length === 0 ? (
-            <p className="py-8 text-sm text-gray-400">
+            <p className="py-8 text-sm text-gray-600">
               {m.admin_users_empty()}
             </p>
           ) : controls.filteredCount === 0 ? (
-            <p className="py-8 text-sm text-gray-400">
+            <p className="py-8 text-sm text-gray-600">
               {m.list_no_results()}
             </p>
           ) : (

--- a/klai-portal/frontend/src/routes/admin/widgets/$id.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/$id.tsx
@@ -67,7 +67,7 @@ function WidgetDetailPage() {
   if (isLoading) {
     return (
       <div className="p-6">
-        <p className="py-8 text-sm text-gray-400">
+        <p className="py-8 text-sm text-gray-600">
           <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
           {m.admin_widgets_loading()}
         </p>
@@ -116,7 +116,7 @@ function WidgetDetailPage() {
             {widget.name}
           </h1>
           {widget.description && (
-            <p className="text-sm text-gray-400 mt-1">
+            <p className="text-sm text-gray-600 mt-1">
               {widget.description}
             </p>
           )}

--- a/klai-portal/frontend/src/routes/admin/widgets/$id_.test.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/$id_.test.tsx
@@ -61,7 +61,7 @@ function WidgetTestPage() {
       <div className="fixed inset-0 z-[60] flex items-center justify-center bg-white px-6">
         <div className="max-w-md text-center">
           <p className="text-sm font-medium text-gray-900">{m.widget_chat_preview_session_error()}</p>
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-1 text-xs text-gray-600">
             {sessionQuery.error instanceof Error ? sessionQuery.error.message : m.admin_shared_error_generic()}
           </p>
         </div>

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/EmbedSnippet.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/EmbedSnippet.tsx
@@ -37,7 +37,7 @@ export function EmbedSnippet({ widgetId, title, welcomeMessage }: EmbedSnippetPr
         >
           {copied ? (
             <>
-              <Check className="h-3.5 w-3.5 text-[var(--color-success)]" />
+              <Check className="h-3.5 w-3.5 text-[var(--color-success-text)]" />
               {m.admin_widgets_widget_embed_copied()}
             </>
           ) : (

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/ActivityTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/ActivityTab.tsx
@@ -125,9 +125,9 @@ export function ActivityTab({ widget }: Props) {
       <div>
         <SectionHeading>{m.admin_widgets_activity_top_questions_title()}</SectionHeading>
         {statsQuery.isLoading ? (
-          <p className="text-sm text-gray-400">{m.admin_shared_loading()}</p>
+          <p className="text-sm text-gray-600">{m.admin_shared_loading()}</p>
         ) : (statsQuery.data?.top_queries ?? []).length === 0 ? (
-          <p className="text-sm text-gray-400">{m.admin_widgets_activity_no_questions()}</p>
+          <p className="text-sm text-gray-600">{m.admin_widgets_activity_no_questions()}</p>
         ) : (
           <ol className="space-y-2">
             {(statsQuery.data?.top_queries ?? []).map((q, idx) => (
@@ -136,7 +136,7 @@ export function ActivityTab({ widget }: Props) {
                 className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 px-3 py-2.5"
               >
                 <span className="text-sm text-gray-900 truncate">{q.query}</span>
-                <span className="text-xs font-medium text-gray-400 tabular-nums shrink-0">
+                <span className="text-xs font-medium text-gray-600 tabular-nums shrink-0">
                   {q.count}×
                 </span>
               </li>
@@ -149,12 +149,12 @@ export function ActivityTab({ widget }: Props) {
       <div>
         <SectionHeading>{m.admin_widgets_activity_recent_conversations_title()}</SectionHeading>
         {convsQuery.isLoading ? (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
             {m.admin_widgets_loading()}
           </p>
         ) : conversations.length === 0 ? (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             Nog geen gesprekken. Zodra iemand met de bot praat verschijnt
             het hier.
           </p>
@@ -168,16 +168,16 @@ export function ActivityTab({ widget }: Props) {
                   onClick={() => setOpenConvId(c.id)}
                   className="h-auto w-full justify-start rounded-none px-2 py-3.5 text-left"
                 >
-                  <MessageSquare className="h-4 w-4 mt-0.5 text-gray-400 shrink-0" />
+                  <MessageSquare className="h-4 w-4 mt-0.5 text-gray-500 shrink-0" />
                   <div className="flex-1 min-w-0">
                     <p className="truncate text-sm text-gray-900">
                       {c.first_user_query || (
-                        <span className="text-gray-400 italic">
+                        <span className="text-gray-600 italic">
                           (geen vraag opgeslagen)
                         </span>
                       )}
                     </p>
-                    <p className="mt-0.5 flex items-center gap-2 text-xs text-gray-400">
+                    <p className="mt-0.5 flex items-center gap-2 text-xs text-gray-600">
                       <span>{formatRelative(c.started_at)}</span>
                       <span>·</span>
                       <span>
@@ -216,7 +216,7 @@ export function ActivityTab({ widget }: Props) {
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400 mb-3">
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600 mb-3">
       {children}
     </h3>
   )
@@ -233,12 +233,12 @@ function StatCard({
 }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-white px-4 py-3">
-      <p className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400">
+      <p className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
         {label}
       </p>
       <p className="mt-1 text-2xl font-display-bold text-gray-900 tabular-nums">
         {loading ? (
-          <Loader2 className="inline h-4 w-4 animate-spin text-gray-400" />
+          <Loader2 className="inline h-4 w-4 animate-spin text-gray-500" />
         ) : value === undefined ? (
           '-'
         ) : (
@@ -274,7 +274,7 @@ function HourlySparkline({ data }: { data: number[] | undefined }) {
           )
         })}
       </div>
-      <div className="mt-1 flex justify-between text-[0.625rem] text-gray-400 tabular-nums">
+      <div className="mt-1 flex justify-between text-[0.625rem] text-gray-600 tabular-nums">
         <span>00</span>
         <span>06</span>
         <span>12</span>
@@ -313,7 +313,7 @@ function ConversationDrawer({
               Gesprek #{convId}
             </p>
             {query.data && (
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-gray-600">
                 {formatRelative(query.data.started_at)} ·{' '}
                 {query.data.message_count === 1
                   ? '1 bericht'
@@ -335,7 +335,7 @@ function ConversationDrawer({
 
         <div className="px-5 py-4 space-y-3">
           {query.isLoading && (
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
               Laden…
             </p>

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/AppearanceTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/AppearanceTab.tsx
@@ -88,7 +88,7 @@ export function AppearanceTab({ widget }: Props) {
         <SectionHeading>{m.admin_widgets_appearance_section_brand()}</SectionHeading>
         <div className="space-y-1.5 max-w-sm">
           <Label htmlFor="widget-primary-color">{m.admin_widgets_brand_color_label()}</Label>
-          <p className="text-xs text-gray-400">{m.admin_widgets_brand_color_help()}</p>
+          <p className="text-xs text-gray-600">{m.admin_widgets_brand_color_help()}</p>
           <div className="flex items-center gap-2">
             <Input
               id="widget-primary-color"
@@ -137,7 +137,7 @@ export function AppearanceTab({ widget }: Props) {
         <SectionHeading>{m.admin_widgets_appearance_section_welcome()}</SectionHeading>
         <div className="space-y-1.5">
           <Label htmlFor="widget-welcome">{m.admin_widgets_welcome_label()}</Label>
-          <p className="text-xs text-gray-400">{m.admin_widgets_welcome_help()}</p>
+          <p className="text-xs text-gray-600">{m.admin_widgets_welcome_help()}</p>
           <Input
             id="widget-welcome"
             value={welcome}
@@ -152,7 +152,7 @@ export function AppearanceTab({ widget }: Props) {
         <SectionHeading>{m.admin_widgets_appearance_section_starters()}</SectionHeading>
         <div className="space-y-1.5">
           <Label htmlFor="widget-starters">{m.admin_widgets_widget_starters_label()}</Label>
-          <p className="text-xs text-gray-400">{m.admin_widgets_widget_starters_help()}</p>
+          <p className="text-xs text-gray-600">{m.admin_widgets_widget_starters_help()}</p>
           <Textarea
             id="widget-starters"
             value={startersRaw}
@@ -160,7 +160,7 @@ export function AppearanceTab({ widget }: Props) {
             rows={4}
             placeholder={m.admin_widgets_widget_starters_placeholder()}
           />
-          <p className="text-xs text-gray-400">{starters.length}/{MAX_STARTERS}</p>
+          <p className="text-xs text-gray-600">{starters.length}/{MAX_STARTERS}</p>
         </div>
       </section>
 
@@ -222,6 +222,6 @@ export function AppearanceTab({ widget }: Props) {
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400 mb-3">{children}</h3>
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600 mb-3">{children}</h3>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/DangerTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/DangerTab.tsx
@@ -32,7 +32,7 @@ export function DangerTab({ widget }: Props) {
         <h2 className="text-sm font-medium text-[var(--color-destructive)] mb-2">
           {m.admin_widgets_delete_section_title()}
         </h2>
-        <p className="text-sm text-gray-400 mb-4">
+        <p className="text-sm text-gray-600 mb-4">
           {m.admin_widgets_delete_section_description()}
         </p>
         <InlineDeleteConfirm

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/DetailsTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/DetailsTab.tsx
@@ -97,7 +97,7 @@ export function DetailsTab({ widget }: Props) {
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="widget-description">{m.admin_widgets_details_role_scope_label()}</Label>
-            <p className="text-xs text-gray-400">{m.admin_widgets_details_role_scope_help()}</p>
+            <p className="text-xs text-gray-600">{m.admin_widgets_details_role_scope_help()}</p>
             <Textarea
               id="widget-description"
               value={description}
@@ -116,7 +116,7 @@ export function DetailsTab({ widget }: Props) {
           {templatesQuery.data && templatesQuery.data.length > 0 && (
             <div className="space-y-1.5">
               <Label htmlFor="widget-template">{m.admin_widgets_widget_template_label()}</Label>
-              <p className="text-xs text-gray-400">{m.admin_widgets_widget_template_help()}</p>
+              <p className="text-xs text-gray-600">{m.admin_widgets_widget_template_help()}</p>
               <Select
                 id="widget-template"
                 value={templateSlug}
@@ -132,7 +132,7 @@ export function DetailsTab({ widget }: Props) {
           )}
           <div className="space-y-1.5">
             <Label htmlFor="widget-system-prompt">{m.admin_widgets_widget_system_prompt_label()}</Label>
-            <p className="text-xs text-gray-400">{m.admin_widgets_widget_system_prompt_help()}</p>
+            <p className="text-xs text-gray-600">{m.admin_widgets_widget_system_prompt_help()}</p>
             <Textarea
               id="widget-system-prompt"
               value={systemPrompt}
@@ -170,6 +170,6 @@ export function DetailsTab({ widget }: Props) {
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400 mb-3">{children}</h3>
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600 mb-3">{children}</h3>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
@@ -187,7 +187,7 @@ export function EmbedTab({ widget }: Props) {
               {m.admin_widgets_allow_any_origin_label()}
             </label>
             {allowAnyOrigin && (
-              <div className="flex items-start gap-1.5 text-xs text-[var(--color-warning)]">
+              <div className="flex items-start gap-1.5 text-xs text-[var(--color-warning-text)]">
                 <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-px" />
                 {m.admin_widgets_allow_any_origin_warning()}
               </div>

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/EmbedTab.tsx
@@ -199,7 +199,7 @@ export function EmbedTab({ widget }: Props) {
           <Label htmlFor="widget-origins">
             {m.admin_widgets_widget_origins_label()}
           </Label>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.admin_widgets_widget_origins_help()}
           </p>
           <Textarea
@@ -219,8 +219,8 @@ export function EmbedTab({ widget }: Props) {
             </p>
           )}
           {origins.length === 0 && !allowAnyOrigin && (
-            <div className="flex items-start gap-1.5 text-xs text-gray-400">
-              <Info className="h-3.5 w-3.5 shrink-0 mt-px text-gray-400" />
+            <div className="flex items-start gap-1.5 text-xs text-gray-600">
+              <Info className="h-3.5 w-3.5 shrink-0 mt-px text-gray-500" />
               {m.admin_widgets_widget_origins_empty_warning()}
             </div>
           )}

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/IntegrationsTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/IntegrationsTab.tsx
@@ -60,7 +60,7 @@ export function IntegrationsTab({ widget }: Props) {
         <h2 className="text-lg font-display-bold text-gray-900">
           {m.admin_widgets_integrations_title()}
         </h2>
-        <p className="max-w-2xl text-sm text-gray-400">
+        <p className="max-w-2xl text-sm text-gray-600">
           {m.admin_widgets_integrations_intro({ name: widget.name })}
         </p>
       </div>
@@ -146,7 +146,7 @@ export function IntegrationsTab({ widget }: Props) {
           </p>
           <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
             <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-              <dt className="text-xs font-medium text-gray-400">
+              <dt className="text-xs font-medium text-gray-600">
                 {m.admin_widgets_integrations_target_label()}
               </dt>
               <dd className="mt-1 font-medium text-gray-800">
@@ -154,7 +154,7 @@ export function IntegrationsTab({ widget }: Props) {
               </dd>
             </div>
             <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-              <dt className="text-xs font-medium text-gray-400">
+              <dt className="text-xs font-medium text-gray-600">
                 {m.admin_widgets_integrations_channel_label()}
               </dt>
               <dd className="mt-1 font-medium text-gray-800">
@@ -162,7 +162,7 @@ export function IntegrationsTab({ widget }: Props) {
               </dd>
             </div>
             <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-              <dt className="text-xs font-medium text-gray-400">
+              <dt className="text-xs font-medium text-gray-600">
                 {m.admin_widgets_integrations_mode_label()}
               </dt>
               <dd className="mt-1 font-medium text-gray-800">
@@ -171,7 +171,7 @@ export function IntegrationsTab({ widget }: Props) {
             </div>
           </dl>
           {(status?.channel_account_id || status?.last_test_thread_id) && (
-            <div className="mt-4 flex flex-wrap gap-x-5 gap-y-1 text-xs text-gray-400">
+            <div className="mt-4 flex flex-wrap gap-x-5 gap-y-1 text-xs text-gray-600">
               {status?.channel_account_id && (
                 <span>
                   {m.admin_widgets_integrations_channel_account_label()}: {status.channel_account_id}

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/KnowledgeBasesTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/KnowledgeBasesTab.tsx
@@ -32,7 +32,7 @@ export function KnowledgeBasesTab({ widget }: Props) {
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       <section className="space-y-4">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.admin_widgets_wizard_kb_access_intro_widget()}
         </p>
         <KbAccessEditor value={kbIds} onChange={setKbIds} />

--- a/klai-portal/frontend/src/routes/admin/widgets/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/new.tsx
@@ -575,7 +575,7 @@ function NewWidgetPage() {
                   {m.admin_widgets_allow_any_origin_label()}
                 </label>
                 {form.allow_any_origin && (
-                  <div className="flex items-start gap-1.5 text-xs text-[var(--color-warning)]">
+                  <div className="flex items-start gap-1.5 text-xs text-[var(--color-warning-text)]">
                     <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-px" />
                     {m.admin_widgets_allow_any_origin_warning()}
                   </div>

--- a/klai-portal/frontend/src/routes/admin/widgets/new.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/new.tsx
@@ -260,7 +260,7 @@ function NewWidgetPage() {
                   <Label htmlFor="widget-description">
                     {m.admin_widgets_details_role_scope_label()}
                   </Label>
-                  <p className="text-xs text-gray-400">
+                  <p className="text-xs text-gray-600">
                     {m.admin_widgets_details_role_scope_help()}
                   </p>
                   <Textarea
@@ -287,7 +287,7 @@ function NewWidgetPage() {
                     <Label htmlFor="widget-template">
                       {m.admin_widgets_widget_template_label()}
                     </Label>
-                    <p className="text-xs text-gray-400">
+                    <p className="text-xs text-gray-600">
                       {m.admin_widgets_widget_template_help()}
                     </p>
                     <Select
@@ -311,7 +311,7 @@ function NewWidgetPage() {
                   <Label htmlFor="widget-system-prompt">
                     {m.admin_widgets_widget_system_prompt_label()}
                   </Label>
-                  <p className="text-xs text-gray-400">
+                  <p className="text-xs text-gray-600">
                     {m.admin_widgets_widget_system_prompt_help()}
                   </p>
                   <Textarea
@@ -341,7 +341,7 @@ function NewWidgetPage() {
 
         {step === 'kbs' && (
           <section className="space-y-4">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.admin_widgets_wizard_kb_access_intro_widget()}
             </p>
             <KbAccessEditor
@@ -362,7 +362,7 @@ function NewWidgetPage() {
                 <Label htmlFor="widget-primary-color">
                   {m.admin_widgets_brand_color_label()}
                 </Label>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {m.admin_widgets_brand_color_help()}
                 </p>
                 <div className="flex items-center gap-2">
@@ -432,7 +432,7 @@ function NewWidgetPage() {
                 <Label htmlFor="widget-welcome">
                   {m.admin_widgets_welcome_label()}
                 </Label>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {m.admin_widgets_welcome_help()}
                 </p>
                 <Input
@@ -455,7 +455,7 @@ function NewWidgetPage() {
                 <Label htmlFor="widget-starters">
                   {m.admin_widgets_widget_starters_label()}
                 </Label>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {m.admin_widgets_widget_starters_help()}
                 </p>
                 <Textarea
@@ -467,7 +467,7 @@ function NewWidgetPage() {
                   rows={4}
                   placeholder={m.admin_widgets_widget_starters_placeholder()}
                 />
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {starters.length}/{MAX_STARTERS}
                 </p>
               </div>
@@ -552,7 +552,7 @@ function NewWidgetPage() {
 
         {step === 'embed' && (
           <section className="space-y-4">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               Standaard werkt je widget overal. Wil je hem alleen op
               specifieke domeinen laten laden? Vul ze hieronder in - één
               per regel. Laat leeg om overal toe te staan.
@@ -585,7 +585,7 @@ function NewWidgetPage() {
             <div className="space-y-1.5">
               <Label htmlFor="widget-origins">
                 {m.admin_widgets_widget_origins_label()}
-                <span className="ml-2 text-xs font-normal text-gray-400">
+                <span className="ml-2 text-xs font-normal text-gray-600">
                   (optioneel)
                 </span>
               </Label>
@@ -603,7 +603,7 @@ function NewWidgetPage() {
                 className="font-mono"
               />
             </div>
-            <p className="text-xs text-gray-400 pt-2">
+            <p className="text-xs text-gray-600 pt-2">
               Na aanmaken vind je de share-link, embed-code en testknop op
               de Insluiten-tab van je widget - daar kun je deze lijst ook
               later nog aanpassen.
@@ -664,7 +664,7 @@ function NewWidgetPage() {
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-400 mb-3">
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600 mb-3">
       {children}
     </h3>
   )

--- a/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
+++ b/klai-portal/frontend/src/routes/app/_components/ChatConfigBar.tsx
@@ -171,7 +171,7 @@ export function ChatConfigBar() {
 
       {/* Chat met: (knowledge collections) */}
       <div className="flex items-center gap-2 min-w-0">
-        <span className="text-[0.8125rem] text-gray-400 whitespace-nowrap">{m.chatbar_chat_with()}</span>
+        <span className="text-[0.8125rem] text-gray-600 whitespace-nowrap">{m.chatbar_chat_with()}</span>
 
         <div className="relative z-50 min-w-0">
           <button
@@ -188,7 +188,7 @@ export function ChatConfigBar() {
           {collOpen && (
             <div className="absolute left-0 top-full z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white py-1.5 shadow-lg">
               <div className="flex items-center justify-between px-3 py-1.5">
-                <span className="text-[0.625rem] font-semibold tracking-wide text-gray-400">{m.chatbar_collections_label()}</span>
+                <span className="text-[0.625rem] font-semibold tracking-wide text-gray-600">{m.chatbar_collections_label()}</span>
                 <button
                   type="button"
                   onClick={toggleAll}
@@ -207,7 +207,7 @@ export function ChatConfigBar() {
                   className={`h-2 w-2 shrink-0 rounded-full ${pref.kb_personal_enabled ? 'bg-[var(--color-success)]' : 'bg-gray-200'}`}
                 />
                 <span
-                  className={pref.kb_personal_enabled ? 'text-gray-900 font-medium' : 'text-gray-400'}
+                  className={pref.kb_personal_enabled ? 'text-gray-900 font-medium' : 'text-gray-600'}
                 >
                   {m.chatbar_personal()}
                 </span>
@@ -227,7 +227,7 @@ export function ChatConfigBar() {
                     className={
                       currentSlugs.includes(kb.slug)
                         ? 'text-gray-900 font-medium'
-                        : 'text-gray-400'
+                        : 'text-gray-600'
                     }
                   >
                     {kb.name}
@@ -258,7 +258,7 @@ export function ChatConfigBar() {
           (deploy/litellm/klai_knowledge.py) reads it per-request and
           injects the corresponding system-prompt header. */}
       <div className="flex items-center gap-2 min-w-0">
-        <span className="text-[0.8125rem] text-gray-400 whitespace-nowrap">
+        <span className="text-[0.8125rem] text-gray-600 whitespace-nowrap">
           {m.chatbar_mode_label()}:
         </span>
         <div
@@ -309,7 +309,7 @@ export function ChatConfigBar() {
             onClick={() => setModeInfoOpen((v) => !v)}
             aria-label={`${m.chatbar_mode_label()} - uitleg`}
             aria-expanded={modeInfoOpen}
-            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-400 hover:text-gray-900 klai-hover"
+            className="inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-500 hover:text-gray-900 klai-hover"
           >
             <Info className="h-3.5 w-3.5" strokeWidth={1.75} />
           </button>
@@ -331,7 +331,7 @@ export function ChatConfigBar() {
       {/* Instructions: multi-select. Hidden when backend has no instructions yet. */}
       {allInstructions.length > 0 && (
         <div className="flex items-center gap-2 min-w-0">
-          <span className="text-[0.8125rem] text-gray-400 whitespace-nowrap">
+          <span className="text-[0.8125rem] text-gray-600 whitespace-nowrap">
             {m.chatbar_instructions_label()}:
           </span>
 
@@ -352,7 +352,7 @@ export function ChatConfigBar() {
             {instrOpen && (
               <div className="absolute left-0 top-full z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white py-1.5 shadow-lg">
                 <div className="flex items-center justify-between px-3 py-1.5">
-                  <span className="text-[0.625rem] font-semibold tracking-wide text-gray-400">
+                  <span className="text-[0.625rem] font-semibold tracking-wide text-gray-600">
                     {m.chatbar_instructions_label()}
                   </span>
                   <button
@@ -375,7 +375,7 @@ export function ChatConfigBar() {
                       <span
                         className={`h-2 w-2 shrink-0 rounded-full ${active ? 'bg-[var(--color-success)]' : 'bg-gray-200'}`}
                       />
-                      <span className={active ? 'text-gray-900 font-medium' : 'text-gray-400'}>
+                      <span className={active ? 'text-gray-900 font-medium' : 'text-gray-600'}>
                         {t.name}
                       </span>
                     </button>

--- a/klai-portal/frontend/src/routes/app/account.tsx
+++ b/klai-portal/frontend/src/routes/app/account.tsx
@@ -215,7 +215,7 @@ function AccountPage() {
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           {m.account_heading()}
         </h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.account_subtitle()}
         </p>
       </div>
@@ -229,13 +229,13 @@ function AccountPage() {
               <dl className="space-y-3">
                 {name && (
                   <div className="flex flex-col gap-1 sm:flex-row sm:gap-4">
-                    <dt className="w-32 shrink-0 text-sm text-gray-400">Naam</dt>
+                    <dt className="w-32 shrink-0 text-sm text-gray-600">Naam</dt>
                     <dd className="text-sm font-medium text-gray-900">{name}</dd>
                   </div>
                 )}
                 {email && (
                   <div className="flex flex-col gap-1 sm:flex-row sm:gap-4">
-                    <dt className="w-32 shrink-0 text-sm text-gray-400">E-mail</dt>
+                    <dt className="w-32 shrink-0 text-sm text-gray-600">E-mail</dt>
                     <dd className="text-sm font-medium text-gray-900">{email}</dd>
                   </div>
                 )}
@@ -247,7 +247,7 @@ function AccountPage() {
             <h2 className="text-sm font-medium text-gray-900 mb-2">
               {m.account_language_title()}
             </h2>
-            <p className="text-sm text-gray-400 mb-6">
+            <p className="text-sm text-gray-600 mb-6">
               {m.account_language_description()}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
@@ -308,7 +308,7 @@ function AccountPage() {
         <div className="space-y-6">
           <div>
             <h2 className="text-sm font-medium text-gray-900 mb-2">{m.account_sar_title()}</h2>
-            <p className="text-sm text-gray-400 mb-4">
+            <p className="text-sm text-gray-600 mb-4">
               {m.account_sar_description()}
             </p>
             <Button
@@ -788,7 +788,7 @@ function FeedRow({
           <h3 className="truncate text-sm font-medium text-gray-900">{title}</h3>
         </div>
         <p className="mt-1 line-clamp-1 text-sm text-gray-500">{snippet}</p>
-        <p className="mt-1 text-xs text-gray-400">{date}</p>
+        <p className="mt-1 text-xs text-gray-600">{date}</p>
       </div>
     </button>
   )
@@ -826,7 +826,7 @@ function FeedbackFeedRow({
         ) : (
           <p className="mt-1 line-clamp-1 text-sm text-gray-500">{item.raw_text}</p>
         )}
-        <p className="mt-1 text-xs text-gray-400">
+        <p className="mt-1 text-xs text-gray-600">
           {m.account_feedback_updated()} {formatFeedbackDate(item.latest_update_at, locale)}
         </p>
       </div>
@@ -853,7 +853,7 @@ function PanelHeader({
     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
       <div>
         <h2 className="text-sm font-medium text-gray-900 mb-2">{title}</h2>
-        <p className="text-sm text-gray-400">{description}</p>
+        <p className="text-sm text-gray-600">{description}</p>
       </div>
       {unreadCount > 0 && (
         <Button

--- a/klai-portal/frontend/src/routes/app/chat.tsx
+++ b/klai-portal/frontend/src/routes/app/chat.tsx
@@ -206,8 +206,8 @@ function ChatPage() {
         {/* Loading overlay */}
         {showOverlay && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-[var(--color-secondary)]">
-            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
-            <span className="text-sm text-gray-400">
+            <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
+            <span className="text-sm text-gray-600">
               {m.chat_health_loading()}
             </span>
           </div>
@@ -216,12 +216,12 @@ function ChatPage() {
         {/* Error / stuck state */}
         {showError && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-[var(--color-secondary)]">
-            <AlertTriangle className="h-8 w-8 text-gray-400" />
+            <AlertTriangle className="h-8 w-8 text-gray-500" />
             <div className="text-center">
               <p className="text-sm font-medium text-gray-900">
                 {phase === 'stuck' ? m.chat_health_stuck_title() : m.chat_health_failed_title()}
               </p>
-              <p className="mt-1 max-w-sm text-xs text-gray-400">
+              <p className="mt-1 max-w-sm text-xs text-gray-600">
                 {phase === 'stuck'
                   ? m.chat_health_stuck_description()
                   : getErrorMessage(errorReason)}

--- a/klai-portal/frontend/src/routes/app/docs/$kbSlug/$pageId.lazy.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/$kbSlug/$pageId.lazy.tsx
@@ -309,7 +309,7 @@ function KBPageEditor() {
   // REQ-STA-04: Page not found UI - shown when UUID/slug is not in pageIndex
   if (pageNotFound) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 text-gray-400">
+      <div className="flex flex-col items-center justify-center h-full gap-4 text-gray-600">
         <p className="text-lg font-medium">{m.docs_page_not_found()}</p>
         <p className="text-sm">{m.docs_page_not_found_desc()}</p>
         <button
@@ -410,7 +410,7 @@ function KBPageEditor() {
             className="w-[360px] max-w-[90vw] rounded-xl border border-gray-200 bg-[var(--color-card)] p-4 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <p className="mb-2 text-xs text-gray-400">{m.docs_wikilink_connect()}</p>
+            <p className="mb-2 text-xs text-gray-600">{m.docs_wikilink_connect()}</p>
             <Input
               autoFocus
               placeholder={m.docs_wikilink_search_placeholder()}
@@ -442,7 +442,7 @@ function KBPageEditor() {
                   </button>
                 ))}
               {pageIndex.filter((p) => p.slug !== selectedPath).length === 0 && (
-                <p className="px-3 py-2 text-xs text-gray-400">{m.docs_wikilink_no_results()}</p>
+                <p className="px-3 py-2 text-xs text-gray-600">{m.docs_wikilink_no_results()}</p>
               )}
             </div>
           </div>

--- a/klai-portal/frontend/src/routes/app/docs/$kbSlug/index.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/$kbSlug/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/app/docs/$kbSlug/')({
 
 function NoPageSelected() {
   return (
-    <div className="flex-1 flex items-center justify-center text-sm text-gray-400">
+    <div className="flex-1 flex items-center justify-center text-sm text-gray-600">
       {m.docs_editor_select_page()}
     </div>
   )

--- a/klai-portal/frontend/src/routes/app/docs/index.tsx
+++ b/klai-portal/frontend/src/routes/app/docs/index.tsx
@@ -94,7 +94,7 @@ function DocsPage() {
               <ListRowContent>
                 <div className="flex items-baseline gap-2 flex-wrap">
                   <ListRowTitle>{kb.name}</ListRowTitle>
-                  <span className="inline-flex items-center gap-1 text-xs text-gray-400">
+                  <span className="inline-flex items-center gap-1 text-xs text-gray-600">
                     {kb.visibility === 'public' ? <Globe size={11} /> : <Lock size={11} />}
                     {kb.visibility === 'public' ? m.docs_kb_visibility_public() : m.docs_kb_visibility_private()}
                   </span>
@@ -134,7 +134,7 @@ function DocsPage() {
                 </ListRowIcon>
                 <ListRowContent>
                   <div className="flex items-baseline gap-2 flex-wrap">
-                    <ListRowTitle className="text-gray-400">{kb.name}</ListRowTitle>
+                    <ListRowTitle className="text-gray-600">{kb.name}</ListRowTitle>
                     <Badge variant="outline" className="text-[0.625rem] py-0 px-1.5">{m.docs_kb_locked_badge()}</Badge>
                   </div>
                 </ListRowContent>

--- a/klai-portal/frontend/src/routes/app/gaps/index.tsx
+++ b/klai-portal/frontend/src/routes/app/gaps/index.tsx
@@ -116,7 +116,7 @@ function GapsPage() {
           </h1>
         </div>
         <Tooltip label={m.capability_tooltip_knowledge_only()}>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.capability_tooltip_knowledge_only()}
           </p>
         </Tooltip>
@@ -143,7 +143,7 @@ function GapsPage() {
         </Button>
       </div>
 
-      <p className="text-gray-400 mb-6 leading-relaxed">
+      <p className="text-gray-600 mb-6 leading-relaxed">
         {m.gaps_index_card_body()}
       </p>
 
@@ -209,13 +209,13 @@ function GapsPage() {
                       {gap.gap_type === 'hard' ? m.gaps_type_hard() : m.gaps_type_soft()}
                     </Badge>
                   </DataTableCell>
-                  <DataTableCell className="text-gray-400">
+                  <DataTableCell className="text-gray-600">
                     {gap.nearest_kb_slug ?? '—'}
                   </DataTableCell>
                   <DataTableCell align="right" className="font-medium tabular-nums">
                     {gap.occurrence_count}
                   </DataTableCell>
-                  <DataTableCell align="right" className="whitespace-nowrap tabular-nums text-gray-400">
+                  <DataTableCell align="right" className="whitespace-nowrap tabular-nums text-gray-600">
                     {new Date(gap.last_occurred).toLocaleDateString()}
                   </DataTableCell>
                   <DataTableCell align="right">

--- a/klai-portal/frontend/src/routes/app/index.tsx
+++ b/klai-portal/frontend/src/routes/app/index.tsx
@@ -36,7 +36,7 @@ function AppHome() {
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           {getGreeting(userName)}
         </h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.app_home_subtitle()}
         </p>
       </div>
@@ -52,14 +52,14 @@ function AppHome() {
                 data-help-id={tool.helpId}
                 className="group flex items-center gap-3 px-2 py-3.5 klai-hover"
               >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center text-gray-400">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center text-gray-500">
                   <tool.icon className="h-4 w-4" />
                 </div>
                 <div className="min-w-0 flex-1">
                   <span className="text-[0.9375rem] font-display text-gray-900">
                     {tool.title()}
                   </span>
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {tool.description()}
                   </p>
                 </div>

--- a/klai-portal/frontend/src/routes/app/instructions/$slug.edit.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/$slug.edit.tsx
@@ -51,7 +51,7 @@ function EditInstructionRoute() {
   if (isLoading) {
     return (
       <PageContainer width="lg">
-        <p className="text-sm text-gray-400">{m.instructions_form_loading()}</p>
+        <p className="text-sm text-gray-600">{m.instructions_form_loading()}</p>
       </PageContainer>
     )
   }

--- a/klai-portal/frontend/src/routes/app/instructions/-instruction-form.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/-instruction-form.tsx
@@ -186,7 +186,7 @@ export function InstructionFormPage({
       <div className="mb-6 flex items-start justify-between gap-3">
         <div className="space-y-1">
           <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">{title}</h1>
-          <p className="text-sm text-gray-400">{m.instructions_form_subtitle()}</p>
+          <p className="text-sm text-gray-600">{m.instructions_form_subtitle()}</p>
         </div>
         <Button
           type="button"
@@ -232,7 +232,7 @@ export function InstructionFormPage({
                   ? 'text-xs text-[var(--color-destructive)]'
                   : promptWarning
                     ? 'text-xs text-[var(--color-warning)]'
-                    : 'text-xs text-gray-400'
+                    : 'text-xs text-gray-600'
               }
               data-testid="prompt-char-count"
             >
@@ -261,7 +261,7 @@ export function InstructionFormPage({
             <option value="personal">{m.instructions_list_scope_personal()}</option>
           </Select>
           {!canManageOrgTemplates && (
-            <p className="text-xs text-gray-400">{m.instructions_form_scope_org_disabled_tooltip()}</p>
+            <p className="text-xs text-gray-600">{m.instructions_form_scope_org_disabled_tooltip()}</p>
           )}
         </div>
 

--- a/klai-portal/frontend/src/routes/app/instructions/-instruction-form.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/-instruction-form.tsx
@@ -231,7 +231,7 @@ export function InstructionFormPage({
                 promptOverLimit
                   ? 'text-xs text-[var(--color-destructive)]'
                   : promptWarning
-                    ? 'text-xs text-[var(--color-warning)]'
+                    ? 'text-xs text-[var(--color-warning-text)]'
                     : 'text-xs text-gray-600'
               }
               data-testid="prompt-char-count"

--- a/klai-portal/frontend/src/routes/app/instructions/__tests__/instructions-form.test.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/__tests__/instructions-form.test.tsx
@@ -189,7 +189,7 @@ describe('InstructionFormPage - char counter', () => {
       </Wrapper>,
     )
     const counter = screen.getByTestId('prompt-char-count')
-    expect(counter.className).toContain('text-gray-400')
+    expect(counter.className).toContain('text-gray-600')
   })
 
   it('counter switches to amber at 7800+ chars', () => {

--- a/klai-portal/frontend/src/routes/app/instructions/__tests__/instructions-form.test.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/__tests__/instructions-form.test.tsx
@@ -200,7 +200,7 @@ describe('InstructionFormPage - char counter', () => {
       </Wrapper>,
     )
     const counter = screen.getByTestId('prompt-char-count')
-    expect(counter.className).toContain('text-[var(--color-warning)]')
+    expect(counter.className).toContain('text-[var(--color-warning-text)]')
   })
 
   it('counter switches to destructive at 8001+ chars', () => {

--- a/klai-portal/frontend/src/routes/app/instructions/index.tsx
+++ b/klai-portal/frontend/src/routes/app/instructions/index.tsx
@@ -149,7 +149,7 @@ export function InstructionsPage() {
         <div className="rounded-lg border border-dashed border-gray-200 py-16 text-center">
           <Sliders className="h-10 w-10 text-gray-300 mx-auto mb-3" />
           <p className="text-base font-medium text-gray-900">{m.instructions_empty_title()}</p>
-          <p className="text-sm text-gray-400 mt-1 max-w-md mx-auto">
+          <p className="text-sm text-gray-600 mt-1 max-w-md mx-auto">
             {m.instructions_empty_description()}
           </p>
           <Button

--- a/klai-portal/frontend/src/routes/app/integrations.tsx
+++ b/klai-portal/frontend/src/routes/app/integrations.tsx
@@ -57,7 +57,7 @@ function IntegrationsPage() {
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           {m.integrations_heading()}
         </h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.integrations_subtitle()}
         </p>
       </div>
@@ -75,7 +75,7 @@ function IntegrationsPage() {
       {isLoading && (
         <Card>
           <CardContent className="pt-6">
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.integrations_loading()}
             </p>
           </CardContent>
@@ -92,7 +92,7 @@ function IntegrationsPage() {
             <div className="rounded-lg bg-[var(--color-muted)] p-4 font-mono text-sm">
               https://mcp.getklai.com/mcp
             </div>
-            <p className="mt-3 text-sm text-gray-400">
+            <p className="mt-3 text-sm text-gray-600">
               {m.integrations_empty_hint()}
             </p>
           </CardContent>
@@ -148,13 +148,13 @@ function IntegrationsPage() {
           <CardContent>
             <dl className="space-y-2 text-sm">
               <div className="flex gap-3">
-                <dt className="w-32 shrink-0 text-gray-400">
+                <dt className="w-32 shrink-0 text-gray-600">
                   {m.integrations_field_created()}
                 </dt>
                 <dd>{formatDate(token.created_at)}</dd>
               </div>
               <div className="flex gap-3">
-                <dt className="w-32 shrink-0 text-gray-400">
+                <dt className="w-32 shrink-0 text-gray-600">
                   {m.integrations_field_last_used()}
                 </dt>
                 <dd>
@@ -164,7 +164,7 @@ function IntegrationsPage() {
                 </dd>
               </div>
               <div className="flex gap-3">
-                <dt className="w-32 shrink-0 text-gray-400">
+                <dt className="w-32 shrink-0 text-gray-600">
                   {m.integrations_field_expires()}
                 </dt>
                 <dd>{formatDate(token.expires_at)}</dd>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-connectors-row.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-connectors-row.tsx
@@ -72,14 +72,14 @@ export function ConnectorRow({
     <DataTableRow className="group klai-hover">
       <DataTableCell className="w-6 px-0 pr-2 align-top">
         <Tooltip className="leading-none mt-px" label={typeLabel}>
-          <Icon className="h-4 w-4 text-gray-400" />
+          <Icon className="h-4 w-4 text-gray-500" />
         </Tooltip>
       </DataTableCell>
       <DataTableCell className="align-top">
         <span className="font-medium text-gray-900">{connector.name}</span>
       </DataTableCell>
       <DataTableCell className="w-28 align-top">
-        <span className="text-xs text-gray-400">{typeLabel}</span>
+        <span className="text-xs text-gray-600">{typeLabel}</span>
       </DataTableCell>
       <DataTableCell className="w-32 align-top">
         <SyncStatusBadge
@@ -111,7 +111,7 @@ export function ConnectorRow({
           </div>
         )}
         {connector.last_sync_documents_ok != null && connector.last_sync_documents_ok > 0 && (
-          <p className="mt-0.5 text-xs text-gray-400 tabular-nums">
+          <p className="mt-0.5 text-xs text-gray-600 tabular-nums">
             {connector.last_sync_documents_ok.toLocaleString()} {m.connectors_documents_indexed()}
           </p>
         )}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-helpers.tsx
@@ -73,7 +73,7 @@ export function SyncStatusBadge({
         <Tooltip label={exact}>
           <div className="inline-flex flex-col items-start gap-1">
             <Badge variant="success" className="whitespace-nowrap">{m.admin_connectors_status_completed()}</Badge>
-            <span className="text-[0.6875rem] text-gray-400 whitespace-nowrap">{formatRelativeTime(lastSyncAt)}</span>
+            <span className="text-[0.6875rem] text-gray-600 whitespace-nowrap">{formatRelativeTime(lastSyncAt)}</span>
           </div>
         </Tooltip>
       )

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-content.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-content.tsx
@@ -35,7 +35,7 @@ function ConnectorContent({ data }: { data: ContentResponse }) {
   const items = data.items ?? []
   if (items.length === 0) {
     return (
-      <div className="pl-[60px] pr-4 pb-3 text-xs text-gray-400">
+      <div className="pl-[60px] pr-4 pb-3 text-xs text-gray-600">
         {m.kb_sources_content_empty_connector()}
       </div>
     )
@@ -44,15 +44,15 @@ function ConnectorContent({ data }: { data: ContentResponse }) {
     <div className="pl-[60px] pr-4 pb-3 space-y-1">
       {items.map((item) => (
         <div key={item.id} className="flex items-center gap-2 text-xs py-1.5">
-          <File className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          <File className="h-3.5 w-3.5 text-gray-500 shrink-0" />
           <span className="text-gray-700 flex-1 truncate">{item.path}</span>
-          <span className="text-gray-400 shrink-0">
+          <span className="text-gray-600 shrink-0">
             {m.kb_sources_content_item_chunks({ count: String(item.chunks_count) })}
           </span>
         </div>
       ))}
       {data.total > items.length && (
-        <p className="text-xs text-gray-400 pt-1">
+        <p className="text-xs text-gray-600 pt-1">
           {m.kb_sources_content_overflow_items({ count: String(data.total - items.length) })}
         </p>
       )}
@@ -66,9 +66,9 @@ function UploadContent({ source, data }: { source: Source; data: ContentResponse
     if (source.source_url) {
       return (
         <div className="pl-[60px] pr-4 pb-3 flex items-center gap-2 text-xs">
-          <File className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          <File className="h-3.5 w-3.5 text-gray-500 shrink-0" />
           <span className="text-gray-700 truncate">{source.source_url}</span>
-          <span className="text-gray-400 shrink-0">{m.kb_sources_content_url_badge()}</span>
+          <span className="text-gray-600 shrink-0">{m.kb_sources_content_url_badge()}</span>
         </div>
       )
     }
@@ -79,7 +79,7 @@ function UploadContent({ source, data }: { source: Source; data: ContentResponse
     // Don't claim "no chunks indexed" in the indexed-Gesynct case - that
     // contradicts the badge. Speak to the preview gap instead.
     return (
-      <div className="pl-[60px] pr-4 pb-3 text-xs text-gray-400">
+      <div className="pl-[60px] pr-4 pb-3 text-xs text-gray-600">
         {m.kb_sources_content_no_preview()}
       </div>
     )
@@ -88,7 +88,7 @@ function UploadContent({ source, data }: { source: Source; data: ContentResponse
     <div className="pl-[60px] pr-4 pb-3 space-y-2">
       {chunks.map((chunk) => (
         <div key={chunk.id} className="text-xs py-1.5">
-          <div className="flex items-center gap-2 text-gray-400 mb-0.5">
+          <div className="flex items-center gap-2 text-gray-600 mb-0.5">
             <span>{m.kb_sources_content_chunk_position({ pos: String(chunk.position + 1) })}</span>
             <span>·</span>
             <span>{m.kb_sources_content_chunk_tokens({ count: String(chunk.token_count) })}</span>
@@ -97,7 +97,7 @@ function UploadContent({ source, data }: { source: Source; data: ContentResponse
         </div>
       ))}
       {data.total > chunks.length && (
-        <p className="text-xs text-gray-400 pt-1">
+        <p className="text-xs text-gray-600 pt-1">
           {m.kb_sources_content_overflow_chunks({ count: String(data.total - chunks.length) })}
         </p>
       )}
@@ -110,7 +110,7 @@ export function SourceContent({ kbSlug, source }: DrillDownProps) {
 
   if (isLoading) {
     return (
-      <div className="pl-[60px] pr-4 pb-3 flex items-center gap-2 text-xs text-gray-400">
+      <div className="pl-[60px] pr-4 pb-3 flex items-center gap-2 text-xs text-gray-600">
         <Loader2 className="h-3 w-3 animate-spin" />
         {m.kb_sources_content_loading()}
       </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -150,7 +150,7 @@ export function StatusBadge({ source }: { source: Source }) {
       return (
         <span className="inline-flex items-center gap-1.5">
           <Badge variant="secondary">{m.kb_status_bezig()}</Badge>
-          <span className="text-xs text-gray-400">
+          <span className="text-xs text-gray-600">
             {m.kb_status_bezig_elapsed({ minutes: String(minutes) })}
           </span>
         </span>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-sources-helpers.tsx
@@ -184,7 +184,7 @@ export function FailedItemsWarning({ source }: { source: Source }) {
   const failedCount = source.items_failed_count ?? 0
   if (failedCount <= 0) return null
   return (
-    <span className="text-xs text-[var(--color-warning)]">
+    <span className="text-xs text-[var(--color-warning-text)]">
       {m.kb_connector_failed_items({ count: String(failedCount) })}
     </span>
   )

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-InviteSection.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-InviteSection.tsx
@@ -68,7 +68,7 @@ export function InviteSection({
             }
           }}
         >
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-600" />
           <Input
             value={search}
             onChange={(e) => onSearchChange(e.target.value)}
@@ -98,7 +98,7 @@ export function InviteSection({
                       className="w-full px-3 py-2 text-left text-sm klai-hover"
                     >
                       <span className="text-gray-900">{user.display_name}</span>
-                      <span className="ml-2 text-xs text-gray-400">{user.email}</span>
+                      <span className="ml-2 text-xs text-gray-600">{user.email}</span>
                     </button>
                   ))}
             </div>
@@ -113,7 +113,7 @@ export function InviteSection({
       {children}
 
       {isEmpty && !isOwner && (
-        <p className="text-sm text-gray-400">{emptyReadOnlyMessage}</p>
+        <p className="text-sm text-gray-600">{emptyReadOnlyMessage}</p>
       )}
     </div>
   )

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-MemberRow.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/-MemberRow.tsx
@@ -32,18 +32,18 @@ export function MemberRow(props: MemberRowProps) {
         <div>
           <span className="text-sm text-gray-900">{props.member.display_name ?? props.member.email ?? props.member.user_id}</span>
           {props.member.display_name && props.member.email && (
-            <span className="ml-2 text-xs text-gray-400">{props.member.email}</span>
+            <span className="ml-2 text-xs text-gray-600">{props.member.email}</span>
           )}
         </div>
       )}
 
       <div className="flex items-center gap-2">
-        <span className="text-xs text-gray-400">{props.member.role}</span>
+        <span className="text-xs text-gray-600">{props.member.role}</span>
         {isOwner && canRemove && (
           <button
             type="button"
             onClick={() => onRemove(props.member.id)}
-            className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
+            className="flex h-6 w-6 items-center justify-center text-gray-500 hover:text-[var(--color-destructive)] transition-colors"
             aria-label="Remove member"
           >
             <X className="h-3.5 w-3.5" />

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageNodeRow.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageNodeRow.tsx
@@ -163,7 +163,7 @@ export function CoverageNodeRow({
               </span>
             )}
             {!isConfirmingDelete && !isEditing && (
-              <span className="text-xs text-gray-400 tabular-nums">
+              <span className="text-xs text-gray-600 tabular-nums">
                 {pct}%
               </span>
             )}
@@ -173,13 +173,13 @@ export function CoverageNodeRow({
           <Textarea
             value={editingDescription}
             onChange={(e) => setEditingDescription(e.target.value)}
-            className="mb-1 resize-none text-xs text-gray-400"
+            className="mb-1 resize-none text-xs text-gray-600"
             rows={2}
             placeholder={m.knowledge_taxonomy_node_description_placeholder()}
             onKeyDown={(e) => { if (e.key === 'Escape') onCancelEdit() }}
           />
         ) : node.description ? (
-          <p className="text-xs text-gray-400 mb-1 line-clamp-2">
+          <p className="text-xs text-gray-600 mb-1 line-clamp-2">
             {node.description}
           </p>
         ) : null}
@@ -191,7 +191,7 @@ export function CoverageNodeRow({
         />
       </div>
       <div className="flex items-center gap-3 mt-1.5">
-        <span className="text-xs text-gray-400">
+        <span className="text-xs text-gray-600">
           {m.knowledge_taxonomy_coverage_chunks({ count: String(node.chunk_count) })}
         </span>
         {node.gap_count > 0 && (

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageNodeRow.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageNodeRow.tsx
@@ -195,7 +195,7 @@ export function CoverageNodeRow({
           {m.knowledge_taxonomy_coverage_chunks({ count: String(node.chunk_count) })}
         </span>
         {node.gap_count > 0 && (
-          <span className="text-xs text-[var(--color-warning)]">
+          <span className="text-xs text-[var(--color-warning-text)]">
             {m.knowledge_taxonomy_coverage_gaps({ count: String(node.gap_count) })}
           </span>
         )}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageWidget.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/CoverageWidget.tsx
@@ -69,11 +69,11 @@ export function CoverageWidget({
     // chunk counts as untagged.
     return (
       <div className="space-y-3">
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.knowledge_taxonomy_coverage_empty()}
         </p>
         {isBackfilling ? (
-          <div className="inline-flex items-center gap-1.5 text-xs text-gray-400">
+          <div className="inline-flex items-center gap-1.5 text-xs text-gray-600">
             <Loader2 className="h-3 w-3 animate-spin" />
             <span>{m.knowledge_taxonomy_categorising_status()}</span>
           </div>
@@ -93,7 +93,7 @@ export function CoverageWidget({
                 }
               </Button>
               {isSuggesting && (
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {m.knowledge_taxonomy_suggest_loading_hint()}
                 </p>
               )}
@@ -147,15 +147,15 @@ export function CoverageWidget({
       {coverage.untagged_count > 0 && (
         <div className="rounded-lg border border-dashed border-gray-200 p-3">
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-sm text-gray-400">
+            <span className="text-sm text-gray-600">
               {m.knowledge_taxonomy_coverage_untagged()}
             </span>
             <div className="flex items-center gap-2 shrink-0">
-              <span className="text-xs text-gray-400 tabular-nums">
+              <span className="text-xs text-gray-600 tabular-nums">
                 {untaggedPct}% {m.knowledge_taxonomy_coverage_untagged().toLowerCase()}
               </span>
               {isBackfilling ? (
-                <div className="inline-flex items-center gap-1 text-xs text-gray-400">
+                <div className="inline-flex items-center gap-1 text-xs text-gray-600">
                   <Loader2 className="h-3 w-3 animate-spin" />
                   <span>{m.knowledge_taxonomy_categorising_status()}</span>
                 </div>
@@ -206,7 +206,7 @@ export function CoverageWidget({
               style={{ width: `${untaggedPct}%` }}
             />
           </div>
-          <span className="text-xs text-gray-400 mt-1.5 block">
+          <span className="text-xs text-gray-600 mt-1.5 block">
             {m.knowledge_taxonomy_coverage_chunks({ count: String(coverage.untagged_count) })}
           </span>
         </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/GoogleDrivePicker.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/GoogleDrivePicker.tsx
@@ -272,7 +272,7 @@ export function GoogleDrivePicker({
     <div className="rounded-lg border border-gray-200 bg-white">
       <div className="border-b border-gray-200 px-3 py-2">
         <p className="text-sm font-medium text-gray-900">Kies wat je wilt syncen</p>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="text-xs text-gray-600 mt-0.5">
           Kies een map of losse ondersteunde bestanden. Docs, Sheets en Slides worden
           automatisch omgezet; video, audio, afbeeldingen en archives worden niet getoond.
         </p>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/KBOverviewSections.tsx
@@ -51,11 +51,11 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
     <div className="space-y-8">
       <DashboardSection icon={BookOpen} title={m.knowledge_detail_section_docs()}>
         {!kb.docs_enabled ? (
-          <p className="text-sm text-gray-400">{m.knowledge_detail_docs_not_enabled()}</p>
+          <p className="text-sm text-gray-600">{m.knowledge_detail_docs_not_enabled()}</p>
         ) : (
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <FileText className="h-4 w-4 text-gray-400" />
+              <FileText className="h-4 w-4 text-gray-500" />
               <span className="text-sm text-gray-900">{docsLabel}</span>
             </div>
             {kb.gitea_repo_slug && (
@@ -72,7 +72,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
       <DashboardSection icon={BarChart2} title={m.knowledge_detail_section_stats()}>
         <div className="flex gap-8 mb-5">
           <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_search_index()}</p>
+            <p className="text-xs text-gray-600 tracking-wide mb-1">{m.knowledge_detail_stats_search_index()}</p>
             <p className="text-sm font-medium text-gray-900">
               {stats?.volume != null
                 ? m.knowledge_detail_volume({ count: String(stats.volume) })
@@ -80,7 +80,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
             </p>
           </div>
           <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_queries()}</p>
+            <p className="text-xs text-gray-600 tracking-wide mb-1">{m.knowledge_detail_stats_queries()}</p>
             <p className="text-sm font-medium text-gray-900">
               {stats?.usage_last_30d != null
                 ? String(stats.usage_last_30d)
@@ -88,7 +88,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
             </p>
           </div>
           <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_users()}</p>
+            <p className="text-xs text-gray-600 tracking-wide mb-1">{m.knowledge_detail_stats_users()}</p>
             <p className="text-sm font-medium text-gray-900">
               {stats?.unique_users_30d != null
                 ? String(stats.unique_users_30d)
@@ -96,7 +96,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
             </p>
           </div>
           <div>
-            <p className="text-xs text-gray-400 tracking-wide mb-1">{m.knowledge_detail_stats_active_days()}</p>
+            <p className="text-xs text-gray-600 tracking-wide mb-1">{m.knowledge_detail_stats_active_days()}</p>
             <p className="text-sm font-medium text-gray-900">
               {stats?.active_days_30d != null
                 ? m.knowledge_detail_active_days_value({ count: String(stats.active_days_30d) })
@@ -106,7 +106,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
           {user?.isAdmin === true && stats?.org_gap_count_7d != null && (
             <Link to="/app/gaps" className="group">
               <div>
-                <p className="text-xs text-gray-400 tracking-wide mb-1 flex items-center gap-1">
+                <p className="text-xs text-gray-600 tracking-wide mb-1 flex items-center gap-1">
                   <AlertTriangle className="h-3 w-3" />
                   {m.gaps_overview_tile()}
                 </p>
@@ -120,12 +120,12 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
 
         {/* Breakdown per database */}
         <div>
-          <p className="text-xs text-gray-400 tracking-wide mb-2">
+          <p className="text-xs text-gray-600 tracking-wide mb-2">
             {m.knowledge_detail_volume_breakdown_title()}
           </p>
           <div className="grid grid-cols-3 gap-3">
             <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <Database className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <Database className="h-4 w-4 text-gray-500 mt-0.5 shrink-0" />
               <div>
                 <p className="text-xs font-medium text-gray-900">
                   {m.knowledge_detail_volume_sources()}
@@ -138,7 +138,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
               </div>
             </div>
             <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <Search className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <Search className="h-4 w-4 text-gray-500 mt-0.5 shrink-0" />
               <div>
                 <p className="text-xs font-medium text-gray-900">
                   {m.knowledge_detail_volume_search_chunks()}
@@ -151,7 +151,7 @@ export function KBOverviewSections({ kbSlug }: { kbSlug: string }) {
               </div>
             </div>
             <div className="flex items-start gap-2 rounded-lg border border-gray-200 p-3">
-              <GitBranch className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <GitBranch className="h-4 w-4 text-gray-500 mt-0.5 shrink-0" />
               <div>
                 <p className="text-xs font-medium text-gray-900">
                   {m.knowledge_detail_volume_graph()}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/MsDocsFolderPicker.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/MsDocsFolderPicker.tsx
@@ -104,7 +104,7 @@ function ItemNode({
               e.stopPropagation()
               setExpanded((p) => !p)
             }}
-            className="inline-flex h-5 w-5 items-center justify-center text-gray-400 hover:text-gray-900"
+            className="inline-flex h-5 w-5 items-center justify-center text-gray-500 hover:text-gray-900"
             aria-label={expanded ? 'Inklappen' : 'Uitklappen'}
           >
             {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
@@ -125,12 +125,12 @@ function ItemNode({
         )}
         {isFolder ? (
           expanded ? (
-            <FolderOpen className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+            <FolderOpen className="h-3.5 w-3.5 text-gray-500 shrink-0" />
           ) : (
-            <Folder className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+            <Folder className="h-3.5 w-3.5 text-gray-500 shrink-0" />
           )
         ) : (
-          <File className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+          <File className="h-3.5 w-3.5 text-gray-500 shrink-0" />
         )}
         <span
           className={[
@@ -141,14 +141,14 @@ function ItemNode({
           {item.name}
         </span>
         {isFolder && item.child_count > 0 && (
-          <span className="text-[0.6875rem] text-gray-400 shrink-0">{item.child_count}</span>
+          <span className="text-[0.6875rem] text-gray-600 shrink-0">{item.child_count}</span>
         )}
       </div>
       {expanded && isFolder && (
         <div>
           {isLoading && (
             <div
-              className="flex items-center gap-2 text-xs text-gray-400 py-1"
+              className="flex items-center gap-2 text-xs text-gray-600 py-1"
               style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
             >
               <Loader2 className="h-3 w-3 animate-spin" />
@@ -157,7 +157,7 @@ function ItemNode({
           )}
           {data && data.folders.length === 0 && !isLoading && (
             <div
-              className="text-xs text-gray-400 italic py-1"
+              className="text-xs text-gray-600 italic py-1"
               style={{ paddingLeft: `${(depth + 1) * 16 + 4}px` }}
             >
               Leeg
@@ -263,7 +263,7 @@ export function MsDocsFolderPicker({
     <div className="rounded-lg border border-gray-200 bg-white">
       <div className="border-b border-gray-200 px-3 py-2">
         <p className="text-sm font-medium text-gray-900">Kies wat je wilt syncen</p>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="text-xs text-gray-600 mt-0.5">
           Klik op &#9656; om een map uit te klappen. Klik op een map om de hele map
           te syncen, of vink losse bestanden aan voor alleen die bestanden.
         </p>
@@ -277,12 +277,12 @@ export function MsDocsFolderPicker({
           ].join(' ')}
           onClick={selectWholeDrive}
         >
-          <Folder className="h-3.5 w-3.5 text-gray-400" />
+          <Folder className="h-3.5 w-3.5 text-gray-500" />
           <span className="text-sm text-gray-900">Hele drive (alles)</span>
         </div>
 
         {isLoading && (
-          <div className="flex items-center gap-2 px-2 py-2 text-xs text-gray-400">
+          <div className="flex items-center gap-2 px-2 py-2 text-xs text-gray-600">
             <Loader2 className="h-3 w-3 animate-spin" />
             Mappen laden…
           </div>
@@ -293,7 +293,7 @@ export function MsDocsFolderPicker({
           </div>
         )}
         {data?.folders.length === 0 && !isLoading && (
-          <div className="px-2 py-2 text-xs text-gray-400">Deze drive is leeg.</div>
+          <div className="px-2 py-2 text-xs text-gray-600">Deze drive is leeg.</div>
         )}
         {data?.folders.map((item) => (
           <ItemNode
@@ -312,7 +312,7 @@ export function MsDocsFolderPicker({
       </div>
 
       <div className="flex items-center justify-between gap-2 border-t border-gray-200 px-3 py-2">
-        <p className="text-xs text-gray-400 truncate">{summary}</p>
+        <p className="text-xs text-gray-600 truncate">{summary}</p>
         <div className="flex items-center gap-2 shrink-0">
           <Button type="button" size="sm" variant="outline" onClick={onCancel}>
             Annuleren

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/ProposalCard.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/ProposalCard.tsx
@@ -113,7 +113,7 @@ export function ProposalCard({
               <Badge variant={statusBadge.variant}>{statusBadge.label}</Badge>
               <Badge variant={typeInfo.variant}>{typeInfo.label()}</Badge>
               {proposal.confidence_score != null && (
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-600">
                   {m.knowledge_taxonomy_proposals_col_confidence()}: {Math.round(proposal.confidence_score * 100)}%
                 </span>
               )}
@@ -164,11 +164,11 @@ export function ProposalCard({
               <>
                 <p className="text-sm font-medium text-gray-900">{proposal.title}</p>
                 {description && (
-                  <p className="text-xs text-gray-400 mt-0.5">
+                  <p className="text-xs text-gray-600 mt-0.5">
                     {description}
                   </p>
                 )}
-                <p className="text-xs text-gray-400 mt-0.5">
+                <p className="text-xs text-gray-600 mt-0.5">
                   {new Date(proposal.created_at).toLocaleDateString()}
                   {proposal.rejection_reason && (
                     <span className="ml-2">- {proposal.rejection_reason}</span>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/_components/TaxonomyTab.tsx
@@ -257,8 +257,8 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
       {/* Active filters bar */}
       {hasFilter && (
         <div className="flex items-center flex-wrap gap-2">
-          <Filter className="h-3.5 w-3.5 text-gray-400 shrink-0" />
-          <span className="text-xs text-gray-400">{m.knowledge_taxonomy_filter_heading()}:</span>
+          <Filter className="h-3.5 w-3.5 text-gray-500 shrink-0" />
+          <span className="text-xs text-gray-600">{m.knowledge_taxonomy_filter_heading()}:</span>
           {activeNode && (
             <button
               type="button"
@@ -283,7 +283,7 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
           <button
             type="button"
             onClick={clearAllFilters}
-            className="text-xs text-gray-400 hover:text-gray-900 transition-colors ml-1"
+            className="text-xs text-gray-600 hover:text-gray-900 transition-colors ml-1"
           >
             {m.knowledge_taxonomy_filter_clear_all()}
           </button>
@@ -302,7 +302,7 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
               <button
                 type="button"
                 onClick={() => setActiveNodeId(null)}
-                className="text-xs text-gray-400 hover:text-gray-900 transition-colors"
+                className="text-xs text-gray-600 hover:text-gray-900 transition-colors"
               >
                 {m.knowledge_taxonomy_coverage_filter_clear()}
               </button>
@@ -317,7 +317,7 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
             </div>
           </div>
           {coverageQuery.isLoading && (
-            <p className="py-3 text-sm text-gray-400">
+            <p className="py-3 text-sm text-gray-600">
               <Loader2 className="inline h-4 w-4 animate-spin mr-1" />
               {m.knowledge_taxonomy_coverage_loading()}
             </p>
@@ -442,19 +442,19 @@ export function TaxonomyTab({ kbSlug: kbSlugProp }: { kbSlug?: string } = {}) {
             {m.knowledge_taxonomy_tags_heading()}
           </h2>
           {activeNodeId !== null && activeNode && (
-            <span className="text-xs text-gray-400">
+            <span className="text-xs text-gray-600">
               {m.knowledge_taxonomy_coverage_filter_active({ name: activeNode.name })}
             </span>
           )}
         </div>
         {topTagsQuery.isLoading && (
-          <p className="py-3 text-sm text-gray-400">
+          <p className="py-3 text-sm text-gray-600">
             <Loader2 className="inline h-4 w-4 animate-spin mr-1" />
             {m.knowledge_taxonomy_tags_loading()}
           </p>
         )}
         {topTagsQuery.data && topTagsQuery.data.tags.length === 0 && (
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.knowledge_taxonomy_tags_empty()}
           </p>
         )}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -144,7 +144,7 @@ function ConnectorsTab() {
   return (
     <div className="space-y-3">
       {showOAuthBanner && (
-        <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success)]">
+        <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success-text)]">
           <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1">{m.admin_connectors_oauth_success()}</span>
           <button onClick={() => setShowOAuthBanner(false)} aria-label={m.admin_connectors_dismiss()} className="hover:opacity-70 transition-opacity">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -232,7 +232,7 @@ function ConnectorsTab() {
             <AlertDialogDescription asChild>
               <div className="space-y-2 text-left">
                 <p>{m.admin_connectors_investigate_body()}</p>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {m.admin_connectors_investigate_hint()}
                 </p>
               </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/items.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/items.tsx
@@ -107,10 +107,10 @@ function ItemsTab() {
                 {item.assertion_mode ? (
                   <Badge variant="secondary">{item.assertion_mode}</Badge>
                 ) : (
-                  <span className="text-gray-400">-</span>
+                  <span className="text-gray-600">-</span>
                 )}
               </DataTableCell>
-              <DataTableCell className="text-gray-400">
+              <DataTableCell className="text-gray-600">
                 {new Date(item.created_at).toLocaleDateString()}
               </DataTableCell>
               <DataTableCell align="right">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/members.tsx
@@ -93,12 +93,12 @@ function MembersTab() {
 
   if (isPersonal) {
     return (
-      <p className="text-sm text-gray-400">{m.knowledge_members_personal_kb_hint()}</p>
+      <p className="text-sm text-gray-600">{m.knowledge_members_personal_kb_hint()}</p>
     )
   }
 
   if (isLoading) {
-    return <p className="text-sm text-gray-400">{m.admin_connectors_loading()}</p>
+    return <p className="text-sm text-gray-600">{m.admin_connectors_loading()}</p>
   }
 
   const visibilityMode = kb ? deriveVisibilityMode(kb) : 'restricted'
@@ -155,13 +155,13 @@ function MembersTab() {
             type="checkbox"
             checked={allowContribute}
             onChange={handleContributeToggle}
-            className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-400 focus:ring-[var(--color-ring)]"
+            className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-500 focus:ring-[var(--color-ring)]"
           />
           <div>
             <span className="text-sm font-medium text-gray-900">
               {m.knowledge_sharing_contributor_toggle()}
             </span>
-            <p className="text-xs text-gray-400 mt-0.5">
+            <p className="text-xs text-gray-600 mt-0.5">
               {m.knowledge_sharing_contributor_toggle_description()}
             </p>
           </div>
@@ -223,7 +223,7 @@ function MembersTab() {
         ))}
       </InviteSection>
 
-      <p className="text-xs text-gray-400 italic">
+      <p className="text-xs text-gray-600 italic">
         {m.knowledge_sharing_creator_note({ name: '' })}
       </p>
 
@@ -307,10 +307,10 @@ function VisibilitySelector({ visibilityMode, onVisibilityChange }: VisibilitySe
                 : 'border-gray-200 hover:border-gray-300'
             }`}
           >
-            <Icon className="h-4 w-4 mt-0.5 shrink-0 text-gray-400" />
+            <Icon className="h-4 w-4 mt-0.5 shrink-0 text-gray-500" />
             <div>
               <span className="text-sm font-medium text-gray-900">{label}</span>
-              <p className="text-xs text-gray-400 mt-0.5">{description}</p>
+              <p className="text-xs text-gray-600 mt-0.5">{description}</p>
             </div>
           </button>
         ))}
@@ -322,7 +322,7 @@ function VisibilitySelector({ visibilityMode, onVisibilityChange }: VisibilitySe
 function VisibilitySummary({ visibilityMode }: { visibilityMode: VisibilityMode }) {
   const Icon = getVisibilityOptions().find((option) => option.mode === visibilityMode)?.icon ?? Lock
   return (
-    <div className="flex items-center gap-2 text-sm text-gray-400">
+    <div className="flex items-center gap-2 text-sm text-gray-600">
       <Icon className="h-4 w-4" />
       <span>
         {visibilityMode === 'public' && m.knowledge_sharing_visibility_public()}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/route.tsx
@@ -173,7 +173,7 @@ function KbLayout() {
 
   if (isError || !kb) {
     return (
-      <div className="mx-auto max-w-3xl px-6 pb-10 pt-10 text-gray-400">
+      <div className="mx-auto max-w-3xl px-6 pb-10 pt-10 text-gray-600">
         {m.knowledge_detail_not_found()}
       </div>
     )
@@ -198,7 +198,7 @@ function KbLayout() {
       </div>
 
       {kb.description && (
-        <p className="text-sm text-gray-400 mb-6">{kb.description}</p>
+        <p className="text-sm text-gray-600 mb-6">{kb.description}</p>
       )}
 
       {/* Tab bar */}
@@ -214,7 +214,7 @@ function KbLayout() {
                 className={`flex items-center gap-1.5 pb-3 text-sm font-medium border-b-2 transition-colors ${
                   isActive
                     ? 'border-gray-900 text-gray-900'
-                    : 'border-transparent text-gray-400 hover:text-gray-900'
+                    : 'border-transparent text-gray-600 hover:text-gray-900'
                 }`}
               >
                 <Icon className="h-4 w-4" />

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
@@ -148,7 +148,7 @@ function SettingsTab() {
               disabled
               className="bg-[var(--color-secondary)] text-gray-400"
             />
-            <p className="text-xs text-gray-400">
+            <p className="text-xs text-gray-600">
               {m.knowledge_settings_slug_hint()}
             </p>
           </div>
@@ -173,7 +173,7 @@ function SettingsTab() {
             </div>
           )}
           {!isOwner && (
-            <p className="text-xs text-gray-400 pt-2">
+            <p className="text-xs text-gray-600 pt-2">
               {m.knowledge_settings_readonly_notice()}
             </p>
           )}
@@ -193,7 +193,7 @@ function SettingsTab() {
                   <ListRowTitle>{u.email || u.user_id}</ListRowTitle>
                 </ListRowContent>
                 <ListRowActions>
-                  <span className="text-xs text-gray-400 capitalize shrink-0">{u.role}</span>
+                  <span className="text-xs text-gray-600 capitalize shrink-0">{u.role}</span>
                 </ListRowActions>
               </ListRow>
             ))}
@@ -207,7 +207,7 @@ function SettingsTab() {
           <h2 className="text-sm font-semibold text-[var(--color-destructive)]">
             {m.knowledge_settings_danger_heading()}
           </h2>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.knowledge_settings_danger_description()}
           </p>
           <div className="pt-2">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/settings.tsx
@@ -165,7 +165,7 @@ function SettingsTab() {
                 {updateMutation.isPending ? m.knowledge_settings_saving() : m.knowledge_settings_save()}
               </Button>
               {showSaved && (
-                <span className="flex items-center gap-1 text-sm text-[var(--color-success)]">
+                <span className="flex items-center gap-1 text-sm text-[var(--color-success-text)]">
                   <Check className="h-4 w-4" />
                   {m.knowledge_settings_saved()}
                 </span>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -442,7 +442,7 @@ function AddConnectorPage() {
                       !available ? 'cursor-not-allowed opacity-50' : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
                     ].join(' ')}
                   >
-                    <Icon className="h-4 w-4 text-gray-400" />
+                    <Icon className="h-4 w-4 text-gray-500" />
                     <span className="text-sm font-medium text-gray-900">{label()}</span>
                     {!available && <Badge variant="outline" className="text-xs">{m.admin_connectors_coming_soon()}</Badge>}
                   </button>
@@ -503,7 +503,7 @@ function AddConnectorPage() {
                     <div className="space-y-1.5">
                       <Label htmlFor="notion-token">{m.admin_connectors_notion_access_token()}</Label>
                       <Input id="notion-token" type="password" required placeholder={m.admin_connectors_notion_access_token_placeholder()} value={notionConfig.access_token} onChange={(e) => setNotionConfig((p) => ({ ...p, access_token: e.target.value }))} />
-                      <p className="text-xs text-gray-400">
+                      <p className="text-xs text-gray-600">
                         {m.admin_connectors_notion_token_help_prefix()}{' '}
                         <a
                           href="https://www.notion.so/my-integrations"
@@ -572,13 +572,13 @@ function AddConnectorPage() {
                 </div>
                 <div className="rounded-lg border border-gray-200 bg-white px-4 py-3">
                   <div className="flex items-start gap-3">
-                    <SiGoogledrive className="mt-0.5 h-5 w-5 shrink-0 text-gray-400" />
+                    <SiGoogledrive className="mt-0.5 h-5 w-5 shrink-0 text-gray-500" />
                     <div className="space-y-3">
                       <div className="space-y-1">
                         <p className="text-sm font-medium text-gray-900">
                           {m.admin_connectors_google_drive_picker_title()}
                         </p>
-                        <p className="text-xs leading-5 text-gray-400">
+                        <p className="text-xs leading-5 text-gray-600">
                           {m.admin_connectors_google_drive_picker_body()}
                         </p>
                       </div>
@@ -594,15 +594,15 @@ function AddConnectorPage() {
                       </div>
                       <div className="grid gap-2 text-xs text-gray-500 sm:grid-cols-3">
                         <span className="flex items-center gap-1.5">
-                          <Shield className="h-3.5 w-3.5 text-gray-400" />
+                          <Shield className="h-3.5 w-3.5 text-gray-500" />
                           {m.admin_connectors_google_drive_flow_auth()}
                         </span>
                         <span className="flex items-center gap-1.5">
-                          <FileText className="h-3.5 w-3.5 text-gray-400" />
+                          <FileText className="h-3.5 w-3.5 text-gray-500" />
                           {m.admin_connectors_google_drive_flow_select()}
                         </span>
                         <span className="flex items-center gap-1.5">
-                          <CheckCircle2 className="h-3.5 w-3.5 text-gray-400" />
+                          <CheckCircle2 className="h-3.5 w-3.5 text-gray-500" />
                           {m.admin_connectors_google_drive_flow_sync()}
                         </span>
                       </div>
@@ -634,7 +634,7 @@ function AddConnectorPage() {
                 </div>
                 <button
                   type="button"
-                  className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+                  className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors"
                   onClick={() => setShowMsAdvanced((p) => !p)}
                 >
                   <Settings className="h-3 w-3" />
@@ -651,7 +651,7 @@ function AddConnectorPage() {
                         value={msSiteUrl}
                         onChange={(e) => { setMsSiteUrl(e.target.value); setMsSiteUrlError(null) }}
                       />
-                      <p className="text-xs text-gray-400">{m.admin_connectors_ms_docs_site_url_help()}</p>
+                      <p className="text-xs text-gray-600">{m.admin_connectors_ms_docs_site_url_help()}</p>
                       {msSiteUrlError && (
                         <p className="text-xs text-[var(--color-destructive)]">{msSiteUrlError}</p>
                       )}
@@ -664,7 +664,7 @@ function AddConnectorPage() {
                         value={msDriveId}
                         onChange={(e) => setMsDriveId(e.target.value)}
                       />
-                      <p className="text-xs text-gray-400">{m.admin_connectors_ms_docs_drive_id_help()}</p>
+                      <p className="text-xs text-gray-600">{m.admin_connectors_ms_docs_drive_id_help()}</p>
                     </div>
                   </div>
                 )}
@@ -770,7 +770,7 @@ function AddConnectorPage() {
                 <div className="space-y-1.5">
                   <Label htmlFor="json-feed-url">{m.admin_connectors_json_feed_url_label()}</Label>
                   <Input id="json-feed-url" type="url" required placeholder={m.admin_connectors_json_feed_url_hint()} value={jsonFeedConfig.url} onChange={(e) => setJsonFeedConfig({ url: e.target.value })} />
-                  <p className="text-xs text-gray-400">{m.admin_connectors_json_feed_help()}</p>
+                  <p className="text-xs text-gray-600">{m.admin_connectors_json_feed_help()}</p>
                 </div>
                 {createMutation.error && (
                   <p className="text-sm text-[var(--color-destructive)]">
@@ -836,7 +836,7 @@ function AddConnectorPage() {
                       <p className="text-sm font-medium text-gray-900">
                         Is this site behind a login?
                       </p>
-                      <p className="text-xs text-gray-400">
+                      <p className="text-xs text-gray-600">
                         Some knowledge bases require you to be logged in to see the content.
                         We&apos;ll verify either way before letting you save.
                       </p>
@@ -969,13 +969,13 @@ function AddConnectorPage() {
                         sites land here only after auth-setup returned auth_ok. */}
                     {requiresLogin === false && (
                       <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
-                        <div className="flex items-center gap-2 text-xs text-gray-400">
+                        <div className="flex items-center gap-2 text-xs text-gray-600">
                           <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success)]" />
                           Public site - no login needed
                         </div>
                         <button
                           type="button"
-                          className="text-xs text-gray-400 hover:text-gray-900"
+                          className="text-xs text-gray-600 hover:text-gray-900"
                           onClick={() => setWcStep('auth-question')}
                         >
                           Actually, it needs login
@@ -990,7 +990,7 @@ function AddConnectorPage() {
                         </div>
                         <button
                           type="button"
-                          className="text-xs text-gray-400 hover:text-gray-900"
+                          className="text-xs text-gray-600 hover:text-gray-900"
                           onClick={() => setWcStep('auth-setup')}
                         >
                           Edit cookies
@@ -1014,7 +1014,7 @@ function AddConnectorPage() {
                         {/* Advanced: content selector */}
                         <button
                           type="button"
-                          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+                          className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors"
                           onClick={() => setShowAdvancedSelector((p) => !p)}
                         >
                           <Settings className="h-3 w-3" />
@@ -1029,7 +1029,7 @@ function AddConnectorPage() {
                               value={webcrawlerConfig.content_selector}
                               onChange={(e) => setWebcrawlerConfig((p) => ({ ...p, content_selector: e.target.value }))}
                             />
-                            <p className="text-xs text-gray-400">
+                            <p className="text-xs text-gray-600">
                               Only needed if the preview picks up menus instead of the article.
                               Leave empty to let AI detect this automatically.
                             </p>
@@ -1060,7 +1060,7 @@ function AddConnectorPage() {
                       {!webcrawlerConfig.content_selector && (
                         <button
                           type="button"
-                          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors disabled:opacity-50"
+                          className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50"
                           disabled={previewMutation.isPending || !wcPreviewUrl}
                           onClick={() => {
                             invalidatePreview()
@@ -1078,14 +1078,14 @@ function AddConnectorPage() {
                     )}
                     {/* Loading state */}
                     {previewMutation.isPending && (
-                      <div className="rounded-lg border border-gray-200 p-4 flex items-center gap-2 text-sm text-gray-400">
+                      <div className="rounded-lg border border-gray-200 p-4 flex items-center gap-2 text-sm text-gray-600">
                         <Loader2 className="h-4 w-4 animate-spin" />
                         {m.admin_connectors_webcrawler_preview_loading()}
                       </div>
                     )}
                     {/* Empty state - before any preview has run */}
                     {!previewResult && !previewMutation.isPending && !previewError && (
-                      <p className="text-sm text-gray-400">{m.admin_connectors_webcrawler_preview_empty()}</p>
+                      <p className="text-sm text-gray-600">{m.admin_connectors_webcrawler_preview_empty()}</p>
                     )}
                     {/* SPEC-CONNECTOR-INPUT-VALIDATION-001 REQ-3:
                         Single source of truth: classification drives ALL feedback.
@@ -1107,7 +1107,7 @@ function AddConnectorPage() {
                             Shown for success and selector_required/empty when AI found something. */}
                         {previewResult.selector_source === 'ai' && previewResult.content_selector && (
                           <div className="rounded-lg border border-gray-200 bg-black/[0.06] p-3 space-y-2">
-                            <div className="flex gap-2 items-center text-xs text-gray-400">
+                            <div className="flex gap-2 items-center text-xs text-gray-600">
                               <Sparkles className="h-3.5 w-3.5 shrink-0" />
                               <span>{m.admin_connectors_webcrawler_ai_selector_detected({ selector: previewResult.content_selector, count: String(previewResult.word_count) })}</span>
                             </div>
@@ -1137,7 +1137,7 @@ function AddConnectorPage() {
                           previewResult.selector_source !== 'ai_failed' && (
                           <button
                             type="button"
-                            className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors disabled:opacity-50"
+                            className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50"
                             disabled={previewMutation.isPending}
                             onClick={() => {
                               invalidatePreview()
@@ -1155,14 +1155,14 @@ function AddConnectorPage() {
                           <div className="rounded-lg border border-gray-200 p-3 space-y-2">
                             <div className="flex items-center justify-between">
                               <span className="text-sm font-medium text-gray-900">{m.admin_connectors_webcrawler_preview_title()}</span>
-                              <span className="text-xs text-gray-400">{m.admin_connectors_webcrawler_preview_word_count({ count: String(previewResult.word_count) })}</span>
+                              <span className="text-xs text-gray-600">{m.admin_connectors_webcrawler_preview_word_count({ count: String(previewResult.word_count) })}</span>
                             </div>
                             {previewResult.fit_markdown.trim() ? (
                               <div className={MARKDOWN_PROSE_CLASSES}>
-                                <ReactMarkdown components={{ a: ({ children }) => <span className="text-gray-400">{children}</span> }}>{previewResult.fit_markdown}</ReactMarkdown>
+                                <ReactMarkdown components={{ a: ({ children }) => <span className="text-gray-600">{children}</span> }}>{previewResult.fit_markdown}</ReactMarkdown>
                               </div>
                             ) : (
-                              <p className="text-sm text-gray-400">{m.admin_connectors_webcrawler_preview_empty()}</p>
+                              <p className="text-sm text-gray-600">{m.admin_connectors_webcrawler_preview_empty()}</p>
                             )}
                           </div>
                         )}
@@ -1179,7 +1179,7 @@ function AddConnectorPage() {
                               <Shield className="h-3.5 w-3.5 shrink-0" />
                               <span>Auth protection enabled</span>
                             </div>
-                            <p className="text-xs text-gray-400 ml-5.5">
+                            <p className="text-xs text-gray-600 ml-5.5">
                               We&apos;ll check this page before every sync to detect expired logins.
                               {authGuard.login_indicator_selector && (
                                 <> Pages without login indicator will be excluded.</>
@@ -1187,7 +1187,7 @@ function AddConnectorPage() {
                             </p>
                             <button
                               type="button"
-                              className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors ml-5.5"
+                              className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors ml-5.5"
                               onClick={() => setShowAdvancedAuthGuard(!showAdvancedAuthGuard)}
                             >
                               <Settings className="h-3 w-3" />

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -970,7 +970,7 @@ function AddConnectorPage() {
                     {requiresLogin === false && (
                       <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
                         <div className="flex items-center gap-2 text-xs text-gray-600">
-                          <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success)]" />
+                          <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success-text)]" />
                           Public site - no login needed
                         </div>
                         <button
@@ -984,7 +984,7 @@ function AddConnectorPage() {
                     )}
                     {requiresLogin === true && authProbeResult?.classification === 'auth_ok' && (
                       <div className="flex items-center justify-between rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 px-4 py-3">
-                        <div className="flex items-center gap-2 text-xs text-[var(--color-success)]">
+                        <div className="flex items-center gap-2 text-xs text-[var(--color-success-text)]">
                           <CheckCircle2 className="h-3.5 w-3.5" />
                           Logged in - cookies verified
                         </div>
@@ -1175,7 +1175,7 @@ function AddConnectorPage() {
                             reads from there. */}
                         {previewResult.classification === 'success' && authGuard?.canary_url && (
                           <div className="rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 space-y-2">
-                            <div className="flex gap-2 items-center text-xs text-[var(--color-success)]">
+                            <div className="flex gap-2 items-center text-xs text-[var(--color-success-text)]">
                               <Shield className="h-3.5 w-3.5 shrink-0" />
                               <span>Auth protection enabled</span>
                             </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
@@ -303,7 +303,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
       {/* Success banner */}
       {allDone && (
         <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success)] shrink-0" />
+          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
           <p className="text-sm text-[var(--color-success-text)]">
             {m.knowledge_add_source_file_success()}
           </p>
@@ -386,7 +386,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
               <FileText className="h-4 w-4 text-gray-500 shrink-0" />
               <span className="flex-1 truncate text-sm text-gray-900">{entry.filename}</span>
               {entry.status === 'done' && (
-                <span className="text-xs text-[var(--color-success)] shrink-0">Verwerkt</span>
+                <span className="text-xs text-[var(--color-success-text)] shrink-0">Verwerkt</span>
               )}
               {(entry.status === 'processing' || entry.status === 'ingesting') && (
                 <span className="text-xs text-gray-600 shrink-0">Bezig met verwerken…</span>
@@ -427,8 +427,8 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
       {/* Server-side per-file skipped */}
       {serverSkipped.length > 0 && (
         <div className="rounded-lg border border-[var(--color-warning)] bg-[var(--color-warning-bg)] p-3">
-          <p className="text-sm font-medium text-[var(--color-warning)] mb-1">Niet verwerkt:</p>
-          <ul className="text-xs text-[var(--color-warning)] space-y-0.5">
+          <p className="text-sm font-medium text-[var(--color-warning-text)] mb-1">Niet verwerkt:</p>
+          <ul className="text-xs text-[var(--color-warning-text)] space-y-0.5">
             {serverSkipped.map((r, i) => (
               <li key={`${r.filename}-${String(i)}`}>
                 {r.filename} - {reasonToMessage(r.reason)}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
@@ -332,7 +332,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
         <p className="text-sm font-medium text-gray-900">
           {m.knowledge_add_source_file_drop_hint()}
         </p>
-        <p className="text-xs text-gray-400 mt-2">{FORMATS_LABEL} (max 200 MB per bestand)</p>
+        <p className="text-xs text-gray-600 mt-2">{FORMATS_LABEL} (max 200 MB per bestand)</p>
         <input
           ref={fileInputRef}
           type="file"
@@ -356,9 +356,9 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
               key={`${file.name}-${String(i)}`}
               className="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5"
             >
-              <FileText className="h-4 w-4 text-gray-400 shrink-0" />
+              <FileText className="h-4 w-4 text-gray-500 shrink-0" />
               <span className="flex-1 truncate text-sm text-gray-900">{file.name}</span>
-              <span className="text-xs text-gray-400 shrink-0">{fileSizeLabel(file.size)}</span>
+              <span className="text-xs text-gray-600 shrink-0">{fileSizeLabel(file.size)}</span>
               <button
                 type="button"
                 aria-label={`Remove ${file.name}`}
@@ -366,7 +366,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
                   e.stopPropagation()
                   setSelectedFiles((prev) => prev.filter((_, j) => j !== i))
                 }}
-                className="text-xs text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
+                className="text-xs text-gray-500 hover:text-[var(--color-destructive)] transition-colors"
               >
                 &times;
               </button>
@@ -383,13 +383,13 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
               key={entry.id}
               className="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5"
             >
-              <FileText className="h-4 w-4 text-gray-400 shrink-0" />
+              <FileText className="h-4 w-4 text-gray-500 shrink-0" />
               <span className="flex-1 truncate text-sm text-gray-900">{entry.filename}</span>
               {entry.status === 'done' && (
                 <span className="text-xs text-[var(--color-success)] shrink-0">Verwerkt</span>
               )}
               {(entry.status === 'processing' || entry.status === 'ingesting') && (
-                <span className="text-xs text-gray-400 shrink-0">Bezig met verwerken…</span>
+                <span className="text-xs text-gray-600 shrink-0">Bezig met verwerken…</span>
               )}
               {entry.status === 'failed' && (
                 <span className="text-xs text-[var(--color-destructive)] shrink-0">
@@ -417,7 +417,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
           <button
             type="button"
             onClick={() => setClientRejections([])}
-            className="mt-2 text-xs text-gray-400 hover:text-gray-900"
+            className="mt-2 text-xs text-gray-600 hover:text-gray-900"
           >
             Sluiten
           </button>
@@ -457,7 +457,7 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
         <button
           type="button"
           onClick={onBack}
-          className="text-sm text-gray-400 hover:text-gray-900 transition-colors"
+          className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
         >
           {m.knowledge_add_source_back()}
         </button>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/SourceTypeGrid.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/SourceTypeGrid.tsx
@@ -24,7 +24,7 @@ export function SourceTypeGrid({ kbSlug, onSelectUpload }: SourceTypeGridProps) 
     <div className="space-y-6">
       {/* Upload group */}
       <section>
-        <h2 className="text-xs font-medium text-gray-400 mb-3 tracking-wide">
+        <h2 className="text-xs font-medium text-gray-600 mb-3 tracking-wide">
           {m.knowledge_add_source_group_upload()}
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -41,12 +41,12 @@ export function SourceTypeGrid({ kbSlug, onSelectUpload }: SourceTypeGridProps) 
 
       {/* Connector group */}
       <section>
-        <h2 className="text-xs font-medium text-gray-400 mb-3 tracking-wide">
+        <h2 className="text-xs font-medium text-gray-600 mb-3 tracking-wide">
           {m.knowledge_add_source_group_connectors()}
         </h2>
         {!hasExternalConnectors ? (
           <Tooltip label={m.connector_type_locked_tooltip()}>
-            <div className="flex items-center gap-2 py-4 text-sm text-gray-400 opacity-60 cursor-default select-none">
+            <div className="flex items-center gap-2 py-4 text-sm text-gray-600 cursor-default select-none">
               <Lock className="h-4 w-4" />
               {m.connector_type_locked_tooltip()}
             </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/SourceTypeTile.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/SourceTypeTile.tsx
@@ -21,9 +21,9 @@ export function SourceTypeTile({ meta, kbSlug, onSelectUpload }: SourceTypeTileP
 
   const inner = (
     <div className={tileClasses} aria-disabled={!available}>
-      <Icon className="h-4 w-4 text-gray-400" />
+      <Icon className="h-4 w-4 text-gray-500" />
       <span className="text-sm font-medium text-gray-900">{label()}</span>
-      <span className="text-xs leading-5 text-gray-400">{subtitle()}</span>
+      <span className="text-xs leading-5 text-gray-600">{subtitle()}</span>
       {badges && badges.length > 0 && (
         <span className="mt-auto flex flex-wrap gap-1.5 pt-1">
           {badges.map((badge) => (

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
@@ -82,7 +82,7 @@ export function TextSourceForm({ kbSlug, onBack }: TextSourceFormProps) {
 
       {successful && (
         <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success)] shrink-0" />
+          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
           <p className="text-sm text-[var(--color-success-text)]">
             {m.knowledge_add_source_success()}
           </p>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
@@ -75,7 +75,7 @@ export function TextSourceForm({ kbSlug, onBack }: TextSourceFormProps) {
           placeholder={m.knowledge_add_source_text_content_placeholder()}
           disabled={mutation.isPending || successful}
         />
-        <p className="text-xs text-gray-400 tabular-nums">
+        <p className="text-xs text-gray-600 tabular-nums">
           {content.length.toLocaleString()} / {MAX_CONTENT_CHARS.toLocaleString()}
         </p>
       </div>
@@ -102,7 +102,7 @@ export function TextSourceForm({ kbSlug, onBack }: TextSourceFormProps) {
         <button
           type="button"
           onClick={onBack}
-          className="text-sm text-gray-400 hover:text-gray-900 transition-colors"
+          className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
         >
           {m.knowledge_add_source_back()}
         </button>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
@@ -52,7 +52,7 @@ export function UrlSourceForm({ kbSlug, onBack }: UrlSourceFormProps) {
 
       {successful && (
         <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success)] shrink-0" />
+          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
           <p className="text-sm text-[var(--color-success-text)]">
             {m.knowledge_add_source_success()}
           </p>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
@@ -31,7 +31,7 @@ export function UrlSourceForm({ kbSlug, onBack }: UrlSourceFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <div className="flex items-center gap-2 text-gray-400">
+      <div className="flex items-center gap-2 text-gray-600">
         <Link2 className="h-5 w-5" />
         <p className="text-sm">{m.knowledge_add_source_url_hint()}</p>
       </div>
@@ -75,7 +75,7 @@ export function UrlSourceForm({ kbSlug, onBack }: UrlSourceFormProps) {
         <button
           type="button"
           onClick={onBack}
-          className="text-sm text-gray-400 hover:text-gray-900 transition-colors"
+          className="text-sm text-gray-600 hover:text-gray-900 transition-colors"
         >
           {m.knowledge_add_source_back()}
         </button>

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source.tsx
@@ -62,7 +62,7 @@ function AddSourcePage() {
           {m.knowledge_add_source_back()}
         </Button>
       </div>
-      <p className="text-sm text-gray-400 mb-6">
+      <p className="text-sm text-gray-600 mb-6">
         {m.knowledge_add_source_subtitle()}
       </p>
 

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -584,7 +584,7 @@ function EditConnectorPage() {
                 Map: {folderName || 'geselecteerd'}
               </p>
             ) : (
-              <p className="text-sm text-gray-400">Hele Google Drive</p>
+              <p className="text-sm text-gray-600">Hele Google Drive</p>
             )}
           </div>
           <Button
@@ -600,7 +600,7 @@ function EditConnectorPage() {
                 : 'Kies mappen / bestanden'}
           </Button>
         </div>
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           Kies de hele Drive, een map of losse bestanden. Google Docs, Sheets en Slides
           worden automatisch omgezet voordat ze worden geindexeerd.
         </p>
@@ -631,7 +631,7 @@ function EditConnectorPage() {
             {m.admin_connectors_edit_title()}
           </h1>
           {connector && (
-            <p className="text-sm text-gray-400">{connector.name}</p>
+            <p className="text-sm text-gray-600">{connector.name}</p>
           )}
         </div>
         <Button type="button" variant="outline" size="sm" onClick={goBack}>
@@ -729,7 +729,7 @@ function EditConnectorPage() {
                     <p className="text-sm font-medium text-gray-900">
                       Is this site behind a login?
                     </p>
-                    <p className="text-xs text-gray-400">
+                    <p className="text-xs text-gray-600">
                       Some knowledge bases require you to be logged in to see the content.
                       We&apos;ll verify either way before letting you save.
                     </p>
@@ -790,7 +790,7 @@ function EditConnectorPage() {
                           Authentication cookies
                         </p>
                         {hasSavedWebCrawlerCredentials && (
-                          <p className="text-xs text-gray-400">
+                          <p className="text-xs text-gray-600">
                             Saved cookies are encrypted and stay hidden.
                           </p>
                         )}
@@ -880,7 +880,7 @@ function EditConnectorPage() {
                           }}
                         />
                         {hasSavedWebCrawlerCredentials && (savedCredentialMetadata?.cookie_names?.length ?? 0) > 0 && (
-                          <p className="text-xs text-gray-400">
+                          <p className="text-xs text-gray-600">
                             Cookie names are prefilled from saved authentication. Paste fresh values only.
                           </p>
                         )}
@@ -950,13 +950,13 @@ function EditConnectorPage() {
                   {/* Auth status reminder */}
                   {requiresLogin === false && (
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
-                      <div className="flex items-center gap-2 text-xs text-gray-400">
+                      <div className="flex items-center gap-2 text-xs text-gray-600">
                         <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success)]" />
                         Public site - no login needed
                       </div>
                       <button
                         type="button"
-                        className="text-xs text-gray-400 hover:text-gray-900"
+                        className="text-xs text-gray-600 hover:text-gray-900"
                         onClick={() => {
                           if (hasSavedWebCrawlerCredentials) {
                             setRequiresLogin(true)
@@ -980,7 +980,7 @@ function EditConnectorPage() {
                       </div>
                       <button
                         type="button"
-                        className="text-xs text-gray-400 hover:text-gray-900"
+                        className="text-xs text-gray-600 hover:text-gray-900"
                         onClick={() => setWcStep('auth-setup')}
                       >
                         {wcAuthMode === 'saved' ? 'Change authentication' : 'Edit cookies'}
@@ -1003,7 +1003,7 @@ function EditConnectorPage() {
                   {/* Advanced: content selector */}
                   <button
                     type="button"
-                    className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+                    className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors"
                     onClick={() => setShowAdvancedSelector((p) => !p)}
                   >
                     <Settings className="h-3 w-3" />
@@ -1021,7 +1021,7 @@ function EditConnectorPage() {
                           invalidatePreview()
                         }}
                       />
-                      <p className="text-xs text-gray-400">
+                      <p className="text-xs text-gray-600">
                         Only needed if the preview picks up menus instead of the article.
                         Leave empty to let AI detect this automatically.
                       </p>
@@ -1052,7 +1052,7 @@ function EditConnectorPage() {
                     </Button>
                     <button
                       type="button"
-                      className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors disabled:opacity-50"
+                      className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50"
                       disabled={previewMutation.isPending || !wcPreviewUrl}
                       onClick={() => {
                         invalidatePreview()
@@ -1073,13 +1073,13 @@ function EditConnectorPage() {
                     <p className="text-sm text-[var(--color-destructive)]">{previewError}</p>
                   )}
                   {previewMutation.isPending && (
-                    <div className="rounded-lg border border-gray-200 p-4 flex items-center gap-2 text-sm text-gray-400">
+                    <div className="rounded-lg border border-gray-200 p-4 flex items-center gap-2 text-sm text-gray-600">
                       <Loader2 className="h-4 w-4 animate-spin" />
                       {m.admin_connectors_webcrawler_preview_loading()}
                     </div>
                   )}
                   {!previewResult && !previewMutation.isPending && !previewError && (
-                    <p className="text-sm text-gray-400">{m.admin_connectors_webcrawler_preview_empty()}</p>
+                    <p className="text-sm text-gray-600">{m.admin_connectors_webcrawler_preview_empty()}</p>
                   )}
                   {previewResult !== null && !previewMutation.isPending && (
                     <div className="space-y-3">
@@ -1099,7 +1099,7 @@ function EditConnectorPage() {
                       {/* AI-detected selector badge + "Use this selector" CTA */}
                       {previewResult.selector_source === 'ai' && previewResult.content_selector && (
                         <div className="rounded-lg border border-gray-200 bg-black/[0.06] p-3 space-y-2">
-                          <div className="flex gap-2 items-center text-xs text-gray-400">
+                          <div className="flex gap-2 items-center text-xs text-gray-600">
                             <Sparkles className="h-3.5 w-3.5 shrink-0" />
                             <span>{m.admin_connectors_webcrawler_ai_selector_detected({ selector: previewResult.content_selector, count: String(previewResult.word_count) })}</span>
                           </div>
@@ -1126,7 +1126,7 @@ function EditConnectorPage() {
                         previewResult.selector_source !== 'ai_failed' && (
                         <button
                           type="button"
-                          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors disabled:opacity-50"
+                          className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50"
                           disabled={previewMutation.isPending}
                           onClick={() => {
                             invalidatePreview()
@@ -1143,14 +1143,14 @@ function EditConnectorPage() {
                         <div className="rounded-lg border border-gray-200 p-3 space-y-2">
                           <div className="flex items-center justify-between">
                             <span className="text-sm font-medium text-gray-900">{m.admin_connectors_webcrawler_preview_title()}</span>
-                            <span className="text-xs text-gray-400">{m.admin_connectors_webcrawler_preview_word_count({ count: String(previewResult.word_count) })}</span>
+                            <span className="text-xs text-gray-600">{m.admin_connectors_webcrawler_preview_word_count({ count: String(previewResult.word_count) })}</span>
                           </div>
                           {previewResult.fit_markdown.trim() ? (
                             <div className={MARKDOWN_PROSE_CLASSES}>
-                              <ReactMarkdown components={{ a: ({ children }) => <span className="text-gray-400">{children}</span> }}>{previewResult.fit_markdown}</ReactMarkdown>
+                              <ReactMarkdown components={{ a: ({ children }) => <span className="text-gray-600">{children}</span> }}>{previewResult.fit_markdown}</ReactMarkdown>
                             </div>
                           ) : (
-                            <p className="text-sm text-gray-400">{m.admin_connectors_webcrawler_preview_empty()}</p>
+                            <p className="text-sm text-gray-600">{m.admin_connectors_webcrawler_preview_empty()}</p>
                           )}
                         </div>
                       )}
@@ -1165,12 +1165,12 @@ function EditConnectorPage() {
                             <Shield className="h-3.5 w-3.5 shrink-0" />
                             <span>Auth protection enabled</span>
                           </div>
-                          <p className="text-xs text-gray-400 ml-5.5">
+                          <p className="text-xs text-gray-600 ml-5.5">
                             We&apos;ll check this page before every sync to detect expired logins.
                           </p>
                           <button
                             type="button"
-                            className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors ml-5.5"
+                            className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors ml-5.5"
                             onClick={() => setShowAdvancedAuthGuard(!showAdvancedAuthGuard)}
                           >
                             <Settings className="h-3 w-3" />
@@ -1307,7 +1307,7 @@ function EditConnectorPage() {
                   value={notionConfig.new_access_token}
                   onChange={(e) => setNotionConfig((p) => ({ ...p, new_access_token: e.target.value }))}
                 />
-                <p className="text-xs text-gray-400">{m.admin_connectors_notion_token_help_update()}</p>
+                <p className="text-xs text-gray-600">{m.admin_connectors_notion_token_help_update()}</p>
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="edit-conn-notion-dbs">{m.admin_connectors_notion_database_ids()}</Label>
@@ -1376,7 +1376,7 @@ function EditConnectorPage() {
                   value={msSiteUrl}
                   onChange={(e) => { setMsSiteUrl(e.target.value); setMsSiteUrlError(null) }}
                 />
-                <p className="text-xs text-gray-400">{m.admin_connectors_ms_docs_site_url_help()}</p>
+                <p className="text-xs text-gray-600">{m.admin_connectors_ms_docs_site_url_help()}</p>
                 {msSiteUrlError && (
                   <p className="text-xs text-[var(--color-destructive)]">{msSiteUrlError}</p>
                 )}
@@ -1384,7 +1384,7 @@ function EditConnectorPage() {
               <div className="space-y-1.5">
                 <Label htmlFor="edit-ms-drive-id">{m.admin_connectors_ms_docs_drive_id()}</Label>
                 <Input id="edit-ms-drive-id" placeholder="b!xyz..." value={msDriveId} onChange={(e) => setMsDriveId(e.target.value)} />
-                <p className="text-xs text-gray-400">{m.admin_connectors_ms_docs_drive_id_help()}</p>
+                <p className="text-xs text-gray-600">{m.admin_connectors_ms_docs_drive_id_help()}</p>
               </div>
               {/* Post-OAuth picker. Three scope modes are mutually
                   exclusive - folder, files, or whole drive (default). */}
@@ -1401,7 +1401,7 @@ function EditConnectorPage() {
                         Map: {msFolderName || 'geselecteerd'}
                       </p>
                     ) : (
-                      <p className="text-sm text-gray-400">Hele drive (alles)</p>
+                      <p className="text-sm text-gray-600">Hele drive (alles)</p>
                     )}
                   </div>
                   <Button
@@ -1417,7 +1417,7 @@ function EditConnectorPage() {
                         : 'Kies mappen / bestanden'}
                   </Button>
                 </div>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   Bestanden groter dan 200 MB worden overgeslagen.
                 </p>
                 {msShowFolderPicker && connector && (
@@ -1461,7 +1461,7 @@ function EditConnectorPage() {
               <div className="space-y-1.5">
                 <Label htmlFor="edit-at-api-key">{m.admin_connectors_airtable_api_key_label()}</Label>
                 <Input id="edit-at-api-key" type="password" placeholder={m.admin_connectors_airtable_api_key_hint()} value={airtableConfig.api_key} onChange={(e) => setAirtableConfig((p) => ({ ...p, api_key: e.target.value }))} />
-                <p className="text-xs text-gray-400">{m.admin_connectors_notion_token_help_update()}</p>
+                <p className="text-xs text-gray-600">{m.admin_connectors_notion_token_help_update()}</p>
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="edit-at-base-id">{m.admin_connectors_airtable_base_id_label()}</Label>
@@ -1529,7 +1529,7 @@ function EditConnectorPage() {
                   value={jsonFeedConfig.url}
                   onChange={(e) => setJsonFeedConfig({ url: e.target.value })}
                 />
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-gray-600">
                   {connector.has_saved_credentials
                     ? m.admin_connectors_json_feed_url_saved_help()
                     : m.admin_connectors_json_feed_help()}
@@ -1562,7 +1562,7 @@ function EditConnectorPage() {
           )}
 
           {!connector && (
-            <p className="text-sm text-gray-400">{m.admin_connectors_loading()}</p>
+            <p className="text-sm text-gray-600">{m.admin_connectors_loading()}</p>
           )}
     </PageContainer>
   )

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -951,7 +951,7 @@ function EditConnectorPage() {
                   {requiresLogin === false && (
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
                       <div className="flex items-center gap-2 text-xs text-gray-600">
-                        <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success)]" />
+                        <CheckCircle2 className="h-3.5 w-3.5 text-[var(--color-success-text)]" />
                         Public site - no login needed
                       </div>
                       <button
@@ -974,7 +974,7 @@ function EditConnectorPage() {
                   )}
                   {requiresLogin === true && authProbeResult?.classification === 'auth_ok' && (
                     <div className="flex items-center justify-between rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 px-4 py-3">
-                      <div className="flex items-center gap-2 text-xs text-[var(--color-success)]">
+                      <div className="flex items-center gap-2 text-xs text-[var(--color-success-text)]">
                         <CheckCircle2 className="h-3.5 w-3.5" />
                         {wcAuthMode === 'saved' ? 'Logged in - saved authentication verified' : 'Logged in - cookies verified'}
                       </div>
@@ -1161,7 +1161,7 @@ function EditConnectorPage() {
                           auth-probe). Source of truth is ``authGuard`` state. */}
                       {previewResult.classification === 'success' && authGuard?.canary_url && (
                         <div className="rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 space-y-2">
-                          <div className="flex gap-2 items-center text-xs text-[var(--color-success)]">
+                          <div className="flex gap-2 items-center text-xs text-[var(--color-success-text)]">
                             <Shield className="h-3.5 w-3.5 shrink-0" />
                             <span>Auth protection enabled</span>
                           </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-constants.ts
@@ -15,7 +15,7 @@ import type { ConnectorType, StepDeepLink } from './-connector-types'
 // wizards. Kept as a single source of truth so style changes don't
 // silently diverge between add and edit views.
 export const MARKDOWN_PROSE_CLASSES =
-  'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-400 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-400 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-400 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
+  'overflow-y-auto max-h-64 text-xs [&_h1]:text-sm [&_h1]:font-semibold [&_h1]:text-gray-900 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-semibold [&_h2]:text-gray-900 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-medium [&_h3]:text-gray-900 [&_h3]:mb-1 [&_p]:text-gray-600 [&_p]:mb-1.5 [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:text-gray-600 [&_ul]:mb-1.5 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:text-gray-600 [&_ol]:mb-1.5 [&_strong]:font-semibold [&_strong]:text-gray-900 [&_hr]:border-gray-200 [&_hr]:my-2'
 
 // Valid `?type=` URL-param values for the add-connector route. Used
 // by the route's validateSearch to gate the deep-link.

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
@@ -131,7 +131,7 @@ export function PreviewClassificationFeedback({
       {classification === 'unknown' && onRetry && (
         <button
           type="button"
-          className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-900 transition-colors"
+          className="flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 transition-colors"
           onClick={onRetry}
         >
           Retry

--- a/klai-portal/frontend/src/routes/app/knowledge/index.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/index.tsx
@@ -162,7 +162,7 @@ function KbRow({
                 Mijn
               </Badge>
             )}
-            <span className="text-xs text-gray-400">
+            <span className="text-xs text-gray-600">
               {statsLabel}
             </span>
           </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepAccess.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepAccess.tsx
@@ -55,12 +55,12 @@ export function StepAccess({
                 : 'border-gray-200 bg-[var(--color-card)] hover:border-gray-300',
             ].join(' ')}
           >
-            <Icon className="h-5 w-5 mt-0.5 text-gray-400" />
+            <Icon className="h-5 w-5 mt-0.5 text-gray-500" />
             <div>
               <span className="text-sm font-medium text-gray-900">
                 {title}
               </span>
-              <span className="block text-xs text-gray-400">{desc}</span>
+              <span className="block text-xs text-gray-600">{desc}</span>
             </div>
           </button>
         ))}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepConfirm.tsx
@@ -54,28 +54,28 @@ export function StepConfirm({
         <CardContent className="pt-4">
           <div className="space-y-3 text-sm">
             <div className="flex items-start gap-2">
-              <Brain className="h-4 w-4 mt-0.5 text-gray-400" />
+              <Brain className="h-4 w-4 mt-0.5 text-gray-500" />
               <div>
                 <p className="font-medium text-gray-900">{data.name}</p>
-                <p className="text-xs text-gray-400">{data.slug}</p>
+                <p className="text-xs text-gray-600">{data.slug}</p>
               </div>
             </div>
 
             {data.description && (
-              <p className="text-gray-400 italic">
+              <p className="text-gray-600 italic">
                 &ldquo;{data.description}&rdquo;
               </p>
             )}
 
             {data.ownerType === 'org' && (
               <div className="flex items-center gap-2">
-                <VisibilityIcon className="h-4 w-4 text-gray-400" />
+                <VisibilityIcon className="h-4 w-4 text-gray-500" />
                 <span className="text-gray-900">{visibilityLabel}</span>
               </div>
             )}
 
             {data.ownerType === 'org' && data.visibilityMode !== 'restricted' && (
-              <p className="text-gray-400">
+              <p className="text-gray-600">
                 {m.knowledge_sharing_summary_org_default({
                   role: data.allowContribute ? 'contributor' : 'viewer',
                 })}
@@ -83,7 +83,7 @@ export function StepConfirm({
             )}
 
             {data.ownerType === 'user' && (
-              <p className="text-gray-400">
+              <p className="text-gray-600">
                 {m.knowledge_wizard_personal_only()}
               </p>
             )}
@@ -92,28 +92,28 @@ export function StepConfirm({
               (data.initialGroups.length > 0 || data.initialUsers.length > 0) && (
                 <div className="border-t border-gray-200 pt-2">
                   {data.visibilityMode === 'restricted' ? (
-                    <p className="text-xs font-medium text-gray-400 mb-1">
+                    <p className="text-xs font-medium text-gray-600 mb-1">
                       {m.knowledge_sharing_summary_only_shared()}
                     </p>
                   ) : (
-                    <p className="text-xs font-medium text-gray-400 mb-1">
+                    <p className="text-xs font-medium text-gray-600 mb-1">
                       {m.knowledge_wizard_extra_permissions_title()}:
                     </p>
                   )}
                   {data.initialGroups.map((g) => (
-                    <p key={g.id} className="text-xs text-gray-400 pl-3">
+                    <p key={g.id} className="text-xs text-gray-600 pl-3">
                       &bull; {g.name} ({g.role})
                     </p>
                   ))}
                   {data.initialUsers.map((u) => (
-                    <p key={u.id} className="text-xs text-gray-400 pl-3">
+                    <p key={u.id} className="text-xs text-gray-600 pl-3">
                       &bull; {u.name || u.email} ({u.role})
                     </p>
                   ))}
                 </div>
               )}
 
-            <p className="text-gray-400">
+            <p className="text-gray-600">
               {m.knowledge_sharing_summary_docs_auto()}
             </p>
           </div>
@@ -145,7 +145,7 @@ export function StepConfirm({
       )}
 
       {personalQuotaReached && (
-        <p className="text-sm text-gray-400 opacity-70">
+        <p className="text-sm text-gray-600">
           {m.kb_limit_tooltip_kb_count()}
         </p>
       )}

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepName.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepName.tsx
@@ -69,14 +69,14 @@ export function StepName({
                 ].join(' ')}
               >
                 {type === 'org' ? (
-                  <Users className="h-4 w-4 text-gray-400" />
+                  <Users className="h-4 w-4 text-gray-500" />
                 ) : (
-                  <User className="h-4 w-4 text-gray-400" />
+                  <User className="h-4 w-4 text-gray-500" />
                 )}
                 <span className="text-sm font-medium text-gray-900">
                   {type === 'org' ? m.knowledge_new_scope_org() : m.knowledge_new_scope_personal()}
                 </span>
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-600">
                   {type === 'org'
                     ? m.knowledge_new_scope_org_description()
                     : m.knowledge_new_scope_personal_description()}
@@ -105,7 +105,7 @@ export function StepName({
           onChange={(e) => handleSlugChange(e.target.value)}
           pattern="[a-z0-9\-]+"
         />
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {m.knowledge_new_slug_hint()}
         </p>
         {errorKey === 'conflict' && (

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepPermissions.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/-StepPermissions.tsx
@@ -42,13 +42,13 @@ export function StepPermissions({
                   onChange={(e) =>
                     setData((prev) => ({ ...prev, allowContribute: e.target.checked }))
                   }
-                  className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-400 focus:ring-[var(--color-ring)]"
+                  className="mt-1 h-4 w-4 rounded border-gray-200 text-gray-500 focus:ring-[var(--color-ring)]"
                 />
                 <div>
                   <span className="text-sm font-medium text-gray-900">
                     {m.knowledge_wizard_contributor_checkbox()}
                   </span>
-                  <span className="block text-xs text-gray-400">
+                  <span className="block text-xs text-gray-600">
                     {m.knowledge_sharing_contributor_toggle_description()}
                   </span>
                 </div>
@@ -59,7 +59,7 @@ export function StepPermissions({
       )}
 
       {isRestricted && (
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.knowledge_wizard_restricted_desc()}
         </p>
       )}
@@ -69,7 +69,7 @@ export function StepPermissions({
           <p className="text-sm font-medium text-gray-900">
             {m.knowledge_wizard_extra_permissions_title()}
           </p>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.knowledge_wizard_extra_permissions_desc()}
           </p>
         </div>
@@ -96,7 +96,7 @@ export function StepPermissions({
         isRestrictedEmpty={isRestricted ? isRestrictedEmpty : false}
       />
 
-      <p className="text-xs text-gray-400 italic">
+      <p className="text-xs text-gray-600 italic">
         {m.knowledge_wizard_owner_info()}
       </p>
     </div>

--- a/klai-portal/frontend/src/routes/app/knowledge/new._components/MemberPicker.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/new._components/MemberPicker.tsx
@@ -87,7 +87,7 @@ export function MemberPicker({
             }
           }}
         >
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
           <Input
             value={groupSearch}
             onChange={(e) => setGroupSearch(e.target.value)}
@@ -135,7 +135,7 @@ export function MemberPicker({
               <button
                 type="button"
                 onClick={() => setInitialGroups((prev) => prev.filter((ig) => ig.id !== g.id))}
-                className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
+                className="flex h-6 w-6 items-center justify-center text-gray-500 hover:text-[var(--color-destructive)] transition-colors"
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -160,7 +160,7 @@ export function MemberPicker({
             }
           }}
         >
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
           <Input
             value={userSearch}
             onChange={(e) => setUserSearch(e.target.value)}
@@ -189,7 +189,7 @@ export function MemberPicker({
                   className="w-full px-3 py-2 text-left text-sm klai-hover"
                 >
                   <span className="text-gray-900">{u.display_name}</span>
-                  <span className="ml-2 text-xs text-gray-400">
+                  <span className="ml-2 text-xs text-gray-600">
                     {u.email}
                   </span>
                 </button>
@@ -204,7 +204,7 @@ export function MemberPicker({
           >
             <div>
               <span className="text-sm text-gray-900">{u.name}</span>
-              <span className="ml-2 text-xs text-gray-400">{u.email}</span>
+              <span className="ml-2 text-xs text-gray-600">{u.email}</span>
             </div>
             <div className="flex items-center gap-2">
               <RoleSelect
@@ -219,7 +219,7 @@ export function MemberPicker({
               <button
                 type="button"
                 onClick={() => setInitialUsers((prev) => prev.filter((iu) => iu.id !== u.id))}
-                className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-[var(--color-destructive)] transition-colors"
+                className="flex h-6 w-6 items-center justify-center text-gray-500 hover:text-[var(--color-destructive)] transition-colors"
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -228,7 +228,7 @@ export function MemberPicker({
         ))}
 
         {isRestrictedEmpty && (
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.knowledge_wizard_min_one_member()}
           </p>
         )}

--- a/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
@@ -227,7 +227,7 @@ function MeetingDetailPage() {
   if (isLoading) {
     return (
       <div className="flex justify-center py-16">
-        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
       </div>
     )
   }
@@ -307,7 +307,7 @@ function MeetingDetailPage() {
         {ACTIVE_STATUSES.includes(meeting.status) ? (
           <Card>
             <CardContent className="pt-4">
-              <p className="text-sm text-gray-400">
+              <p className="text-sm text-gray-600">
                 {activeMeetingInfo(meeting.status)}
               </p>
             </CardContent>
@@ -337,7 +337,7 @@ function MeetingDetailPage() {
             <p className="text-sm font-medium text-[var(--color-destructive)]">
               {m.app_meetings_error_label()}
             </p>
-            <p className="mt-1 text-sm text-gray-400">
+            <p className="mt-1 text-sm text-gray-600">
               {meeting.error_message}
             </p>
           </CardContent>
@@ -419,7 +419,7 @@ function MeetingDetailPage() {
                 <p className="text-sm font-medium text-[var(--color-destructive)]">
                   {m.app_meetings_summary_error()}
                 </p>
-                <p className="mt-1 text-sm text-gray-400">{summaryError}</p>
+                <p className="mt-1 text-sm text-gray-600">{summaryError}</p>
               </CardContent>
             </Card>
           )}
@@ -454,7 +454,7 @@ function MeetingDetailPage() {
                       return (
                         <div key={i} className="flex gap-3">
                           {timestamp && (
-                            <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-gray-400 tabular-nums">
+                            <span className="mt-0.5 shrink-0 whitespace-nowrap text-xs text-gray-600 tabular-nums">
                               [{timestamp}]
                             </span>
                           )}
@@ -470,7 +470,7 @@ function MeetingDetailPage() {
                   })()}
                 </div>
               ) : (
-                <p className="text-sm text-gray-400 whitespace-pre-wrap">
+                <p className="text-sm text-gray-600 whitespace-pre-wrap">
                   {meeting.transcript_text}
                 </p>
               )}
@@ -480,7 +480,7 @@ function MeetingDetailPage() {
       )}
 
       {meeting.status === 'done' && !hasTranscript && (
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.app_meetings_transcript_empty()}
         </p>
       )}

--- a/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/$meetingId.tsx
@@ -358,7 +358,7 @@ function MeetingDetailPage() {
                 <Button variant="outline" size="sm" onClick={copySummaryText}>
                   {summaryCopied === 'text' ? (
                     <>
-                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                       {m.app_meetings_summary_copy_done()}
                     </>
                   ) : (
@@ -371,7 +371,7 @@ function MeetingDetailPage() {
                 <Button variant="outline" size="sm" onClick={copySummaryMarkdown}>
                   {summaryCopied === 'markdown' ? (
                     <>
-                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                       {m.app_meetings_summary_copy_done()}
                     </>
                   ) : (
@@ -389,7 +389,7 @@ function MeetingDetailPage() {
                 <Button variant="outline" size="sm" onClick={copyTranscript}>
                   {copied ? (
                     <>
-                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                       {m.app_meetings_copy_done()}
                     </>
                   ) : (

--- a/klai-portal/frontend/src/routes/app/meetings/start.tsx
+++ b/klai-portal/frontend/src/routes/app/meetings/start.tsx
@@ -150,7 +150,7 @@ function StartMeetingPage() {
             className={urlError ? 'border-[var(--color-destructive)]' : ''}
           />
           {platform && (
-            <p className="text-xs text-gray-400">
+            <p className="text-xs text-gray-600">
               Platform:{' '}
               <span className="font-medium text-gray-900">{platform}</span>
             </p>

--- a/klai-portal/frontend/src/routes/app/scribe.tsx
+++ b/klai-portal/frontend/src/routes/app/scribe.tsx
@@ -13,7 +13,7 @@ function ScribePage() {
     <PageContainer width="3xl" gap="6">
       <div className="space-y-1">
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">{m.app_tool_scribe_title()}</h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.app_scribe_subtitle()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
@@ -148,7 +148,7 @@ function TranscriptionDetailPage() {
               <Button variant="outline" size="sm" onClick={copyTranscript}>
                 {copied ? (
                   <>
-                    <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                    <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                     {m.app_meetings_copy_done()}
                   </>
                 ) : (
@@ -225,7 +225,7 @@ function TranscriptionDetailPage() {
                 <Button variant="outline" size="sm" onClick={copySummaryText}>
                   {summaryCopied === 'text' ? (
                     <>
-                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                       {m.app_transcribe_summary_copy_done()}
                     </>
                   ) : (
@@ -238,7 +238,7 @@ function TranscriptionDetailPage() {
                 <Button variant="outline" size="sm" onClick={copySummaryMarkdown}>
                   {summaryCopied === 'markdown' ? (
                     <>
-                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success)]" />
+                      <CheckCheck className="mr-1.5 h-3.5 w-3.5 text-[var(--color-success-text)]" />
                       {m.app_transcribe_summary_copy_done()}
                     </>
                   ) : (

--- a/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/$transcriptionId.tsx
@@ -109,7 +109,7 @@ function TranscriptionDetailPage() {
   if (isLoading) {
     return (
       <div className="flex justify-center py-16">
-        <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        <Loader2 className="h-6 w-6 animate-spin text-gray-500" />
       </div>
     )
   }
@@ -165,7 +165,7 @@ function TranscriptionDetailPage() {
             </div>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-gray-400 whitespace-pre-wrap">
+            <p className="text-sm text-gray-600 whitespace-pre-wrap">
               {transcription.text}
             </p>
           </CardContent>
@@ -210,7 +210,7 @@ function TranscriptionDetailPage() {
               <p className="text-sm font-medium text-[var(--color-destructive)]">
                 {m.app_transcribe_summary_error()}
               </p>
-              <p className="mt-1 text-sm text-gray-400">{summarizeMutation.error.message}</p>
+              <p className="mt-1 text-sm text-gray-600">{summarizeMutation.error.message}</p>
             </CardContent>
           </Card>
         )}

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/-FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/-FileUploadForm.tsx
@@ -76,18 +76,18 @@ export function FileUploadForm({
             if (file) handleFile(file)
           }}
         />
-        <Upload className="mx-auto mb-3 h-8 w-8 text-gray-400" />
+        <Upload className="mx-auto mb-3 h-8 w-8 text-gray-500" />
         {selectedFile ? (
           <div>
             <p className="font-medium text-sm">{selectedFile.name}</p>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-xs text-gray-600 mt-1">
               {(selectedFile.size / 1024 / 1024).toFixed(1)} MB
             </p>
           </div>
         ) : (
           <div>
             <p className="text-sm font-medium">{m.app_transcribe_dropzone_label()}</p>
-            <p className="text-xs text-gray-400 mt-1">
+            <p className="text-xs text-gray-600 mt-1">
               {m.app_transcribe_dropzone_hint({
                 formats: 'WAV, MP3, M4A, OGG, WebM',
                 max: String(MAX_UPLOAD_MB),

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/-RecordingForm.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/-RecordingForm.tsx
@@ -145,7 +145,7 @@ export function RecordingForm({
 
   if (micPermission === 'requesting') {
     return (
-      <p className="text-sm text-gray-400">
+      <p className="text-sm text-gray-600">
         {m.app_transcribe_record_permission_request()}
       </p>
     )
@@ -188,7 +188,7 @@ export function RecordingForm({
         </Button>
 
         {recording && (
-          <span className="font-mono text-sm text-gray-400">
+          <span className="font-mono text-sm text-gray-600">
             {formatDuration(recordDuration)}
           </span>
         )}
@@ -212,7 +212,7 @@ export function RecordingForm({
       )}
 
       {!recording && !isTranscribing && (
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-gray-600">
           {m.app_transcribe_record_shortcut_hint()}
         </p>
       )}

--- a/klai-portal/frontend/src/routes/app/transcribe/_components/TranscriptionTable.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/_components/TranscriptionTable.tsx
@@ -99,7 +99,7 @@ function MetaText({ item }: { item: UnifiedItem }) {
   const parts = metaParts(item)
 
   return (
-    <span className="text-xs text-gray-400">
+    <span className="text-xs text-gray-600">
       {item.language && (
         <>
           <img
@@ -262,7 +262,7 @@ export function TranscriptionTable({
                 className={`grid items-center gap-x-3 gap-y-3 px-4 py-4 ${transcriptionListGrid}`}
               >
                 <div
-                  className="flex h-8 w-8 items-center justify-center rounded-md text-gray-400"
+                  className="flex h-8 w-8 items-center justify-center rounded-md text-gray-500"
                   aria-label={sourceLabel(item)}
                   title={sourceLabel(item)}
                 >
@@ -295,13 +295,13 @@ export function TranscriptionTable({
                             {item.title}
                           </ListRowTitle>
                         ) : (
-                          <ListRowTitle className="text-gray-400">
+                          <ListRowTitle className="text-gray-600">
                             {item.meeting_url ?? '\u2014'}
                           </ListRowTitle>
                         )}
                         {item.source === 'upload' && item.has_summary && (
                           <FileText
-                            className="h-3.5 w-3.5 shrink-0 text-gray-400"
+                            className="h-3.5 w-3.5 shrink-0 text-gray-500"
                             aria-label={m.app_transcribe_has_summary()}
                           />
                         )}

--- a/klai-portal/frontend/src/routes/app/transcribe/add.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/add.tsx
@@ -115,7 +115,7 @@ function AddTranscribePage() {
                 className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
                   activeTab === tab
                     ? 'bg-[var(--color-background)] shadow-sm text-gray-900'
-                    : 'text-gray-400 hover:text-gray-900'
+                    : 'text-gray-600 hover:text-gray-900'
                 }`}
               >
                 {tab === 'record' ? m.app_transcribe_tab_record() : m.app_transcribe_tab_upload()}
@@ -143,7 +143,7 @@ function AddTranscribePage() {
           {error && <p className="text-sm text-[var(--color-destructive)]">{error}</p>}
 
           {isTranscribing && (
-            <p className="text-xs text-gray-400 text-center">
+            <p className="text-xs text-gray-600 text-center">
               <Loader2 className="mr-2 inline h-3 w-3 animate-spin" />
               {m.app_transcribe_processing_hint()}
             </p>

--- a/klai-portal/frontend/src/routes/app/transcribe/index.tsx
+++ b/klai-portal/frontend/src/routes/app/transcribe/index.tsx
@@ -204,7 +204,7 @@ function TranscribePage() {
       </PageIntro>
 
       {hasActiveMeetings && (
-        <div className="flex items-center gap-2 text-sm text-gray-400">
+        <div className="flex items-center gap-2 text-sm text-gray-600">
           <Loader2 className="h-4 w-4 animate-spin" />
           <span>{m.app_transcribe_auto_refresh()}</span>
         </div>

--- a/klai-portal/frontend/src/routes/bot/$widgetId.tsx
+++ b/klai-portal/frontend/src/routes/bot/$widgetId.tsx
@@ -62,7 +62,7 @@ function PublicBotPage() {
       <div className="fixed inset-0 z-[60] flex items-center justify-center bg-white px-6">
         <div className="max-w-md text-center">
           <p className="text-sm font-medium text-gray-900">{m.widget_chat_unavailable()}</p>
-          <p className="mt-1 text-xs text-gray-400">
+          <p className="mt-1 text-xs text-gray-600">
             {configQuery.error instanceof Error ? configQuery.error.message : m.admin_shared_error_generic()}
           </p>
         </div>

--- a/klai-portal/frontend/src/routes/callback.tsx
+++ b/klai-portal/frontend/src/routes/callback.tsx
@@ -247,7 +247,7 @@ function LoadingScreen() {
     <div className="flex min-h-screen items-center justify-center bg-[var(--color-background)]">
       <div className="space-y-3 text-center">
         <div className="mx-auto h-6 w-6 animate-spin rounded-full border-2 border-[var(--color-rl-accent)] border-t-transparent" />
-        <p className="text-sm text-gray-400">{m.callback_loading()}</p>
+        <p className="text-sm text-gray-600">{m.callback_loading()}</p>
       </div>
     </div>
   )
@@ -268,8 +268,8 @@ function ErrorScreen({ error, retryable }: ErrorScreenProps) {
         <p className="text-sm font-medium text-[var(--color-destructive-text)]">
           {m.callback_error_heading()}
         </p>
-        <p className="text-sm text-gray-400">{friendly}</p>
-        <p className="text-xs font-mono break-all opacity-60 text-gray-400">
+        <p className="text-sm text-gray-600">{friendly}</p>
+        <p className="text-xs font-mono break-all text-gray-600">
           {technical}
         </p>
         <div className="flex items-center justify-center gap-2 pt-1">

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -329,7 +329,7 @@ function UiCatalogPage() {
   if (!import.meta.env.DEV) {
     return (
       <PageContainer width="3xl">
-        <p className="text-sm text-gray-400">UI catalog is alleen lokaal beschikbaar.</p>
+        <p className="text-sm text-gray-600">UI catalog is alleen lokaal beschikbaar.</p>
       </PageContainer>
     )
   }
@@ -340,7 +340,7 @@ function UiCatalogPage() {
         <h1 className="page-title text-[1.625rem] font-display-bold text-gray-900">
           UI catalog
         </h1>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           Lokale referentie voor list rows, row actions en basiscomponenten.
         </p>
       </div>
@@ -528,7 +528,7 @@ function UiCatalogPage() {
               </Button>
             }
           />
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             Subtitel is gecapt op <code>sm:max-w-[60%]</code> zodat hij nooit
             onder de primaire actie doorloopt. Houd de subtitel kort; langere
             uitleg hoort in een <code>PageIntro</code> hieronder.
@@ -579,7 +579,7 @@ function UiCatalogPage() {
                 <span className="text-sm font-medium text-gray-900">{item.label}</span>
               </div>
               <p className="text-sm text-gray-500">{item.meaning}</p>
-              <p className="text-xs text-gray-400 sm:text-right">{item.examples}</p>
+              <p className="text-xs text-gray-600 sm:text-right">{item.examples}</p>
             </div>
           ))}
         </div>
@@ -608,7 +608,7 @@ function UiCatalogPage() {
             {actionKinds.map((action) => (
               <div key={action} className="flex items-center gap-1 rounded-md border border-gray-200 px-2 py-1">
                 <RowActionIconButton label={action} action={action} />
-                <span className="text-xs text-gray-400">{action}</span>
+                <span className="text-xs text-gray-600">{action}</span>
               </div>
             ))}
           </div>
@@ -696,7 +696,7 @@ function UiCatalogPage() {
           <ListRow confirming={confirming} className={`grid items-center gap-x-3 px-4 ${dividerListGrid}`}>
             <ListRowContent>
               <div className="flex items-center gap-2">
-                <FileText className="h-4 w-4 shrink-0 text-gray-400" />
+                <FileText className="h-4 w-4 shrink-0 text-gray-500" />
                 <ListRowTitle className="text-sm font-sans font-medium">Inline delete confirm</ListRowTitle>
               </div>
               <ListRowDescription>De overlay houdt dezelfde action-cell breedte.</ListRowDescription>
@@ -824,7 +824,7 @@ function UiCatalogPage() {
             placeholder="Reageer op deze melding"
             sendLabel="Verstuur reactie"
           />
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             Eén rustige tijdlijn: gegroepeerd per afzender en dag, met
             dag-scheiders en stille systeemregels (statuswijzigingen). Eigen
             berichten rechts (cream), Klai-team links (wit met rand). Eigen
@@ -838,7 +838,7 @@ function UiCatalogPage() {
       <Section title="Pagination">
         <div className="space-y-4">
           <Pagination page={demoPage} pageCount={10} onPageChange={setDemoPage} />
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             Genummerde pagination (standaard): Vorige / klikbare paginanummers
             met <code>…</code> ellipsis / Volgende. Eerste en laatste pagina
             altijd zichtbaar, huidige pagina gemarkeerd en niet klikbaar,
@@ -883,19 +883,19 @@ function UiCatalogPage() {
       <Section title="Tabs">
         <div className="space-y-8">
           <div className="space-y-2">
-            <p className="text-xs text-gray-400">Standaard — alleen tekst (canon)</p>
+            <p className="text-xs text-gray-600">Standaard — alleen tekst (canon)</p>
             <Tabs tabs={tabItems} value={activeTab} onValueChange={setActiveTab} />
           </div>
           <div className="space-y-2">
-            <p className="text-xs text-gray-400">Met iconen (spaarzaam, voor detail/instellingen)</p>
+            <p className="text-xs text-gray-600">Met iconen (spaarzaam, voor detail/instellingen)</p>
             <Tabs tabs={tabItemsWithIcons} value={activeTab} onValueChange={setActiveTab} />
           </div>
           <div className="space-y-2">
-            <p className="text-xs text-gray-400">Met gewone aantallen</p>
+            <p className="text-xs text-gray-600">Met gewone aantallen</p>
             <Tabs tabs={tabItemsWithCount} value={activeTab} onValueChange={setActiveTab} />
           </div>
           <div className="space-y-2">
-            <p className="text-xs text-gray-400">Met meldingenteller</p>
+            <p className="text-xs text-gray-600">Met meldingenteller</p>
             <Tabs tabs={tabItemsWithNotifications} value={activeTab} onValueChange={setActiveTab} />
           </div>
           <p className="text-sm text-gray-500">Actieve tab: {activeTab}</p>

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -71,7 +71,7 @@ function JoinRequestPage() {
       <AuthPageLayout leftContent={leftContent} showLocale>
         <div className="flex flex-col items-center gap-4 text-center">
           <CheckCircle2 className="h-10 w-10 text-[var(--color-success)]" />
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.join_request_success()}
           </p>
         </div>
@@ -85,7 +85,7 @@ function JoinRequestPage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.join_request_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.join_request_body()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/join-request.tsx
+++ b/klai-portal/frontend/src/routes/join-request.tsx
@@ -70,7 +70,7 @@ function JoinRequestPage() {
     return (
       <AuthPageLayout leftContent={leftContent} showLocale>
         <div className="flex flex-col items-center gap-4 text-center">
-          <CheckCircle2 className="h-10 w-10 text-[var(--color-success)]" />
+          <CheckCircle2 className="h-10 w-10 text-[var(--color-success-text)]" />
           <p className="text-sm text-gray-600">
             {m.join_request_success()}
           </p>

--- a/klai-portal/frontend/src/routes/join-request/sent.tsx
+++ b/klai-portal/frontend/src/routes/join-request/sent.tsx
@@ -27,7 +27,7 @@ function JoinRequestSentPage() {
   return (
     <AuthPageLayout leftContent={leftContent} showLocale>
       <div className="flex flex-col items-center gap-4 text-center">
-        <CheckCircle2 className="h-10 w-10 text-[var(--color-success)]" />
+        <CheckCircle2 className="h-10 w-10 text-[var(--color-success-text)]" />
         <p className="text-sm text-gray-600">
           {m.join_request_success()}
         </p>

--- a/klai-portal/frontend/src/routes/join-request/sent.tsx
+++ b/klai-portal/frontend/src/routes/join-request/sent.tsx
@@ -28,7 +28,7 @@ function JoinRequestSentPage() {
     <AuthPageLayout leftContent={leftContent} showLocale>
       <div className="flex flex-col items-center gap-4 text-center">
         <CheckCircle2 className="h-10 w-10 text-[var(--color-success)]" />
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.join_request_success()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/logged-out.tsx
+++ b/klai-portal/frontend/src/routes/logged-out.tsx
@@ -33,7 +33,7 @@ function LoggedOutPage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.logged_out_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.logged_out_body()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/login.tsx
+++ b/klai-portal/frontend/src/routes/login.tsx
@@ -256,7 +256,7 @@ function LoginPage() {
             <h2 className="text-2xl font-semibold tracking-tight text-gray-900">
               {m.totp_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.totp_subheading()}
             </p>
           </div>
@@ -291,7 +291,7 @@ function LoginPage() {
             </Button>
           </form>
 
-          <p className="text-center text-xs text-gray-400">
+          <p className="text-center text-xs text-gray-600">
             <button
               onClick={() => { setTotpStep(false); setTotpCode(''); setError(null) }}
               className="text-[var(--color-rl-accent-dark)] hover:underline"
@@ -307,7 +307,7 @@ function LoginPage() {
             <h2 className="text-2xl font-semibold tracking-tight text-gray-900">
               {m.login_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.login_subheading()}
             </p>
           </div>
@@ -357,7 +357,7 @@ function LoginPage() {
           {/* Social login */}
           <div className="relative flex items-center gap-3 pt-1">
             <div className="h-px flex-1 bg-gray-200" />
-            <span className="text-xs tracking-wide text-gray-400">
+            <span className="text-xs tracking-wide text-gray-600">
               {m.login_or_continue_with()}
             </span>
             <div className="h-px flex-1 bg-gray-200" />
@@ -397,7 +397,7 @@ function LoginPage() {
             </button>
           </div>
 
-          <div className="flex items-center justify-between text-center text-xs text-gray-400">
+          <div className="flex items-center justify-between text-center text-xs text-gray-600">
             <Link
               to="/$locale/password/forgot"
               params={{ locale }}

--- a/klai-portal/frontend/src/routes/no-account.tsx
+++ b/klai-portal/frontend/src/routes/no-account.tsx
@@ -44,7 +44,7 @@ function NoAccountPage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.no_account_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.no_account_body()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -172,7 +172,7 @@ function PasswordSetPage() {
           <p className="text-xl font-semibold text-gray-900">
             {m.set_done_heading()}
           </p>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.set_done_body()}
           </p>
           {/* Anchor wrapped in Button styling - native browser navigation
@@ -188,7 +188,7 @@ function PasswordSetPage() {
             <h2 className="text-xl font-semibold text-gray-900">
               {m.set_invalid_link_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.set_invalid_link_body()}
             </p>
           </div>
@@ -205,7 +205,7 @@ function PasswordSetPage() {
             <h2 className="text-xl font-semibold text-gray-900">
               {m.set_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {passwordPolicy
                 ? m.set_subheading({ minLength: String(passwordPolicy.min_length) })
                 : m.set_subheading_loading()}
@@ -261,7 +261,7 @@ function PasswordSetPage() {
             </Button>
           </form>
 
-          <p className="text-center text-xs text-gray-400">
+          <p className="text-center text-xs text-gray-600">
             <a href="/" className="text-[var(--color-rl-accent-dark)] hover:underline">
               {m.set_back()}
             </a>

--- a/klai-portal/frontend/src/routes/provisioning.tsx
+++ b/klai-portal/frontend/src/routes/provisioning.tsx
@@ -230,7 +230,7 @@ function PollingView({ dots }: { dots: string }) {
           {m.provisioning_polling_title()}
           {dots}
         </p>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.provisioning_polling_subtitle()}
         </p>
       </div>
@@ -245,7 +245,7 @@ function ReadyView() {
       <p className="text-xl font-semibold text-gray-900">
         {m.provisioning_ready_title()}
       </p>
-      <p className="text-sm text-gray-400">
+      <p className="text-sm text-gray-600">
         {m.provisioning_ready_subtitle()}
       </p>
     </>
@@ -260,7 +260,7 @@ function RecoverableErrorView() {
         <p className="text-xl font-semibold text-gray-900">
           {m.provisioning_error_title()}
         </p>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.provisioning_error_body()}
         </p>
       </div>
@@ -279,7 +279,7 @@ function FatalErrorView() {
         <p className="text-xl font-semibold text-gray-900">
           {m.provisioning_failed_title()}
         </p>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.provisioning_failed_body()}{' '}
           <a
             href="mailto:support@getklai.com"

--- a/klai-portal/frontend/src/routes/select-workspace.tsx
+++ b/klai-portal/frontend/src/routes/select-workspace.tsx
@@ -79,7 +79,7 @@ function SelectWorkspacePage() {
     return (
       <AuthPageLayout leftContent={leftContent} showLocale>
         <div className="flex items-center justify-center py-8">
-          <span className="text-sm text-gray-400">…</span>
+          <span className="text-sm text-gray-600">…</span>
         </div>
       </AuthPageLayout>
     )
@@ -113,7 +113,7 @@ function SelectWorkspacePage() {
         <h2 className="text-xl font-semibold text-gray-900">
           {m.select_workspace_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.select_workspace_body()}
         </p>
       </div>
@@ -134,7 +134,7 @@ function SelectWorkspacePage() {
             <span className="block font-medium text-gray-900">
               {org.name}
             </span>
-            <span className="block text-xs text-gray-400">
+            <span className="block text-xs text-gray-600">
               {org.kind === 'domain_match'
                 ? org.auto_accept
                   ? m.select_workspace_join_auto_hint()

--- a/klai-portal/frontend/src/routes/setup/_components/-EmailOTPSetup.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-EmailOTPSetup.tsx
@@ -66,7 +66,7 @@ export function EmailOTPSetup({
             <h2 className="text-xl font-semibold text-gray-900">
               {m.setup_mfa_email_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.setup_mfa_email_body({ email })}
             </p>
           </div>
@@ -81,7 +81,7 @@ export function EmailOTPSetup({
             <h2 className="text-xl font-semibold text-gray-900">
               {m.setup_mfa_email_code_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.setup_mfa_email_code_body()}
             </p>
           </div>
@@ -131,7 +131,7 @@ export function EmailOTPSetup({
                   {m.setup_mfa_email_resend()}
                 </button>
               ) : (
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-600">
                   {m.setup_mfa_email_resend()} ({Math.ceil(((state.resendAt ?? state.now) - state.now) / 1000)}s)
                 </span>
               )}

--- a/klai-portal/frontend/src/routes/setup/_components/-MfaMethodCard.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-MfaMethodCard.tsx
@@ -39,7 +39,7 @@ export function MfaMethodCard({
               </span>
             )}
           </div>
-          <p className="text-xs text-gray-400">{description}</p>
+          <p className="text-xs text-gray-600">{description}</p>
         </div>
         {selected && (
           <div className="mt-0.5 shrink-0 text-[var(--color-rl-accent)]">

--- a/klai-portal/frontend/src/routes/setup/_components/-PasskeySetup.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-PasskeySetup.tsx
@@ -69,7 +69,7 @@ export function PasskeySetup({
         <h2 className="text-xl font-semibold text-gray-900">
           {m.setup_mfa_passkey_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.setup_mfa_passkey_body()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/setup/_components/-TOTPSetup.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-TOTPSetup.tsx
@@ -53,7 +53,7 @@ export function TOTPSetup({
         <h2 className="text-xl font-semibold text-gray-900">
           {m.setup_2fa_heading()}
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-600">
           {m.setup_2fa_subheading()}
         </p>
       </div>

--- a/klai-portal/frontend/src/routes/setup/mfa.lazy.tsx
+++ b/klai-portal/frontend/src/routes/setup/mfa.lazy.tsx
@@ -71,7 +71,7 @@ function SetupMFAPage() {
           <p className="text-xl font-semibold text-gray-900">
             {m.setup_mfa_done_heading()}
           </p>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.setup_mfa_done_body()}
           </p>
         </div>
@@ -83,7 +83,7 @@ function SetupMFAPage() {
             <h2 className="text-xl font-semibold text-gray-900">
               {m.setup_mfa_heading()}
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.setup_mfa_subheading()}
             </p>
           </div>
@@ -128,7 +128,7 @@ function SetupMFAPage() {
               <button
                 type="button"
                 onClick={redirectAfterSetup}
-                className="text-xs text-gray-400 hover:text-[var(--color-rl-accent-dark)] hover:underline"
+                className="text-xs text-gray-600 hover:text-[var(--color-rl-accent-dark)] hover:underline"
               >
                 {m.setup_mfa_skip()}
               </button>

--- a/klai-portal/frontend/src/routes/tenant-deleted.tsx
+++ b/klai-portal/frontend/src/routes/tenant-deleted.tsx
@@ -15,7 +15,7 @@ function TenantDeletedPage() {
       <div className="w-full max-w-md space-y-6 px-6 text-center">
         <CheckCircle
           size={40}
-          className="mx-auto text-[var(--color-success)]"
+          className="mx-auto text-[var(--color-success-text)]"
           strokeWidth={1.5}
         />
         <div className="space-y-2">

--- a/klai-portal/frontend/src/routes/tenant-deleted.tsx
+++ b/klai-portal/frontend/src/routes/tenant-deleted.tsx
@@ -22,7 +22,7 @@ function TenantDeletedPage() {
           <p className="text-xl font-semibold text-gray-900">
             {m.tenant_deleted_heading()}
           </p>
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.tenant_deleted_body()}
           </p>
         </div>

--- a/klai-portal/frontend/src/routes/verify.tsx
+++ b/klai-portal/frontend/src/routes/verify.tsx
@@ -99,7 +99,7 @@ function VerifyEmailPage() {
       {status === 'success' && (
         <div className="space-y-6 text-center">
           <div className="space-y-3">
-            <CheckCircle className="mx-auto h-12 w-12 text-[var(--color-success)]" />
+            <CheckCircle className="mx-auto h-12 w-12 text-[var(--color-success-text)]" />
             <h1 className="text-xl font-semibold text-gray-900">
               {m.verify_success_heading()}
             </h1>

--- a/klai-portal/frontend/src/routes/verify.tsx
+++ b/klai-portal/frontend/src/routes/verify.tsx
@@ -90,7 +90,7 @@ function VerifyEmailPage() {
       {status === 'loading' && (
         <div className="space-y-4 text-center">
           <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-[var(--color-rl-accent)] border-t-transparent" />
-          <p className="text-sm text-gray-400">
+          <p className="text-sm text-gray-600">
             {m.verify_loading()}
           </p>
         </div>
@@ -103,7 +103,7 @@ function VerifyEmailPage() {
             <h1 className="text-xl font-semibold text-gray-900">
               {m.verify_success_heading()}
             </h1>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {m.verify_success_body()}
             </p>
           </div>
@@ -121,11 +121,11 @@ function VerifyEmailPage() {
             <h1 className="text-xl font-semibold text-gray-900">
               {m.verify_error_heading()}
             </h1>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm text-gray-600">
               {errorMessage ?? m.verify_error_invalid_link()}
             </p>
           </div>
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-gray-600">
             {m.verify_error_hint()}{' '}
             <a href="mailto:support@getklai.com" className="text-[var(--color-rl-accent-dark)] hover:underline">
               support@getklai.com

--- a/klai-portal/frontend/tests/design/documented-contrast.test.ts
+++ b/klai-portal/frontend/tests/design/documented-contrast.test.ts
@@ -21,6 +21,7 @@ const AA_NORMAL_TEXT = 4.5
 const TAILWIND_TEXT_COLORS = new Map([
   ['text-gray-900', '#111827'],
   ['text-gray-600', '#4b5563'],
+  ['text-gray-500', '#6b7280'],
   ['text-gray-400', '#9ca3af'],
 ])
 
@@ -29,7 +30,11 @@ const PORTAL_SURFACES = ['--color-background', '--color-secondary']
 const DOCUMENTED_EXCEPTIONS = new Map([
   [
     'text-gray-400',
-    "The portal's default secondary colour at ~605 uses. Replacing it is a counted migration, not a sweep; see SPEC-DESIGN-SOURCE-001.",
+    'Documented for decorative and disabled use only; it does not carry information in those roles.',
+  ],
+  [
+    'text-gray-500',
+    'The documented non-text colour; it clears the 3:1 contrast bar that applies to icons and other informative non-text.',
   ],
   [
     '--color-success',

--- a/klai-portal/frontend/tests/design/documented-contrast.test.ts
+++ b/klai-portal/frontend/tests/design/documented-contrast.test.ts
@@ -36,14 +36,6 @@ const DOCUMENTED_EXCEPTIONS = new Map([
     'text-gray-500',
     'The documented non-text colour; it clears the 3:1 contrast bar that applies to icons and other informative non-text.',
   ],
-  [
-    '--color-success',
-    'Used as an icon and badge tone, which is non-text and needs 3:1 rather than 4.5:1. At 2.73:1 it does not clear 3:1 either, so this is a real defect.',
-  ],
-  [
-    '--color-warning',
-    'Used as an icon and badge tone, which is non-text and needs 3:1 rather than 4.5:1.',
-  ],
 ])
 
 type NamedColor = {


### PR DESCRIPTION
Follow-up to #1285, implementing Units 1–2 of `SPEC-DESIGN-SOURCE-001` plus the colour migration that fell out of them.

## Rules moved onto the components they govern

Twenty-one ledger rules stated something about a single component and had no connection to that component's file. Delete the component and the rule stayed behind; change its variants and the rule quietly became untrue. Both have happened here.

They now live in the component's header doc comment, next to the `@purpose` tag that was already there, and the generator renders the ledger rows from them:

```js
/**
 * @purpose Inline status labels
 * @guideline KLAI-UI-044 must Status pills use `Badge` semantic variants,
 * never ad-hoc tinted pills
 */
```

This is a move, not a rewrite, and that is checkable: all 51 rows are byte-identical to their previous text — same rule, same level, same verification mode, same reason. The component files gained comments and nothing else; zero non-comment lines changed. `ui-standards.md` drops from 1144 to 1140 lines.

Three guards proven by fixture: editing a ledger row by hand fails `--check`, editing a guideline without regenerating fails it too, and deleting a component removes both its rule and one from the count with no human action.

## Secondary text is now legible

`text-gray-400` was the portal's default secondary colour. At 2.41:1 and 2.31:1 on our two surfaces it clears neither the 4.5:1 bar for text nor the 3:1 bar for non-text, so it was not legitimate for anything carrying information.

Classifying all 608 occurrences found 521 were a genuine readability defect — 330 body prose, 191 metadata — against 12 decorative and 4 disabled. An earlier guess that a third were decorative was wrong; it is 2%.

The documented scale is now four lines with the ratio and the role for each: gray-900 for primary text, gray-600 for secondary, gray-500 for informative non-text, and gray-400 for decorative and disabled only. 525 sites moved to gray-600, 70 to gray-500, and 6 remain — all states WCAG exempts.

The twenty sites in `src/components/ui/` were decided individually rather than swept, because one line there renders hundreds of times. `row-action.tsx` is worth naming: its `neutral` tone is the icon colour for every neutral row action in the portal.

Five opacity utilities are gone. They were faking the muting the colour now provides honestly, and pulled effective contrast back under the threshold.

## Verification

`npm run lint`, `npx tsc -b --force`, the generator's `--check` and `npx vitest run` (88 files, 604 tests) are green. Beyond that: all 51 ledger rows compared byte-for-byte against the base commit, every component diff confirmed comment-only, all four contrast ratios recomputed independently, three guards attacked with negative fixtures, and `/dev/ui` rendered to judge the two things arithmetic cannot — that placeholders stay distinct from entered text, and that list hierarchy survives.

One regression surfaced in review and is fixed: a link had `text-gray-400 hover:text-gray-600`, so raising the resting colour made the hover a no-op. A search for the same shape found one other occurrence, predating this change and left alone.

## Known gaps

- Not seen on real authenticated routes. The local backend does not start in this workspace, and the `e2e` job is path-filtered off these changes. Components were verified in `/dev/ui`, which caught the two defects static analysis could not.
- Fourteen hand-rolled callouts still bypass `Alert`, counted and listed, deliberately not swept.
- Unit 3 of the spec — emitting DESIGN.md or DSDS — is not done. It is interop, not workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)