### PR TITLE
fix(cors): widget routes declare their own CORS marker instead of a hard-coded path list

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -31,6 +31,7 @@ from app.api.partner_dependencies import (
     require_permission,
     validate_kb_access,
 )
+from app.api.widget_public import WIDGET_PUBLIC_CORS, WIDGET_ROUTE_DECIDES_CORS
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal, get_db, set_tenant
 from app.core.permissions import assert_platform_unlocked
@@ -1594,7 +1595,7 @@ async def _maybe_apply_web_search(
     return enriched_prompt, web_results_as_chunks(web_results), web_query
 
 
-@router.post("/chat/completions", response_model=None)
+@router.post("/chat/completions", response_model=None, openapi_extra=WIDGET_PUBLIC_CORS)
 async def canonical_chat_completions(
     http_request: Request,
     auth: PartnerAuthContext = Depends(get_partner_key),
@@ -2272,7 +2273,7 @@ async def _require_hubspot_widget_handoff_enabled(
         raise _hubspot_handoff_forbidden()
 
 
-@router.post("/widget-handoffs/hubspot/start", response_model=HubSpotHandoffResponse)
+@router.post("/widget-handoffs/hubspot/start", response_model=HubSpotHandoffResponse, openapi_extra=WIDGET_PUBLIC_CORS)
 async def start_widget_hubspot_handoff(
     http_request: Request,
     request: StartHubSpotHandoffRequest,
@@ -2300,7 +2301,11 @@ async def start_widget_hubspot_handoff(
     return HubSpotHandoffResponse(**result)
 
 
-@router.post("/widget-handoffs/hubspot/messages", response_model=HubSpotHandoffMessageResponse)
+@router.post(
+    "/widget-handoffs/hubspot/messages",
+    response_model=HubSpotHandoffMessageResponse,
+    openapi_extra=WIDGET_PUBLIC_CORS,
+)
 async def send_widget_hubspot_handoff_message(
     http_request: Request,
     request: SendHubSpotHandoffMessageRequest,
@@ -2331,7 +2336,7 @@ async def send_widget_hubspot_handoff_message(
     return HubSpotHandoffMessageResponse(**result)
 
 
-@router.get("/widget-handoffs/hubspot/events")
+@router.get("/widget-handoffs/hubspot/events", openapi_extra=WIDGET_PUBLIC_CORS)
 async def stream_widget_hubspot_handoff_events(
     request: Request,
     last_event_id: int = 0,
@@ -2509,7 +2514,7 @@ class WidgetFeedbackRequest(BaseModel):
     rating: Literal["thumbsUp", "thumbsDown"] | None = None
 
 
-@router.post("/widget/feedback")
+@router.post("/widget/feedback", openapi_extra=WIDGET_PUBLIC_CORS)
 async def submit_widget_feedback(
     request: WidgetFeedbackRequest,
     auth: PartnerAuthContext = Depends(get_partner_key),
@@ -2668,6 +2673,12 @@ async def append_knowledge(
 # Bearer JWT in the Authorization header; cookies are not involved. The
 # helper centralises this contract so the GET and OPTIONS handlers can
 # never drift apart.
+#
+# /widget-config carries the WIDGET_ROUTE_DECIDES_CORS marker (see
+# app/api/widget_public.py): the per-widget allowed_origins gate below needs
+# a DB read, so its routes answer CORS themselves and KlaiCORSMiddleware
+# passes those requests through untouched — unlike the "echo" marker the
+# other widget routes carry.
 # ---------------------------------------------------------------------------
 
 
@@ -2815,7 +2826,7 @@ def _widget_nerds_integration(widget_config_data: dict[str, Any]) -> dict[str, A
 # ---------------------------------------------------------------------------
 
 
-@router.get("/widget-config")
+@router.get("/widget-config", openapi_extra=WIDGET_ROUTE_DECIDES_CORS)
 async def widget_config(
     id: str,
     request: Request,
@@ -3106,7 +3117,7 @@ async def public_bot_config(
     )
 
 
-@router.options("/widget-config")
+@router.options("/widget-config", openapi_extra=WIDGET_ROUTE_DECIDES_CORS)
 async def widget_config_preflight(
     id: str,
     request: Request,

--- a/klai-portal/backend/app/api/widget_public.py
+++ b/klai-portal/backend/app/api/widget_public.py
@@ -1,0 +1,50 @@
+"""The widget-public CORS marker — the route declares, the middleware obeys.
+
+The widget bundle (klai-widget/) runs on the customer's own domain and calls
+a subset of the Partner API cross-origin. Each of those routes declares it
+here, via ``openapi_extra`` on its decorator, instead of a path list in
+``app/middleware/klai_cors.py`` that every new widget endpoint had to be
+remembered in — forgetting one 400s its preflight only on customer domains
+and silently (the help.voys.nl breakage, PR #1361).
+
+Two modes, because the CORS ownership genuinely differs:
+
+- ``WIDGET_PUBLIC_CORS`` (``"echo"``): the middleware answers the preflight
+  and injects ``Access-Control-Allow-Origin`` — the origin is echoed,
+  credentials are never allowed. The security boundary on these routes is
+  the widget session JWT, not the origin allowlist.
+- ``WIDGET_ROUTE_DECIDES_CORS`` (``"route"``): the middleware passes the
+  request through untouched; the route builds its own CORS headers. For
+  ``/widget-config``, whose per-widget ``allowed_origins`` allowlist needs a
+  DB read and which must answer a disallowed origin WITHOUT an
+  ``Access-Control-Allow-Origin`` (SPEC-SEC-CORS-001 AC-10) — a generic
+  middleware echo cannot express that.
+
+@MX:NOTE: The security behaviour this replaced is pinned by
+tests/test_cors_allowlist.py and tests/test_partner_cors.py. Adding a widget
+endpoint = mark its route here, never edit the middleware.
+"""
+
+from __future__ import annotations
+
+WIDGET_CORS_MARKER = "x-klai-widget-cors"
+
+MODE_ECHO = "echo"
+MODE_ROUTE_DECIDES = "route"
+
+WIDGET_PUBLIC_CORS: dict[str, str] = {WIDGET_CORS_MARKER: MODE_ECHO}
+WIDGET_ROUTE_DECIDES_CORS: dict[str, str] = {WIDGET_CORS_MARKER: MODE_ROUTE_DECIDES}
+
+
+def widget_cors_mode_of(route: object) -> str | None:
+    """Return the route's declared widget CORS mode, or ``None`` when the
+    route did not declare one. Reads only the ``openapi_extra`` attribute —
+    present on APIRoute and on FastAPI's effective include contexts, absent
+    on containers (Mount, _IncludedRouter) and on routes that did not
+    declare one, which are therefore never widget-public."""
+    extra = getattr(route, "openapi_extra", None)
+    if isinstance(extra, dict):
+        mode = extra.get(WIDGET_CORS_MARKER)
+        if mode == MODE_ECHO or mode == MODE_ROUTE_DECIDES:
+            return str(mode)
+    return None

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -31,18 +31,31 @@ e.g. ``https://*.customer.com``). It is intentionally separate — different
 algorithm for a different problem (per-widget partner allowlists vs
 first-party portal allowlist). Do not consolidate without a SPEC: the
 shapes diverge enough that a single helper would parameter-sprawl.
+
+@MX:NOTE: This middleware holds NO widget paths. The widget bundle runs on
+the customer's own site, so the first-party allowlist cannot apply there;
+each widget route declares itself via the marker in
+``app.api.widget_public`` and the middleware reads that from the app's
+resolved route tree — routers wrapped by ``include_router`` and ``Mount``
+containers included (see ``_widget_cors_mode``). Adding a widget endpoint
+means marking its route in ``app/api/partner.py`` — never editing this file.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
+from typing import Any
 
 import structlog
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import Response
+from starlette.routing import BaseRoute, Match
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.api.widget_public import MODE_ROUTE_DECIDES, widget_cors_mode_of
 
 # The fixed first-party origin pattern. Exposed as a module constant so the
 # AC-14 test can monkeypatch it before re-invoking _compile_first_party_regex().
@@ -58,27 +71,6 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 #   https://evil.my.getklai.com              (multi-label blocked)
 #   https://evil.getklai.com.attacker.tld    (not the getklai.com TLD)
 _FIRST_PARTY_ORIGIN_PATTERN = r"^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$"
-
-# Public widget endpoints (app/api/partner.py). The widget bundle calls these
-# from the customer's own site, so the first-party allowlist cannot apply.
-# The security boundary there is the widget session JWT minted by
-# /widget-config (see its docstring), never the BFF cookie: the origin is
-# echoed and credentials are never allowed. /widget-config keeps its own
-# widget-aware OPTIONS route, which decides per widget allowlist.
-_WIDGET_CONFIG_PATH = "/partner/v1/widget-config"
-_WIDGET_PUBLIC_PATHS = frozenset(
-    {
-        _WIDGET_CONFIG_PATH,
-        "/partner/v1/chat/completions",
-        "/partner/v1/widget/feedback",
-    }
-)
-_WIDGET_HANDOFF_PREFIX = "/partner/v1/widget-handoffs/"
-
-
-def _is_widget_public_path(path: str) -> bool:
-    return path in _WIDGET_PUBLIC_PATHS or path.startswith(_WIDGET_HANDOFF_PREFIX)
-
 
 logger = structlog.get_logger()
 _startup_logger = logging.getLogger(__name__)
@@ -109,6 +101,70 @@ def _compile_first_party_regex() -> re.Pattern[str]:
 # CORSMiddleware compiles its own copy from the string at __init__ time. The
 # call is here purely to fail-closed if the pattern is malformed (AC-14).
 _compile_first_party_regex()
+
+# One route-table entry: (leaf route, Mount ancestors to replay, declared
+# widget mode or None when the leaf did not declare one).
+_WidgetEntry = tuple[Any, tuple[BaseRoute, ...], str | None]
+
+
+# @MX:NOTE: Regression (PR #1361 follow-up): app.include_router() on FastAPI
+# 0.141+ puts an _IncludedRouter in app.routes and the APIRoute objects sit
+# INSIDE it; routes under a Starlette Mount sit inside that. A flat scan of
+# app.routes therefore saw no marked route at all and 400'd every widget
+# preflight from a customer domain although the whole test suite stayed
+# green (its fixture registered routes directly on FastAPI). Flatten the
+# tree the way the router walks it, and resolve matches per leaf.
+def _collect_widget_cors_entries(routes: Iterable[Any], ancestors: tuple[BaseRoute, ...] = ()) -> list[_WidgetEntry]:
+    """Flatten the route tree into router-visit-order entries.
+
+    - FastAPI's ``_IncludedRouter`` (what ``include_router`` appends since
+      0.141) exposes its matching list as ``effective_candidates()``; those
+      ``_EffectiveRouteContext`` leaves carry the route's ``openapi_extra``
+      and already match the fully effective path, so no scope replay is
+      needed for them.
+    - ``Mount``/``Host`` rewrite the path when dispatching, so leaves below
+      them record the mount chain as ancestors and replay the rewrite in
+      ``_entry_match``. A mount's children live on ``.routes``, on the
+      ``.routes`` of a whole ASGI app it was mounted with, or — when the
+      mount sits inside an ``include_router`` wrapper — on the effective
+      context's ``starlette_route``.
+    """
+    entries: list[_WidgetEntry] = []
+    for route in routes:
+        effective = getattr(route, "effective_candidates", None)
+        if effective is not None:
+            entries.extend(_collect_widget_cors_entries(effective(), ancestors))
+            continue
+        child_routes = _child_routes(route)
+        if isinstance(child_routes, Iterable) and child_routes:
+            entries.extend(_collect_widget_cors_entries(child_routes, (*ancestors, route)))
+            continue
+        entries.append((route, ancestors, widget_cors_mode_of(route)))
+    return entries
+
+
+def _child_routes(route: Any) -> Any:
+    """The route's nested routes when it is a container, else ``None``. Duck-
+    typed on purpose: Mount/Router expose ``.routes``; a mount of a whole ASGI
+    app exposes them via ``.app``; a FastAPI effective context wrapping a Mount
+    via ``.starlette_route``. Leaves (APIRoute, Route, WebSocketRoute, plain
+    contexts) have none of those as route collections."""
+    children = getattr(route, "routes", None) or getattr(getattr(route, "app", None), "routes", None)
+    if children is None:
+        inner = getattr(route, "starlette_route", None)
+        if inner is not None:
+            children = getattr(inner, "routes", None) or getattr(getattr(inner, "app", None), "routes", None)
+    return children
+
+
+def _entry_match(entry: _WidgetEntry, scope: Scope) -> Match:
+    leaf, ancestors, _ = entry
+    for mount in ancestors:
+        match, child_scope = mount.matches(scope)
+        if match is Match.NONE:
+            return Match.NONE
+        scope = {**scope, **child_scope}
+    return leaf.matches(scope)[0]
 
 
 class KlaiCORSMiddleware(CORSMiddleware):
@@ -166,6 +222,60 @@ class KlaiCORSMiddleware(CORSMiddleware):
             allow_methods=tuple(allow_methods) if allow_methods else ("*",),
             allow_headers=tuple(allow_headers) if allow_headers else ("*",),
         )
+        # Route table flattened once per instance on the first
+        # cross-origin request (full entries + the marked subset); the walk
+        # mirrors routing, so re-running it per request would double the
+        # hot path. See _widget_cors_mode for the staleness contract.
+        self._widget_cors_table: tuple[list[_WidgetEntry], list[_WidgetEntry]] | None = None
+
+    def _widget_cors_mode(self, scope: Scope, headers: Headers) -> str | None:
+        """Widget CORS mode for this request, learned from the routes that
+        carry the ``app.api.widget_public`` marker — this module knows no
+        paths. ``None`` when no marked route is involved at all (first-party
+        routes, and paths matching no registered route, so a near-miss on a
+        widget path stays on the first-party policy) and when the winning
+        route did not declare a marker.
+
+        Matching mirrors Starlette's own routing, including ``include_router``
+        wrappers and Mounts (see _collect_widget_cors_entries):
+        - a preflight is resolved with ``Access-Control-Request-Method`` as
+          the method — a preflight probing a POST route is decided by that
+          POST route, never by a marked GET registered on the same path;
+        - a FULL match wins and the FIRST PARTIAL applies only when no FULL
+          exists anywhere, so a marked route the real request would 405 on
+          cannot absorb an unmarked route the router would actually reach.
+
+        @MX:NOTE: Staleness contract — the flattened table is built once, on
+        the first cross-origin request. klai-portal registers every router at
+        import time in main.py, so routes added after that first request are
+        invisible here until the process restarts. Tests must therefore build
+        the complete app before its first request (all fixtures do).
+        """
+        table = self._widget_cors_table
+        if table is None:
+            entries = _collect_widget_cors_entries(getattr(scope.get("app"), "routes", ()))
+            table = (entries, [entry for entry in entries if entry[2] is not None])
+            self._widget_cors_table = table
+        entries, marked = table
+
+        lookup: Scope = scope
+        if scope.get("method") == "OPTIONS" and "access-control-request-method" in headers:
+            lookup = {**scope, "method": headers["access-control-request-method"]}
+
+        # Cheap prefilter: only requests that hit a marked route at all pay
+        # for the full winner scan (the marked subset is a handful of
+        # regexes; the full scan is one routing pass over the whole table).
+        if not any(_entry_match(entry, lookup) is not Match.NONE for entry in marked):
+            return None
+
+        partial: _WidgetEntry | None = None
+        for entry in entries:
+            match = _entry_match(entry, lookup)
+            if match is Match.FULL:
+                return entry[2]
+            if match is Match.PARTIAL and partial is None:
+                partial = entry
+        return partial[2] if partial is not None else None
 
     # @MX:NOTE: Observability hook — log every rejected cross-origin request
     # exactly once. The actual header behaviour (preflight 400, simple 200
@@ -178,22 +288,24 @@ class KlaiCORSMiddleware(CORSMiddleware):
         headers = Headers(scope=scope)
         origin = headers.get("origin")
 
-        if origin and _is_widget_public_path(scope.get("path", "")):
-            await self._widget_cors(scope, receive, send, origin=origin, headers=headers)
-            return
+        if origin:
+            widget_mode = self._widget_cors_mode(scope, headers)
+            if widget_mode is not None:
+                await self._widget_cors(scope, receive, send, origin=origin, headers=headers, mode=widget_mode)
+                return
 
-        if origin and not self.is_allowed_origin(origin):
-            method = scope.get("method", "")
-            is_preflight = method == "OPTIONS" and "access-control-request-method" in headers
-            # Truncate both attacker-controlled fields to bounded lengths to
-            # prevent log-bloat. UUIDs are 36 chars; 64 is generous headroom.
-            logger.info(
-                "cors_origin_rejected",
-                origin=origin[:256],
-                path=scope.get("path", ""),
-                request_id=(headers.get("x-request-id") or "unknown")[:64],
-                kind="preflight" if is_preflight else "simple",
-            )
+            if not self.is_allowed_origin(origin):
+                method = scope.get("method", "")
+                is_preflight = method == "OPTIONS" and "access-control-request-method" in headers
+                # Truncate both attacker-controlled fields to bounded lengths to
+                # prevent log-bloat. UUIDs are 36 chars; 64 is generous headroom.
+                logger.info(
+                    "cors_origin_rejected",
+                    origin=origin[:256],
+                    path=scope.get("path", ""),
+                    request_id=(headers.get("x-request-id") or "unknown")[:64],
+                    kind="preflight" if is_preflight else "simple",
+                )
 
         await super().__call__(scope, receive, send)
 
@@ -205,12 +317,14 @@ class KlaiCORSMiddleware(CORSMiddleware):
         *,
         origin: str,
         headers: Headers,
+        mode: str,
     ) -> None:
         """CORS for the public widget endpoints: echo the origin, no credentials."""
-        if scope.get("path") == _WIDGET_CONFIG_PATH:
-            # Its routes decide per widget allowlist and set ACAO themselves,
-            # on the preflight as well as on the GET (403 without ACAO when
-            # the origin is not allowed).
+        if mode == MODE_ROUTE_DECIDES:
+            # The route decides per widget allowlist and sets ACAO itself,
+            # on the preflight as well as on the actual request (403 without
+            # ACAO when the origin is not allowed) — see
+            # WIDGET_ROUTE_DECIDES_CORS in app/api/widget_public.py.
             await self.app(scope, receive, send)
             return
         if scope.get("method") == "OPTIONS" and "access-control-request-method" in headers:

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 
+import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.testclient import TestClient
 
@@ -58,33 +59,47 @@ def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
     async def internal() -> JSONResponse:
         return JSONResponse({"ok": True})
 
-    # Public widget endpoints, mirrored from app/api/partner.py: the widget
-    # bundle calls these from the customer's own site. /widget-config has a
-    # widget-aware preflight route that echoes the origin when the widget's
-    # allowlist matches.
-    @app.post("/partner/v1/chat/completions")
+    # Public widget endpoints, mirrored from app/api/partner.py IN ITS
+    # PRODUCTION SHAPE: an APIRouter with prefix="/partner/v1", registered
+    # with app.include_router(). The widget bundle calls these from the
+    # customer's own site; they carry the same marker the production routes
+    # carry, and /widget-config has a widget-aware preflight route that
+    # echoes the origin when the widget's allowlist matches. Registering
+    # them any other way hides the include_router wrapper bug the marker
+    # walk had in FastAPI 0.141+ (see _collect_widget_cors_entries).
+    from app.api.widget_public import WIDGET_PUBLIC_CORS, WIDGET_ROUTE_DECIDES_CORS
+
+    widget_router = APIRouter(prefix="/partner/v1")
+
+    @widget_router.post("/chat/completions", openapi_extra=WIDGET_PUBLIC_CORS)
     async def widget_chat() -> JSONResponse:
         return JSONResponse({"ok": True})
 
-    @app.options("/partner/v1/widget-config")
+    @widget_router.post("/widget/feedback", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def widget_feedback() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @widget_router.options("/widget-config", openapi_extra=WIDGET_ROUTE_DECIDES_CORS)
     async def widget_config_preflight(id: str) -> JSONResponse:
         headers = {"X-Widget-Route": id}
         if id == "wgt_allows_customer":
             headers["Access-Control-Allow-Origin"] = "https://help.customer.example"
         return JSONResponse(None, status_code=204, headers=headers)
 
-    @app.get("/partner/v1/widget-config")
+    @widget_router.get("/widget-config", openapi_extra=WIDGET_ROUTE_DECIDES_CORS)
     async def widget_config(id: str) -> JSONResponse:
         if id == "wgt_allows_customer":
             return JSONResponse({"ok": True}, headers={"Access-Control-Allow-Origin": "https://help.customer.example"})
         return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
 
-    @app.get("/partner/v1/widget-handoffs/hubspot/events")
+    @widget_router.get("/widget-handoffs/hubspot/events", openapi_extra=WIDGET_PUBLIC_CORS)
     async def widget_handoff_events() -> StreamingResponse:
         async def events() -> AsyncIterator[bytes]:
             yield b"id: 1\ndata: {}\n\n"
 
         return StreamingResponse(events(), media_type="text/event-stream")
+
+    app.include_router(widget_router)
 
     app.add_middleware(
         KlaiCORSMiddleware,
@@ -553,3 +568,244 @@ def test_customer_origin_is_still_rejected_outside_widget_paths(cors_client: Tes
     )
     assert response.status_code == 400
     assert "access-control-allow-origin" not in response.headers
+
+
+# ---------------------------------------------------------------------------
+# Ownership: the route carries the marker, klai_cors.py knows no paths
+# ---------------------------------------------------------------------------
+
+
+def test_widget_public_marker_teaches_the_middleware_a_new_route() -> None:
+    """A NEW route that only carries the widget-public marker gets its
+    preflight answered from a customer origin — without klai_cors.py knowing
+    anything about its path. A route WITHOUT the marker on the same app still
+    gets 400."""
+    from app.api.widget_public import WIDGET_PUBLIC_CORS
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    app = FastAPI()
+
+    @app.post("/partner/v1/bookings", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def booking() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.post("/partner/v1/internal-secret")
+    async def internal_secret() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    preflight = client.options(
+        "/partner/v1/bookings",
+        headers={
+            "Origin": CUSTOMER_ORIGIN,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert preflight.status_code == 204, preflight.text
+    assert preflight.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+    assert "access-control-allow-credentials" not in preflight.headers
+
+    denied = client.options(
+        "/partner/v1/internal-secret",
+        headers={"Origin": CUSTOMER_ORIGIN, "Access-Control-Request-Method": "POST"},
+    )
+    assert denied.status_code == 400
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def _preflight(client: TestClient, path: str, method: str) -> httpx.Response:
+    return client.options(
+        path,
+        headers={
+            "Origin": CUSTOMER_ORIGIN,
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+
+def test_widget_routes_registered_with_include_router_are_answered() -> None:
+    """Regression (review finding 1): production registers the partner
+    routes with ``app.include_router(partner_router)``, which on FastAPI
+    0.141+ puts an ``_IncludedRouter`` (without ``openapi_extra``) in
+    ``app.routes``. A flat top-level scan saw no marked route and 400'd
+    every widget preflight from a customer domain. Build the app exactly
+    like production — APIRouter with prefix, included, middleware added
+    last — and the preflight must get 204 with the origin echoed."""
+    from app.api.widget_public import WIDGET_PUBLIC_CORS
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    router = APIRouter(prefix="/partner/v1")
+
+    @router.post("/chat/completions", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def chat() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app = FastAPI()
+    app.include_router(router)
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    preflight = _preflight(client, "/partner/v1/chat/completions", "POST")
+    assert preflight.status_code == 204, preflight.text
+    assert preflight.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+    assert "access-control-allow-credentials" not in preflight.headers
+
+
+def test_widget_routes_under_a_mount_are_answered() -> None:
+    """Same bug class as the include_router regression: a marked route
+    registered under ``app.mount()`` is invisible to a flat scan of
+    app.routes, and Starlette Mounts rewrite the path before their inner
+    routes match. It must still echo."""
+    from app.api.widget_public import WIDGET_PUBLIC_CORS
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    inner = APIRouter()
+
+    @inner.post("/widget/feedback", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def feedback() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app = FastAPI()
+    app.mount("/outer", inner)
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    preflight = _preflight(client, "/outer/widget/feedback", "POST")
+    assert preflight.status_code == 204, preflight.text
+    assert preflight.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+
+def test_widget_routes_under_a_mount_inside_an_include_router_are_answered() -> None:
+    """Both wrappers at once: include_router wraps the Mount in a FastAPI
+    effective context, and the mount itself rewrites the path again before
+    its inner routes match (a Mount skips its router's own prefix, so the
+    router-resolvable path here is /m/widget/feedback). The walk must follow
+    the context to the mounted app's routes and replay both rewrites."""
+    from app.api.widget_public import WIDGET_PUBLIC_CORS
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    inner = APIRouter()
+
+    @inner.post("/widget/feedback", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def feedback() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    outer = APIRouter()
+    outer.mount("/m", inner)
+
+    app = FastAPI()
+    app.include_router(outer)
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    preflight = _preflight(client, "/m/widget/feedback", "POST")
+    assert preflight.status_code == 204, preflight.text
+    assert preflight.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+
+def test_unmarked_full_match_wins_over_marked_partial_on_the_same_path() -> None:
+    """Regression (review finding 2): Starlette keeps looking for a FULL
+    match after a PARTIAL one. A marked GET registered BEFORE an unmarked
+    POST on the same path must not make the POST inherit the widget echo:
+    the preflight is decided with Access-Control-Request-Method as the
+    method, so a POST preflight resolves to the POST route (unmarked ->
+    first-party policy -> 400 from a customer origin) and only a GET
+    preflight resolves to the marked GET."""
+    from app.api.widget_public import WIDGET_PUBLIC_CORS
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    app = FastAPI()
+
+    @app.get("/partner/v1/bookings", openapi_extra=WIDGET_PUBLIC_CORS)
+    async def list_bookings() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @app.post("/partner/v1/bookings")
+    async def create_booking() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    post_preflight = _preflight(client, "/partner/v1/bookings", "POST")
+    assert post_preflight.status_code == 400, post_preflight.text
+    assert "access-control-allow-origin" not in post_preflight.headers
+
+    actual_post = client.post("/partner/v1/bookings", headers={"Origin": CUSTOMER_ORIGIN})
+    assert actual_post.status_code == 200
+    assert "access-control-allow-origin" not in actual_post.headers
+
+    get_preflight = _preflight(client, "/partner/v1/bookings", "GET")
+    assert get_preflight.status_code == 204, get_preflight.text
+    assert get_preflight.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "expected_status"),
+    [
+        ("/partner/v1/chat/completions", "POST", 204),
+        ("/partner/v1/widget/feedback", "POST", 204),
+        ("/partner/v1/widget-handoffs/hubspot/start", "POST", 204),
+        ("/partner/v1/widget-handoffs/hubspot/messages", "POST", 204),
+        ("/partner/v1/widget-handoffs/hubspot/events", "GET", 204),
+        # Unmarked sibling on the same production router: must NOT inherit.
+        ("/partner/v1/responses", "POST", 400),
+    ],
+)
+def test_production_partner_router_answers_widget_preflights(path: str, method: str, expected_status: int) -> None:
+    """End-to-end on the real app.api.partner router, registered exactly as
+    main.py does (APIRouter with prefix, include_router, middleware added
+    last). Preflights are answered by the middleware and never reach the
+    endpoints, so no DB is needed. This is the shape the fixture-level tests
+    could not cover while they registered routes directly on FastAPI."""
+    from app.api.partner import router as partner_router
+    from app.middleware.klai_cors import KlaiCORSMiddleware
+
+    app = FastAPI()
+    app.include_router(partner_router)
+    app.add_middleware(KlaiCORSMiddleware, cors_origins=[])
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = _preflight(client, path, method)
+    assert response.status_code == expected_status, response.text
+    if expected_status == 204:
+        assert response.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+        assert "access-control-allow-credentials" not in response.headers
+    else:
+        assert "access-control-allow-origin" not in response.headers
+
+
+def test_production_widget_routes_carry_their_marker() -> None:
+    """Review finding 4: the widget bundle's production endpoints must all
+    declare their CORS mode, or a customer-domain widget breaks silently
+    (help.voys.nl, PR #1361). Import app.api.partner directly — no DB, no
+    app — and assert the marker inventory on every route the bundle calls.
+    An unmarked new widget endpoint fails here; marking a route nobody
+    calls fails here too (equality, not subset)."""
+    from app.api.partner import router as partner_router
+    from app.api.widget_public import MODE_ECHO, MODE_ROUTE_DECIDES, widget_cors_mode_of
+
+    expected = {
+        ("POST", "/partner/v1/chat/completions"): MODE_ECHO,
+        ("POST", "/partner/v1/widget/feedback"): MODE_ECHO,
+        ("POST", "/partner/v1/widget-handoffs/hubspot/start"): MODE_ECHO,
+        ("POST", "/partner/v1/widget-handoffs/hubspot/messages"): MODE_ECHO,
+        ("GET", "/partner/v1/widget-handoffs/hubspot/events"): MODE_ECHO,
+        ("GET", "/partner/v1/widget-config"): MODE_ROUTE_DECIDES,
+        ("OPTIONS", "/partner/v1/widget-config"): MODE_ROUTE_DECIDES,
+    }
+
+    declared: dict[tuple[str, str], str] = {}
+    for route in partner_router.routes:
+        mode = widget_cors_mode_of(route)
+        if mode is None:
+            continue
+        methods = {str(m) for m in getattr(route, "methods", set())} - {"HEAD"}
+        for method in methods:
+            declared[(method, str(route.path))] = mode
+
+    assert declared == expected


### PR DESCRIPTION
## Probleem
`klai_cors.py` hield een hard-coded set widget-publieke paden bij. Een nieuw
widget-endpoint dat vergat zich daar te registreren, kreeg een stil 400 op
zijn preflight — maar alleen vanaf klantdomeinen (de help.voys.nl-breakage
achter #1361).

## Fix
Elke widget-route in `app/api/partner.py` markeert zichzelf via een
`openapi_extra`-marker (nieuw: `app/api/widget_public.py`, twee modi: `echo`
voor middleware-afgehandelde CORS, `route` voor `/widget-config` dat zijn
eigen per-widget allowlist afhandelt). De middleware leest die marker uit de
resolved route tree van de app in plaats van een eigen pad-lijst te
onderhouden.

Twee Sol-rondes vonden en corrigeerden:
- **CRITICAL**: `app.include_router()` wikkelt routes in een `_IncludedRouter`;
  een platte scan van `app.routes` zag geen enkele marker, dus elke
  widget-preflight vanaf een klantdomein kreeg 400 — terwijl de volledige
  testsuite groen bleef, omdat de fixture routes rechtstreeks op FastAPI
  registreerde in plaats van via `include_router`.
- **HIGH**: een FULL-match moet winnen van een EERSTE PARTIAL-match op
  hetzelfde pad, zoals Starlette's eigen `Router.app` dat doet.
- Route-tabel wordt eenmalig per middleware-instance gecached na het eerste
  gebruik; staleness-contract gedocumenteerd in de docstring.
- Tests importeren nu de echte partner-router in plaats van een handgebouwde
  fixture.

Ronde 2 (delta-review) vond drie low-severity edge cases, niet bereikbaar
vanuit de huidige route-tabel, gedocumenteerd als vervolgwerk:
- Mount-grenzen worden plat gescand in plaats van recursief zoals Starlette,
  wat theoretisch een gemarkeerde sibling kan laten winnen op een pad dat de
  echte router 404't.
- Trailing-slash redirects worden niet gespiegeld.
- `Access-Control-Allow-Methods` blijft hardcoded op `GET, POST, OPTIONS`.

## Verificatie
- Zelf gereproduceerd (los van de Qwen-tests): productie-topologie
  (`APIRouter(prefix="/partner/v1")` + `app.include_router` +
  `KlaiCORSMiddleware` als laatste) — gemarkeerde POST-preflight → 204 met
  origin-echo; FULL wint van gemarkeerde PARTIAL-sibling; ongemarkeerde
  `/api/auth/login` blijft 400.
- `uv run pytest -q -x -p no:cacheprovider` → 3976 passed, 1 xfailed.
- `ruff check` + `ruff format --check` → schoon.
- `pyright` op de gewijzigde bestanden → 0 errors.
- `rules/tests/test_cors_middleware_last_lint.py` → 10 passed.

Geïmplementeerd door Qwen build-agent, Sol 2 rondes, geverifieerd door Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)