### PR TITLE
fix(cors): let the widget on a customer's own site through the CORS middleware

### DIFF
--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -59,6 +59,27 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 #   https://evil.getklai.com.attacker.tld    (not the getklai.com TLD)
 _FIRST_PARTY_ORIGIN_PATTERN = r"^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$"
 
+# Public widget endpoints (app/api/partner.py). The widget bundle calls these
+# from the customer's own site, so the first-party allowlist cannot apply.
+# The security boundary there is the widget session JWT minted by
+# /widget-config (see its docstring), never the BFF cookie: the origin is
+# echoed and credentials are never allowed. /widget-config keeps its own
+# widget-aware OPTIONS route, which decides per widget allowlist.
+_WIDGET_CONFIG_PATH = "/partner/v1/widget-config"
+_WIDGET_PUBLIC_PATHS = frozenset(
+    {
+        _WIDGET_CONFIG_PATH,
+        "/partner/v1/chat/completions",
+        "/partner/v1/widget/feedback",
+    }
+)
+_WIDGET_HANDOFF_PREFIX = "/partner/v1/widget-handoffs/"
+
+
+def _is_widget_public_path(path: str) -> bool:
+    return path in _WIDGET_PUBLIC_PATHS or path.startswith(_WIDGET_HANDOFF_PREFIX)
+
+
 logger = structlog.get_logger()
 _startup_logger = logging.getLogger(__name__)
 
@@ -157,6 +178,10 @@ class KlaiCORSMiddleware(CORSMiddleware):
         headers = Headers(scope=scope)
         origin = headers.get("origin")
 
+        if origin and _is_widget_public_path(scope.get("path", "")):
+            await self._widget_cors(scope, receive, send, origin=origin, headers=headers)
+            return
+
         if origin and not self.is_allowed_origin(origin):
             method = scope.get("method", "")
             is_preflight = method == "OPTIONS" and "access-control-request-method" in headers
@@ -171,6 +196,51 @@ class KlaiCORSMiddleware(CORSMiddleware):
             )
 
         await super().__call__(scope, receive, send)
+
+    async def _widget_cors(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        *,
+        origin: str,
+        headers: Headers,
+    ) -> None:
+        """CORS for the public widget endpoints: echo the origin, no credentials."""
+        if scope.get("path") == _WIDGET_CONFIG_PATH:
+            # Its routes decide per widget allowlist and set ACAO themselves,
+            # on the preflight as well as on the GET (403 without ACAO when
+            # the origin is not allowed).
+            await self.app(scope, receive, send)
+            return
+        if scope.get("method") == "OPTIONS" and "access-control-request-method" in headers:
+            response = Response(
+                status_code=204,
+                headers={
+                    "Access-Control-Allow-Origin": origin,
+                    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                    # Mirror what the browser asks for (Starlette does the same
+                    # for allow_headers="*"): the SSE client adds Last-Event-ID
+                    # on reconnect, the widget its session id and bearer token.
+                    "Access-Control-Allow-Headers": headers.get("access-control-request-headers", "*"),
+                    "Access-Control-Max-Age": "600",
+                    "Vary": "Origin",
+                },
+            )
+            await response(scope, receive, send)
+            return
+
+        async def send_with_origin(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", [])
+                response_headers = MutableHeaders(scope=message)
+                response_headers.setdefault("Access-Control-Allow-Origin", origin)
+                if "access-control-allow-credentials" in response_headers:
+                    del response_headers["access-control-allow-credentials"]
+                response_headers.add_vary_header("Origin")
+            await send(message)
+
+        await self.app(scope, receive, send_with_origin)
 
     # @MX:NOTE: REQ-1.5 enforcement — Starlette's CORSMiddleware always sets
     # Access-Control-Allow-Credentials: true when allow_credentials=True,

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -15,9 +15,11 @@ constant) use pytest's `monkeypatch` for idempotent cleanup.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+
 import pytest
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.testclient import TestClient
 
 # ---------------------------------------------------------------------------
@@ -55,6 +57,34 @@ def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
     @app.get("/internal/anything")
     async def internal() -> JSONResponse:
         return JSONResponse({"ok": True})
+
+    # Public widget endpoints, mirrored from app/api/partner.py: the widget
+    # bundle calls these from the customer's own site. /widget-config has a
+    # widget-aware preflight route that echoes the origin when the widget's
+    # allowlist matches.
+    @app.post("/partner/v1/chat/completions")
+    async def widget_chat() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.options("/partner/v1/widget-config")
+    async def widget_config_preflight(id: str) -> JSONResponse:
+        headers = {"X-Widget-Route": id}
+        if id == "wgt_allows_customer":
+            headers["Access-Control-Allow-Origin"] = "https://help.customer.example"
+        return JSONResponse(None, status_code=204, headers=headers)
+
+    @app.get("/partner/v1/widget-config")
+    async def widget_config(id: str) -> JSONResponse:
+        if id == "wgt_allows_customer":
+            return JSONResponse({"ok": True}, headers={"Access-Control-Allow-Origin": "https://help.customer.example"})
+        return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
+
+    @app.get("/partner/v1/widget-handoffs/hubspot/events")
+    async def widget_handoff_events() -> StreamingResponse:
+        async def events() -> AsyncIterator[bytes]:
+            yield b"id: 1\ndata: {}\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
 
     app.add_middleware(
         KlaiCORSMiddleware,
@@ -423,3 +453,103 @@ def test_cors_regex_compile_failure_raises_system_exit(
 
     with pytest.raises(SystemExit):
         cors_module._compile_first_party_regex()
+
+
+# ---------------------------------------------------------------------------
+# Public widget endpoints: a customer's own origin is the normal caller
+# ---------------------------------------------------------------------------
+
+CUSTOMER_ORIGIN = "https://help.customer.example"
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "requested_headers"),
+    [
+        ("/partner/v1/chat/completions", "POST", "content-type,authorization"),
+        ("/partner/v1/widget/feedback", "POST", "content-type,authorization"),
+        # The SSE client re-sends Last-Event-ID when it reconnects.
+        ("/partner/v1/widget-handoffs/hubspot/events", "GET", "authorization,last-event-id"),
+    ],
+)
+def test_widget_preflight_from_customer_origin_is_answered(
+    cors_client: TestClient, path: str, method: str, requested_headers: str
+) -> None:
+    """The widget on a customer's site must get through the preflight: the
+    security boundary there is the widget session JWT, not the first-party
+    origin allowlist."""
+    response = cors_client.options(
+        path,
+        headers={
+            "Origin": CUSTOMER_ORIGIN,
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": requested_headers,
+        },
+    )
+    assert response.status_code == 204, response.text
+    assert response.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+    allowed = response.headers.get("access-control-allow-headers", "").lower()
+    assert all(h in allowed for h in requested_headers.split(","))
+    assert "access-control-allow-credentials" not in response.headers
+
+
+def test_widget_chat_response_from_customer_origin_carries_acao(cors_client: TestClient) -> None:
+    response = cors_client.post("/partner/v1/chat/completions", headers={"Origin": CUSTOMER_ORIGIN})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+    assert "access-control-allow-credentials" not in response.headers
+
+
+def test_widget_sse_stream_from_customer_origin_carries_acao(cors_client: TestClient) -> None:
+    with cors_client.stream(
+        "GET", "/partner/v1/widget-handoffs/hubspot/events", headers={"Origin": CUSTOMER_ORIGIN}
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+        assert b"id: 1" in b"".join(response.iter_bytes())
+
+
+def test_widget_config_preflight_is_decided_by_the_widget_route(cors_client: TestClient) -> None:
+    """/widget-config decides per widget allowlist in its own OPTIONS route;
+    the global middleware hands the preflight through and must not add an
+    origin echo the route deliberately left out."""
+    headers = {
+        "Origin": CUSTOMER_ORIGIN,
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "x-klai-widget-session-id",
+    }
+    allowed = cors_client.options("/partner/v1/widget-config?id=wgt_allows_customer", headers=headers)
+    assert allowed.status_code == 204, allowed.text
+    assert allowed.headers.get("x-widget-route") == "wgt_allows_customer"
+    assert allowed.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+    rejected = cors_client.options("/partner/v1/widget-config?id=wgt_other", headers=headers)
+    assert rejected.status_code == 204, rejected.text
+    assert rejected.headers.get("x-widget-route") == "wgt_other"
+    assert "access-control-allow-origin" not in rejected.headers
+
+    # The GET follows the same rule: a 403 for a disallowed origin stays
+    # unreadable cross-origin (AC-10), an allowed origin keeps the route's echo.
+    denied = cors_client.get("/partner/v1/widget-config?id=wgt_other", headers={"Origin": CUSTOMER_ORIGIN})
+    assert denied.status_code == 403
+    assert "access-control-allow-origin" not in denied.headers
+    granted = cors_client.get("/partner/v1/widget-config?id=wgt_allows_customer", headers={"Origin": CUSTOMER_ORIGIN})
+    assert granted.status_code == 200
+    assert granted.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+
+def test_widget_path_match_is_exact(cors_client: TestClient) -> None:
+    response = cors_client.options(
+        "/partner/v1/chat/completions-admin",
+        headers={"Origin": CUSTOMER_ORIGIN, "Access-Control-Request-Method": "POST"},
+    )
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_customer_origin_is_still_rejected_outside_widget_paths(cors_client: TestClient) -> None:
+    response = cors_client.options(
+        "/api/auth/login",
+        headers={"Origin": CUSTOMER_ORIGIN, "Access-Control-Request-Method": "POST"},
+    )
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
## Problem

The widget bundle runs on customers' own sites. `KlaiCORSMiddleware` (outermost, a Starlette `CORSMiddleware` subclass) answers every preflight itself and rejects any origin outside `*.getklai.com` with 400, so:

- the widget-aware `OPTIONS /partner/v1/widget-config` route was never reached (the widget sends `X-Klai-Widget-Session-Id`, which forces a preflight);
- `POST /partner/v1/chat/completions`, feedback and the HubSpot handoff calls from a customer origin could not pass preflight and their responses carried no `Access-Control-Allow-Origin`.

Live evidence on help.voys.nl after #1359: bubble mounts, click → preflight 400 "Disallowed CORS origin", `cors_origin_rejected kind=preflight path=/partner/v1/widget-config origin=https://help.voys.nl` in VictoriaLogs. SPEC-VOYS-HELPBOT-001 already lists this gap ("A widget on a customer's own domain will fail CORS preflight").

## Fix

`klai_cors.py`: for the public widget paths (`/partner/v1/chat/completions`, `/partner/v1/widget/feedback`, `/partner/v1/widget-handoffs/*`) the middleware answers the preflight with the origin echoed, `Allow-Headers` mirrored from the request (SSE reconnect sends `Last-Event-ID`), never `Allow-Credentials`, and adds the origin echo to actual responses (ACAC stripped). `/partner/v1/widget-config` passes through untouched: its own routes decide per widget allowlist (403 without ACAO for a disallowed origin, AC-10 preserved). All other paths keep the first-party allowlist unchanged.

Security model: on these paths the boundary is the widget session JWT (bearer, no cookies), as the `widget_config` docstring states; Origin remains a UX gate enforced at mint time.

## Verification

- `tests/test_cors_allowlist.py`: new tests fail on main with the same 400 as production and pass with the fix (preflight for chat/feedback/handoffs incl. `last-event-id`, ACAO on JSON and SSE responses, no ACAC, widget-config preflight and GET decided by the route, suffix collision `/chat/completions-admin` still rejected, customer origin still rejected on `/api/auth/login`).
- Full portal backend suite: 3960 passed. ruff, pyright clean. `rules/tests/test_cors_middleware_last_lint.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)