### PR TITLE
Pay the audit's colour debt — and the token it exposed

### DIFF
--- a/klai-portal/frontend/DESIGN.md
+++ b/klai-portal/frontend/DESIGN.md
@@ -8,6 +8,7 @@ colors:
   rl-dark-60: "#19191899"
   rl-accent: "#fcaa2d"
   rl-accent-dark: "#a36404"
+  accent-text: "#7D4D03"
   rl-accent-hover: "#e89a1f"
   rl-cream: "#f3f2e7"
   rl-border: "#e3e2d8"
@@ -137,8 +138,9 @@ Use:
 - `klai-hover` for interactive hover states.
 - Semantic base tokens are for fills and borders. On a light surface, foregrounds
   use the matching `-text` token: `var(--color-success-text)` (7.30:1),
-  `var(--color-warning-text)` (6.73:1), and `var(--color-destructive-text)`
-  (6.15:1). Existing `var(--color-destructive)` foregrounds remain valid because
+  `var(--color-warning-text)` (6.73:1), `var(--color-destructive-text)`
+  (6.15:1), and `var(--color-accent-text)` (6.80:1 — measured on the amber
+  tint too, where `--color-rl-accent-dark` falls short at 4.28:1). Existing `var(--color-destructive)` foregrounds remain valid because
   the base token itself clears AA at 5.17:1.
 
 Do not use raw Tailwind semantic colors such as `text-green-*`, `text-red-*`,

--- a/klai-portal/frontend/docs/ui-standards.md
+++ b/klai-portal/frontend/docs/ui-standards.md
@@ -914,8 +914,9 @@ Use:
 - `klai-hover` for interactive hover states.
 - Semantic base tokens are for fills and borders. On a light surface, foregrounds
   use the matching `-text` token: `var(--color-success-text)` (7.30:1),
-  `var(--color-warning-text)` (6.73:1), and `var(--color-destructive-text)`
-  (6.15:1). Existing `var(--color-destructive)` foregrounds remain valid because
+  `var(--color-warning-text)` (6.73:1), `var(--color-destructive-text)`
+  (6.15:1), and `var(--color-accent-text)` (6.80:1 — measured on the amber
+  tint too, where `--color-rl-accent-dark` falls short at 4.28:1). Existing `var(--color-destructive)` foregrounds remain valid because
   the base token itself clears AA at 5.17:1.
 
 Do not use raw Tailwind semantic colors such as `text-green-*`, `text-red-*`,

--- a/klai-portal/frontend/e2e/visual/ui-catalog.a11y.spec.ts
+++ b/klai-portal/frontend/e2e/visual/ui-catalog.a11y.spec.ts
@@ -22,20 +22,6 @@ type DocumentedException = Pick<CatalogFinding, 'rule' | 'section' | 'target'> &
  */
 const DOCUMENTED_EXCEPTIONS: DocumentedException[] = [
   {
-    rule: 'color-contrast',
-    section: 'Conversation',
-    target: '.bg-\\[var\\(--color-secondary\\)\\].px-3.py-1',
-    reason:
-      'Real component debt: the day-separator pill sets text-gray-500 — the documented non-text colour — as text on the secondary tint, 4.39:1 against the 4.5:1 bar. Fix as its own unit (gray-600).',
-  },
-  {
-    rule: 'color-contrast',
-    section: 'Selection inputs',
-    target: '.bg-\\[var\\(--color-accent\\)\\]\\/10',
-    reason:
-      'Real component debt: the multi-select chip uses the amber accent as its text colour on a 10% amber tint — the exact combination the styleguide bans. Fix as its own unit (--color-rl-accent-dark).',
-  },
-  {
     rule: 'nested-interactive',
     section: 'Selection inputs',
     target: '.min-h-9',

--- a/klai-portal/frontend/src/components/ui/conversation.tsx
+++ b/klai-portal/frontend/src/components/ui/conversation.tsx
@@ -197,7 +197,7 @@ export function ConversationTimeline({
           {bucket.blocks.map((block, index) =>
             'label' in block ? (
               <div key={`sys-${block.id}`} className="flex justify-center">
-                <span className="rounded-full bg-[var(--color-secondary)] px-3 py-1 text-xs text-gray-500">
+                <span className="rounded-full bg-[var(--color-secondary)] px-3 py-1 text-xs text-gray-600">
                   {block.label}
                 </span>
               </div>

--- a/klai-portal/frontend/src/components/ui/multi-select.tsx
+++ b/klai-portal/frontend/src/components/ui/multi-select.tsx
@@ -74,7 +74,7 @@ export function MultiSelect({
             {selectedLabels.map((label, i) => (
               <span
                 key={value[i]}
-                className="inline-flex items-center gap-1 rounded-sm bg-[var(--color-accent)]/10 px-1.5 py-0.5 text-xs font-medium text-[var(--color-accent)]"
+                className="inline-flex items-center gap-1 rounded-sm bg-[var(--color-accent)]/10 px-1.5 py-0.5 text-xs font-medium text-[var(--color-accent-text)]"
               >
                 {label}
                 <span

--- a/klai-portal/frontend/src/index.css
+++ b/klai-portal/frontend/src/index.css
@@ -14,6 +14,7 @@
   --color-rl-dark-60:      #19191899;
   --color-rl-accent:       #fcaa2d;
   --color-rl-accent-dark:  #a36404;
+  --color-accent-text:     #7D4D03;
   --color-rl-accent-hover: #e89a1f;
   --color-rl-cream:        #f3f2e7;
   --color-rl-border:       #e3e2d8;


### PR DESCRIPTION
The two colour findings from the first accessibility audit (#1303), plus the deeper thing fixing them uncovered.

The conversation day-separator pill moves from `text-gray-500` — the documented *non-text* colour — to `text-gray-600` (6.86:1).

**The multi-select chip is the interesting one.** Sol applied the styleguide's own prescription — "#fcaa2d fails as text, use #a36404" — and the audit rejected the prescription: `--color-rl-accent-dark` measures **4.28:1 on the chip's 10% amber tint**, under the 4.5:1 bar. The guidance was written for plain light surfaces and nobody had ever measured it on a tint. Every other semantic colour has a `-text` variant in the 6–7:1 band for exactly this reason; accent was the one member of the family without one.

So the family is complete: **`--color-accent-text` (#7D4D03)** — same hue, measured before it was chosen: 6.80:1 on background, 6.50:1 on secondary, 6.39:1 on the amber tint. The chip uses it, the Colors section documents it with the measurement, DESIGN.md is regenerated, and the documented-contrast test checks it on every run from now on.

The two stale exceptions are gone from the a11y suite — its reverse guard demanded that — leaving only the structural `nested-interactive` entry. Both Playwright projects pass in the container. **No visual baselines changed**: both fixes fall inside the screenshot tolerance of their large sections, which is precisely why the axe audit exists alongside the pixel diff.

Known follow-on, deliberately not a drive-by: the shared styleguide still recommends `rl-accent-dark` for text, now measured-false on tints. It is a cross-surface file (website + portal); correcting it belongs to the queued cross-surface unit.

All gates green: both generators' `--check`, tsc, lint, vitest (92/632), documented-contrast 3/3, both Playwright projects (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)