### PR TITLE
fix(widget): the mint 429 carries CORS headers so the browser sees it

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -2827,13 +2827,22 @@ _WIDGET_MINT_IP_RATE_LIMIT_PER_MINUTE = 20
 _WIDGET_MINT_RATE_LIMIT_PER_MINUTE = 120
 
 
-def _widget_mint_rate_limited(retry_after: int) -> Response:
-    """429 shared by the public mint paths (REQ-7 / Finding B-4)."""
+def _widget_mint_rate_limited(retry_after: int, origin: str) -> Response:
+    """429 shared by the public mint paths (REQ-7 / Finding B-4).
+
+    The origin is echoed (no credentials) so a browser on the customer's
+    site sees the 429 and its Retry-After instead of an opaque CORS error;
+    the response carries nothing the widget allowlist protects."""
+    headers = {"Retry-After": str(retry_after)}
+    if origin:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Access-Control-Expose-Headers"] = "Retry-After"
+        headers["Vary"] = "Origin"
     return Response(
         content='{"detail":"Rate limit exceeded"}',
         status_code=429,
         media_type="application/json",
-        headers={"Retry-After": str(retry_after)},
+        headers=headers,
     )
 
 
@@ -2929,7 +2938,7 @@ async def widget_config(
                 limit="client",
                 ip_hash=hash_audit_value(caller_ip),
             )
-            return _widget_mint_rate_limited(client_retry_after)
+            return _widget_mint_rate_limited(client_retry_after, request.headers.get("origin", ""))
 
         allowed, retry_after = await check_rate_limit(
             redis, f"widget_mint:{id}", limit_per_minute=_WIDGET_MINT_RATE_LIMIT_PER_MINUTE, window_seconds=60
@@ -2944,7 +2953,7 @@ async def widget_config(
                 limit="widget",
                 ip_hash=hash_audit_value(caller_ip),
             )
-            return _widget_mint_rate_limited(retry_after)
+            return _widget_mint_rate_limited(retry_after, request.headers.get("origin", ""))
 
     # Look up widget by public widget_id (SPEC-WIDGET-002: own table)
     # REQ-16: soft-deleted widgets are 404 to the public/partner endpoints.
@@ -3094,7 +3103,7 @@ async def public_bot_config(
                 limit="client",
                 ip_hash=hash_audit_value(caller_ip),
             )
-            return _widget_mint_rate_limited(client_retry_after)
+            return _widget_mint_rate_limited(client_retry_after, request.headers.get("origin", ""))
 
         allowed, retry_after = await check_rate_limit(
             redis, f"widget_mint:{id}", limit_per_minute=_WIDGET_MINT_RATE_LIMIT_PER_MINUTE, window_seconds=60
@@ -3107,7 +3116,7 @@ async def public_bot_config(
                 limit="widget",
                 ip_hash=hash_audit_value(caller_ip),
             )
-            return _widget_mint_rate_limited(retry_after)
+            return _widget_mint_rate_limited(retry_after, request.headers.get("origin", ""))
 
     # REQ-16: soft-deleted widgets are 404 to the public/partner endpoints.
     result = await db.execute(select(Widget).where(Widget.widget_id == id, Widget.deleted_at.is_(None)))

--- a/klai-portal/backend/tests/test_widget_mint_rate_limit.py
+++ b/klai-portal/backend/tests/test_widget_mint_rate_limit.py
@@ -284,6 +284,12 @@ async def test_widget_config_429_when_client_limit_fires():
     assert response.status_code == 429
     assert "Retry-After" in response.headers
     assert response.headers["Retry-After"] == "45"
+    # A browser on the customer's site must be able to read the 429: without
+    # the origin echo it only sees an opaque CORS error and never the
+    # Retry-After (help.voys.nl, 2026-09-10).
+    assert response.headers["Access-Control-Allow-Origin"] == "https://example.com"
+    assert response.headers["Access-Control-Expose-Headers"] == "Retry-After"
+    assert "access-control-allow-credentials" not in {k.lower() for k in response.headers}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Verified live on help.voys.nl after #1367: when the mint rate limit fires, the 429 from `/partner/v1/widget-config` has no `Access-Control-Allow-Origin`, so the browser reports "blocked by CORS policy" and the widget sees a network error instead of a 429 with `Retry-After`.

## Change

`_widget_mint_rate_limited` echoes the request origin (no credentials), exposes `Retry-After` and sets `Vary: Origin`; all four call sites pass the origin. The response carries nothing the widget allowlist protects. Test asserts the headers on the 429.

## Verification

Full portal backend suite 3972 passed; ruff and pyright clean. Sol review: expose header added on its finding; its second (low) note concerns the first-party path through the outer middleware and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)