### PR TITLE
fix(hooks): judge where a push is going, not what branch the shell is on

### DIFF
--- a/.claude/hooks/klai/public-github-mutation-guard.py
+++ b/.claude/hooks/klai/public-github-mutation-guard.py
@@ -13,7 +13,7 @@ import re
 import shlex
 import subprocess
 import sys
-
+from typing import NamedTuple
 
 APPROVAL_MARKER = "KLAI_ALLOW_PUBLIC_ISSUE_MUTATION=1"
 CODE_APPROVAL_MARKER = "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"
@@ -49,6 +49,51 @@ PULL_GRAPHQL_MUTATION = re.compile(
     r"markPullRequestReadyForReview|reopenPullRequest|updatePullRequest)\b",
     re.IGNORECASE,
 )
+
+SHELL_WORD = r"""(?:'[^']*'|"(?:\\.|[^"])*"|(?:\\.|[^\s;&|])+)"""
+GIT_PUSH = re.compile(
+    rf"\bgit(?P<git_options>(?:\s+-C\s+{SHELL_WORD})*)\s+push\b",
+    re.IGNORECASE,
+)
+UNPARSED_GIT_PUSH = re.compile(r"\bgit\b[^;&|\n]*\bpush\b", re.IGNORECASE)
+PUSH_FLAG_OPTIONS = {
+    "-f",
+    "--force",
+    "-u",
+    "--set-upstream",
+    "--force-if-includes",
+    "--no-force-if-includes",
+    "--atomic",
+    "--no-atomic",
+    "-n",
+    "--dry-run",
+    "--porcelain",
+    "--prune",
+    "--no-prune",
+    "--follow-tags",
+    "--no-follow-tags",
+    "--signed",
+    "--no-signed",
+    "--ipv4",
+    "--ipv6",
+    "-q",
+    "--quiet",
+    "-v",
+    "--verbose",
+    "--verify",
+    "--no-verify",
+    "--progress",
+    "--no-progress",
+    "--thin",
+    "--no-thin",
+}
+
+
+class PushInvocation(NamedTuple):
+    arguments: list[str] | None
+    git_options: list[str]
+    cwd: str | None
+    branch_context_known: bool
 
 
 def is_public_issue_mutation(command: str) -> bool:
@@ -95,70 +140,147 @@ def is_public_pr_mutation(command: str) -> bool:
     return False
 
 
-def _push_arguments(command: str) -> list[list[str]]:
-    invocations: list[list[str]] = []
-    for match in re.finditer(r"\bgit\s+push\b", command, re.IGNORECASE):
-        invocation = re.split(r"&&|\|\||[;|\n]", command[match.start() :], maxsplit=1)[0]
+def _branch_context(command: str, git_start: int) -> tuple[str | None, bool]:
+    prefix = command[:git_start]
+    if not prefix.strip():
+        return None, True
+    has_shell_context = re.search(r"&&|\|\||[;|\n]", prefix) is not None
+    try:
+        tokens = shlex.split(prefix)
+    except ValueError:
+        starts_with_cd = re.match(r"^\s*cd\b", prefix, re.IGNORECASE) is not None
+        return None, not (starts_with_cd or has_shell_context)
+    if len(tokens) == 3 and tokens[0].lower() == "cd" and tokens[2] == "&&":
+        return tokens[1], True
+    if has_shell_context or any(token.lower() == "cd" for token in tokens):
+        return None, False
+    return None, True
+
+
+def _push_invocations(command: str) -> list[PushInvocation]:
+    invocations: list[PushInvocation] = []
+    parsed_starts: set[int] = set()
+    for match in GIT_PUSH.finditer(command):
+        parsed_starts.add(match.start())
+        invocation = re.split(r"&&|\|\||[;|\n]", command[match.start() :], maxsplit=1)[
+            0
+        ]
+        cwd, branch_context_known = _branch_context(command, match.start())
+        if not branch_context_known:
+            invocations.append(PushInvocation(None, [], None, False))
+            continue
         try:
             tokens = shlex.split(invocation)
         except ValueError:
-            tokens = invocation.replace("'", "").replace('"', "").split()
-        if len(tokens) >= 2:
-            invocations.append(tokens[2:])
+            invocations.append(PushInvocation(None, [], cwd, False))
+            continue
+        try:
+            push_index = len(shlex.split(match.group(0))) - 1
+        except ValueError:
+            invocations.append(PushInvocation(None, [], cwd, False))
+            continue
+        invocations.append(
+            PushInvocation(
+                tokens[push_index + 1 :],
+                tokens[1:push_index],
+                cwd,
+                branch_context_known,
+            )
+        )
+    for match in UNPARSED_GIT_PUSH.finditer(command):
+        if match.start() not in parsed_starts:
+            invocations.append(PushInvocation(None, [], None, False))
     return invocations
 
 
-def _current_git_branch() -> str | None:
+def _current_git_branch(git_options: list[str], cwd: str | None) -> str | None:
     try:
         result = subprocess.run(
-            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            ["git", *git_options, "symbolic-ref", "--quiet", "--short", "HEAD"],
             capture_output=True,
             check=False,
+            cwd=cwd,
             text=True,
             timeout=2,
         )
     except (OSError, subprocess.SubprocessError):
-        # Branch state is contextual evidence only. Fail open when it cannot be
-        # resolved; explicit main destinations are still blocked above.
         return None
     if result.returncode != 0:
-        # Detached HEAD and non-repository working directories have no branch.
-        # Fail open because the command string alone cannot resolve HEAD safely.
         return None
     branch = result.stdout.strip()
     return branch or None
 
 
-def is_public_main_push(command: str, current_branch: str | None = None) -> bool:
-    for arguments in _push_arguments(command):
-        if any(argument in {"--all", "--mirror"} for argument in arguments):
+def _push_refspecs(arguments: list[str]) -> tuple[list[str] | None, bool]:
+    positionals: list[str] = []
+    delete = False
+    index = 0
+    options_done = False
+    while index < len(arguments):
+        argument = arguments[index]
+        if not options_done and argument == "--":
+            options_done = True
+        elif not options_done and argument in {"--all", "--mirror"}:
+            return None, True
+        elif not options_done and argument == "--delete":
+            delete = True
+        elif not options_done and argument.startswith("--delete="):
+            positionals.append(argument.split("=", 1)[1])
+            delete = True
+        elif not options_done and (
+            argument in PUSH_FLAG_OPTIONS
+            or argument == "--force-with-lease"
+            or argument.startswith(("--force-with-lease=", "--signed="))
+        ):
+            pass
+        elif not options_done and argument.startswith("-"):
+            return None, True
+        else:
+            positionals.append(argument)
+        index += 1
+
+    if delete:
+        if not positionals:
+            return None, True
+        return positionals[1:] if len(positionals) > 1 else None, False
+    return positionals[1:] if positionals else [], False
+
+
+def _destination_for_refspec(refspec: str, invocation: PushInvocation) -> str | None:
+    normalized = refspec.removeprefix("+")
+    if "*" in normalized:
+        return None
+    if ":" in normalized:
+        destination = normalized.rsplit(":", 1)[1]
+        return destination or None
+    if normalized not in {"@", "HEAD"}:
+        return normalized
+    if not invocation.branch_context_known:
+        return None
+    return _current_git_branch(invocation.git_options, invocation.cwd)
+
+
+def is_public_main_push(command: str) -> bool:
+    for invocation in _push_invocations(command):
+        if invocation.arguments is None:
             return True
-
-        for index, argument in enumerate(arguments):
-            normalized = argument.lstrip("+")
-            if normalized.startswith("--delete="):
-                destination = normalized.split("=", 1)[1]
-                if destination in {"main", "refs/heads/main"}:
-                    return True
-            if ":" in normalized:
-                destination = normalized.rsplit(":", 1)[1]
-                if destination in {"main", "refs/heads/main"}:
-                    return True
-            if (
-                normalized in {"main", "refs/heads/main"}
-                and index > 0
-                and ":" not in normalized
-            ):
+        refspecs, must_block = _push_refspecs(invocation.arguments)
+        if must_block:
+            return True
+        if refspecs is None:
+            return True
+        if not refspecs:
+            if not invocation.branch_context_known:
                 return True
-
-        if current_branch == "main":
-            positionals = [
-                argument for argument in arguments if not argument.startswith("-")
-            ]
-            refspecs = positionals[1:]
-            if not refspecs or any(
-                refspec.lstrip("+") in {"@", "HEAD"} for refspec in refspecs
-            ):
+            branch = _current_git_branch(invocation.git_options, invocation.cwd)
+            if branch is None:
+                return True
+            refspecs = [branch]
+        for refspec in refspecs:
+            destination = _destination_for_refspec(refspec, invocation)
+            if destination is None:
+                return True
+            if destination in {"main", "refs/heads/main"}:
                 return True
 
     return False
@@ -195,9 +317,7 @@ def main() -> int:
         )
         return 2
 
-    if CODE_APPROVAL_MARKER not in command and is_public_main_push(
-        command, _current_git_branch()
-    ):
+    if CODE_APPROVAL_MARKER not in command and is_public_main_push(command):
         print(
             "BLOCKED: public main branch push.\n\n"
             "Direct publication to main requires explicit authorization. Routine "

--- a/rules/tests/test_public_issue_publication.py
+++ b/rules/tests/test_public_issue_publication.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
+import shlex
 import subprocess
 import textwrap
+from pathlib import Path
 
 import pytest
 import yaml
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
@@ -31,6 +31,15 @@ def _run_hook(
         capture_output=True,
         check=False,
         cwd=cwd,
+        text=True,
+    )
+
+
+def _init_git_repo(path: Path, branch: str) -> None:
+    subprocess.run(
+        ["git", "init", f"--initial-branch={branch}", str(path)],
+        capture_output=True,
+        check=True,
         text=True,
     )
 
@@ -207,10 +216,18 @@ def test_hook_blocks_unapproved_public_pr_mutations(command: str) -> None:
     "command",
     [
         "git push origin main",
+        "git push --force origin main",
+        "git push --set-upstream origin main",
         "git push --force-with-lease origin HEAD:main",
+        "git push origin HEAD:refs/heads/main",
         "git push origin fix/publication-guard:refs/heads/main",
+        "git push origin deadbeef:refs/heads/main",
+        "git push origin +deadbeef:refs/heads/main",
+        "git push origin +main",
         "git push origin --delete main",
+        "git push --all",
         "git push --all origin",
+        "git push --mirror",
         "git push --mirror origin",
     ],
 )
@@ -230,8 +247,14 @@ def test_hook_blocks_unapproved_pushes_that_can_mutate_main(command: str) -> Non
         "gh pr diff 42",
         "gh pr checkout 42",
         "git push origin feature/foo",
+        "git push --force origin feature/foo",
         "git push -u origin fix/publication-guard",
+        "git push --set-upstream origin feature/foo",
         "git push origin HEAD:refs/heads/fix/publication-guard",
+        "git push origin deadbeef:refs/heads/fix/publication-guard",
+        "git push origin +deadbeef:refs/heads/fix/publication-guard",
+        "git push origin +feature/foo",
+        "git push origin --delete feature/foo",
     ],
 )
 def test_hook_allows_read_only_pr_commands_and_named_feature_branch_pushes(
@@ -244,41 +267,54 @@ def test_hook_allows_read_only_pr_commands_and_named_feature_branch_pushes(
 
 @pytest.mark.parametrize(
     "command",
-    ["git push -u origin HEAD", "git push --force origin HEAD", "git push"],
+    [
+        "git push",
+        "git push --force",
+        "git push -f",
+        "git push origin",
+        "git push origin HEAD",
+        "git push --force origin HEAD",
+        "git push -f origin HEAD",
+        "git push -u origin HEAD",
+        "git push --set-upstream origin HEAD",
+    ],
 )
 def test_hook_allows_head_pushes_from_a_feature_branch(
     command: str, tmp_path: Path
 ) -> None:
     """HEAD-relative pushes depend on the checked-out branch, so pin it.
 
-    These three were asserted without controlling the branch. That passed on a
-    feature worktree and on a detached PR checkout, and failed on main -- where
-    the hook is right to block them. The test was reading its environment
+    These forms were once asserted without controlling the branch. That passed
+    on a feature worktree and on a detached PR checkout, and failed on main --
+    where the hook is right to block them. The test was reading its environment
     rather than the contract. Its sibling below pins main; this one pins a
     feature branch, so both outcomes are asserted deliberately.
     """
-    subprocess.run(
-        ["git", "init", "--initial-branch=feature/guard-context", str(tmp_path)],
-        capture_output=True,
-        check=True,
-        text=True,
-    )
+    _init_git_repo(tmp_path, "feature/guard-context")
 
     result = _run_hook(command, cwd=tmp_path)
 
     assert result.returncode == 0
 
 
-@pytest.mark.parametrize("command", ["git push", "git push --force origin HEAD"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push",
+        "git push --force",
+        "git push -f",
+        "git push origin",
+        "git push origin HEAD",
+        "git push --force origin HEAD",
+        "git push -f origin HEAD",
+        "git push -u origin HEAD",
+        "git push --set-upstream origin HEAD",
+    ],
+)
 def test_hook_resolves_head_pushes_to_main(
     command: str, tmp_path: Path
 ) -> None:
-    subprocess.run(
-        ["git", "init", "--initial-branch=main", str(tmp_path)],
-        capture_output=True,
-        check=True,
-        text=True,
-    )
+    _init_git_repo(tmp_path, "main")
 
     result = _run_hook(command, cwd=tmp_path)
 
@@ -286,11 +322,96 @@ def test_hook_resolves_head_pushes_to_main(
     assert "public main branch push" in result.stderr
 
 
-def test_hook_fails_open_when_head_branch_cannot_be_resolved(tmp_path: Path) -> None:
+def test_hook_blocks_when_head_branch_cannot_be_resolved(tmp_path: Path) -> None:
     result = _run_hook("git push --force origin HEAD", cwd=tmp_path)
 
-    assert result.returncode == 0
+    assert result.returncode == 2
     assert "symbolic-ref" in HOOK.read_text()
+
+
+def test_hook_resolves_head_in_leading_cd_worktree(tmp_path: Path) -> None:
+    session_repo = tmp_path / "session-main"
+    feature_repo = tmp_path / "target feature"
+    _init_git_repo(session_repo, "main")
+    _init_git_repo(feature_repo, "feature/worktree-target")
+
+    command = f"cd {shlex.quote(str(feature_repo))} && git push -u origin HEAD"
+    result = _run_hook(command, cwd=session_repo)
+
+    assert result.returncode == 0
+
+
+def test_hook_blocks_head_in_leading_cd_main_worktree(tmp_path: Path) -> None:
+    session_repo = tmp_path / "session-feature"
+    main_repo = tmp_path / "target main"
+    _init_git_repo(session_repo, "feature/session")
+    _init_git_repo(main_repo, "main")
+
+    command = f"cd {shlex.quote(str(main_repo))} && git push origin HEAD"
+    result = _run_hook(command, cwd=session_repo)
+
+    assert result.returncode == 2
+    assert "public main branch push" in result.stderr
+
+
+def test_hook_blocks_branch_dependent_push_in_unsupported_shell_context(
+    tmp_path: Path,
+) -> None:
+    session_repo = tmp_path / "session-feature"
+    main_repo = tmp_path / "target-main"
+    _init_git_repo(session_repo, "feature/session")
+    _init_git_repo(main_repo, "main")
+
+    command = f"(cd {shlex.quote(str(main_repo))} && git push origin HEAD)"
+    result = _run_hook(command, cwd=session_repo)
+
+    assert result.returncode == 2
+    assert "public main branch push" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("branch", "expected_exit"),
+    [("feature/git-c-target", 0), ("main", 2)],
+)
+def test_hook_resolves_head_in_git_c_worktree(
+    branch: str, expected_exit: int, tmp_path: Path
+) -> None:
+    target_repo = tmp_path / branch.replace("/", "-")
+    _init_git_repo(target_repo, branch)
+
+    result = _run_hook(
+        f"git -C {shlex.quote(str(target_repo))} push origin HEAD", cwd=tmp_path
+    )
+
+    assert result.returncode == expected_exit
+
+
+def test_hook_prefers_explicit_refspec_destination_over_current_branch(
+    tmp_path: Path,
+) -> None:
+    _init_git_repo(tmp_path, "main")
+
+    result = _run_hook(
+        "git push origin HEAD:refs/heads/fix/explicit-target", cwd=tmp_path
+    )
+
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push --unknown-option origin feature/guard",
+        "git --no-pager push origin feature/guard",
+        "git push origin refs/heads/*:refs/heads/*",
+        "git push origin deadbeef:",
+    ],
+)
+def test_hook_blocks_push_shapes_with_ambiguous_destinations(command: str) -> None:
+    result = _run_hook(command)
+
+    assert result.returncode == 2
+    assert "public main branch push" in result.stderr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The push guard resolved the current branch with `git symbolic-ref` in the **hook's own working directory**, so it answered *"what branch is my shell on"* rather than *"what am I pushing, and where"*.

In this repo that is wrong most of the time. Conductor gives every task its own worktree, and the normal shape is to commit in a worktree and push from it. A session sitting on `main` running `cd <worktree> && git push -u origin HEAD` was blocked even though the push went to a feature branch.

## Why it was worth fixing

I hit it twice today and worked around it both times rather than reaching for the approval marker. That is the actual cost — not the friction, the habit. A marker used to silence a false positive stops meaning anything within a week, and then the guard is decoration.

## What changed

An explicit refspec now decides: `<branch>`, `<sha>:<branch>` and `HEAD:<branch>` all resolve to the right-hand side, with a leading `+` stripped. Only a bare `HEAD`, `@`, or no refspec falls back to the current branch — and that lookup runs in the directory the command will actually use: a simple leading `cd <dir> &&`, or `git -C <dir>`.

**More is blocked than before, not less.** `--all` and `--mirror` can carry `main` and are treated as main pushes. Anything the parser cannot resolve with confidence blocks: unknown or value-taking options, short option clusters, unterminated quoting, wildcard refspecs, subshells and pipelines, and a HEAD-relative push whose branch cannot be resolved at all, including detached HEAD.

A false block costs one marker. A false allow costs an unreviewed push to `main`.

## Deliberately unchanged

`gh` command matching stays text-based, and a command that merely *contains* the string continues to match. Fixing that would mean parsing shell inside a security hook, and the cure is worse than the disease. The marker covers that rare case.

## Verification

`rules/tests`: **126 passed**. Both halves proven able to fail — neutralising the refspec destination, or the `cd`/`git -C` context, each turns 21 cases red including `test_hook_prefers_explicit_refspec_destination_over_current_branch`.

Verified by hand from a session on `main` against a worktree on a feature branch:

| | |
|---|---|
| `cd <worktree> && git push -u origin HEAD` | allowed |
| `git -C <worktree> push origin HEAD` | allowed |
| the same push without the `cd` | blocked |
| `--all`, `--mirror`, `+main` | blocked |
| with the marker | allowed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)