### PR TITLE
feat(observability): alert when recordings stop producing transcripts

### DIFF
--- a/deploy/grafana/provisioning/alerting/meeting-recording-rules.yaml
+++ b/deploy/grafana/provisioning/alerting/meeting-recording-rules.yaml
@@ -1,0 +1,201 @@
+# Meeting recording and transcript outcome alerts.
+#
+# These rules deliberately observe the persisted user-visible contract rather
+# than a Vexa bot error string. The bot containers emit unstructured lines with
+# no `level` field, and teaching Alloy one incident phrase would cover only that
+# implementation. A meeting row is written before the bot starts, so the DB
+# signals below cover failures in the bot, recording, STT, portal transcription,
+# and status finalisation paths.
+#
+# Production firing proof (read-only query, 2026-09-01): evaluating both rules
+# at 2026-08-28 12:00 UTC against the real vexa_meetings history returned:
+#   bad_outcome_rate = 100.0
+#   transcript_silence = 1
+# The only meeting in the preceding 24h was `done` with zero transcript
+# characters and zero transcript segments. Both thresholds below therefore
+# evaluate true, without matching the incident's error text.
+#
+# Datasource access: portal_meeting_transcript_health is a superuser-owned,
+# non-security-invoker view. See deploy/grafana/sql/grafana-reader-setup.sql.
+# It exposes status/timestamps/a derived boolean only; grafana_reader receives
+# public-schema USAGE and SELECT on the view, never an RLS bypass or a wider
+# grant on vexa_meetings.
+
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: meeting-recording-health
+    folder: Klai
+    interval: 10m
+    rules:
+
+      # A terminal result is unhealthy when the pipeline reports failed/error,
+      # or when it says done without producing any transcript content. The
+      # threshold is intentionally zero-tolerance: `done` is a success contract,
+      # and PR #1288 makes no-recording outcomes honest failures instead.
+      - uid: obs-meeting-bad-outcome-rate
+        title: meeting_recording_bad_outcome_rate
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: portal-postgres
+            queryType: ''
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                SELECT count(*) FILTER (
+                           WHERE status IN ('failed', 'error')
+                              OR (status = 'done' AND NOT has_transcript)
+                       ) * 100.0 / NULLIF(count(*), 0) AS value
+                  FROM portal_meeting_transcript_health
+                 WHERE outcome_at >= now() - interval '24 hours'
+                   AND outcome_at <= now()
+                   AND status IN ('done', 'failed', 'error')
+                HAVING count(*) > 0
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        keepFiringFor: 1h
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-OBS-001
+          service: meetings
+        annotations:
+          summary: 'A meeting ended failed or done without a transcript'
+          runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md'
+          description: |
+            At least one terminal meeting outcome in the last 24 hours was
+            `failed`/`error`, or was marked `done` without non-blank transcript
+            text or any transcript segment. The value is the percentage of
+            terminal outcomes that violated that contract; any non-zero value
+            alerts.
+
+            This is independent of error_message. It therefore catches the new
+            "ended before recording was confirmed" failure, bot-start errors,
+            transcription errors, and the old hollow `done` outcome.
+
+            Inspect the safe aggregate view first:
+              SELECT status, has_transcript, count(*)
+                FROM portal_meeting_transcript_health
+               WHERE outcome_at >= now() - interval '24 hours'
+               GROUP BY 1, 2 ORDER BY 1, 2;
+
+      # Absence-of-success, demand-gated. A terminal row proves demand
+      # immediately; a non-cancelled row that has not finished after four hours
+      # proves a stuck attempt. No meetings means value=0, not an alert.
+      - uid: obs-meeting-transcript-silence
+        title: meeting_transcript_silence
+        condition: threshold
+        data:
+          - refId: query
+            datasourceUid: portal-postgres
+            queryType: ''
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: query
+              datasource:
+                type: postgres
+                uid: portal-postgres
+              format: table
+              rawSql: |
+                SELECT CASE
+                         WHEN count(*) FILTER (
+                                  WHERE status IN ('done', 'failed', 'error')
+                                     OR (
+                                         status <> 'cancelled'
+                                         AND created_at <= now() - interval '4 hours'
+                                     )
+                              ) > 0
+                          AND count(*) FILTER (WHERE has_transcript) = 0
+                         THEN 1
+                         ELSE 0
+                       END AS value
+                  FROM portal_meeting_transcript_health
+                 WHERE created_at >= now() - interval '24 hours'
+                   AND created_at <= now()
+          - refId: reduce
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: reduce
+              type: reduce
+              reducer: last
+              expression: query
+          - refId: threshold
+            datasourceUid: __expr__
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            model:
+              refId: threshold
+              type: threshold
+              expression: reduce
+              conditions:
+                - evaluator: { params: [0], type: gt }
+                  operator: { type: and }
+                  reducer: { params: [], type: last }
+                  type: query
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        keepFiringFor: 1h
+        isPaused: false
+        labels:
+          severity: warning
+          spec: SPEC-OBS-001
+          service: meetings
+        annotations:
+          summary: 'Meeting demand exists but no transcript succeeded in 24 hours'
+          runbook_url: 'https://github.com/GetKlai/klai-infra/blob/main/docs/runbooks/platform-recovery.md'
+          description: |
+            In the last 24 hours at least one meeting reached a terminal state,
+            or a non-cancelled attempt has been stuck for four hours, but not one
+            meeting produced non-blank transcript text or a transcript segment.
+
+            Tenants that simply held no meetings do not contribute demand, so a
+            quiet day stays healthy. This catches a system-wide silent pipeline
+            failure and also a component that leaves meetings non-terminal,
+            rather than only the STT error text from the 2026-08 incident.
+
+            Inspect the safe aggregate view first:
+              SELECT status, has_transcript, count(*)
+                FROM portal_meeting_transcript_health
+               WHERE created_at >= now() - interval '24 hours'
+               GROUP BY 1, 2 ORDER BY 1, 2;

--- a/deploy/grafana/sql/grafana-reader-setup.sql
+++ b/deploy/grafana/sql/grafana-reader-setup.sql
@@ -83,9 +83,37 @@ CREATE OR REPLACE VIEW portal_telemetry_mode_changes AS
 
 GRANT SELECT ON portal_telemetry_mode_changes TO grafana_reader;
 
+-- ── Meeting recording and transcript health ─────────────────────────────
+--
+-- vexa_meetings is a category-D RLS table. Its SELECT policy requires the
+-- app.current_org_id tenant GUC, which Grafana never sets: grafana_reader has
+-- SELECT on the base table but reads zero rows (verified in production on
+-- 2026-09-01: superuser 17 rows, grafana_reader 0). Granting the base table
+-- again would not fix that blackhole, and bypassing its RLS would expose
+-- meeting URLs, titles, transcript text, and user identifiers.
+--
+-- This superuser-owned, non-security-invoker view exposes only the four
+-- derived/operational fields the alert needs. The view owner evaluates the
+-- base table's RLS; grafana_reader never receives a wider base-table grant.
+CREATE OR REPLACE VIEW portal_meeting_transcript_health
+WITH (security_invoker = false, security_barrier = true) AS
+    SELECT status,
+           created_at,
+           updated_at AS outcome_at,
+           (
+               NULLIF(btrim(transcript_text), '') IS NOT NULL
+               OR jsonb_array_length(COALESCE(transcript_segments, '[]'::jsonb)) > 0
+           ) AS has_transcript
+      FROM vexa_meetings;
+
+REVOKE ALL ON portal_meeting_transcript_health FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO grafana_reader;
+GRANT SELECT ON portal_meeting_transcript_health TO grafana_reader;
+
 -- Verify after running (must return a non-zero count, not an error and not 0):
 --   SET ROLE grafana_reader;
 --   SELECT count(*) FROM portal_feedback_correlation_stats;
+--   SELECT count(*) FROM portal_meeting_transcript_health;
 --
 -- Audit which granted tables still read as empty for this role -- an RLS
 -- policy scoped to another role looks identical to "no data" from Grafana:

--- a/deploy/scripts/tests/verify-alert-datasource-access.test.sh
+++ b/deploy/scripts/tests/verify-alert-datasource-access.test.sh
@@ -39,6 +39,8 @@ fi
 for expected in \
   "spec-kb-015-feedback-correlation-low	portal_feedback_correlation_stats" \
   "spec-kb-015-feedback-correlation-low	portal_orgs" \
+  "obs-meeting-bad-outcome-rate	portal_meeting_transcript_health" \
+  "obs-meeting-transcript-silence	portal_meeting_transcript_health" \
   "spec-priv-001-tenant-stuck-full	portal_telemetry_mode_changes" \
   "rag-eval-001-faithfulness-low	knowledge.rag_eval_results"; do
   if printf '%s\n' "$out" | grep -qF "$expected"; then


### PR DESCRIPTION
Between 2026-08-17 and 2026-09-01 **every Klai recording produced an empty transcript.** Fifteen days, and nothing could have told us:

- the bot's failures are logged without a `level` field, so every `level:error` alert misses them by construction
- none of the twenty-odd provisioned rules covers meetings or transcription
- worst, the system reported success — the meetings reached `done`

## Two rules

Both read the meeting **outcome** rather than any error string, so they catch the same class of failure in a different component instead of only this incident.

**`meeting_recording_bad_outcome_rate`** — share of terminal meetings in 24h that failed or finished with no transcript. Catches bot, capture, STT and portal faults alike.

**`meeting_transcript_silence`** — there was demand in 24h and not one transcript succeeded. Demand means a terminal meeting, or an uncancelled attempt stuck for four hours — so a tenant that simply held no meetings scores 0 and stays quiet. This is the one that would have caught 17 August earliest.

Both use `execErrState: Error`, per the observability rule about alerts whose purpose is catching silence.

Alloy is deliberately untouched. Alerting on the bot's log lines would mean phrase-matching text only the current bot implementation emits; the database outcome is implementation-independent.

## The datasource half, which is what quietly kills alerts here

`vexa_meetings` is an RLS table whose SELECT policy needs the tenant GUC Grafana never sets. `grafana_reader` holds SELECT on the base table and reads **zero rows forever** — which looks exactly like "nothing wrong".

So the rules read a superuser-owned `security_invoker = false` view exposing four operational fields: `status`, two timestamps, and whether a transcript exists. No transcript text, no meeting URLs, no user identifiers, and no widening of the base-table grant.

## Verified on production, not asserted

| | |
|---|---|
| before the view | `grafana_reader` 0 rows from `vexa_meetings`, superuser 17 |
| after the view | `grafana_reader` **17 rows** |
| rule 1, right now | **66.7** — above threshold, would be firing |
| rule 1, across the outage window | 3 terminal meetings, all 3 bad: **100.0** |

## One manual step already taken

The view was applied to core-01 by hand, because `grafana-reader-setup.sql` is an operator script no pipeline runs. That had to happen **before** this merges: `verify-alert-datasource-access.py` gates the deploy on blind rules and would have failed on a rule whose view did not exist yet.

It is additive and reversible (`DROP VIEW portal_meeting_transcript_health`).

## Known gaps

Stated so they are not mistaken for covered: a transcript that is non-empty but wrong or unusable; a single-tenant outage while other tenants succeed and the broken meetings stay non-terminal under four hours; bot faults with no meeting row; and alert delivery itself, which is not end-to-end tested here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)