### PR TITLE
fix(widget): mint rate limit per visitor, with the per-widget bucket as an abuse ceiling

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -62,6 +62,7 @@ from app.services.partner_support import (
 )
 from app.services.quality_scorer import schedule_quality_update
 from app.services.redis_client import get_redis_pool
+from app.services.request_ip import resolve_caller_ip
 from app.services.retrieval_log import find_correlated_log, write_retrieval_log
 from app.services.web_search import build_web_results_block, search_web, web_results_as_chunks
 from app.services.widget_audit import (
@@ -2814,6 +2815,27 @@ def _widget_nerds_integration(widget_config_data: dict[str, Any]) -> dict[str, A
 # Public endpoint — NO auth dependency
 # ---------------------------------------------------------------------------
 
+# REQ-7 (Finding B-4) abuse ceilings for the public mint paths. The per-widget
+# number used to be 10/min, which was a traffic cap, not an abuse cap: every
+# visitor of every page embedding the widget shares one bucket (help.voys.nl
+# hit it on the 11th visitor/min). Now: 20/min per client IP (real visitors get
+# an individual budget) under a 120/min per-widget backstop (order of magnitude
+# above real traffic, mirrors the Caddy partner_per_ip edge zone). Actual LLM
+# drain stays bounded by the untouched per-widget 60/min chat-auth bucket in
+# partner_dependencies._auth_via_session_token.
+_WIDGET_MINT_IP_RATE_LIMIT_PER_MINUTE = 20
+_WIDGET_MINT_RATE_LIMIT_PER_MINUTE = 120
+
+
+def _widget_mint_rate_limited(retry_after: int) -> Response:
+    """429 shared by the public mint paths (REQ-7 / Finding B-4)."""
+    return Response(
+        content='{"detail":"Rate limit exceeded"}',
+        status_code=429,
+        media_type="application/json",
+        headers={"Retry-After": str(retry_after)},
+    )
+
 
 @router.get("/widget-config")
 async def widget_config(
@@ -2876,22 +2898,53 @@ async def widget_config(
             media_type="application/json",
         )
 
-    # REQ-7 (Finding B-4): per-widget mint rate-limit BEFORE DB lookup.
-    # @MX:NOTE: [AUTO] Rate-limit key is widget_mint:{id} (public widget_id from URL param).
-    # Limit is 10/min per widget to prevent unbounded LLM-token drain via the public mint path.
+    # REQ-7 (Finding B-4): mint rate-limit BEFORE DB lookup, two layers, checked
+    # client-first so a rejected attempt never counts against the shared widget
+    # ceiling — one hammering client can only ever use its own IP share of it:
+    # 1. per client IP — the caller IP comes from uvicorn's proxy-header
+    #    validation behind Caddy (app.services.request_ip), so it is not
+    #    spoofable like the widget session-id header.
+    # 2. per widget — the REQ-7 abuse ceiling and backstop: key-rotating
+    #    clients still stop here.
+    # @MX:NOTE: [AUTO] Rate-limit keys are widget_mint_ip:{id}:{caller_ip} and
+    # widget_mint:{id} (public widget_id from URL param).
+    # Limits: 20/min per client IP, 120/min per-widget ceiling — see
+    # _WIDGET_MINT_RATE_LIMIT_PER_MINUTE for why the old 10/min was a traffic cap.
     # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
     redis = await get_redis_pool()
     if redis is not None:
+        caller_ip = resolve_caller_ip(request)
+        client_allowed, client_retry_after = await check_rate_limit(
+            redis,
+            f"widget_mint_ip:{id}:{caller_ip}",
+            limit_per_minute=_WIDGET_MINT_IP_RATE_LIMIT_PER_MINUTE,
+            window_seconds=60,
+        )
+        if not client_allowed:
+            # Visitor IPs are logged hashed, never raw (widget-audit convention).
+            logger.warning(
+                "widget_mint_rate_limited",
+                path="widget-config",
+                widget_id=id,
+                limit="client",
+                ip_hash=hash_audit_value(caller_ip),
+            )
+            return _widget_mint_rate_limited(client_retry_after)
+
         allowed, retry_after = await check_rate_limit(
-            redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60
+            redis, f"widget_mint:{id}", limit_per_minute=_WIDGET_MINT_RATE_LIMIT_PER_MINUTE, window_seconds=60
         )
         if not allowed:
-            return Response(
-                content='{"detail":"Rate limit exceeded"}',
-                status_code=429,
-                media_type="application/json",
-                headers={"Retry-After": str(retry_after)},
+            # Review finding 5: the ceiling event carries the same ip_hash as the
+            # client event — a rejected visitor is traceable whichever layer fired.
+            logger.warning(
+                "widget_mint_rate_limited",
+                path="widget-config",
+                widget_id=id,
+                limit="widget",
+                ip_hash=hash_audit_value(caller_ip),
             )
+            return _widget_mint_rate_limited(retry_after)
 
     # Look up widget by public widget_id (SPEC-WIDGET-002: own table)
     # REQ-16: soft-deleted widgets are 404 to the public/partner endpoints.
@@ -2995,6 +3048,7 @@ async def widget_config(
 @router.get("/public-bot-config")
 async def public_bot_config(
     id: str,
+    request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> Response:
     """Public bot share-link endpoint — no Origin check.
@@ -3012,22 +3066,48 @@ async def public_bot_config(
             media_type="application/json",
         )
 
-    # REQ-7 (Finding B-4): per-widget mint rate-limit BEFORE DB lookup.
-    # @MX:NOTE: [AUTO] Same rate-limit as widget_config — isolates public share-link
-    # mint path from the embed mint path with separate per-widget keys.
+    # REQ-7 (Finding B-4): mint rate-limit BEFORE DB lookup — same two layers,
+    # keys and order as widget_config. Without the per-client layer here, one
+    # share-link client could burn the whole shared widget_mint:{id} ceiling and
+    # lock out the embed visitors of the same widget (Caddy's edge zone is also
+    # 120/min/IP, so it does not stop that).
+    # @MX:NOTE: [AUTO] Rate-limit keys are widget_mint_ip:{id}:{caller_ip} and
+    # widget_mint:{id}, deliberately shared with the embed path: one client has
+    # one 20/min mint budget per widget no matter which of the two public doors
+    # it enters, under the same 120/min per-widget abuse ceiling.
     # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
     redis = await get_redis_pool()
     if redis is not None:
+        caller_ip = resolve_caller_ip(request)
+        client_allowed, client_retry_after = await check_rate_limit(
+            redis,
+            f"widget_mint_ip:{id}:{caller_ip}",
+            limit_per_minute=_WIDGET_MINT_IP_RATE_LIMIT_PER_MINUTE,
+            window_seconds=60,
+        )
+        if not client_allowed:
+            # Visitor IPs are logged hashed, never raw (widget-audit convention).
+            logger.warning(
+                "widget_mint_rate_limited",
+                path="public-bot-config",
+                widget_id=id,
+                limit="client",
+                ip_hash=hash_audit_value(caller_ip),
+            )
+            return _widget_mint_rate_limited(client_retry_after)
+
         allowed, retry_after = await check_rate_limit(
-            redis, f"widget_mint:{id}", limit_per_minute=10, window_seconds=60
+            redis, f"widget_mint:{id}", limit_per_minute=_WIDGET_MINT_RATE_LIMIT_PER_MINUTE, window_seconds=60
         )
         if not allowed:
-            return Response(
-                content='{"detail":"Rate limit exceeded"}',
-                status_code=429,
-                media_type="application/json",
-                headers={"Retry-After": str(retry_after)},
+            logger.warning(
+                "widget_mint_rate_limited",
+                path="public-bot-config",
+                widget_id=id,
+                limit="widget",
+                ip_hash=hash_audit_value(caller_ip),
             )
+            return _widget_mint_rate_limited(retry_after)
 
     # REQ-16: soft-deleted widgets are 404 to the public/partner endpoints.
     result = await db.execute(select(Widget).where(Widget.widget_id == id, Widget.deleted_at.is_(None)))

--- a/klai-portal/backend/tests/test_widget_config.py
+++ b/klai-portal/backend/tests/test_widget_config.py
@@ -278,7 +278,7 @@ async def test_public_bot_config_strips_non_http_booking_url():
         patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
-        response = await public_bot_config(id=widget.widget_id, db=db)
+        response = await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     assert json.loads(response.body.decode())["booking_url"] == ""
 
@@ -427,7 +427,7 @@ async def test_public_bot_config_strips_non_http_nerds_booking_url():
         patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
-        response = await public_bot_config(id=widget.widget_id, db=db)
+        response = await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     body = json.loads(response.body.decode())
     assert body["nerds"] == {"enabled": False, "booking_url": ""}
@@ -459,7 +459,7 @@ async def test_public_bot_config_delivers_enabled_nerds_integration():
         patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
-        response = await public_bot_config(id=widget.widget_id, db=db)
+        response = await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     body = json.loads(response.body.decode())
     assert body["nerds"] == {"enabled": True, "booking_url": "https://support.voys.nl/book/voys?t=abc"}
@@ -782,7 +782,7 @@ async def test_public_bot_config_rejects_when_share_disabled():
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
         with pytest.raises(Exception) as exc_info:
-            await public_bot_config(id=widget.widget_id, db=db)
+            await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     assert exc_info.value.status_code == 404
 
@@ -813,7 +813,7 @@ async def test_public_bot_config_returns_token_when_share_enabled():
         patch("app.api.partner.generate_session_token", return_value="public.jwt.token"),
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
-        response = await public_bot_config(id=widget.widget_id, db=db)
+        response = await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     assert response.status_code == 200
     assert '"session_token": "public.jwt.token"' in response.body.decode()

--- a/klai-portal/backend/tests/test_widget_mint_rate_limit.py
+++ b/klai-portal/backend/tests/test_widget_mint_rate_limit.py
@@ -1,24 +1,34 @@
-"""RED: Per-widget mint rate-limit on /partner/v1/widget-config and /public-bot-config.
+"""Per-widget + per-client mint rate-limit on /partner/v1/widget-config and /public-bot-config.
 
 REQ-7 (Finding B-4, SPEC-SEC-CROSS-TENANT-FOLLOWUP-001):
-- widget-config must call check_rate_limit before DB lookup
-- public-bot-config must call check_rate_limit before DB lookup
-- 429 is returned with Retry-After header when limit exceeded
+- widget-config must rate-limit before DB lookup: per client IP (20/min) then
+  per widget abuse ceiling (120/min). The ceiling used to be 10/min, which was
+  a traffic cap shared by every visitor of a widget (help.voys.nl 429s).
+- public-bot-config must apply the same two layers before DB lookup: the
+  client bucket widget_mint_ip:{id}:{ip} is shared with the embed path, so a
+  share-link hammerer can never burn more of the 120/min widget_mint:{id}
+  ceiling than its own IP share (20/min) and lock out embed visitors.
+- 429 is returned with Retry-After header when a limit fires.
 
 AC7.1, AC7.2, AC7.3 from acceptance.md.
 
 # @MX:NOTE: [AUTO] Tests patch app.services.partner_rate_limit.check_rate_limit
-# because partner.py imports the function directly from that module.
+# where only the wiring is under test; the acceptance tests run the REAL limiter
+# on the fakeredis pool from conftest so multi-client traffic is actually admitted.
 # @MX:SPEC: SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7
 """
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+WIDGET_ID = "wgt_abcdef1234567890abcdef1234567890abcdef12"
 
 # ---------------------------------------------------------------------------
 # Shared fakes (mirrors test_widget_platform_unlock.py)
@@ -75,20 +85,140 @@ def _make_db_mock(widget_row=None, org_row=None):
     return db
 
 
-def _make_request(origin: str = "https://example.com"):
+def _make_request(origin: str = "https://example.com", caller_ip: str = "203.0.113.5"):
     req = MagicMock()
     req.headers = {"origin": origin}
+    # resolve_caller_ip() reads request.client.host — uvicorn fills it from the
+    # Caddy-validated X-Forwarded-For in production.
+    req.client.host = caller_ip
     return req
 
 
+@contextmanager
+def _mint_stubs() -> Any:
+    """Stub everything around the mint handler EXCEPT the real rate limiter,
+    so acceptance tests drive app.services.partner_rate_limit.check_rate_limit
+    against the fakeredis pool (fake_redis fixture)."""
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+        patch("app.api.partner.generate_session_token", return_value="tok"),
+        patch("app.api.partner.assert_platform_unlocked"),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        yield
+
+
 # ---------------------------------------------------------------------------
-# AC7.2: 429 returned on widget-config when rate limit exceeded
+# Acceptance (real limiter, one minute, one widget):
+# reported symptom — the 11th visitor of help.voys.nl got 429.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_widget_config_429_after_10_calls_per_minute():
-    """widget-config returns 429 with Retry-After when rate limit exceeded (AC7.2)."""
+async def test_twelve_mints_from_twelve_clients_all_succeed(fake_redis):
+    """12 distinct client IPs minting the same widget within a minute all get 200.
+
+    Regression for the reported traffic-cap: the per-widget number must never
+    be a shared-by-all-visitors 10/min (REQ-7 ceiling is 120/min now)."""
+    from app.api.partner import widget_config
+
+    with _mint_stubs():
+        for n in range(12):
+            request = _make_request(caller_ip=f"203.0.113.{n + 1}")
+            response = await widget_config(id=WIDGET_ID, request=request, db=_make_db_mock())
+            assert response.status_code == 200, f"visitor {n + 1} got {response.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_one_client_hammering_one_widget_stops_at_per_client_limit(fake_redis):
+    """A single client IP is capped at 20 mints/min (REQ-7 abuse bound).
+
+    The 21st mint from the same IP is 429 while other clients are unaffected."""
+    from app.api.partner import widget_config
+
+    with _mint_stubs():
+        hammerer = _make_request(caller_ip="198.51.100.7")
+        for n in range(20):
+            response = await widget_config(id=WIDGET_ID, request=hammerer, db=_make_db_mock())
+            assert response.status_code == 200, f"mint {n + 1} from one client got 429"
+        response = await widget_config(id=WIDGET_ID, request=hammerer, db=_make_db_mock())
+        assert response.status_code == 429
+        # A different client is not punished for the hammerer's volume:
+        bystander = _make_request(caller_ip="198.51.100.8")
+        bystander_response = await widget_config(id=WIDGET_ID, request=bystander, db=_make_db_mock())
+        assert bystander_response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_widget_ceiling_stops_many_distinct_clients(fake_redis):
+    """The per-widget ceiling (120/min, REQ-7) is the backstop: 121 distinct
+    client IPs within a minute → the 121st is 429 even though no client hit
+    its own per-IP limit (simulates an IP-rotating botnet)."""
+    from app.api.partner import widget_config
+
+    with _mint_stubs():
+        for n in range(120):
+            request = _make_request(caller_ip=f"198.18.0.{n}")
+            response = await widget_config(id=WIDGET_ID, request=request, db=_make_db_mock())
+            assert response.status_code == 200, f"mint {n + 1} got {response.status_code}"
+        last = _make_request(caller_ip="198.18.1.0")
+        response = await widget_config(id=WIDGET_ID, request=last, db=_make_db_mock())
+        assert response.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_share_link_hammerer_stops_at_20_and_embed_visitor_is_unaffected(fake_redis):
+    """Review finding 2: the share-link path enforces the same per-client layer.
+
+    One client hammering public-bot-config is stopped at 20/min; because the
+    per-client bucket is shared with the embed path, it can never take more
+    than its own IP share of the 120/min widget_mint:{id} ceiling. A
+    widget-config visitor of the same widget keeps minting."""
+    from app.api.partner import public_bot_config, widget_config
+
+    with _mint_stubs():
+        hammerer = _make_request(caller_ip="198.51.100.9")
+        for n in range(20):
+            response = await public_bot_config(id=WIDGET_ID, request=hammerer, db=_make_db_mock())
+            assert response.status_code == 200, f"share-link mint {n + 1} from one client got {response.status_code}"
+        response = await public_bot_config(id=WIDGET_ID, request=hammerer, db=_make_db_mock())
+        assert response.status_code == 429
+        embed_visitor = _make_request(caller_ip="198.51.100.11")
+        visitor_response = await widget_config(id=WIDGET_ID, request=embed_visitor, db=_make_db_mock())
+        assert visitor_response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Observability: a 429 says which limit fired; raw visitor IPs are not logged
+# (widget-audit privacy convention: visitor IPs go out as hash_audit_value).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_client_429_logs_limit_and_hashed_ip_without_raw_ip(fake_redis):
+    from app.api.partner import widget_config
+
+    caller_ip = "198.51.100.42"
+    with _mint_stubs(), patch("app.api.partner.logger") as mock_logger:
+        request = _make_request(caller_ip=caller_ip)
+        for _ in range(20):
+            await widget_config(id=WIDGET_ID, request=request, db=_make_db_mock())
+        response = await widget_config(id=WIDGET_ID, request=request, db=_make_db_mock())
+
+    assert response.status_code == 429
+    events = [c for c in mock_logger.warning.call_args_list if c.args and c.args[0] == "widget_mint_rate_limited"]
+    assert len(events) == 1
+    kw = events[0].kwargs
+    assert kw["limit"] == "client"
+    assert kw["widget_id"] == WIDGET_ID
+    assert kw["ip_hash"]
+    assert caller_ip not in str(events)
+
+
+@pytest.mark.asyncio
+async def test_widget_ceiling_429_logs_widget_limit():
+    """Per-widget ceiling rejection names limit="widget" with the widget_id."""
     from app.api.partner import widget_config
 
     db = _make_db_mock()
@@ -98,6 +228,48 @@ async def test_widget_config_429_after_10_calls_per_minute():
         patch("app.api.partner.settings") as mock_settings,
         patch("app.api.partner.get_redis_pool") as mock_get_redis,
         patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.logger") as mock_logger,
+        patch("app.api.partner.set_tenant", new_callable=AsyncMock),
+    ):
+        mock_settings.widget_jwt_secret = "test-secret"
+        mock_get_redis.return_value = AsyncMock()
+        # per-IP layer passes, per-widget ceiling rejects
+        mock_rl.side_effect = [(True, 0), (False, 7)]
+
+        response = await widget_config(id=WIDGET_ID, request=request, db=db)
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "7"
+    events = [c for c in mock_logger.warning.call_args_list if c.args and c.args[0] == "widget_mint_rate_limited"]
+    assert len(events) == 1
+    assert events[0].kwargs["limit"] == "widget"
+    assert events[0].kwargs["widget_id"] == WIDGET_ID
+    # Review finding 5: the widget ceiling carries ip_hash like the client event.
+    assert events[0].kwargs["ip_hash"]
+    assert request.client.host not in str(events)
+
+
+# ---------------------------------------------------------------------------
+# AC7.2: 429 returned on widget-config when a rate limit fires
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widget_config_429_when_client_limit_fires():
+    """widget-config returns 429 with Retry-After when a limit fires (AC7.2).
+
+    The per-client bucket is checked first, so the first rejection is the
+    client layer; Retry-After must still propagate."""
+    from app.api.partner import widget_config
+
+    db = _make_db_mock()
+    request = _make_request()
+
+    with (
+        patch("app.api.partner.settings") as mock_settings,
+        patch("app.api.partner.get_redis_pool") as mock_get_redis,
+        patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.logger"),
         patch("app.api.partner.set_tenant", new_callable=AsyncMock),
         patch("app.api.partner.generate_session_token", return_value="tok"),
     ):
@@ -107,7 +279,7 @@ async def test_widget_config_429_after_10_calls_per_minute():
         # Simulate rate limit exceeded: allowed=False, retry_after=45
         mock_rl.return_value = (False, 45)
 
-        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+        response = await widget_config(id=WIDGET_ID, request=request, db=db)
 
     assert response.status_code == 429
     assert "Retry-After" in response.headers
@@ -115,26 +287,28 @@ async def test_widget_config_429_after_10_calls_per_minute():
 
 
 @pytest.mark.asyncio
-async def test_public_bot_config_429_after_10_calls_per_minute():
+async def test_public_bot_config_429_when_rate_limit_fires():
     """public-bot-config returns 429 with Retry-After when rate limit exceeded (AC7.2)."""
     from app.api.partner import public_bot_config
 
     db = _make_db_mock()
+    request = _make_request()
 
     with (
         patch("app.api.partner.settings") as mock_settings,
         patch("app.api.partner.get_redis_pool") as mock_get_redis,
         patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.logger"),
         patch("app.api.partner.set_tenant", new_callable=AsyncMock),
         patch("app.api.partner.generate_session_token", return_value="tok"),
     ):
         mock_settings.widget_jwt_secret = "test-secret"
         mock_redis = AsyncMock()
         mock_get_redis.return_value = mock_redis
-        # Simulate rate limit exceeded
+        # Simulate rate limit exceeded (first layer checked: per client)
         mock_rl.return_value = (False, 30)
 
-        response = await public_bot_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", db=db)
+        response = await public_bot_config(id=WIDGET_ID, request=request, db=db)
 
     assert response.status_code == 429
     assert "Retry-After" in response.headers
@@ -153,6 +327,7 @@ async def test_429_includes_retry_after_header():
         patch("app.api.partner.settings") as mock_settings,
         patch("app.api.partner.get_redis_pool") as mock_get_redis,
         patch("app.api.partner.check_rate_limit", new_callable=AsyncMock) as mock_rl,
+        patch("app.api.partner.logger"),
         patch("app.api.partner.set_tenant", new_callable=AsyncMock),
     ):
         mock_settings.widget_jwt_secret = "test-secret"
@@ -160,7 +335,7 @@ async def test_429_includes_retry_after_header():
         mock_get_redis.return_value = mock_redis
         mock_rl.return_value = (False, 60)
 
-        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+        response = await widget_config(id=WIDGET_ID, request=request, db=db)
 
     assert response.status_code == 429
     retry_after = int(response.headers["Retry-After"])
@@ -193,7 +368,7 @@ async def test_widget_config_200_within_limit():
         mock_get_redis.return_value = mock_redis
         mock_rl.return_value = (True, 0)
 
-        response = await widget_config(id="wgt_abcdef1234567890abcdef1234567890abcdef12", request=request, db=db)
+        response = await widget_config(id=WIDGET_ID, request=request, db=db)
 
     assert response.status_code == 200
 
@@ -204,16 +379,14 @@ async def test_widget_config_200_within_limit():
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_key_uses_widget_id():
-    """check_rate_limit is called with a key scoped to the widget_id (AC7.3).
-
-    The key must be f'widget_mint:{widget_id}' so each widget is isolated.
-    """
+async def test_rate_limit_keys_scope_widget_and_client():
+    """The per-widget ceiling key AND the per-client key (widget + caller IP) are
+    both used, and the client layer is checked first (AC7.3)."""
     from app.api.partner import widget_config
 
-    widget_id = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    widget_id = WIDGET_ID
     db = _make_db_mock()
-    request = _make_request()
+    request = _make_request(caller_ip="203.0.113.5")
 
     with (
         patch("app.api.partner.settings") as mock_settings,
@@ -230,18 +403,18 @@ async def test_rate_limit_key_uses_widget_id():
 
         await widget_config(id=widget_id, request=request, db=db)
 
-    mock_rl.assert_called_once()
-    call_args = mock_rl.call_args[0]  # positional args
-    key_arg = call_args[1]  # second positional: key_id
-    assert key_arg == f"widget_mint:{widget_id}"
+    keys = [c.args[1] for c in mock_rl.call_args_list]
+    assert keys[0] == f"widget_mint_ip:{widget_id}:203.0.113.5"
+    assert keys[1] == f"widget_mint:{widget_id}"
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_uses_limit_10_per_minute():
-    """check_rate_limit is called with limit_per_minute=10 (REQ-7 spec)."""
+async def test_widget_ceiling_is_120_per_minute():
+    """Per-widget ceiling is 120/min (raised from 10 for REQ-7/B-4: 10/min was a
+    traffic cap on legitimate visitors, 120/min is the abuse backstop)."""
     from app.api.partner import widget_config
 
-    widget_id = "wgt_abcdef1234567890abcdef1234567890abcdef12"
+    widget_id = WIDGET_ID
     db = _make_db_mock()
     request = _make_request()
 
@@ -260,6 +433,6 @@ async def test_rate_limit_uses_limit_10_per_minute():
 
         await widget_config(id=widget_id, request=request, db=db)
 
-    mock_rl.assert_called_once()
-    call_kwargs = mock_rl.call_args[1]  # keyword args
-    assert call_kwargs.get("limit_per_minute") == 10
+    calls = {c.args[1]: c for c in mock_rl.call_args_list}
+    assert calls[f"widget_mint:{widget_id}"].kwargs.get("limit_per_minute") == 120
+    assert calls[f"widget_mint_ip:{widget_id}:203.0.113.5"].kwargs.get("limit_per_minute") == 20

--- a/klai-portal/backend/tests/test_widget_platform_unlock.py
+++ b/klai-portal/backend/tests/test_widget_platform_unlock.py
@@ -172,7 +172,7 @@ async def test_public_bot_config_returns_404_when_widgets_not_unlocked():
         mock_settings.widget_jwt_secret = "shared-secret"
 
         with pytest.raises(HTTPException) as exc_info:
-            await public_bot_config(id=widget.widget_id, db=db)
+            await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     assert exc_info.value.status_code == 404
 
@@ -193,7 +193,7 @@ async def test_public_bot_config_returns_200_when_widgets_unlocked():
     ):
         mock_settings.widget_jwt_secret = "shared-secret"
 
-        response = await public_bot_config(id=widget.widget_id, db=db)
+        response = await public_bot_config(id=widget.widget_id, request=_make_request(), db=db)
 
     assert response.status_code == 200
 


### PR DESCRIPTION
## Problem

`GET /partner/v1/widget-config` (and the share-link twin `/public-bot-config`) mints the widget session token and was rate-limited at 10/min **per widget**, one bucket shared by every visitor of every page that embeds it. With help.voys.nl live, the 11th visitor who opens the chat within a minute gets 429 and the widget shows a server error. The limit exists for SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-7 (finding B-4, token drain via the public mint path); that protection has to stay.

## Change

Both public mint paths now check, before the DB lookup:

1. per client IP: `widget_mint_ip:{id}:{ip}`, 20/min, using `resolve_caller_ip` (uvicorn's proxy-header-validated address behind Caddy, not the client-controlled session-id header);
2. per widget backstop: `widget_mint:{id}`, 10 → 120/min.

A rejected client attempt never consumes the widget bucket, so one hammering client cannot starve the other visitors of a widget. Every 429 logs `widget_mint_rate_limited` with `path`, `widget_id`, `limit=client|widget` and a hashed IP (widget-audit convention, never raw). Actual LLM drain stays bounded by the untouched 60/min per-widget chat bucket in `partner_dependencies`.

## Verification

- `tests/test_widget_mint_rate_limit.py` on the real limiter over fakeredis: 12 visitors within a minute all succeed (failed on main with "visitor 11 got 429"); one client hammering stops at 20/min while a bystander is unaffected; the widget ceiling stops many distinct clients at 120; share-link path shares the client budget; log events carry the hash and never the raw IP.
- Full portal backend suite: 3970 passed. ruff, pyright clean.

## Known limits (not in this change)

- `check_rate_limit` is not atomic (three Redis commands), so under concurrent requests every limiter in the portal is soft, including the existing chat bucket. Separate task on the shared helper.
- uvicorn learns Caddy's container IP once at startup (`scripts/uvicorn-launch.sh`); if Caddy is force-recreated with a new IP without restarting portal-api, X-Forwarded-For is ignored and all visitors collapse into one 20/min bucket. Visible in logs as a storm of `limit=client` events with one `ip_hash`.

Implemented by the local Qwen build agent from a brief, reviewed by Sol (2 rounds) and verified by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)