### PR TITLE
fix(widget): mount the bubble when the embed snippet sits in <head>

### DIFF
--- a/klai-widget/src/main.ts
+++ b/klai-widget/src/main.ts
@@ -71,6 +71,17 @@ function cssVariableOverrides(config: WidgetConfig): string {
     .join(" ");
 }
 
+// The snippet often lands in <head> (help.voys.nl, most CMSs), so the bundle
+// runs before <body> is parsed. Wait for it; the script tag itself must be
+// resolved before this await because document.currentScript is only set
+// while the script executes synchronously.
+function whenBodyReady(): Promise<void> {
+  if (document.body) return Promise.resolve();
+  return new Promise((resolve) => {
+    document.addEventListener("DOMContentLoaded", () => resolve(), { once: true });
+  });
+}
+
 async function bootstrap(): Promise<void> {
   const scriptTag = findScriptTag();
 
@@ -103,6 +114,7 @@ async function bootstrap(): Promise<void> {
 
     setChatOpen(true);
     // Inline mode: mount ChatWindow directly into a page element, no shadow DOM
+    await whenBodyReady();
     const target = document.querySelector(containerSelector);
     if (!target) {
       console.error(`KLAI_WIDGET: Container "${containerSelector}" not found`);
@@ -142,6 +154,7 @@ async function bootstrap(): Promise<void> {
   // renders at page load — no network request until the first click —
   // so visitors who never open the chat cost no config call and no
   // session token.
+  await whenBodyReady();
   const container = document.createElement("div");
   container.setAttribute("id", "klai-widget-root");
   document.body.appendChild(container);

--- a/klai-widget/tests/bootstrap.test.ts
+++ b/klai-widget/tests/bootstrap.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Customers paste the embed snippet wherever their CMS puts third-party
+// scripts, often in <head>. The bundle then runs before <body> is parsed.
+
+function embedScriptInHead(): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.src = "https://my.getklai.com/widget/klai-chat.js";
+  script.setAttribute("data-widget-id", "wgt_test");
+  document.head.appendChild(script);
+  return script;
+}
+
+describe("widget bootstrap", () => {
+  let body: HTMLElement;
+  let unhandled: unknown[];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+
+  beforeEach(() => {
+    vi.resetModules();
+    unhandled = [];
+    process.on("unhandledRejection", onUnhandled);
+    body = document.body;
+    document.documentElement.removeChild(body);
+    embedScriptInHead();
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", onUnhandled);
+    document.head.innerHTML = "";
+    if (!document.body) document.documentElement.appendChild(body);
+    document.body.innerHTML = "";
+  });
+
+  it("mounts the bubble once the body exists when the snippet sits in <head>", async () => {
+    expect(document.body).toBeNull();
+
+    await import("../src/main");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(unhandled).toEqual([]);
+
+    document.documentElement.appendChild(body);
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(document.getElementById("klai-widget-root")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

help.voys.nl embeds the widget script in `<head>`. The bundle ran before `<body>` was parsed, `document.body.appendChild` threw `TypeError: Cannot read properties of null`, and the chat bubble never mounted. Verified on the live page: script tag parent is HEAD, no `#klai-widget-root`, the TypeError in the console. The widget-config endpoint itself answers 200 for origin https://help.voys.nl.

## Fix

`klai-widget/src/main.ts`: resolve the script tag synchronously (`document.currentScript` is only set during sync execution), then wait for DOMContentLoaded right before the first DOM access in bubble and inline mode.

## Verification

- New test `tests/bootstrap.test.ts` reproduces the TypeError on the old code and passes on the new code.
- klai-widget vitest 11/11, `tsc -b` clean, build ok, bundle size 37.5 kB gzip.
- Playwright against the live help.voys.nl page with the rebuilt bundle injected: bubble mounts under HEAD placement, widget-config returns 200, chat opens, no page errors.

Merging deploys the new `klai-chat.js` through the portal-frontend workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)