### PR TITLE
feat(widget): reuse the session token across help pages instead of minting on every chat open

### DIFF
--- a/klai-portal/frontend/src/routes/widget-test.tsx
+++ b/klai-portal/frontend/src/routes/widget-test.tsx
@@ -42,6 +42,9 @@ function WidgetTestEmbedPage() {
     const s = document.createElement('script')
     s.src = '/widget/klai-chat.js'
     s.setAttribute('data-widget-id', id)
+    // The widget bundle caches its session-token mint; on this test page an
+    // admin must always see the just-saved config, so disable cache reuse.
+    s.setAttribute('data-fresh-config', 'true')
     s.onload = () => setScriptStatus('loaded')
     s.onerror = () => setScriptStatus('error')
     document.body.appendChild(s)

--- a/klai-widget/src/api/chat-stream.ts
+++ b/klai-widget/src/api/chat-stream.ts
@@ -1,5 +1,5 @@
 import { fetchEventSource } from "@microsoft/fetch-event-source";
-import { fetchWidgetConfig, KlaiWidgetError } from "./widget-config";
+import { clearCachedWidgetSession, fetchWidgetConfig, KlaiWidgetError } from "./widget-config";
 
 export type MessageRating = "thumbsUp" | "thumbsDown";
 
@@ -69,6 +69,10 @@ export interface StreamCallbacks {
   onEscalation?: (escalation: MessageEscalation) => void;
   onDone: () => void;
   onError: (error: KlaiWidgetError | Error) => void;
+  /** Fired after a 401 re-mint succeeded, with the replacement token. The
+   * caller must store it: every next turn reads chatState.sessionToken,
+   * and replaying the rejected one would 401 and re-mint all over again. */
+  onTokenRefreshed?: (token: string) => void;
 }
 
 interface ChatStreamOptions {
@@ -76,6 +80,10 @@ interface ChatStreamOptions {
   token: string;
   messages: Message[];
   widgetId: string;
+  /** Active conversation id, sent as X-Klai-Widget-Session-Id when the 401
+   * re-mint runs: the backend stamps it into the new JWT as `jti`, so the
+   * replacement token stays bound to the same conversation as the rejected one. */
+  sessionId?: string;
   pageContext?: PageContext;
   /** Client-generated id for the assistant turn being generated; stored
    * server-side on the audit row so feedback buttons can address it. */
@@ -285,6 +293,7 @@ export async function streamChat(options: ChatStreamOptions): Promise<void> {
     token,
     messages,
     widgetId,
+    sessionId,
     pageContext,
     widgetTurnId,
     broadMode,
@@ -431,11 +440,20 @@ export async function streamChat(options: ChatStreamOptions): Promise<void> {
       // Attempt token refresh once
       retried = true;
       try {
-        const freshConfig = await fetchWidgetConfig(widgetId);
+        // The rejected token may live in the session cache; it must never
+        // be replayed on the next page load, so evict before re-minting.
+        clearCachedWidgetSession(widgetId, currentToken);
+        // Re-mint for the active conversation: the backend binds the new
+        // JWT's `jti` to this session id, and the mint refreshes the cache.
+        const freshConfig = await fetchWidgetConfig(widgetId, { sessionId });
         currentToken = freshConfig.session_token;
+        callbacks.onTokenRefreshed?.(currentToken);
         try {
           await doStream(currentToken);
         } catch (retryError) {
+          // The replacement token was rejected as well: it must not survive
+          // in the cache either, or a reload replays it.
+          clearCachedWidgetSession(widgetId, currentToken);
           const wrappedError =
             retryError instanceof KlaiWidgetError
               ? retryError

--- a/klai-widget/src/api/widget-config.ts
+++ b/klai-widget/src/api/widget-config.ts
@@ -72,10 +72,115 @@ const WIDGET_CONFIG_BASE_URL =
 
 declare const __WIDGET_CONFIG_BASE_URL__: string;
 
+// Every successful call to /partner/v1/widget-config mints a fresh session
+// token server-side, and that mint path is rate-limited per widget (10/min).
+// Reopening the chat on the next help article therefore burned the whole
+// customer site's budget on tokens that were still valid for an hour. The
+// complete response is cached under a per-widget localStorage key. The
+// backend stamps the mint request's X-Klai-Widget-Session-Id into the JWT
+// as `jti` and derives the audit/handoff session key from it, so a cached
+// token only belongs to the conversation it was minted for: reuse is bound
+// to the stored sessionId and a mint for any other conversation overwrites
+// the entry. Reuse is capped at 15 minutes after mint and always ends 60s
+// before the server-side expiry. Staleness trade-off: portal edits to
+// settings only reach a visitor after that window — bounded and cosmetic,
+// the alternative is the mint storm this fixes.
+interface CachedWidgetSession {
+  /** Conversation the token was minted for; becomes the JWT `jti`. */
+  sessionId: string;
+  mintedAtMs: number;
+  config: WidgetConfig;
+}
+
+const SESSION_CACHE_MARGIN_MS = 60_000;
+const SESSION_CACHE_REUSE_MS = 15 * 60_000;
+
+function sessionCacheKey(widgetId: string): string {
+  return `klai-widget:${widgetId}:config-session:v1`;
+}
+
+function readCachedWidgetSession(
+  widgetId: string,
+  sessionId: string | undefined,
+): WidgetConfig | null {
+  if (!sessionId) return null;
+  try {
+    const raw = window.localStorage.getItem(sessionCacheKey(widgetId));
+    if (!raw) return null;
+    const cached = JSON.parse(raw) as Partial<CachedWidgetSession>;
+    const config = cached.config;
+    const expiresAtMs = config ? Date.parse(config.session_expires_at) : Number.NaN;
+    if (
+      !config ||
+      typeof config !== "object" ||
+      typeof config.session_token !== "string" ||
+      !config.session_token ||
+      !Number.isFinite(cached.mintedAtMs) ||
+      !Number.isFinite(expiresAtMs)
+    ) {
+      return null;
+    }
+    // Minted for another conversation: a hit would replay the old `jti`.
+    // Leave the entry; only a mint for its own session may overwrite it.
+    if (cached.sessionId !== sessionId) return null;
+    const now = Date.now();
+    if (
+      now - (cached.mintedAtMs as number) >= SESSION_CACHE_REUSE_MS ||
+      now >= expiresAtMs - SESSION_CACHE_MARGIN_MS
+    ) {
+      window.localStorage.removeItem(sessionCacheKey(widgetId));
+      return null;
+    }
+    return config;
+  } catch {
+    // Private mode or corrupted entry: fall back to minting on every open.
+    return null;
+  }
+}
+
+/** Drop the cached mint after its token was rejected (401 from the chat
+ * endpoint), so it can never be replayed on reload. Only removes when the
+ * entry still holds that exact token — a newer mint (another tab refreshed
+ * it) must survive. */
+export function clearCachedWidgetSession(widgetId: string, rejectedToken: string): void {
+  try {
+    const raw = window.localStorage.getItem(sessionCacheKey(widgetId));
+    if (!raw) return;
+    const cached = JSON.parse(raw) as Partial<CachedWidgetSession>;
+    if (cached.config?.session_token !== rejectedToken) return;
+    window.localStorage.removeItem(sessionCacheKey(widgetId));
+  } catch {
+    // Same silent fallback as the read path.
+  }
+}
+
+function writeCachedWidgetSession(
+  widgetId: string,
+  sessionId: string,
+  config: WidgetConfig,
+): void {
+  if (!config.session_token || !Number.isFinite(Date.parse(config.session_expires_at))) return;
+  try {
+    const cached: CachedWidgetSession = {
+      sessionId,
+      mintedAtMs: Date.now(),
+      config,
+    };
+    window.localStorage.setItem(sessionCacheKey(widgetId), JSON.stringify(cached));
+  } catch {
+    // Storage failures (private mode, quota) keep today's behaviour.
+  }
+}
+
 export async function fetchWidgetConfig(
   widgetId: string,
-  options: { sessionId?: string } = {},
+  options: { sessionId?: string; reuseCachedSession?: boolean } = {},
 ): Promise<WidgetConfig> {
+  if (options.reuseCachedSession) {
+    const cached = readCachedWidgetSession(widgetId, options.sessionId);
+    if (cached) return cached;
+  }
+
   let response: Response;
 
   try {
@@ -137,6 +242,13 @@ export async function fetchWidgetConfig(
   // Resolve relative chat_endpoint against the API base URL
   if (data.chat_endpoint && data.chat_endpoint.startsWith("/")) {
     data.chat_endpoint = `${WIDGET_CONFIG_BASE_URL}${data.chat_endpoint}`;
+  }
+
+  // Every mint refreshes the entry, so a reload — or the launch after a
+  // conversation switch or a 401 re-mint — reuses the token minted for the
+  // conversation that is actually active.
+  if (options.sessionId) {
+    writeCachedWidgetSession(widgetId, options.sessionId, data);
   }
 
   return data;

--- a/klai-widget/src/components/ChatWindow.tsx
+++ b/klai-widget/src/components/ChatWindow.tsx
@@ -18,6 +18,7 @@ import {
   finishStreaming,
   setError,
   clearError,
+  updateSessionToken,
   setHandoffActive,
   setHandoffConnecting,
   setVisitorIdentity,
@@ -233,6 +234,7 @@ export function ChatWindow(props: ChatWindowProps) {
       endpoint: chatState.config!.chat_endpoint,
       token: chatState.sessionToken,
       widgetId: chatState.widgetId,
+      sessionId: chatState.clientSessionId,
       messages: withVisitorInfo(chatState.messages.slice(0, -1)),
       widgetTurnId: turnId,
       broadMode: chatState.broadMode || undefined,
@@ -267,6 +269,11 @@ export function ChatWindow(props: ChatWindowProps) {
               ? t().errorSessionExpired
               : t().errorGeneric
           );
+        },
+        onTokenRefreshed: (token) => {
+          // Keep the store on the fresh token, or every next turn replays
+          // the rejected one and 401s into another re-mint.
+          updateSessionToken(token);
         },
       },
     });

--- a/klai-widget/src/main.ts
+++ b/klai-widget/src/main.ts
@@ -36,8 +36,12 @@ async function loadConfigAndInitStore(
   widgetId: string,
   locale: string | undefined,
   clientSessionId: string,
+  reuseCachedSession: boolean,
 ): Promise<WidgetConfig> {
-  const config = await fetchWidgetConfig(widgetId, { sessionId: clientSessionId });
+  const config = await fetchWidgetConfig(widgetId, {
+    sessionId: clientSessionId,
+    reuseCachedSession,
+  });
 
   // Init i18n labels after config so the widget copy can hint the locale.
   initLabels(locale, [
@@ -101,12 +105,18 @@ async function bootstrap(): Promise<void> {
   const containerSelector = scriptTag.getAttribute("data-container");
   const clientSessionId = getInitialConversationSessionId(widgetId);
 
+  // Presence of data-fresh-config disables reuse of a cached session-token
+  // mint: the portal's own widget-test page loads the same bundle, and an
+  // admin who just saved changes must see the fresh config immediately
+  // instead of whatever a real visitor cached (up to the reuse window).
+  const reuseCachedSession = !scriptTag.hasAttribute("data-fresh-config");
+
   if (mode === "inline" && containerSelector) {
     // Inline mode has no facade: the chat window sits on the page
     // deliberately, so the config is fetched immediately as before.
     let config;
     try {
-      config = await loadConfigAndInitStore(widgetId, locale, clientSessionId);
+      config = await loadConfigAndInitStore(widgetId, locale, clientSessionId, reuseCachedSession);
     } catch (error) {
       logFetchError(error);
       return;
@@ -186,7 +196,12 @@ async function bootstrap(): Promise<void> {
   // again once it resolved. On success the facade swaps to the real
   // ChatBubble with the chat window already open.
   const launch = async (): Promise<void> => {
-    const config = await loadConfigAndInitStore(widgetId, locale, clientSessionId);
+    const config = await loadConfigAndInitStore(
+      widgetId,
+      locale,
+      clientSessionId,
+      reuseCachedSession,
+    );
     const cssVariables = cssVariableOverrides(config);
     if (cssVariables) {
       styleEl.textContent = `${widgetCss}\n:host { ${cssVariables} }`;

--- a/klai-widget/tests/widget-session-cache.test.ts
+++ b/klai-widget/tests/widget-session-cache.test.ts
@@ -1,0 +1,286 @@
+/**
+ * The session-token cache for /partner/v1/widget-config.
+ *
+ * Every fetch of that endpoint mints a fresh session token server-side and
+ * the mint path is rate-limited to 10/min per widget, so a visitor clicking
+ * through help articles used to burn the customer site's whole budget on
+ * reopens of one still-valid hour. These tests replay the reported flow:
+ * open the chat, simulate a page reload (reset modules, keep localStorage),
+ * open again — the mint must happen once, until the reuse window or the
+ * token expiry passes, a conversation switch changes the session id (the
+ * backend stamps it into the JWT as `jti`), or a chat call 401s.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WIDGET_ID = "wgt_test";
+const CONV = "conv-current";
+const MINUTE = 60_000;
+
+// Captures every fetchEventSource call so the 401 test can drive the real
+// onopen/onerror/onmessage handlers from src/api/chat-stream.ts.
+const fesCalls = vi.hoisted(() => ({
+  opts: [] as Array<{
+    headers: Record<string, string>;
+    onopen: (response: Response) => Promise<void>;
+    onerror: (error: unknown) => void;
+    onmessage: (event: { data: string }) => void;
+  }>,
+}));
+
+vi.mock("@microsoft/fetch-event-source", () => ({
+  fetchEventSource: (_url: string, opts: unknown) => {
+    fesCalls.opts.push(opts as (typeof fesCalls.opts)[number]);
+    return Promise.resolve();
+  },
+}));
+
+let mints = 0;
+let tokenLifetimeMs = 60 * MINUTE;
+
+function configResponse(): Response {
+  mints += 1;
+  return new Response(
+    JSON.stringify({
+      title: "Klai",
+      welcome_message: "Hoi!",
+      css_variables: {},
+      chat_endpoint: "/partner/v1/widget-chat/completions",
+      session_token: `tok-${mints}`,
+      session_expires_at: new Date(Date.now() + tokenLifetimeMs).toISOString(),
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+// Everything in this file is microtasks and mocked promises; fake timers are
+// here for the clock (expiry, reuse window), never for waiting. settle()
+// drains the microtask chain.
+async function settle(rounds = 25): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+}
+
+/** Fresh bootstrap (simulated reload: old DOM gone, modules re-imported,
+ * localStorage untouched) plus the facade click that launches the chat. */
+async function openChat(): Promise<void> {
+  document.querySelectorAll("#klai-widget-root").forEach((node) => node.remove());
+  vi.resetModules();
+  await import("../src/main");
+  await settle();
+
+  const root = document.getElementById("klai-widget-root");
+  expect(root).not.toBeNull();
+  const bubble = root!.shadowRoot!.querySelector("button.klai-bubble");
+  expect(bubble).not.toBeNull();
+  (bubble as HTMLButtonElement).click();
+  await settle();
+}
+
+describe("widget session-token cache", () => {
+  beforeEach(() => {
+    mints = 0;
+    tokenLifetimeMs = 60 * MINUTE;
+    fesCalls.opts.length = 0;
+    vi.useFakeTimers();
+    vi.resetModules();
+    window.localStorage.clear();
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+    const script = document.createElement("script");
+    script.src = "https://my.getklai.com/widget/klai-chat.js";
+    script.setAttribute("data-widget-id", WIDGET_ID);
+    document.head.appendChild(script);
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/partner/v1/widget-config")) return configResponse();
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("reuses the cached mint when the chat reopens after a reload", async () => {
+    await openChat();
+    expect(mints).toBe(1);
+
+    await openChat();
+    expect(mints).toBe(1);
+  });
+
+  it("disables cache reuse when the embed script sets data-fresh-config", async () => {
+    document
+      .querySelector("script[data-widget-id]")!
+      .setAttribute("data-fresh-config", "true");
+
+    await openChat();
+    await openChat();
+    expect(mints).toBe(2);
+  });
+
+  it("re-mints once the 15-minute reuse window passes", async () => {
+    const { fetchWidgetConfig } = await import("../src/api/widget-config");
+    const reused = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(reused.session_token).toBe("tok-1");
+
+    // 14m59s after mint: still inside the window (token itself is good for an hour).
+    await vi.advanceTimersByTimeAsync(15 * MINUTE - 1000);
+    const hit = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(hit.session_token).toBe("tok-1");
+    expect(mints).toBe(1);
+
+    // 15m01s after mint: stale settings ceiling, re-mint and refresh the entry.
+    await vi.advanceTimersByTimeAsync(2000);
+    const miss = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(miss.session_token).toBe("tok-2");
+    expect(mints).toBe(2);
+  });
+
+  it("stops reusing 60s before the token expiry, inside the reuse window", async () => {
+    tokenLifetimeMs = 10 * MINUTE;
+    const { fetchWidgetConfig } = await import("../src/api/widget-config");
+    await fetchWidgetConfig(WIDGET_ID, { sessionId: CONV, reuseCachedSession: true });
+
+    // 8m59s after mint = expiry − 61s: one second of usable life above the margin.
+    await vi.advanceTimersByTimeAsync(9 * MINUTE - 1000);
+    const hit = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(hit.session_token).toBe("tok-1");
+    expect(mints).toBe(1);
+
+    // 9m01s after mint = expiry − 59s: inside the 60s margin, must re-mint.
+    await vi.advanceTimersByTimeAsync(2000);
+    const miss = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(miss.session_token).toBe("tok-2");
+    expect(mints).toBe(2);
+  });
+
+  it("never replays a token minted for another conversation", async () => {
+    const { fetchWidgetConfig } = await import("../src/api/widget-config");
+    await fetchWidgetConfig(WIDGET_ID, { sessionId: "conv-a", reuseCachedSession: true });
+    expect(mints).toBe(1);
+
+    // Conversation switch: ChatWindow mints straight for the new id, which
+    // overwrites the single entry.
+    await fetchWidgetConfig(WIDGET_ID, { sessionId: "conv-b" });
+    expect(mints).toBe(2);
+
+    // A reopen for the old conversation must not receive conv-b's token —
+    // its jti is a different conversation's audit key.
+    const a = await fetchWidgetConfig(WIDGET_ID, { sessionId: "conv-a", reuseCachedSession: true });
+    expect(mints).toBe(3);
+    expect(a.session_token).toBe("tok-3");
+
+    // And conv-a's mint in turn overwrote conv-b: reopens of the active
+    // conversation reuse, switches mint.
+    const b1 = await fetchWidgetConfig(WIDGET_ID, { sessionId: "conv-b", reuseCachedSession: true });
+    expect(mints).toBe(4);
+    const b2 = await fetchWidgetConfig(WIDGET_ID, { sessionId: "conv-b", reuseCachedSession: true });
+    expect(b2.session_token).toBe(b1.session_token);
+    expect(mints).toBe(4);
+  });
+
+  it("re-mints once after a 401, hands the fresh token to the caller and refreshes the cache", async () => {
+    const { fetchWidgetConfig, clearCachedWidgetSession } = await import(
+      "../src/api/widget-config"
+    );
+    await fetchWidgetConfig(WIDGET_ID, { sessionId: CONV, reuseCachedSession: true });
+    expect(mints).toBe(1); // tok-1 cached for CONV
+
+    const { streamChat } = await import("../src/api/chat-stream");
+    const errors: unknown[] = [];
+    const refreshed: string[] = [];
+    const turn = (token: string) =>
+      streamChat({
+        endpoint: "https://api.getklai.com/partner/v1/widget-chat/completions",
+        token,
+        widgetId: WIDGET_ID,
+        sessionId: CONV,
+        messages: [{ role: "user", content: "hallo" }],
+        callbacks: {
+          onToken: () => {},
+          onDone: () => {},
+          onError: (error) => errors.push(error),
+          onTokenRefreshed: (fresh) => refreshed.push(fresh),
+        },
+      });
+
+    const first = turn("tok-1");
+    await settle();
+    expect(fesCalls.opts[0]!.headers.Authorization).toBe("Bearer tok-1");
+
+    // Mirror the library's contract: onopen rejects, the error goes to
+    // onerror, and onerror rethrowing is what stops the library's retry.
+    try {
+      await fesCalls.opts[0]!.onopen(new Response("", { status: 401 }));
+    } catch (error) {
+      try {
+        fesCalls.opts[0]!.onerror(error);
+      } catch {
+        /* expected rethrow */
+      }
+    }
+    await settle();
+
+    // The retried stream runs on a freshly minted token for the same
+    // conversation…
+    expect(fesCalls.opts[1]!.headers.Authorization).toBe("Bearer tok-2");
+    await fesCalls.opts[1]!.onopen(new Response("", { status: 200 }));
+    fesCalls.opts[1]!.onmessage({ data: "[DONE]" });
+    await first;
+    expect(errors).toEqual([]);
+    // …and the caller is handed the fresh token (ChatWindow stores it).
+    expect(refreshed).toEqual(["tok-2"]);
+
+    // A second real turn on the fresh token streams without 401 and above
+    // all without minting again.
+    const second = turn(refreshed[0]!);
+    await settle();
+    expect(fesCalls.opts[2]!.headers.Authorization).toBe("Bearer tok-2");
+    await fesCalls.opts[2]!.onopen(new Response("", { status: 200 }));
+    fesCalls.opts[2]!.onmessage({ data: "[DONE]" });
+    await second;
+    expect(mints).toBe(2);
+
+    // The 401ed token was evicted and the re-mint refreshed the cache: a
+    // reload reuses tok-2.
+    const reloaded = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(reloaded.session_token).toBe("tok-2");
+    expect(mints).toBe(2);
+
+    // A stale tab retrying with the rejected token must not wipe the newer
+    // entry; clearing only removes when the cached token matches.
+    clearCachedWidgetSession(WIDGET_ID, "tok-1");
+    const survives = await fetchWidgetConfig(WIDGET_ID, {
+      sessionId: CONV,
+      reuseCachedSession: true,
+    });
+    expect(survives.session_token).toBe("tok-2");
+    expect(mints).toBe(2);
+
+    clearCachedWidgetSession(WIDGET_ID, "tok-2");
+    await fetchWidgetConfig(WIDGET_ID, { sessionId: CONV, reuseCachedSession: true });
+    expect(mints).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

The widget fetched `/partner/v1/widget-config` (which mints a 1-hour session token and is rate-limited per widget) every time a visitor opened the chat, on every help article: the token lived only in memory while the conversation itself was already persisted. Needless mints ate the customer site's shared budget and cost a DB round-trip each.

## Change

- `widget-config.ts`: the response is cached per widget in localStorage as `{sessionId, mintedAtMs, config}`. It is reused only for the conversation it was minted for (the backend stamps the session id into the JWT as `jti` and derives the audit/handoff session from it), for at most 15 minutes after mint and never within 60s of expiry. Every mint with a session id refreshes the entry, so conversation switches stay in step. Storage failures fall back to today's behaviour.
- `chat-stream.ts`: the 401 re-mint evicts the rejected token (only if the entry still holds that exact token), re-mints for the active conversation and reports the fresh token through `onTokenRefreshed`; a second 401 evicts again.
- `ChatWindow.tsx`: stores the refreshed token, so the next turn does not 401 and re-mint again.
- `main.ts`: a `data-fresh-config` attribute on the script tag disables reuse; `widget-test.tsx` (the portal's own test page) sets it so admins always see what they just saved.

## Verification

- `tests/widget-session-cache.test.ts`: reuse across a simulated reload (one mint), re-mint at 15m01s and at expiry−59s, reuse at 14m59s and expiry−61s, conversation-bound reuse, 401 → eviction + fresh token on the next real turn without a new mint, eviction only for the matching token.
- klai-widget vitest 17/17, tsc clean, bundle 37.9 kB gzip; portal frontend tsc and eslint clean.

## Left for later

Handoff and feedback calls use the same token but their 401 paths do not evict the cache; a token rejected there is replayed until the 15-minute window ends or a chat turn 401s.

Implemented by the local Qwen build agent from a brief, reviewed by Sol (2 rounds), one-line second-401 eviction added and verified by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)