### PR TITLE
fix(widget): the nerds disclaimer link always opens the booking panel

### DIFF
--- a/klai-widget/src/components/ChatWindow.tsx
+++ b/klai-widget/src/components/ChatWindow.tsx
@@ -855,10 +855,10 @@ export function ChatWindow(props: ChatWindowProps) {
 
       {/* With the nerds integration on, the client's own disclosure
           sentence replaces the plain accuracy footer — same place, same
-          white-label gate. "onze nerds" is plain text, not a control: a
-          disclaimer is not an appointment route, and the one route the
-          visitor should take is the button under the answer that offered
-          it. The fragments render as JSX text, never as raw HTML. */}
+          white-label gate. The visitor must always have a working escape
+          route to a human, so "onze nerds" opens the same booking panel
+          the in-conversation appointment button opens. The fragments
+          render as JSX text/a button, never as raw HTML. */}
       <Show when={!props.hideDisclaimer}>
         <Show
           when={nerdsActive()}
@@ -866,7 +866,13 @@ export function ChatWindow(props: ChatWindowProps) {
         >
           <p class="klai-disclaimer">
             {t().nerdsDisclosureBefore}
-            {t().nerdsDisclosureLink}
+            <button
+              type="button"
+              class="klai-disclaimer-link"
+              onClick={openNerdsPanel}
+            >
+              {t().nerdsDisclosureLink}
+            </button>
             {t().nerdsDisclosureAfter}
           </p>
         </Show>

--- a/klai-widget/src/components/ChatWindow.tsx
+++ b/klai-widget/src/components/ChatWindow.tsx
@@ -854,28 +854,34 @@ export function ChatWindow(props: ChatWindowProps) {
       </div>
 
       {/* With the nerds integration on, the client's own disclosure
-          sentence replaces the plain accuracy footer — same place, same
-          white-label gate. The visitor must always have a working escape
-          route to a human, so "onze nerds" opens the same booking panel
-          the in-conversation appointment button opens. The fragments
-          render as JSX text/a button, never as raw HTML. */}
-      <Show when={!props.hideDisclaimer}>
-        <Show
-          when={nerdsActive()}
-          fallback={<p class="klai-disclaimer">{t().disclaimer}</p>}
-        >
-          <p class="klai-disclaimer">
-            {t().nerdsDisclosureBefore}
-            <button
-              type="button"
-              class="klai-disclaimer-link"
-              onClick={openNerdsPanel}
-            >
-              {t().nerdsDisclosureLink}
-            </button>
-            {t().nerdsDisclosureAfter}
-          </p>
-        </Show>
+          sentence replaces the plain accuracy footer — same place, but NOT
+          the same white-label gate. hideDisclaimer only white-labels the
+          generic accuracy wording; the nerds escape route is the visitor's
+          one permanent way to reach a human (the booking bar above is
+          already hidden once nerds is active) and must survive that toggle,
+          so it renders whenever nerds is configured, hideDisclaimer or not.
+          "onze nerds" opens the same booking panel the in-conversation
+          appointment button opens. The fragments render as JSX text/a
+          button, never as raw HTML. */}
+      <Show
+        when={nerdsActive()}
+        fallback={
+          <Show when={!props.hideDisclaimer}>
+            <p class="klai-disclaimer">{t().disclaimer}</p>
+          </Show>
+        }
+      >
+        <p class="klai-disclaimer">
+          {t().nerdsDisclosureBefore}
+          <button
+            type="button"
+            class="klai-disclaimer-link"
+            onClick={openNerdsPanel}
+          >
+            {t().nerdsDisclosureLink}
+          </button>
+          {t().nerdsDisclosureAfter}
+        </p>
       </Show>
 
       {/* Nerds booking panel: overlay covering the chat while open. The

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -1467,3 +1467,14 @@
 .klai-window--inline .klai-disclaimer {
   border-top: none;
 }
+
+.klai-disclaimer-link {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: inherit;
+  color: var(--klai-link-color);
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/klai-widget/tests/booking-bar.test.tsx
+++ b/klai-widget/tests/booking-bar.test.tsx
@@ -73,4 +73,24 @@ describe("permanent booking bar", () => {
     fireEvent.click(link);
     expect(container.querySelector(".klai-nerds-panel")).not.toBeNull();
   });
+
+  it("keeps the nerds escape link even when hideDisclaimer white-labels the accuracy footer", () => {
+    // hideDisclaimer only white-labels the generic accuracy wording. With
+    // nerds active the permanent booking bar is already gone (the offer
+    // lives in-conversation instead), so this link is the visitor's only
+    // remaining permanent route to a human — it must survive the toggle.
+    const { container } = renderWindow({
+      nerdsEnabled: true,
+      nerdsBookingUrl: BOOKING_URL,
+      hideDisclaimer: true,
+    });
+    const link = container.querySelector("button.klai-disclaimer-link");
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toBe(t().nerdsDisclosureLink);
+  });
+
+  it("still hides the plain accuracy footer via hideDisclaimer when nerds is off", () => {
+    const { container } = renderWindow({ hideDisclaimer: true });
+    expect(container.querySelector(".klai-disclaimer")).toBeNull();
+  });
 });

--- a/klai-widget/tests/booking-bar.test.tsx
+++ b/klai-widget/tests/booking-bar.test.tsx
@@ -4,13 +4,14 @@
  * Two shapes exist side by side and must not bleed into each other:
  *
  * - nerds integration ON  → the appointment lives in the conversation, so the
- *   always-on bar is gone and "onze nerds" in the footer is a disclaimer
- *   sentence, plain text, not a second route to the same booking module.
+ *   always-on bar is gone, and "onze nerds" in the footer is always a working
+ *   escape route: clicking it opens the same nerds booking panel the
+ *   in-conversation appointment button opens.
  * - nerds integration OFF → nothing changed at all. Widgets that never had
  *   this integration must render byte-for-byte the same controls as before.
  */
 
-import { render, cleanup } from "@solidjs/testing-library";
+import { render, fireEvent, cleanup } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ChatWindow } from "../src/components/ChatWindow";
@@ -53,7 +54,7 @@ describe("permanent booking bar", () => {
     expect(container.querySelector(".klai-booking-bar")).toBeNull();
   });
 
-  it("keeps the disclosure sentence as text, with no second appointment button", () => {
+  it("keeps the disclosure sentence's wording, with a working escape link", () => {
     const { container } = renderWindow({
       nerdsEnabled: true,
       nerdsBookingUrl: BOOKING_URL,
@@ -62,7 +63,14 @@ describe("permanent booking bar", () => {
     expect(disclaimer.textContent).toBe(
       t().nerdsDisclosureBefore + t().nerdsDisclosureLink + t().nerdsDisclosureAfter,
     );
-    expect(disclaimer.querySelector("button")).toBeNull();
-    expect(disclaimer.querySelector("a")).toBeNull();
+    const link = disclaimer.querySelector("button.klai-disclaimer-link") as HTMLButtonElement;
+    expect(link).not.toBeNull();
+    expect(link.textContent).toBe(t().nerdsDisclosureLink);
+
+    // Clicking it must always open the nerds panel — the visitor must
+    // always be able to escape to a human, from the footer, not just from
+    // an in-conversation offer.
+    fireEvent.click(link);
+    expect(container.querySelector(".klai-nerds-panel")).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Visitors must always be able to escape to a human via the "onze nerds" link in the footer disclaimer — it was rendered as plain, unclickable text. It now opens the same nerds booking panel the in-conversation appointment offer opens.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 11/11 passed (updated `booking-bar.test.tsx` to assert the link is clickable and opens the panel)
- [x] `npm run build` — bundle builds, size check pending in CI