### PR TITLE
Guard hook: parse the push, not the prose around it

### DIFF
--- a/.claude/hooks/klai/public-github-mutation-guard.py
+++ b/.claude/hooks/klai/public-github-mutation-guard.py
@@ -96,6 +96,115 @@ class PushInvocation(NamedTuple):
     branch_context_known: bool
 
 
+class Heredoc(NamedTuple):
+    delimiter: str
+    strip_tabs: bool
+
+
+def _heredocs_declared_on(line: str) -> list[Heredoc]:
+    heredocs: list[Heredoc] = []
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if character == "\\":
+            index += 2
+            continue
+        if line.startswith("$((", index) or line.startswith("((", index):
+            cursor = index + (3 if line.startswith("$((", index) else 2)
+            depth = 1
+            while cursor < len(line) and depth:
+                if line.startswith("((", cursor):
+                    depth += 1
+                    cursor += 2
+                elif line.startswith("))", cursor):
+                    depth -= 1
+                    cursor += 2
+                elif line[cursor] == "\\":
+                    cursor += 2
+                else:
+                    cursor += 1
+            index = cursor
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            index += 1
+            while index < len(line):
+                if quote == '"' and line[index] == "\\":
+                    index += 2
+                elif line[index] == quote:
+                    index += 1
+                    break
+                else:
+                    index += 1
+            continue
+        if character == "#" and (
+            index == 0 or line[index - 1].isspace() or line[index - 1] in ";|&()"
+        ):
+            break
+        if not line.startswith("<<", index) or line.startswith("<<<", index):
+            index += 1
+            continue
+
+        cursor = index + 2
+        strip_tabs = cursor < len(line) and line[cursor] == "-"
+        if strip_tabs:
+            cursor += 1
+        while cursor < len(line) and line[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(line) or line[cursor] in "\r\n;&|<>()":
+            index = cursor
+            continue
+
+        if line[cursor] in {"'", '"'}:
+            quote = line[cursor]
+            cursor += 1
+            delimiter_start = cursor
+            while cursor < len(line) and line[cursor] != quote:
+                cursor += 1
+            if cursor >= len(line):
+                index = cursor
+                continue
+            delimiter = line[delimiter_start:cursor]
+            cursor += 1
+            supported = quote == "'" or "\\" not in delimiter
+            supported = supported and (
+                cursor >= len(line)
+                or line[cursor].isspace()
+                or line[cursor] in ";&|<>()"
+            )
+        else:
+            delimiter_start = cursor
+            while cursor < len(line) and not (
+                line[cursor].isspace() or line[cursor] in ";&|<>()"
+            ):
+                cursor += 1
+            delimiter = line[delimiter_start:cursor]
+            supported = not any(character in delimiter for character in "'\"\\")
+
+        if delimiter and supported:
+            heredocs.append(Heredoc(delimiter, strip_tabs))
+        index = cursor
+    return heredocs
+
+
+def _without_heredoc_bodies(command: str) -> str:
+    cleaned_lines: list[str] = []
+    pending: list[Heredoc] = []
+    for line in command.splitlines(keepends=True):
+        if not pending:
+            cleaned_lines.append(line)
+            pending.extend(_heredocs_declared_on(line))
+            continue
+
+        content = line.rstrip("\r\n")
+        line_ending = line[len(content) :]
+        candidate = content.lstrip("\t") if pending[0].strip_tabs else content
+        if candidate == pending[0].delimiter:
+            pending.pop(0)
+        cleaned_lines.append(line_ending)
+    return "".join(cleaned_lines)
+
+
 def is_public_issue_mutation(command: str) -> bool:
     for match in re.finditer(r"\bgh\s+issue\s+([a-z-]+)\b", command, re.IGNORECASE):
         if match.group(1).lower() not in READ_ONLY_ISSUE_VERBS:
@@ -162,13 +271,10 @@ def _push_invocations(command: str) -> list[PushInvocation]:
     parsed_starts: set[int] = set()
     for match in GIT_PUSH.finditer(command):
         parsed_starts.add(match.start())
-        invocation = re.split(r"&&|\|\||[;|\n]", command[match.start() :], maxsplit=1)[
-            0
-        ]
+        invocation = re.split(
+            r"&&|\|\||[;|()\n]", command[match.start() :], maxsplit=1
+        )[0]
         cwd, branch_context_known = _branch_context(command, match.start())
-        if not branch_context_known:
-            invocations.append(PushInvocation(None, [], None, False))
-            continue
         try:
             tokens = shlex.split(invocation)
         except ValueError:
@@ -295,6 +401,7 @@ def main() -> int:
     command = payload.get("tool_input", {}).get("command", "")
     if not isinstance(command, str):
         return 0
+    command = _without_heredoc_bodies(command)
 
     if APPROVAL_MARKER not in command and is_public_issue_mutation(command):
         print(

--- a/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
+++ b/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Regression tests for the public GitHub mutation guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+HOOK = Path(__file__).resolve().parents[1] / "public-github-mutation-guard.py"
+SPEC = importlib.util.spec_from_file_location("public_github_mutation_guard", HOOK)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot import hook from {HOOK}")
+GUARD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GUARD
+sys.dont_write_bytecode = True
+SPEC.loader.exec_module(GUARD)
+
+
+class PublicGitHubMutationGuardTest(unittest.TestCase):
+    def run_guard(
+        self, command: str, *, current_branch: str | None = None
+    ) -> tuple[int, str, mock.Mock]:
+        payload = io.StringIO(json.dumps({"tool_input": {"command": command}}))
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(sys, "stdin", payload),
+            mock.patch.object(
+                GUARD, "_current_git_branch", return_value=current_branch
+            ) as branch_lookup,
+            redirect_stderr(stderr),
+        ):
+            exit_code = GUARD.main()
+        return exit_code, stderr.getvalue(), branch_lookup
+
+    def assert_allowed(
+        self, command: str, *, current_branch: str | None = None
+    ) -> mock.Mock:
+        exit_code, stderr, branch_lookup = self.run_guard(
+            command, current_branch=current_branch
+        )
+        self.assertEqual(0, exit_code, stderr)
+        return branch_lookup
+
+    def assert_blocked(
+        self,
+        command: str,
+        message: str,
+        *,
+        current_branch: str | None = None,
+    ) -> mock.Mock:
+        exit_code, stderr, branch_lookup = self.run_guard(
+            command, current_branch=current_branch
+        )
+        self.assertEqual(2, exit_code, stderr)
+        self.assertIn(message, stderr)
+        return branch_lookup
+
+    def test_allows_named_feature_push_after_heredoc_commit(self) -> None:
+        command = """\
+cd /path/to/repo
+git add -A klai-portal/frontend
+git commit -q -F - <<'MSG'
+It's a `design-callouts` change — with “quotes”.
+MSG
+git push -q -u origin mvletter/design-callouts && echo "pushed"
+"""
+
+        branch_lookup = self.assert_allowed(command)
+
+        branch_lookup.assert_not_called()
+
+    def test_allows_named_feature_push_in_simple_compound(self) -> None:
+        command = (
+            'git status --short; echo "---"; '
+            "git push -u origin mvletter/design-callouts 2>&1 | tail -3"
+        )
+
+        branch_lookup = self.assert_allowed(command)
+
+        branch_lookup.assert_not_called()
+
+    def test_allows_pr_mutation_words_inside_heredoc_data(self) -> None:
+        command = """\
+cat > /tmp/notes.md <<'EOF'
+Then we ran gh pr merge 123 and it worked.
+EOF
+"""
+
+        self.assert_allowed(command)
+
+    def test_allows_mutation_words_in_unquoted_and_tab_stripped_heredocs(
+        self,
+    ) -> None:
+        commands = [
+            "cat <<EOF\ngit push origin main\nEOF\n",
+            "cat <<-EOF\n\tgh issue close 123\n\tEOF\n",
+        ]
+
+        for command in commands:
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_heredoc_data_cannot_supply_the_code_approval_marker(self) -> None:
+        command = """\
+cat <<'EOF'
+KLAI_ALLOW_PUBLIC_CODE_MUTATION=1
+EOF
+gh pr merge 123
+"""
+
+        self.assert_blocked(
+            command, "autonomous public GitHub PR mutation"
+        )
+
+    def test_non_heredoc_shift_operators_do_not_hide_a_real_mutation(self) -> None:
+        commands = [
+            "printf '%s\\n' \"<<'EOF'\"\ngh pr merge 123\nEOF\n",
+            "echo $((1 <<EOF))\ngh pr merge 123\nEOF\n",
+        ]
+
+        for command in commands:
+            with self.subTest(command=command):
+                self.assert_blocked(
+                    command, "autonomous public GitHub PR mutation"
+                )
+
+    def test_unsupported_compound_delimiter_fails_closed(self) -> None:
+        command = """\
+cat <<E'OF'
+notes
+EOF
+gh pr merge 123
+"""
+
+        self.assert_blocked(
+            command, "autonomous public GitHub PR mutation"
+        )
+
+    def test_allows_standalone_named_feature_push(self) -> None:
+        branch_lookup = self.assert_allowed(
+            "git push origin mvletter/design-callouts", current_branch="main"
+        )
+
+        branch_lookup.assert_not_called()
+
+    def test_blocks_every_explicit_main_destination(self) -> None:
+        commands = [
+            "git push origin main",
+            "git push origin refs/heads/main",
+            "git push origin HEAD:main",
+            "git push origin feature:main",
+            "git push origin feature:refs/heads/main",
+            "git push origin :main",
+            "git push origin --delete main",
+            "git push --all",
+            "git push --mirror origin",
+            "git push --force origin main",
+            "git push -f origin feature:main",
+            "git push --force-with-lease origin HEAD:main",
+            "git push origin +feature:main",
+        ]
+
+        for command in commands:
+            with self.subTest(command=command):
+                branch_lookup = self.assert_blocked(
+                    command, "public main branch push", current_branch="feature/safe"
+                )
+                branch_lookup.assert_not_called()
+
+    def test_bare_push_uses_current_branch_and_fails_closed_when_unknown(self) -> None:
+        cases = [
+            ("main", True),
+            ("feature/design-callouts", False),
+            (None, True),
+        ]
+
+        for current_branch, should_block in cases:
+            with self.subTest(current_branch=current_branch):
+                if should_block:
+                    branch_lookup = self.assert_blocked(
+                        "git push",
+                        "public main branch push",
+                        current_branch=current_branch,
+                    )
+                else:
+                    branch_lookup = self.assert_allowed(
+                        "git push", current_branch=current_branch
+                    )
+                branch_lookup.assert_called_once_with([], None)
+
+    def test_head_push_in_unsupported_shell_context_fails_closed(self) -> None:
+        branch_lookup = self.assert_blocked(
+            "(cd /path/to/repo && git push origin HEAD)",
+            "public main branch push",
+            current_branch="feature/session",
+        )
+
+        branch_lookup.assert_not_called()
+
+    def test_blocks_real_pr_mutation_outside_heredoc_without_marker(self) -> None:
+        self.assert_blocked(
+            "gh pr merge 123 --squash", "autonomous public GitHub PR mutation"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/rules-tests.yml
+++ b/.github/workflows/rules-tests.yml
@@ -74,5 +74,10 @@ jobs:
         # no service .venv needed. uv brings pytest in via tool-run.
         run: uv tool run --with pytest --with pyyaml pytest rules/tests/ -v
 
+      - name: Run hook guard tests
+        # The public-github-mutation-guard is a security hook; its regression
+        # suite is plain unittest with no dependencies.
+        run: python3 .claude/hooks/klai/tests/public-github-mutation-guard.test.py
+
       - name: Check active agent knowledge
         run: bash scripts/check-agent-knowledge.sh


### PR DESCRIPTION
Follow-on item 4 of `SPEC-DESIGN-SOURCE-001`. The public-github-mutation-guard blocked three routine feature-branch pushes today as "public main branch push", and then blocked the authoring of its own fix brief because prose inside a heredoc mentioned a PR-merge command. Two defects, one root: the guard judged the whole command string instead of the actual invocations in it.

## The fixes

**Compound pushes.** A push inside a compound command lost its branch context — and an apostrophe in a heredoc commit message could break `shlex` for the whole string — after which even a push with an **explicit non-main refspec** fell into the unknown-context path and was blocked as a main push. The refspec names the destination; that is the one case where no shell context is needed. Push invocations are now parsed independently, and unknown branch context only matters for bare pushes and bare `HEAD`.

**Heredoc bodies.** They were scanned as if they were commands, so writing a markdown file whose *text* mentions a PR mutation tripped the PR guard. Bodies of `<<WORD`, `<<'WORD'`, `<<"WORD"` and `<<-WORD` are stripped before any marker or mutation scan. An approval marker appearing only inside heredoc data authorises nothing.

## Fail-closed is preserved, and pinned

Regression tests were written first and failed on exactly the three reported shapes. The suite pins what must survive: `main` in any refspec form (bare, `HEAD:main`, `feature:main`, `+feature:main`, `--delete`), `--all`/`--mirror`/force variants, bare pushes on main or unknown context, and real PR mutations without the env var — all still blocked. Ambiguous options, wildcards and malformed invocations deliberately remain fail-closed.

## Verification

Beyond the 12-test unit suite (run independently by the reviewer), the fixed hook was probed **end-to-end through its real stdin contract** with twelve live cases, including today's three verbatim false positives: 12/12 correct, including the subtlest — an approval marker inside heredoc data authorises nothing. The `rules/tests` suite (126 tests) passes untouched. The new suite is wired into `rules-tests.yml`, which already triggers on `.claude/hooks/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)