### PR TITLE
Route callouts through the owned Alert component

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/connectors.tsx
@@ -2,7 +2,8 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useAuth } from '@/lib/auth'
 import { useQuery, useQueries } from '@tanstack/react-query'
 import { useState, useEffect } from 'react'
-import { Plus, CheckCircle2, AlertTriangle, X } from 'lucide-react'
+import { Plus, X } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import {
   DataTable,
@@ -144,22 +145,24 @@ function ConnectorsTab() {
   return (
     <div className="space-y-3">
       {showOAuthBanner && (
-        <div className="flex gap-2 items-center rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 p-3 text-xs text-[var(--color-success-text)]">
-          <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
-          <span className="flex-1">{m.admin_connectors_oauth_success()}</span>
-          <button onClick={() => setShowOAuthBanner(false)} aria-label={m.admin_connectors_dismiss()} className="hover:opacity-70 transition-opacity">
-            <X className="h-3 w-3" />
-          </button>
-        </div>
+        <Alert variant="success" size="sm">
+          <div className="flex items-center gap-2">
+            <span className="flex-1">{m.admin_connectors_oauth_success()}</span>
+            <button onClick={() => setShowOAuthBanner(false)} aria-label={m.admin_connectors_dismiss()} className="hover:opacity-70 transition-opacity">
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        </Alert>
       )}
       {showOAuthFailedBanner && (
-        <div className="flex gap-2 items-center rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 p-3 text-xs text-[var(--color-destructive)]">
-          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-          <span className="flex-1">{m.admin_connectors_oauth_failed()}</span>
-          <button onClick={() => setShowOAuthFailedBanner(false)} aria-label={m.admin_connectors_dismiss()} className="hover:opacity-70 transition-opacity">
-            <X className="h-3 w-3" />
-          </button>
-        </div>
+        <Alert variant="destructive" size="sm">
+          <div className="flex items-center gap-2">
+            <span className="flex-1">{m.admin_connectors_oauth_failed()}</span>
+            <button onClick={() => setShowOAuthFailedBanner(false)} aria-label={m.admin_connectors_dismiss()} className="hover:opacity-70 transition-opacity">
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        </Alert>
       )}
       {connectors.length > 0 && (
         <DataTable className="table-fixed">

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { SiGithub, SiNotion, SiGoogledrive, SiAirtable, SiConfluence } from '@icons-pack/react-simple-icons'
 import { Button } from '@/components/ui/button'
+import { Alert } from '@/components/ui/alert'
 import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
@@ -983,19 +984,18 @@ function AddConnectorPage() {
                       </div>
                     )}
                     {requiresLogin === true && authProbeResult?.classification === 'auth_ok' && (
-                      <div className="flex items-center justify-between rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 px-4 py-3">
-                        <div className="flex items-center gap-2 text-xs text-[var(--color-success-text)]">
-                          <CheckCircle2 className="h-3.5 w-3.5" />
-                          Logged in - cookies verified
+                      <Alert variant="success" size="sm">
+                        <div className="flex items-center justify-between">
+                          <span>Logged in - cookies verified</span>
+                          <button
+                            type="button"
+                            className="text-xs text-gray-600 hover:text-gray-900"
+                            onClick={() => setWcStep('auth-setup')}
+                          >
+                            Edit cookies
+                          </button>
                         </div>
-                        <button
-                          type="button"
-                          className="text-xs text-gray-600 hover:text-gray-900"
-                          onClick={() => setWcStep('auth-setup')}
-                        >
-                          Edit cookies
-                        </button>
-                      </div>
+                      </Alert>
                     )}
 
                     {/* Preview URL */}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/FileUploadForm.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { CheckCircle2, FileText, Upload } from 'lucide-react'
+import { FileText, Upload } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import * as m from '@/paraglide/messages'
 import { ApiError, apiFetch } from '@/lib/apiFetch'
@@ -302,12 +303,11 @@ export function FileUploadForm({ kbSlug, onBack }: FileUploadFormProps) {
     <div className="space-y-6">
       {/* Success banner */}
       {allDone && (
-        <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
-          <p className="text-sm text-[var(--color-success-text)]">
+        <Alert variant="success">
+          <p>
             {m.knowledge_add_source_file_success()}
           </p>
-        </div>
+        </Alert>
       )}
 
       {/* Drop zone */}

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/TextSourceForm.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { CheckCircle2 } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -81,12 +81,11 @@ export function TextSourceForm({ kbSlug, onBack }: TextSourceFormProps) {
       </div>
 
       {successful && (
-        <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
-          <p className="text-sm text-[var(--color-success-text)]">
+        <Alert variant="success">
+          <p>
             {m.knowledge_add_source_success()}
           </p>
-        </div>
+        </Alert>
       )}
 
       {errorMessage && !successful && (

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-source._components/UrlSourceForm.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react'
-import { CheckCircle2, Link2 } from 'lucide-react'
+import { Link2 } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -51,12 +52,11 @@ export function UrlSourceForm({ kbSlug, onBack }: UrlSourceFormProps) {
       </div>
 
       {successful && (
-        <div className="flex items-center gap-2 rounded-lg border border-[var(--color-success)] bg-[var(--color-success-bg)] px-4 py-3">
-          <CheckCircle2 className="h-4 w-4 text-[var(--color-success-text)] shrink-0" />
-          <p className="text-sm text-[var(--color-success-text)]">
+        <Alert variant="success">
+          <p>
             {m.knowledge_add_source_success()}
           </p>
-        </div>
+        </Alert>
       )}
 
       {errorMessage && !successful && (

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircle2, Loader2, Sparkles, Settings, ChevronDown, ChevronRight, KeyRound,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Alert } from '@/components/ui/alert'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { StepIndicator, type StepItem } from '@/components/ui/step-indicator'
@@ -973,19 +974,20 @@ function EditConnectorPage() {
                     </div>
                   )}
                   {requiresLogin === true && authProbeResult?.classification === 'auth_ok' && (
-                    <div className="flex items-center justify-between rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/5 px-4 py-3">
-                      <div className="flex items-center gap-2 text-xs text-[var(--color-success-text)]">
-                        <CheckCircle2 className="h-3.5 w-3.5" />
-                        {wcAuthMode === 'saved' ? 'Logged in - saved authentication verified' : 'Logged in - cookies verified'}
+                    <Alert variant="success" size="sm">
+                      <div className="flex items-center justify-between">
+                        <span>
+                          {wcAuthMode === 'saved' ? 'Logged in - saved authentication verified' : 'Logged in - cookies verified'}
+                        </span>
+                        <button
+                          type="button"
+                          className="text-xs text-gray-600 hover:text-gray-900"
+                          onClick={() => setWcStep('auth-setup')}
+                        >
+                          {wcAuthMode === 'saved' ? 'Change authentication' : 'Edit cookies'}
+                        </button>
                       </div>
-                      <button
-                        type="button"
-                        className="text-xs text-gray-600 hover:text-gray-900"
-                        onClick={() => setWcStep('auth-setup')}
-                      >
-                        {wcAuthMode === 'saved' ? 'Change authentication' : 'Edit cookies'}
-                      </button>
-                    </div>
+                    </Alert>
                   )}
 
                   {/* Preview URL */}

--- a/klai-portal/frontend/src/routes/widget-test.tsx
+++ b/klai-portal/frontend/src/routes/widget-test.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { ArrowLeft, AlertTriangle, Info, Loader2 } from 'lucide-react'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
 
 // Public widget-test page - TWD's WidgetTest.vue equivalent. Loads
 // klai-chat.js with the widget's data-widget-id so the floating chat
@@ -126,12 +127,11 @@ function WidgetTestEmbedPage() {
             </div>
           )}
           {scriptStatus === 'error' && (
-            <div className="mb-5 flex items-center gap-3 rounded-lg border border-[var(--color-destructive)]/30 bg-[var(--color-destructive)]/5 p-4">
-              <AlertTriangle className="h-5 w-5 text-[var(--color-destructive)]" />
-              <span className="text-sm text-[var(--color-destructive)]">
+            <Alert variant="destructive" className="mb-5">
+              <span>
                 Kon widget-script niet laden.
               </span>
-            </div>
+            </Alert>
           )}
 
           <p className="mb-5 text-sm leading-relaxed text-[var(--color-rl-dark)]/70">
@@ -153,16 +153,15 @@ function WidgetTestEmbedPage() {
           </div>
 
           {/* Hint */}
-          <div className="mt-5 flex items-start gap-3 rounded-lg border border-[var(--color-rl-border)] bg-[var(--color-rl-accent)]/10 p-4">
-            <Info className="mt-0.5 h-5 w-5 shrink-0 text-[var(--color-rl-accent-dark)]" />
-            <p className="text-sm text-[var(--color-rl-dark)]/80">
+          <Alert variant="info" className="mt-5">
+            <p>
               Plak deze snippet vóór de{' '}
               <code className="rounded bg-white px-1 py-0.5 font-mono text-xs">
                 &lt;/body&gt;
               </code>{' '}
               tag op je site. De widget verschijnt automatisch rechtsonder.
             </p>
-          </div>
+          </Alert>
         </div>
       </main>
     </div>


### PR DESCRIPTION
Nine hand-rolled callouts now use `Alert`.

`Alert` supplies the surface, the border and the semantic icon, and its variants use the `-text` token variants so labels clear WCAG AA on the tint. That is the whole reason the component exists, and it is exactly what a hand-rolled box does not get — the gap that shipped a customer-facing notice at 2.31:1 earlier today. `docs/ui-standards.md` § Current Deprecated Patterns has forbidden the pattern for a while; nothing enforced it.

The variant follows what each callout means rather than the colour it happened to use: `success` for confirmations, `destructive` for failures, `info` for guidance. Compact banners keep `size="sm"`. Dismiss buttons, conditional rendering and handlers are unchanged, and no copy moved out of Paraglide.

One of the ten was left alone. `widget-test.tsx` has a spinner and "Widget laden…", which is a status line rather than a semantic callout, and it lives in a development harness rather than a customer surface. Forcing it into `Alert` would have cleared a list without improving anything.

Alert usage goes from 3 files to 10.

## Verification

`npm run lint`, `npx tsc -b --force`, the generator's `--check` and `npx vitest run` (88 files, 604 tests) are green.

The diff was checked line by line for anything that is not a wrapper, icon or import change: Paraglide message calls balance exactly in and out, and the hardcoded English strings that moved were already hardcoded before. `Alert` itself was verified on the rendered catalog earlier today, all four variants legible.

## Known gap

The nine converted sites sit on success states behind an OAuth flow or a completed upload. The local stack cannot reach those, so those specific renders are unverified. The component they now use is verified; their own layout is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)