### PR TITLE
fix(widget): persist configurable footer text independently

### DIFF
--- a/klai-portal/backend/app/api/admin_widgets.py
+++ b/klai-portal/backend/app/api/admin_widgets.py
@@ -91,11 +91,8 @@ class WidgetConfig(BaseModel):
     # TalkWithData convention. Each entry is rendered as a clickable
     # pill that submits the text as the first user message.
     conversation_starters: list[str] = Field(default_factory=list, max_length=6)
-    # When true, the widget hides the "AI-antwoorden kunnen fouten
-    # bevatten…" footer (white-label / power-user flag, matches the
-    # "Verberg 'Powered by'" pattern in the TWD editor). It does NOT hide
-    # the EU AI Act art. 50 AI notice in the empty state — that one is
-    # mandatory and not switchable per widget.
+    # When true, the widget hides the AI introduction in the empty state.
+    # The footer is configured independently through footer_text.
     hide_disclaimer: bool = False
     # Tenant-supplied replacement for the whole AI-notice sentence (the
     # EU AI Act art. 50 notice + the auto-appended booking sentence) shown
@@ -105,6 +102,9 @@ class WidgetConfig(BaseModel):
     # switchable, only its exact wording. Empty/unset → the default
     # templated notice, unchanged.
     ai_disclosure_override: str | None = Field(default=None, max_length=500)
+    # Tenant-editable Markdown shown below the chat input. Links are rendered
+    # and sanitised by the widget; no separate link-label or URL fields exist.
+    footer_text: str | None = Field(default=None, max_length=2000)
     # Optional reference to a Template (app/templates) — when set, the
     # template's prompt_text is appended to system_prompt at runtime so
     # admins can re-use named prompts across widgets without copy-paste.
@@ -222,6 +222,7 @@ def _widget_to_response(widget: Widget, kb_access_count: int) -> WidgetResponse:
             conversation_starters=config.get("conversation_starters", []),
             hide_disclaimer=config.get("hide_disclaimer", False),
             ai_disclosure_override=config.get("ai_disclosure_override"),
+            footer_text=config.get("footer_text"),
             template_slug=config.get("template_slug"),
             primary_color=config.get("primary_color", "#fcaa2d"),
             theme=config.get("theme", "light"),

--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -3030,10 +3030,12 @@ async def widget_config(
         "chat_endpoint": "/partner/v1/chat/completions",
         "session_token": session_token,
         "session_expires_at": expires_at.isoformat(),
-        # TWD-style additions: chips on empty state, white-label
-        # disclaimer toggle. system_prompt stays server-side only.
+        # TWD-style additions: chips and the optional AI-intro toggle.
+        # system_prompt stays server-side only; footer Markdown is a separate
+        # presentation field interpreted by the widget.
         "conversation_starters": widget_config_data.get("conversation_starters", []),
         "hide_disclaimer": widget_config_data.get("hide_disclaimer", False),
+        "footer_text": widget_config_data.get("footer_text") or "",
         # Name drives the TWD-pattern header (avatar + title). description
         # is admin-only scope/behaviour config, not rendered to visitors —
         # kept in the response only as a widget-frontend locale hint.
@@ -3181,6 +3183,7 @@ async def public_bot_config(
         "session_expires_at": expires_at.isoformat(),
         "conversation_starters": widget_config_data.get("conversation_starters", []),
         "hide_disclaimer": widget_config_data.get("hide_disclaimer", False),
+        "footer_text": widget_config_data.get("footer_text") or "",
         "primary_color": widget_config_data.get("primary_color", "#fcaa2d"),
         "theme": widget_config_data.get("theme", "light"),
         "collect_user_info": widget_config_data.get("collect_user_info", False),

--- a/klai-portal/backend/tests/test_admin_widgets.py
+++ b/klai-portal/backend/tests/test_admin_widgets.py
@@ -85,8 +85,35 @@ def test_widget_config_defaults():
     assert config.welcome_message == ""
     assert config.system_prompt == ""
     assert config.css_variables == {}
+    assert config.footer_text is None
     assert config.integrations.hubspot.status == "not_connected"
     assert "public_share_enabled" not in WidgetConfig.model_fields
+
+
+def test_widget_config_footer_text_roundtrip():
+    """Editable Markdown footer survives admin response normalisation."""
+    import pytest
+
+    from app.api.admin_widgets import WidgetConfig, _widget_to_response
+
+    footer = "Plan een afspraak met [onze nerds](https://example.com/afspraak)."
+    assert WidgetConfig(footer_text=footer).footer_text == footer
+    with pytest.raises(ValueError):
+        WidgetConfig(footer_text="x" * 2001)
+
+    widget = MagicMock()
+    widget.id = "uuid-footer"
+    widget.name = "Help Bot"
+    widget.description = None
+    widget.widget_id = "wgt_footer"
+    widget.widget_config = {"footer_text": footer}
+    widget.public_share_enabled = False
+    widget.rate_limit_rpm = 60
+    widget.last_used_at = None
+    widget.created_at = "2026-01-01"
+    widget.created_by = "user-1"
+
+    assert _widget_to_response(widget, kb_access_count=0).widget_config.footer_text == footer
 
 
 def test_widget_config_nerds_integration_defaults_and_roundtrip():

--- a/klai-portal/backend/tests/test_widget_config.py
+++ b/klai-portal/backend/tests/test_widget_config.py
@@ -93,6 +93,7 @@ def _make_db_chain(widget: FakeWidget | None, org: FakeOrg | None, kb_ids: list[
 async def test_widget_config_happy_path():
     """Valid wgt_id + allowed origin returns 200 with session token."""
     widget = FakeWidget()
+    widget.widget_config["footer_text"] = "Lees [meer](https://example.com/help)."
     org = FakeOrg()
     db = _make_db_chain(widget, org, [1, 2])
     request = _make_request("https://example.com")
@@ -113,6 +114,7 @@ async def test_widget_config_happy_path():
     assert '"session_token": "fake.jwt.token"' in body
     assert '"title": "Chat"' in body
     assert '"page_context_enabled": false' in body
+    assert json.loads(body)["footer_text"] == "Lees [meer](https://example.com/help)."
     assert "system_prompt" not in body
 
 
@@ -446,6 +448,7 @@ async def test_public_bot_config_delivers_enabled_nerds_integration():
             "welcome_message": "",
             "system_prompt": "",
             "css_variables": {},
+            "footer_text": "Plan met [onze nerds](https://support.voys.nl/book/voys).",
             **_nerds_config({"enabled": True, "booking_url": "https://support.voys.nl/book/voys?t=abc"}),
         },
     )
@@ -463,6 +466,7 @@ async def test_public_bot_config_delivers_enabled_nerds_integration():
 
     body = json.loads(response.body.decode())
     assert body["nerds"] == {"enabled": True, "booking_url": "https://support.voys.nl/book/voys?t=abc"}
+    assert body["footer_text"] == "Plan met [onze nerds](https://support.voys.nl/book/voys)."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds an optional Markdown footer to widget settings and both public configuration responses, preserving it across admin saves. Existing widgets retain their current defaults. Validation: 53 widget configuration, admin, and theme tests pass; Ruff and git diff --check pass.