### PR TITLE
Field: absorb the auth-field pattern, lock raw text inputs

### DIFF
--- a/.moai/specs/SPEC-DESIGN-SOURCE-001/spec.md
+++ b/.moai/specs/SPEC-DESIGN-SOURCE-001/spec.md
@@ -1,6 +1,6 @@
 # SPEC-DESIGN-SOURCE-001 — The design contract rests on code
 
-**Status:** accepted · **Area:** klai-portal/frontend · **Opened:** 2026-09-01
+**Status:** implemented · **Area:** klai-portal/frontend · **Opened:** 2026-09-01 · **Landed:** 2026-09-01
 
 ## Problem
 
@@ -96,3 +96,44 @@ answer we have. The judgement layer is unsolved industry-wide.
   prose is the correct place for them.
 - Adopting DSDS or DESIGN.md as an authoring format.
 - Writing lint rules for patterns that have not been counted.
+
+## Implementation status (2026-09-01)
+
+All three units are on main.
+
+- **Unit 1** — documented-contrast check: PR #1285 follow-up work in #1293
+  (`a234887c6`). Exceptions now hold only `text-gray-400` and `text-gray-500`.
+- **Unit 2** — 21 component rules moved onto their components, ledger rows
+  generated: #1293 (`d4ea5a77a`). All 51 rows byte-identical through the move.
+- **Unit 3** — DESIGN.md emitted from the theme, component metadata and UI
+  standards: #1298 (`940bd201c`). Committed artefact, staleness-checked.
+
+Landed beside the units, same PRs: the full `text-gray-400` migration
+(601 → 6, all six WCAG-exempt), the semantic `-text` foreground fix
+(46 sites), and nine hand-rolled callouts onto `Alert` (#1297).
+
+Ledger at landing: 53 rules — 10 automated, 4 assisted, 35 manual,
+4 deliberately unchecked. It was 3 automated checks and unlabelled prose at
+the start of the day.
+
+## Follow-on work, tracked here so it is not re-litigated
+
+1. **`Field` component + the last ten raw auth inputs.** One consistent
+   hand-rolled label+input pattern across login, signup, password and 2FA
+   setup. Absorb into a `Field` primitive with the exact current appearance,
+   then lock with a lint rule mirroring `klai/no-raw-textarea`. The two
+   widget chat inputs stay raw by documented decision (dark-mode variant).
+2. **Authoring-time integration.** Point the always-loaded design rules and
+   the `klai-portal-ui` skill at `DESIGN.md` and the ledger, so agents get
+   the contract at write time instead of build-fail time.
+3. **Verification gaps.** The nine converted callouts sit on OAuth/upload
+   success states no local stack reaches; the `e2e` job is path-filtered off
+   frontend design changes. Both mean "CI green" still does not mean "seen".
+4. **Hook defect.** `public-github-mutation-guard.py` misclassifies a
+   feature-branch push inside a compound command as a main push. Found
+   2026-09-01; fix needs its own reviewed change, not a drive-by.
+5. **Local bootstrap.** A working `make dev-bootstrap` needs: dev-up →
+   extract only the `_rls_current_org_id()` definition → migrate → all
+   post_deploy scripts → backend. Backend-owned; the widget post_deploy
+   scripts also fail on tables this chain does not create.
+

--- a/klai-portal/frontend/DESIGN.md
+++ b/klai-portal/frontend/DESIGN.md
@@ -83,6 +83,7 @@ components:
   delete-org-modal: {}
   dialog: {}
   dropdown-menu: {}
+  field: {}
   inline-delete-confirm: {}
   inline-edit-row: {}
   inline-edit: {}
@@ -331,6 +332,12 @@ Generic modal
 ### `dropdown-menu`
 
 Menus, popovers, command/combobox
+
+### `field`
+
+Labeled form-field composition with automatic control association and feedback
+
+- **must (KLAI-UI-034):** Every form field has a `Label` with matching id and htmlFor
 
 ### `inline-delete-confirm`
 

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -23,7 +23,7 @@ catalog and be described here in the same change.
 
 The normative rules in this document are catalogued in the Rules Ledger at the
 end of this file, each with an ID, an RFC 2119 level and a declared
-verification mode. The count today: **53 rules — 10 automated, 4 assisted,
+verification mode. The count today: **54 rules — 11 automated, 4 assisted,
 35 manual, 4 deliberately unchecked.**
 
 The catalogue is maintained by hand. The ledger's own preamble says which of
@@ -36,6 +36,7 @@ These checks fail the build:
 |---|---|---|
 | `klai/no-hardcoded-brand-color` | `eslint-rules/`, runs in `npm run lint` | A hex in `className` that equals a token in `index.css`. Use `bg-[var(--color-rl-dark)]`. Third-party brand marks (Google, HubSpot) never match, by design |
 | `klai/no-window-confirm` | `eslint-rules/`, runs in `npm run lint` | `window.confirm` / `alert` / `prompt`. Use `InlineDeleteConfirm` or `AlertDialog` |
+| `klai/no-raw-text-input` | `eslint-rules/`, runs in `npm run lint` | A raw textual, dynamically typed, or untyped `<input>` outside `src/components/ui/`. Use `Input` or another owned control; documented widget dark-mode exceptions are locally disabled |
 | `klai/no-raw-textarea` | `eslint-rules/`, runs in `npm run lint` | A raw `<textarea>` outside `src/components/ui/`. Use `Textarea` from `@/components/ui/textarea` |
 | Generated component reference | `tests/design/component-reference-generated.test.ts` | The generated table is stale relative to the UI module source comments or `cva(...)` variants |
 | Generated `DESIGN.md` | `tests/design/design-md-generated.test.ts` | The committed design document is stale relative to the theme, UI module metadata, or UI standards |
@@ -53,11 +54,10 @@ beside it.
 
 Raw `<button>` is not linted because it is not a violation. See Component
 Library Reference: 96 of 100 uses are the prescribed pattern for interactive
-rows, and the remaining four are correct too. Raw `<textarea>` is linted and
-the count outside `components/ui/` is zero. Raw `<input>` is not linted: ten
-sites are one consistent auth-field pattern awaiting a design decision, and
-two widget inputs deliberately implement a dark-mode variant the owned
-`Input` cannot express.
+rows, and the remaining four are correct too. Raw `<textarea>` and textual
+`<input>` are linted. The raw text-control count outside `components/ui/` is
+zero except for two locally disabled widget inputs that deliberately implement
+a dark-mode variant the owned `Input` cannot express.
 
 Do not add enforcement for a pattern you have not first counted. The button
 rule that was nearly written here would have flagged 96 correct decisions.
@@ -97,14 +97,12 @@ vendors dictate (`login.tsx`), and kb-editor chrome at `h-7`, which no
 rules that work.
 
 A 2026-09 follow-up sweep reduced raw `<textarea>` elements outside
-`components/ui/` to zero and added a lint guard. Twelve raw text, password and
-email `<input>` elements remain, and only ten of them are debt: one consistent
-auth-field pattern across login, signup, password and 2FA setup, awaiting a
-design decision because converting it means converting its hand-rolled
-`<label>` too. The other two are correct — the widget chat surface implements
-a dark-mode variant the owned `Input` cannot express. Checkbox and radio
-inputs inside composed controls (`RadioCardGroup`, permission pickers) are not
-violations either.
+`components/ui/` to zero and added a lint guard. The next sweep absorbed the
+ten consistent auth label/input sites into `Field` and added the matching input
+guard. Two raw textual inputs remain by documented decision: the widget chat
+surface implements a dark-mode variant the owned `Input` cannot express, and
+each site carries a local reasoned disable. Checkbox and radio inputs inside
+composed controls (`RadioCardGroup`, permission pickers) are not violations.
 
 Generated from source comments by `npm run docs:components`; do not edit by hand.
 
@@ -125,6 +123,7 @@ Generated from source comments by `npm run docs:components`; do not edit by hand
 | `delete-org-modal` | Feature-specific destructive modals (not generic) | Feature |
 | `dialog` | Generic modal | Yes |
 | `dropdown-menu` | Menus, popovers, command/combobox | Yes |
+| `field` | Labeled form-field composition with automatic control association and feedback | Yes |
 | `inline-delete-confirm` | Inline destructive confirmation inside a row (no layout shift) | Yes |
 | `inline-edit-row` | Canonical inline edit for a list row (`InlineEditRow`): name + optional description, zero layout shift, owns Save/Cancel | Yes |
 | `inline-edit` | Low-level single-field click-to-edit overlay, for custom row layouts that own their own buttons. Prefer `InlineEditRow` for new rows | Yes |
@@ -736,13 +735,14 @@ destructive actions.
 
 Use owned UI components from `src/components/ui/`.
 
-Every field needs `Label` plus matching `id`/`htmlFor`.
+Text fields use `Field` to compose the label, control, and optional hint or
+error. `Field` clones an explicit id onto the control or generates one, so the
+rendered `Label` always has a matching `htmlFor`.
 
 ```tsx
-<div className="space-y-1.5">
-  <Label htmlFor="field-id">Label</Label>
-  <Input id="field-id" value={value} onChange={...} />
-</div>
+<Field id="field-id" label="Label" hint="Optional guidance">
+  <Input value={value} onChange={...} />
+</Field>
 ```
 
 - **Search fields** use `SearchInput` (leading magnifier icon), never a bare
@@ -1092,7 +1092,7 @@ restatement of these rules, not a separate set.
 | KLAI-UI-004 | Hex values quoted in the always-loaded design rule docs match `index.css` | must | automated | `tests/design/rule-doc-token-values.test.ts` |
 | KLAI-UI-005 | The widget default primary colour equals `--color-rl-accent` and the literal is defined in exactly one place | must | automated | `tests/design/widget-default-color.test.ts` |
 | KLAI-UI-006 | A new or changed shared UI component is described here and rendered in `/dev/ui` in the same change | must | assisted | KLAI-UI-003 catches the module half; the catalog half is a reviewer step |
-| KLAI-UI-007 | Pages are built from `src/components/ui/`; a raw `input`, `select`, list row or delete confirmation with inline Tailwind is a defect | must-not | none | The raw `<input>` sites are ten instances of one auth-field pattern awaiting a design decision, plus two correct dark-variant widget inputs; `<select>`, list rows and delete confirmations are uncounted |
+| KLAI-UI-007 | Pages are built from `src/components/ui/`; a raw `input`, `select`, list row or delete confirmation with inline Tailwind is a defect | must-not | none | The raw textual-input half is paid and the two widget exceptions carry local reasoned disables; `<select>`, list rows and delete confirmations remain uncounted |
 | KLAI-UI-008 | `Button` is for an action; a raw `button` is for an interactive surface (clickable row, toggle, tree item), plus the documented avatar, vendor SSO and unsupported-size editor controls | must | none | Measured and rejected: 96 of 100 raw `button` elements outside `components/ui/` are the prescribed pattern. A rule here would flag 96 correct decisions |
 | KLAI-UI-009 | The reference screen is named in the work notes before portal UI is edited | must | manual | Reviewer step; see Required Workflow |
 | KLAI-UI-010 | Normal page containers use `PageContainer`; padding and centering are not hand-written, and an intentionally full-width parent or tool surface owns its own layout | must | manual | Reviewer step; see Layout |
@@ -1139,6 +1139,7 @@ restatement of these rules, not a separate set.
 | KLAI-UI-051 | Foreground colours documented in the Colors section meet WCAG AA on both portal surfaces or carry a current, reasoned exception | must | automated | `tests/design/documented-contrast.test.ts` |
 | KLAI-UI-052 | Semantic base colour tokens are used for fills and borders; foregrounds on light portal surfaces use the matching `-text` token, while the passing destructive base foreground remains valid | must | manual | The documented contrast check covers only colours named in the Colors section, so it does not catch a base token used as a foreground elsewhere |
 | KLAI-UI-053 | `DESIGN.md` is generated from the portal theme, component metadata and UI standards, and a stale committed artefact fails the build | must | automated | `tests/design/design-md-generated.test.ts` |
+| KLAI-UI-054 | A raw textual, dynamically typed or untyped `<input>` outside `src/components/ui/` is forbidden unless a local disable documents an unsupported owned-control variant | must-not | automated | `klai/no-raw-text-input` |
 <!-- /generated:component-guidelines -->
 
 ### Retired IDs

--- a/klai-portal/frontend/eslint-rules/__tests__/no-raw-text-input.test.js
+++ b/klai-portal/frontend/eslint-rules/__tests__/no-raw-text-input.test.js
@@ -1,0 +1,58 @@
+/**
+ * Tests for `klai/no-raw-text-input`.
+ *
+ * RuleTester from `eslint` registers its own describe/it blocks against
+ * vitest's globals and MUST be called at module top-level.
+ */
+import { RuleTester } from 'eslint'
+import rule from '../no-raw-text-input.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+})
+
+ruleTester.run('klai/no-raw-text-input', rule, {
+  valid: [
+    {
+      code: `import { Input } from '@/components/ui/input'\nconst field = <Input type="email" />`,
+      filename: '/repo/src/routes/login.tsx',
+    },
+    {
+      code: `const field = <input type="text" />`,
+      filename: '/repo/src/components/ui/input.tsx',
+    },
+    {
+      code: `const controls = <><input type="checkbox" /><input type="radio" /><input type="file" /><input type="hidden" /></>`,
+      filename: '/repo/src/routes/example.tsx',
+    },
+    {
+      code: `const field = <input type="number" />`,
+      filename: '/repo/src/routes/example.tsx',
+    },
+  ],
+  invalid: [
+    ...['text', 'email', 'password', 'search', 'url', 'tel'].map((type) => ({
+      code: `const field = <input type="${type}" />`,
+      filename: '/repo/src/routes/example.tsx',
+      errors: [{ messageId: 'rawTextInput' }],
+    })),
+    {
+      code: `const field = <input />`,
+      filename: '/repo/src/routes/example.tsx',
+      errors: [{ messageId: 'rawTextInput' }],
+    },
+    {
+      code: `const type = 'email'\nconst field = <input type={type} />`,
+      filename: '/repo/src/routes/example.tsx',
+      errors: [
+        {
+          message: 'use `Input` or another owned control from `@/components/ui/`.',
+        },
+      ],
+    },
+  ],
+})

--- a/klai-portal/frontend/eslint-rules/no-raw-text-input.js
+++ b/klai-portal/frontend/eslint-rules/no-raw-text-input.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Forbid raw textual JSX `<input>` elements outside the
+ * portal's owned UI component directory.
+ *
+ * Text-like, absent, and dynamic types must use an owned component so labels,
+ * styling, and behavior stay coupled to the portal design contract. Native
+ * non-text controls remain valid. The widget chat surface has two deliberate,
+ * inline-disabled exceptions for its unsupported dark-mode variant.
+ */
+
+const TEXT_INPUT_TYPES = new Set([
+  'text',
+  'email',
+  'password',
+  'search',
+  'url',
+  'tel',
+])
+
+/**
+ * @param {string} filename Absolute or project-relative filename from ESLint
+ */
+function isOwnedUiFile(filename) {
+  const normalized = filename.replaceAll('\\', '/')
+  return /(?:^|\/)src\/components\/ui(?:\/|$)/.test(normalized)
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow raw textual JSX input elements outside the owned UI component directory.',
+    },
+    schema: [],
+    messages: {
+      rawTextInput: 'use `Input` or another owned control from `@/components/ui/`.',
+    },
+  },
+  create(context) {
+    if (isOwnedUiFile(context.filename)) return {}
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'input') {
+          return
+        }
+
+        const typeAttribute = node.attributes.find(
+          (attribute) =>
+            attribute.type === 'JSXAttribute' &&
+            attribute.name.type === 'JSXIdentifier' &&
+            attribute.name.name === 'type',
+        )
+
+        if (!typeAttribute || !typeAttribute.value) {
+          context.report({ node, messageId: 'rawTextInput' })
+          return
+        }
+
+        if (typeAttribute.value.type !== 'Literal') {
+          context.report({ node, messageId: 'rawTextInput' })
+          return
+        }
+
+        const type = String(typeAttribute.value.value).toLowerCase()
+        if (TEXT_INPUT_TYPES.has(type)) {
+          context.report({ node, messageId: 'rawTextInput' })
+        }
+      },
+    }
+  },
+}

--- a/klai-portal/frontend/eslint.config.js
+++ b/klai-portal/frontend/eslint.config.js
@@ -7,6 +7,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 import noDirectKbQuerykey from './eslint-rules/no-direct-kb-querykey.js'
 import noCrossRouteImport from './eslint-rules/no-cross-route-import.js'
 import noHardcodedBrandColor from './eslint-rules/no-hardcoded-brand-color.js'
+import noRawTextInput from './eslint-rules/no-raw-text-input.js'
 import noRawTextarea from './eslint-rules/no-raw-textarea.js'
 import noWindowConfirm from './eslint-rules/no-window-confirm.js'
 
@@ -27,6 +28,7 @@ export default defineConfig([
           'no-direct-kb-querykey': noDirectKbQuerykey,
           'no-cross-route-import': noCrossRouteImport,
           'no-hardcoded-brand-color': noHardcodedBrandColor,
+          'no-raw-text-input': noRawTextInput,
           'no-raw-textarea': noRawTextarea,
           'no-window-confirm': noWindowConfirm,
         },
@@ -51,6 +53,7 @@ export default defineConfig([
       'klai/no-direct-kb-querykey': 'error',
       'klai/no-cross-route-import': 'error',
       'klai/no-hardcoded-brand-color': 'error',
+      'klai/no-raw-text-input': 'error',
       'klai/no-raw-textarea': 'error',
       'klai/no-window-confirm': 'error',
       // TanStack Router uses async functions in route config (beforeLoad, loader)

--- a/klai-portal/frontend/src/components/ui/__tests__/field.test.tsx
+++ b/klai-portal/frontend/src/components/ui/__tests__/field.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+
+describe('Field', () => {
+  it('generates an id and associates the label with its control', () => {
+    render(
+      <Field label="Email">
+        <Input type="email" />
+      </Field>,
+    )
+
+    const input = screen.getByLabelText('Email')
+    expect(input.id).not.toBe('')
+    expect(screen.getByText('Email').getAttribute('for')).toBe(input.id)
+  })
+
+  it('clones an explicit id while preserving input props', () => {
+    render(
+      <Field id="verification-code" label="Code">
+        <Input
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          maxLength={6}
+          autoComplete="one-time-code"
+          autoFocus
+          required
+        />
+      </Field>,
+    )
+
+    const input = screen.getByLabelText('Code')
+    expect(input.getAttribute('id')).toBe('verification-code')
+    expect(input.getAttribute('type')).toBe('text')
+    expect(input.getAttribute('inputmode')).toBe('numeric')
+    expect(input.getAttribute('pattern')).toBe('[0-9]*')
+    expect(input.getAttribute('maxlength')).toBe('6')
+    expect(input.getAttribute('autocomplete')).toBe('one-time-code')
+    expect(document.activeElement).toBe(input)
+    expect((input as HTMLInputElement).required).toBe(true)
+  })
+
+  it('associates hint and error feedback with the control', () => {
+    const { rerender } = render(
+      <Field id="password" label="Password" hint="Use at least 12 characters">
+        <Input type="password" aria-describedby="policy" />
+      </Field>,
+    )
+
+    const input = screen.getByLabelText('Password')
+    expect(input.getAttribute('aria-describedby')).toBe(
+      'policy password-description',
+    )
+    expect(input.hasAttribute('aria-invalid')).toBe(false)
+
+    rerender(
+      <Field id="password" label="Password" error="Password is too short">
+        <Input type="password" />
+      </Field>,
+    )
+
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(screen.getByRole('alert').textContent).toBe('Password is too short')
+  })
+})

--- a/klai-portal/frontend/src/components/ui/field.tsx
+++ b/klai-portal/frontend/src/components/ui/field.tsx
@@ -1,0 +1,66 @@
+/**
+ * @purpose Labeled form-field composition with automatic control association and feedback
+ * @guideline KLAI-UI-034 must Every form field has a `Label` with matching id
+ * and htmlFor
+ */
+import * as React from 'react'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+
+type FieldControlProps = Pick<
+  React.HTMLAttributes<HTMLElement>,
+  'id' | 'aria-describedby' | 'aria-invalid'
+>
+
+export interface FieldProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  label: React.ReactNode
+  hint?: React.ReactNode
+  error?: React.ReactNode
+  children: React.ReactElement<FieldControlProps>
+}
+
+function Field({
+  id,
+  label,
+  hint,
+  error,
+  children,
+  className,
+  ...props
+}: FieldProps) {
+  const generatedId = React.useId()
+  const controlId = id ?? children.props.id ?? generatedId
+  const feedback = error ?? hint
+  const feedbackId = feedback ? `${controlId}-description` : undefined
+  const describedBy = [children.props['aria-describedby'], feedbackId]
+    .filter(Boolean)
+    .join(' ') || undefined
+
+  const control = React.cloneElement(children, {
+    id: controlId,
+    'aria-describedby': describedBy,
+    'aria-invalid': error ? true : children.props['aria-invalid'],
+  })
+
+  return (
+    <div className={cn('space-y-1', className)} {...props}>
+      <Label htmlFor={controlId}>{label}</Label>
+      {control}
+      {feedback && (
+        <p
+          id={feedbackId}
+          role={error ? 'alert' : undefined}
+          className={cn(
+            'text-xs',
+            error ? 'text-[var(--color-destructive-text)]' : 'text-gray-600',
+          )}
+        >
+          {feedback}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export { Field }

--- a/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
+++ b/klai-portal/frontend/src/features/widgets/chat/WidgetChatSurface.tsx
@@ -431,6 +431,7 @@ export function WidgetChatSurface({
                 {m.widget_chat_user_info_help()}
               </p>
               <div className="grid gap-2 sm:grid-cols-2">
+                {/* eslint-disable-next-line klai/no-raw-text-input -- dark-mode variant the owned Input cannot express */}
                 <input
                   type="text"
                   autoComplete="name"
@@ -439,6 +440,7 @@ export function WidgetChatSurface({
                   placeholder={m.widget_chat_user_info_name()}
                   className={`min-w-0 rounded-xl border px-3 py-2 text-sm outline-none transition-colors focus:border-gray-300 ${isDark ? 'border-white/10 bg-white/5 text-[var(--color-rl-bg)] placeholder:text-[var(--color-rl-bg)]/35' : 'border-gray-200 bg-white text-gray-900 placeholder:text-gray-600'}`}
                 />
+                {/* eslint-disable-next-line klai/no-raw-text-input -- dark-mode variant the owned Input cannot express */}
                 <input
                   type="email"
                   autoComplete="email"

--- a/klai-portal/frontend/src/routes/$locale/password/forgot.tsx
+++ b/klai-portal/frontend/src/routes/$locale/password/forgot.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { Mail } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
@@ -87,21 +89,16 @@ function ForgotPasswordPage() {
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="email" className="block text-sm font-medium text-gray-900">
-                {m.forgot_field_email()}
-              </label>
-              <input
-                id="email"
+            <Field id="email" label={m.forgot_field_email()}>
+              <Input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 autoComplete="email"
                 autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
               />
-            </div>
+            </Field>
 
             {error && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{error}</p>

--- a/klai-portal/frontend/src/routes/$locale/signup/index.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { ArrowRight, CheckCircle } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
@@ -352,14 +354,14 @@ function SignupPage() {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-2 gap-3">
-          <Field
+          <SignupField
             label={m.signup_field_first_name()}
             name="first_name"
             value={form.first_name}
             onChange={(v) => setForm((f) => ({ ...f, first_name: v }))}
             required
           />
-          <Field
+          <SignupField
             label={m.signup_field_last_name()}
             name="last_name"
             value={form.last_name}
@@ -367,14 +369,14 @@ function SignupPage() {
             required
           />
         </div>
-        <Field
+        <SignupField
           label={m.signup_field_company()}
           name="company_name"
           value={form.company_name}
           onChange={(v) => setForm((f) => ({ ...f, company_name: v }))}
           required
         />
-        <Field
+        <SignupField
           label={m.signup_field_email()}
           name="email"
           type="email"
@@ -382,7 +384,7 @@ function SignupPage() {
           onChange={(v) => setForm((f) => ({ ...f, email: v }))}
           required
         />
-        <Field
+        <SignupField
           label={m.signup_field_password()}
           name="password"
           type="password"
@@ -459,7 +461,7 @@ function readSignupError(data: unknown, status: number) {
   return m.signup_error_server({ status: String(status) })
 }
 
-function Field({
+function SignupField({
   label,
   name,
   type = 'text',
@@ -477,20 +479,14 @@ function Field({
   required?: boolean
 }) {
   return (
-    <div className="space-y-1">
-      <label htmlFor={name} className="block text-sm font-medium text-gray-900">
-        {label}
-      </label>
-      <input
-        id={name}
+    <Field id={name} label={label} hint={hint}>
+      <Input
         name={name}
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         required={required}
-        className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
       />
-      {hint && <p className="text-xs text-gray-600">{hint}</p>}
-    </div>
+    </Field>
   )
 }

--- a/klai-portal/frontend/src/routes/$locale/signup/social.tsx
+++ b/klai-portal/frontend/src/routes/$locale/signup/social.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { ArrowRight } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
@@ -216,24 +218,16 @@ function SocialSignupPage() {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-1">
-          <label
-            htmlFor="company_name"
-            className="block text-sm font-medium text-gray-900"
-          >
-            {m.signup_social_company_label()}
-          </label>
-          <input
-            id="company_name"
+        <Field id="company_name" label={m.signup_social_company_label()}>
+          <Input
             name="company_name"
             type="text"
             value={companyName}
             onChange={(e) => setCompanyName(e.target.value)}
             required
             autoFocus
-            className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
           />
-        </div>
+        </Field>
 
         {/* SPEC-AUTH-010 R5: founder's auto-accept choice (server-side guarded). */}
         {emailDomain && (

--- a/klai-portal/frontend/src/routes/dev/ui.tsx
+++ b/klai-portal/frontend/src/routes/dev/ui.tsx
@@ -64,6 +64,7 @@ import {
 } from '@/components/ui/data-table'
 import { InlineDeleteConfirm } from '@/components/ui/inline-delete-confirm'
 import { InlineEditRow } from '@/components/ui/inline-edit-row'
+import { Field } from '@/components/ui/field'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { MultiSelect } from '@/components/ui/multi-select'
@@ -899,6 +900,17 @@ function UiCatalogPage() {
             <Tabs tabs={tabItemsWithNotifications} value={activeTab} onValueChange={setActiveTab} />
           </div>
           <p className="text-sm text-gray-500">Actieve tab: {activeTab}</p>
+        </div>
+      </Section>
+
+      <Section title="Field">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Automatisch gekoppeld label" hint="Field genereert de id wanneer die ontbreekt.">
+            <Input defaultValue="Klai component" />
+          </Field>
+          <Field id="catalog-field-error" label="Veld met fout" error="Controleer deze waarde.">
+            <Input defaultValue="Onjuiste waarde" />
+          </Field>
         </div>
       </Section>
 

--- a/klai-portal/frontend/src/routes/login.tsx
+++ b/klai-portal/frontend/src/routes/login.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { ArrowRight, Lock, Shield } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 import { AuthPageLayout } from '@/components/layout/AuthPageLayout'
@@ -262,12 +264,8 @@ function LoginPage() {
           </div>
 
           <form onSubmit={handleTotpSubmit} className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="totp-code" className="block text-sm font-medium text-gray-900">
-                {m.totp_field_code()}
-              </label>
-              <input
-                id="totp-code"
+            <Field id="totp-code" label={m.totp_field_code()}>
+              <Input
                 type="text"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -277,9 +275,9 @@ function LoginPage() {
                 required
                 autoComplete="one-time-code"
                 autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)] tracking-widest text-center text-base font-mono"
+                className="text-center font-mono text-base tracking-widest"
               />
-            </div>
+            </Field>
 
             {error && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{error}</p>
@@ -313,36 +311,26 @@ function LoginPage() {
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="email" className="block text-sm font-medium text-gray-900">
-                {m.login_field_email()}
-              </label>
-              <input
-                id="email"
+            <Field id="email" label={m.login_field_email()}>
+              <Input
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 autoComplete="email"
                 autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
               />
-            </div>
+            </Field>
 
-            <div className="space-y-1">
-              <label htmlFor="password" className="block text-sm font-medium text-gray-900">
-                {m.login_field_password()}
-              </label>
-              <input
-                id="password"
+            <Field id="password" label={m.login_field_password()}>
+              <Input
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 autoComplete="current-password"
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
               />
-            </div>
+            </Field>
 
             {error && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{error}</p>

--- a/klai-portal/frontend/src/routes/password/set.tsx
+++ b/klai-portal/frontend/src/routes/password/set.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { KeyRound } from 'lucide-react'
 import * as m from '@/paraglide/messages'
 import { useLocale } from '@/lib/locale'
@@ -214,19 +216,16 @@ function PasswordSetPage() {
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-1">
-              <label htmlFor="password" className="block text-sm font-medium text-gray-900">
-                {m.set_field_password()}
-              </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                autoComplete="new-password"
-                autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
-              />
+              <Field id="password" label={m.set_field_password()}>
+                <Input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  autoComplete="new-password"
+                  autoFocus
+                />
+              </Field>
               <PasswordStrengthMeter
                 score={passwordStrength.score}
                 issues={passwordStrength.issues}
@@ -237,20 +236,15 @@ function PasswordSetPage() {
               />
             </div>
 
-            <div className="space-y-1">
-              <label htmlFor="confirm" className="block text-sm font-medium text-gray-900">
-                {m.set_field_confirm()}
-              </label>
-              <input
-                id="confirm"
+            <Field id="confirm" label={m.set_field_confirm()}>
+              <Input
                 type="password"
                 value={confirm}
                 onChange={(e) => setConfirm(e.target.value)}
                 required
                 autoComplete="new-password"
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
               />
-            </div>
+            </Field>
 
             {error && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{error}</p>

--- a/klai-portal/frontend/src/routes/setup/_components/-EmailOTPSetup.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-EmailOTPSetup.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useReducer } from 'react'
 import { ArrowRight, Mail } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { apiFetch } from '@/lib/apiFetch'
 import * as m from '@/paraglide/messages'
 import { canResendEmailOtp, createInitialEmailOtpState, emailOtpReducer } from './-mfa-state'
@@ -87,12 +89,8 @@ export function EmailOTPSetup({
           </div>
 
           <form onSubmit={handleVerify} className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="email-otp-code" className="block text-sm font-medium text-gray-900">
-                {m.setup_mfa_email_field_code()}
-              </label>
-              <input
-                id="email-otp-code"
+            <Field id="email-otp-code" label={m.setup_mfa_email_field_code()}>
+              <Input
                 type="text"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -102,9 +100,9 @@ export function EmailOTPSetup({
                 required
                 autoComplete="one-time-code"
                 autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-center font-mono text-base tracking-widest outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
+                className="text-center font-mono text-base tracking-widest"
               />
-            </div>
+            </Field>
 
             {state.error && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{state.error}</p>

--- a/klai-portal/frontend/src/routes/setup/_components/-TOTPSetup.tsx
+++ b/klai-portal/frontend/src/routes/setup/_components/-TOTPSetup.tsx
@@ -2,6 +2,8 @@ import { useEffect, useReducer } from 'react'
 import { ArrowRight } from 'lucide-react'
 import QRCode from 'react-qr-code'
 import { Button } from '@/components/ui/button'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
 import { apiFetch } from '@/lib/apiFetch'
 import { authLogger } from '@/lib/logger'
 import * as m from '@/paraglide/messages'
@@ -93,12 +95,8 @@ export function TOTPSetup({
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-1">
-              <label htmlFor="totp-code" className="block text-sm font-medium text-gray-900">
-                {m.setup_2fa_field_code()}
-              </label>
-              <input
-                id="totp-code"
+            <Field id="totp-code" label={m.setup_2fa_field_code()}>
+              <Input
                 type="text"
                 inputMode="numeric"
                 pattern="[0-9]*"
@@ -108,9 +106,9 @@ export function TOTPSetup({
                 required
                 autoComplete="one-time-code"
                 autoFocus
-                className="w-full rounded-lg border border-gray-200 bg-[var(--color-background)] px-3 py-2 text-center font-mono text-base tracking-widest outline-none transition focus:ring-2 focus:ring-[var(--color-ring)]"
+                className="text-center font-mono text-base tracking-widest"
               />
-            </div>
+            </Field>
             {state.submitError && (
               <p className="rounded-lg bg-[var(--color-destructive-bg)] px-3 py-2 text-sm text-[var(--color-destructive-text)]">{state.submitError}</p>
             )}


### PR DESCRIPTION
Follow-on item 1 of `SPEC-DESIGN-SOURCE-001`, plus the spec's implementation-status update.

## What changed

Ten auth screens hand-rolled the same label+input pair across login, signup, password reset and 2FA setup. They now compose the owned primitives through a new `Field`, which wires `id`/`htmlFor` automatically via `useId` — a field without an associated label is no longer expressible. Field also carries the hint/error line with `aria-describedby` and `role="alert"`.

With the debt at zero, `klai/no-raw-text-input` locks it: a JSX `<input>` with a textual, dynamic or absent type outside `src/components/ui/` is an error. Checkbox, radio, file and hidden are untouched. The two widget chat inputs stay raw by documented decision (dark-mode variant the owned Input cannot express) and carry visible, reasoned inline disables.

Ledger: KLAI-UI-054 added, KLAI-UI-007's reason updated. **54 rules — 11 automated, 4 assisted, 35 manual, 4 unchecked.** The spec is marked implemented with a tracked follow-on list.

## Verification

All six gates green: both generators' `--check`, `tsc -b --force`, lint, and vitest (91 files, 620 tests).

The one risky substitution was proven rather than assumed. The hand-rolled inputs carried `bg-[var(--color-background)]` where the owned Input is `bg-transparent`; `AuthPageLayout` puts that same background on the page shell and the form panel adds none of its own, so transparent renders the identical pixel on every converted site. The nearby background hits — error banners, the identity box, an icon badge, the TOTP secret block — were checked and are siblings, not ancestors.

The lint rule was attacked with fixtures: raw email input errors, checkbox stays clean, typeless input errors, the widget file passes through its disables. The Field catalog section was rendered locally with the id-wiring verified live in the DOM.

## Known gaps

- The real auth screens cannot render locally (auth dev mode bypasses `/login`), so the ten conversions rest on the class-set proof and the layout-shell analysis, not on a screenshot of each screen.
- Field defaults to the `space-y-1` rhythm the auth screens used; the Forms section documents `space-y-1.5`. One should win before Field spreads beyond auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)