### PR TITLE
refactor(cors): widget routes declare their own CORS mode; the middleware holds no path list

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -31,6 +31,7 @@ from app.api.partner_dependencies import (
     require_permission,
     validate_kb_access,
 )
+from app.api.widget_public import ECHO, ROUTE_DECIDES, widget_cors
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal, get_db, set_tenant
 from app.core.permissions import assert_platform_unlocked
@@ -1595,6 +1596,7 @@ async def _maybe_apply_web_search(
     return enriched_prompt, web_results_as_chunks(web_results), web_query
 
 
+@widget_cors(router, ECHO)
 @router.post("/chat/completions", response_model=None)
 async def canonical_chat_completions(
     http_request: Request,
@@ -2273,6 +2275,7 @@ async def _require_hubspot_widget_handoff_enabled(
         raise _hubspot_handoff_forbidden()
 
 
+@widget_cors(router, ECHO)
 @router.post("/widget-handoffs/hubspot/start", response_model=HubSpotHandoffResponse)
 async def start_widget_hubspot_handoff(
     http_request: Request,
@@ -2301,6 +2304,7 @@ async def start_widget_hubspot_handoff(
     return HubSpotHandoffResponse(**result)
 
 
+@widget_cors(router, ECHO)
 @router.post("/widget-handoffs/hubspot/messages", response_model=HubSpotHandoffMessageResponse)
 async def send_widget_hubspot_handoff_message(
     http_request: Request,
@@ -2332,6 +2336,7 @@ async def send_widget_hubspot_handoff_message(
     return HubSpotHandoffMessageResponse(**result)
 
 
+@widget_cors(router, ECHO)
 @router.get("/widget-handoffs/hubspot/events")
 async def stream_widget_hubspot_handoff_events(
     request: Request,
@@ -2510,6 +2515,7 @@ class WidgetFeedbackRequest(BaseModel):
     rating: Literal["thumbsUp", "thumbsDown"] | None = None
 
 
+@widget_cors(router, ECHO)
 @router.post("/widget/feedback")
 async def submit_widget_feedback(
     request: WidgetFeedbackRequest,
@@ -2837,6 +2843,7 @@ def _widget_mint_rate_limited(retry_after: int) -> Response:
     )
 
 
+@widget_cors(router, ROUTE_DECIDES)
 @router.get("/widget-config")
 async def widget_config(
     id: str,
@@ -3192,6 +3199,7 @@ async def public_bot_config(
     )
 
 
+@widget_cors(router, ROUTE_DECIDES)
 @router.options("/widget-config")
 async def widget_config_preflight(
     id: str,

--- a/klai-portal/backend/app/api/widget_public.py
+++ b/klai-portal/backend/app/api/widget_public.py
@@ -1,0 +1,75 @@
+"""Widget-public CORS: the route declares it, the middleware looks it up.
+
+The widget bundle (klai-widget/) runs on the customer's own domain and calls
+a handful of Partner API routes cross-origin. Which ones is declared on the
+route itself with ``@widget_cors(router, ECHO)`` placed directly above the
+``@router.<method>(...)`` decorator, so KlaiCORSMiddleware holds no path
+list that a new widget endpoint could be forgotten in (that omission fails
+only on customer domains and silently: help.voys.nl, PR #1361).
+
+Two modes, because the CORS ownership genuinely differs:
+
+- ``ECHO``: the middleware answers the preflight and adds
+  ``Access-Control-Allow-Origin`` with the origin echoed, credentials never
+  allowed. The security boundary on these routes is the widget session JWT.
+- ``ROUTE_DECIDES``: the middleware passes the request through untouched;
+  the route builds its own CORS headers. ``/widget-config`` needs this: its
+  per-widget ``allowed_origins`` gate needs a DB read and must answer a
+  disallowed origin WITHOUT an origin echo (SPEC-SEC-CORS-001 AC-10).
+
+The lookup is exact on (method, path); a preflight is looked up with its
+``Access-Control-Request-Method``. Nothing here reads FastAPI internals: the
+decorator records ``router.routes[-1]``, the route the decorator below it
+just registered, through the public ``APIRoute.path`` and ``.methods``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from fastapi import APIRouter
+from fastapi.routing import APIRoute
+
+ECHO = "echo"
+ROUTE_DECIDES = "route"
+
+_REGISTRY: dict[tuple[str, str], str] = {}
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+def widget_cors(router: APIRouter, mode: str) -> Callable[[F], F]:
+    """Mark the route registered by the ``@router.<method>`` decorator directly below."""
+
+    if mode not in (ECHO, ROUTE_DECIDES):
+        raise ValueError(f"widget_cors mode must be ECHO or ROUTE_DECIDES, got {mode!r}")
+
+    def decorate(endpoint: F) -> F:
+        route = router.routes[-1] if router.routes else None
+        if not isinstance(route, APIRoute) or route.endpoint is not endpoint:
+            raise RuntimeError("@widget_cors must sit directly above the @router.<method>(...) decorator")
+        for method in route.methods or ():
+            key = (method, route.path)
+            if _REGISTRY.get(key, mode) != mode:
+                raise RuntimeError(f"{method} {route.path} is already declared with mode {_REGISTRY[key]!r}")
+            _REGISTRY[key] = mode
+        return endpoint
+
+    return decorate
+
+
+def widget_cors_mode(method: str, path: str) -> str | None:
+    """Declared mode for this (method, path), or ``None`` for every other route."""
+    return _REGISTRY.get((method.upper(), path))
+
+
+def registered_widget_routes() -> dict[tuple[str, str], str]:
+    """Snapshot of every declared route, for the test that pins the production set."""
+    return dict(_REGISTRY)
+
+
+def _replace_registry(entries: dict[tuple[str, str], str]) -> None:
+    """Test hook: swap the registry so a test can register from one router only."""
+    _REGISTRY.clear()
+    _REGISTRY.update(entries)

--- a/klai-portal/backend/app/middleware/klai_cors.py
+++ b/klai-portal/backend/app/middleware/klai_cors.py
@@ -44,6 +44,8 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from app.api.widget_public import ROUTE_DECIDES, widget_cors_mode
+
 # The fixed first-party origin pattern. Exposed as a module constant so the
 # AC-14 test can monkeypatch it before re-invoking _compile_first_party_regex().
 #
@@ -59,25 +61,18 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 #   https://evil.getklai.com.attacker.tld    (not the getklai.com TLD)
 _FIRST_PARTY_ORIGIN_PATTERN = r"^https://([a-z0-9][a-z0-9-]*\.)?getklai\.com$"
 
-# Public widget endpoints (app/api/partner.py). The widget bundle calls these
-# from the customer's own site, so the first-party allowlist cannot apply.
-# The security boundary there is the widget session JWT minted by
-# /widget-config (see its docstring), never the BFF cookie: the origin is
-# echoed and credentials are never allowed. /widget-config keeps its own
-# widget-aware OPTIONS route, which decides per widget allowlist.
-_WIDGET_CONFIG_PATH = "/partner/v1/widget-config"
-_WIDGET_PUBLIC_PATHS = frozenset(
-    {
-        _WIDGET_CONFIG_PATH,
-        "/partner/v1/chat/completions",
-        "/partner/v1/widget/feedback",
-    }
-)
-_WIDGET_HANDOFF_PREFIX = "/partner/v1/widget-handoffs/"
 
-
-def _is_widget_public_path(path: str) -> bool:
-    return path in _WIDGET_PUBLIC_PATHS or path.startswith(_WIDGET_HANDOFF_PREFIX)
+# The widget bundle runs on the customer's own site, so the first-party
+# allowlist cannot apply to the routes it calls. Those routes declare
+# themselves with @widget_cors in app/api/partner.py (see
+# app/api/widget_public.py); this module holds no widget paths. A preflight is
+# looked up with the method it asks for, so an unmarked route sharing a path
+# with a marked one keeps the first-party policy.
+def _widget_mode_for(scope: Scope, headers: Headers) -> str | None:
+    method = scope.get("method", "")
+    if method == "OPTIONS" and "access-control-request-method" in headers:
+        method = headers["access-control-request-method"]
+    return widget_cors_mode(method, scope.get("path", ""))
 
 
 logger = structlog.get_logger()
@@ -178,9 +173,11 @@ class KlaiCORSMiddleware(CORSMiddleware):
         headers = Headers(scope=scope)
         origin = headers.get("origin")
 
-        if origin and _is_widget_public_path(scope.get("path", "")):
-            await self._widget_cors(scope, receive, send, origin=origin, headers=headers)
-            return
+        if origin:
+            mode = _widget_mode_for(scope, headers)
+            if mode is not None:
+                await self._widget_cors(scope, receive, send, origin=origin, headers=headers, mode=mode)
+                return
 
         if origin and not self.is_allowed_origin(origin):
             method = scope.get("method", "")
@@ -205,12 +202,13 @@ class KlaiCORSMiddleware(CORSMiddleware):
         *,
         origin: str,
         headers: Headers,
+        mode: str,
     ) -> None:
         """CORS for the public widget endpoints: echo the origin, no credentials."""
-        if scope.get("path") == _WIDGET_CONFIG_PATH:
-            # Its routes decide per widget allowlist and set ACAO themselves,
-            # on the preflight as well as on the GET (403 without ACAO when
-            # the origin is not allowed).
+        if mode == ROUTE_DECIDES:
+            # The route decides per widget allowlist and sets ACAO itself, on
+            # the preflight as well as on the actual request (403 without
+            # ACAO when the origin is not allowed) — see app/api/widget_public.py.
             await self.app(scope, receive, send)
             return
         if scope.get("method") == "OPTIONS" and "access-control-request-method" in headers:
@@ -218,7 +216,10 @@ class KlaiCORSMiddleware(CORSMiddleware):
                 status_code=204,
                 headers={
                     "Access-Control-Allow-Origin": origin,
-                    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                    # Only the method this preflight asked for: browsers cache
+                    # each advertised method, and an unmarked route sharing
+                    # the path must not ride on a marked one's preflight.
+                    "Access-Control-Allow-Methods": headers["access-control-request-method"],
                     # Mirror what the browser asks for (Starlette does the same
                     # for allow_headers="*"): the SSE client adds Last-Event-ID
                     # on reconnect, the widget its session id and bearer token.

--- a/klai-portal/backend/tests/test_cors_allowlist.py
+++ b/klai-portal/backend/tests/test_cors_allowlist.py
@@ -18,13 +18,69 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.testclient import TestClient
 
 # ---------------------------------------------------------------------------
 # Test app factory + module-scoped fixtures
 # ---------------------------------------------------------------------------
+
+
+def _widget_router() -> APIRouter:
+    # Public widget endpoints, shaped like production: an APIRouter with the
+    # partner prefix, routes marked with @widget_cors, included on the app.
+    # /widget-config has a widget-aware preflight route that echoes the origin
+    # when the widget's allowlist matches.
+    from app.api.widget_public import ECHO, ROUTE_DECIDES, widget_cors
+
+    router = APIRouter(prefix="/partner/v1")
+
+    @widget_cors(router, ECHO)
+    @router.post("/chat/completions")
+    async def widget_chat() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @widget_cors(router, ROUTE_DECIDES)
+    @router.options("/widget-config")
+    async def widget_config_preflight(id: str) -> JSONResponse:
+        headers = {"X-Widget-Route": id}
+        if id == "wgt_allows_customer":
+            headers["Access-Control-Allow-Origin"] = "https://help.customer.example"
+        return JSONResponse(None, status_code=204, headers=headers)
+
+    @widget_cors(router, ROUTE_DECIDES)
+    @router.get("/widget-config")
+    async def widget_config(id: str) -> JSONResponse:
+        if id == "wgt_allows_customer":
+            return JSONResponse({"ok": True}, headers={"Access-Control-Allow-Origin": "https://help.customer.example"})
+        return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
+
+    @widget_cors(router, ECHO)
+    @router.get("/widget-handoffs/hubspot/events")
+    async def widget_handoff_events() -> StreamingResponse:
+        async def events() -> AsyncIterator[bytes]:
+            yield b"id: 1\ndata: {}\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    @widget_cors(router, ECHO)
+    @router.post("/widget/feedback")
+    async def widget_feedback() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    # Same path as a marked route, different method, no marker: must keep
+    # the first-party policy.
+    @widget_cors(router, ECHO)
+    @router.get("/shared")
+    async def shared_marked() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    @router.post("/shared")
+    async def shared_unmarked() -> JSONResponse:
+        return JSONResponse({"ok": True})
+
+    return router
 
 
 def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
@@ -58,33 +114,7 @@ def _make_test_app(cors_origins: str = "http://localhost:5174") -> FastAPI:
     async def internal() -> JSONResponse:
         return JSONResponse({"ok": True})
 
-    # Public widget endpoints, mirrored from app/api/partner.py: the widget
-    # bundle calls these from the customer's own site. /widget-config has a
-    # widget-aware preflight route that echoes the origin when the widget's
-    # allowlist matches.
-    @app.post("/partner/v1/chat/completions")
-    async def widget_chat() -> JSONResponse:
-        return JSONResponse({"ok": True})
-
-    @app.options("/partner/v1/widget-config")
-    async def widget_config_preflight(id: str) -> JSONResponse:
-        headers = {"X-Widget-Route": id}
-        if id == "wgt_allows_customer":
-            headers["Access-Control-Allow-Origin"] = "https://help.customer.example"
-        return JSONResponse(None, status_code=204, headers=headers)
-
-    @app.get("/partner/v1/widget-config")
-    async def widget_config(id: str) -> JSONResponse:
-        if id == "wgt_allows_customer":
-            return JSONResponse({"ok": True}, headers={"Access-Control-Allow-Origin": "https://help.customer.example"})
-        return JSONResponse({"detail": "Origin not allowed"}, status_code=403)
-
-    @app.get("/partner/v1/widget-handoffs/hubspot/events")
-    async def widget_handoff_events() -> StreamingResponse:
-        async def events() -> AsyncIterator[bytes]:
-            yield b"id: 1\ndata: {}\n\n"
-
-        return StreamingResponse(events(), media_type="text/event-stream")
+    app.include_router(_widget_router())
 
     app.add_middleware(
         KlaiCORSMiddleware,
@@ -487,6 +517,7 @@ def test_widget_preflight_from_customer_origin_is_answered(
     )
     assert response.status_code == 204, response.text
     assert response.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+    assert response.headers.get("access-control-allow-methods") == method
     allowed = response.headers.get("access-control-allow-headers", "").lower()
     assert all(h in allowed for h in requested_headers.split(","))
     assert "access-control-allow-credentials" not in response.headers
@@ -553,3 +584,50 @@ def test_customer_origin_is_still_rejected_outside_widget_paths(cors_client: Tes
     )
     assert response.status_code == 400
     assert "access-control-allow-origin" not in response.headers
+
+
+def test_unmarked_route_on_a_marked_path_keeps_the_first_party_policy(cors_client: TestClient) -> None:
+    preflight = cors_client.options(
+        "/partner/v1/shared",
+        headers={"Origin": CUSTOMER_ORIGIN, "Access-Control-Request-Method": "POST"},
+    )
+    assert preflight.status_code == 400
+    actual = cors_client.post("/partner/v1/shared", headers={"Origin": CUSTOMER_ORIGIN})
+    assert actual.status_code == 200
+    assert "access-control-allow-origin" not in actual.headers
+    marked = cors_client.options(
+        "/partner/v1/shared",
+        headers={"Origin": CUSTOMER_ORIGIN, "Access-Control-Request-Method": "GET"},
+    )
+    assert marked.status_code == 204
+    assert marked.headers.get("access-control-allow-origin") == CUSTOMER_ORIGIN
+
+
+def test_production_widget_routes_carry_the_marker() -> None:
+    """Every route the widget bundle calls (klai-widget/src/api) declares its
+    CORS mode on the real partner router. A new widget endpoint that forgets
+    the marker fails here instead of only on a customer domain."""
+    import importlib
+
+    from app.api import widget_public
+    from app.api.widget_public import ECHO, ROUTE_DECIDES, registered_widget_routes
+
+    # The fixture router above registers the same keys; start from an empty
+    # registry so only the real partner router counts, then put it back.
+    before = registered_widget_routes()
+    widget_public._replace_registry({})
+    try:
+        importlib.reload(importlib.import_module("app.api.partner"))
+        registered = registered_widget_routes()
+    finally:
+        widget_public._replace_registry(before)
+    expected = {
+        ("POST", "/partner/v1/chat/completions"): ECHO,
+        ("POST", "/partner/v1/widget/feedback"): ECHO,
+        ("POST", "/partner/v1/widget-handoffs/hubspot/start"): ECHO,
+        ("POST", "/partner/v1/widget-handoffs/hubspot/messages"): ECHO,
+        ("GET", "/partner/v1/widget-handoffs/hubspot/events"): ECHO,
+        ("GET", "/partner/v1/widget-config"): ROUTE_DECIDES,
+        ("OPTIONS", "/partner/v1/widget-config"): ROUTE_DECIDES,
+    }
+    assert registered == expected


### PR DESCRIPTION
## Why

Since #1361 `KlaiCORSMiddleware` decided which partner routes the widget bundle may call from a customer's site from a hard-coded set of paths, while the routes live in `partner.py`. A new widget endpoint that forgets the list fails at preflight only on customer domains and silently.

## Change

- `app/api/widget_public.py` (new): `@widget_cors(router, ECHO | ROUTE_DECIDES)` placed directly above `@router.<method>(...)` records `(method, route.path)` from the public `APIRoute` attributes into a module registry at import time. Invalid mode or a conflicting duplicate raises at import.
- `klai_cors.py`: no widget paths; exact `(method, path)` lookup, a preflight is looked up with its `Access-Control-Request-Method` and answered for that method only. `ECHO` = origin echoed, never credentials; `ROUTE_DECIDES` = pass through untouched (`/widget-config` GET+OPTIONS, per-widget allowlist, 403 without ACAO preserved).
- `partner.py`: the seven widget routes marked.
- Tests: fixture app built like production (APIRouter with prefix → include_router → middleware last); unmarked POST on a path whose GET is marked keeps the first-party policy; the real partner router carries exactly the seven expected markers (registry isolated for that test).

No FastAPI internals: an earlier attempt via `openapi_extra` plus a route walk broke on `include_router` (`_IncludedRouter`) while 3965 tests stayed green, which is why the fixture now mirrors production.

## Verification

Full portal backend suite 3974 passed; ruff, pyright, middleware-order lint green. Sol review: 4 findings (2 medium: allow-methods advertised all methods; production-marker test polluted by the fixture registry; 2 low: invalid mode fell open, duplicate registration silent), all four corrected before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)