### PR TITLE
fix(crawl): move cookie injection to crawl4ai's declarative add_cookies hook

### DIFF
--- a/klai-connector/app/routes/fingerprint.py
+++ b/klai-connector/app/routes/fingerprint.py
@@ -93,14 +93,15 @@ def _build_crawl_payload(
         "crawler_config": {"type": "CrawlerRunConfig", "params": config},
     }
     if cookies:
-        # Native cookie injection via BrowserConfig.cookies — crawl4ai's
-        # recommended path for authenticated crawls (see Identity-Based
-        # Crawling docs). Replaces the on_page_context_created hook pattern
-        # that has known timing issues (Playwright #26786, crawl4ai #322).
-        # Mirrors knowledge_ingest.crawl4ai_client._build_browser_config_with_cookies.
-        payload["browser_config"] = {
-            "type": "BrowserConfig",
-            "params": {"cookies": cookies},
+        # Declarative add_cookies hook — crawl4ai's currently-supported path
+        # for authenticated crawls via the Docker API. Raw BrowserConfig.cookies
+        # (used here previously) is rejected with HTTP 400 by crawl4ai >= 0.9's
+        # untrusted-config boundary (CVE-2026-57572 hardening); add_cookies is
+        # the server-validated declarative replacement, still running at
+        # on_page_context_created (pre-navigation), same timing as before.
+        # Mirrors knowledge_ingest.crawl4ai_client._build_cookie_hooks.
+        payload["hooks_config"] = {
+            "hooks": [{"action": "add_cookies", "params": {"cookies": cookies}}]
         }
     return payload
 

--- a/klai-connector/tests/test_compute_fingerprint.py
+++ b/klai-connector/tests/test_compute_fingerprint.py
@@ -36,6 +36,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.routes.fingerprint import _build_crawl_payload
 from app.routes.fingerprint import router as fingerprint_router
 
 _PORTAL_TEST_URL = "https://example.test/article"
@@ -234,6 +235,31 @@ def test_502_body_does_not_leak_internal_topology(
 #   - ``_extract_markdown`` handles the dict-shaped ``markdown`` field.
 #   - End-to-end: response feeds into ``compute_content_fingerprint`` and
 #     produces a valid 16-hex-char SimHash.
+#
+# NOTE: the canned response below matches the shape crawl4ai emits today
+# (0.9.2) - it does not, and cannot, prove the *request* would be accepted
+# by a live server. That gap is exactly what let the browser_config.cookies
+# regression below ship silently; see test_build_crawl_payload_cookies_use_hooks.
+
+
+def test_build_crawl_payload_cookies_use_hooks() -> None:
+    """Regression: crawl4ai >= 0.9 rejects a ``cookies`` key inside
+    ``browser_config.params`` with HTTP 400 ("not permitted on BrowserConfig
+    from an untrusted request") - its CVE-2026-57572 untrusted-config
+    boundary. Cookies must travel via the declarative ``add_cookies`` hook
+    instead; verified live against our own crawl4ai server 2026-09-10.
+    """
+    cookies = [{"name": "session", "value": "abc", "domain": "example.com", "path": "/"}]
+
+    payload = _build_crawl_payload("https://example.com/page", cookies)
+    assert "browser_config" not in payload
+    assert payload["hooks_config"] == {
+        "hooks": [{"action": "add_cookies", "params": {"cookies": cookies}}]
+    }
+
+    no_cookies = _build_crawl_payload("https://example.com/page", None)
+    assert "hooks_config" not in no_cookies
+    assert "browser_config" not in no_cookies
 
 
 class _FakeResponse:

--- a/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
+++ b/klai-knowledge-ingest/knowledge_ingest/crawl4ai_client.py
@@ -947,41 +947,34 @@ def _build_browser_config_with_cookies(
     *,
     stealth: bool = False,
 ) -> dict[str, Any] | None:
-    """Build a BrowserConfig payload that injects cookies natively at browser
-    context creation.
+    """Build a BrowserConfig payload for stealth mode.
 
-    ``stealth=True`` additionally turns on crawl4ai's own ``enable_stealth``
-    and a randomised user agent. Both are shipped crawl4ai features and both
-    pass its untrusted-config boundary (``magic``, ``simulate_user`` and
+    ``stealth=True`` turns on crawl4ai's own ``enable_stealth`` and a
+    randomised user agent. Both are shipped crawl4ai features and both pass
+    its untrusted-config boundary (``magic``, ``simulate_user`` and
     ``override_navigator`` do NOT — the server rejects those with HTTP 400).
     Reserved for the escalation path in ``crawl_site``: it is not the default
     because a randomised UA can change what a site serves, and every crawl
     that works today does so without it.
 
-    Why not the ``on_page_context_created`` hook we used before? The hook
-    pattern has known timing issues — Playwright #26786 (cookies added before
-    goto can appear empty after load) and crawl4ai #322 (hook actions don't
-    always propagate to ``crawler.arun``). crawl4ai's own docs explicitly
-    recommend identity-based crawling over hooks for "robust auth":
+    ``cookies`` is accepted but no longer placed on ``BrowserConfig`` here —
+    see ``_build_cookie_hooks``. crawl4ai >= 0.9's untrusted-config boundary
+    (CVE-2026-57572 hardening) added ``cookies``/``storage_state`` to
+    ``BrowserConfig``'s forbidden-field list for every network request, the
+    same wall #873 hit for ``js_code`` (see that commit). Verified live
+    against our own crawl4ai server 2026-09-10: a ``cookies`` key in
+    ``browser_config.params`` now gets HTTP 400 "field 'cookies' is not
+    permitted on BrowserConfig from an untrusted request" — this used to
+    work on crawl4ai 0.8.x and silently stopped once we moved to 0.9.x.
 
-      "Run your initial login steps in a separate, well-defined process,
-      then feed that session to your main crawl — rather than shoehorning
-      complex authentication into early hooks."
-
-    crawl4ai 0.8.x's ``BrowserConfig`` accepts a ``cookies`` list directly
-    (async_configs.py line 634). The Docker REST API server deserializes it
-    via ``BrowserConfig.load`` (api.py line 567), so the same payload shape
-    works in our deployed setup.
-
-    Returns ``None`` when no cookies are provided, so callers can do:
+    Returns ``None`` when stealth is off, so callers can do:
 
         bc = _build_browser_config_with_cookies(cookies)
         if bc:
             payload["browser_config"] = bc
     """
+    del cookies  # kept in the signature so callers don't need two branches
     params: dict[str, Any] = {}
-    if cookies:
-        params["cookies"] = cookies
     if stealth:
         params["enable_stealth"] = True
         params["user_agent_mode"] = "random"
@@ -991,6 +984,29 @@ def _build_browser_config_with_cookies(
         "type": "BrowserConfig",
         "params": params,
     }
+
+
+def _build_cookie_hooks(cookies: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    """Build a declarative ``hooks_config`` payload that injects cookies.
+
+    crawl4ai's server-side "untrusted-config boundary" (introduced fixing
+    CVE-2026-57572) forbids raw ``BrowserConfig.cookies``/``storage_state``
+    on every network request — see ``_build_browser_config_with_cookies``.
+    The safe, currently-supported replacement is a declarative hook: a
+    fixed, server-validated action (``add_cookies``) instead of an arbitrary
+    config field. It runs at ``on_page_context_created``, i.e. before
+    navigation — same timing as the old ``BrowserConfig.cookies`` approach,
+    so Playwright's BrowserContext still receives the cookies pre-goto.
+
+    Returns ``None`` when no cookies are provided, so callers can do:
+
+        hooks = _build_cookie_hooks(cookies)
+        if hooks:
+            payload["hooks_config"] = hooks
+    """
+    if not cookies:
+        return None
+    return {"hooks": [{"action": "add_cookies", "params": {"cookies": cookies}}]}
 
 
 async def crawl_page(
@@ -1078,6 +1094,9 @@ async def _crawl_page_with_config(
     bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
     if bc:
         payload["browser_config"] = bc
+    hooks = _build_cookie_hooks(cookies)
+    if hooks:
+        payload["hooks_config"] = hooks
 
     async with httpx.AsyncClient(timeout=timeout) as client:
         try:
@@ -2148,6 +2167,9 @@ async def _fetch_seed_page(
     bc = _build_browser_config_with_cookies(cookies)
     if bc:
         payload["browser_config"] = bc
+    hooks = _build_cookie_hooks(cookies)
+    if hooks:
+        payload["hooks_config"] = hooks
 
     try:
         async with httpx.AsyncClient(timeout=90.0) as client:
@@ -3052,6 +3074,9 @@ async def _bfs_deep_crawl(
     bc = _build_browser_config_with_cookies(cookies)
     if bc:
         payload["browser_config"] = bc
+    hooks = _build_cookie_hooks(cookies)
+    if hooks:
+        payload["hooks_config"] = hooks
 
     try:
         async with httpx.AsyncClient(timeout=90.0) as client:
@@ -3327,6 +3352,9 @@ async def _chunked_bulk_fetch_with_session(
         bc = _build_browser_config_with_cookies(cookies, stealth=stealth)
         if bc:
             payload["browser_config"] = bc
+        hooks = _build_cookie_hooks(cookies)
+        if hooks:
+            payload["hooks_config"] = hooks
 
         chunk_reason_codes: set[str] = set()
         # Fed to host_circuit_breaker.evaluate_chunk below — a whole-chunk

--- a/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
+++ b/klai-knowledge-ingest/tests/test_crawl_site_reconcile.py
@@ -2723,20 +2723,40 @@ async def test_crawl_site_recovery_stops_mid_batch_once_time_budget_genuinely_sp
     assert by_url["https://example.com/page-c"]["reason_code"] == FetchReasonCode.HTTP_5XX.value
 
 
-def test_browser_config_merges_cookies_and_stealth() -> None:
-    """Stealth must not drop an authenticated crawl's cookies."""
+def test_browser_config_never_carries_cookies() -> None:
+    """Regression: crawl4ai >= 0.9 rejects a ``cookies`` key inside
+    ``browser_config.params`` with HTTP 400 ("not permitted on BrowserConfig
+    from an untrusted request") - its CVE-2026-57572 untrusted-config
+    boundary. ``_build_browser_config_with_cookies`` must never place cookies
+    there again; verified live against our own crawl4ai server 2026-09-10.
+    Stealth must still work and must not resurrect a ``cookies`` key.
+    """
     cookies = [{"name": "session", "value": "abc", "domain": "example.com", "path": "/"}]
 
     plain = crawl4ai_client._build_browser_config_with_cookies(cookies)
-    assert plain is not None
-    assert plain["params"] == {"cookies": cookies}
+    assert plain is None
 
-    both = crawl4ai_client._build_browser_config_with_cookies(cookies, stealth=True)
-    assert both is not None
-    assert both["params"]["cookies"] == cookies
-    assert both["params"]["enable_stealth"] is True
+    stealth = crawl4ai_client._build_browser_config_with_cookies(cookies, stealth=True)
+    assert stealth is not None
+    assert "cookies" not in stealth["params"]
+    assert stealth["params"]["enable_stealth"] is True
 
     assert crawl4ai_client._build_browser_config_with_cookies(None) is None
     stealth_only = crawl4ai_client._build_browser_config_with_cookies(None, stealth=True)
     assert stealth_only is not None
     assert "cookies" not in stealth_only["params"]
+
+
+def test_cookie_hooks_use_declarative_add_cookies_action() -> None:
+    """Cookies travel via the declarative ``add_cookies`` hook - crawl4ai's
+    server-validated, currently-supported replacement for raw
+    ``BrowserConfig.cookies`` (see ``hook_registry.py`` on the crawl4ai
+    server: the action is described there as "Add cookies to the browser
+    context before navigation (auth)" - exactly this use case)."""
+    cookies = [{"name": "session", "value": "abc", "domain": "example.com", "path": "/"}]
+
+    hooks = crawl4ai_client._build_cookie_hooks(cookies)
+    assert hooks == {"hooks": [{"action": "add_cookies", "params": {"cookies": cookies}}]}
+
+    assert crawl4ai_client._build_cookie_hooks(None) is None
+    assert crawl4ai_client._build_cookie_hooks([]) is None

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime
 from typing import Literal
+from urllib.parse import urlsplit
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -476,6 +477,43 @@ def _require_credential_store_for_sensitive_config(connector_type: str, config: 
         )
 
 
+def _origin(url: object) -> tuple[str, str] | None:
+    """``(scheme, netloc.lower())`` for a URL, or ``None`` if not a usable URL."""
+    if not isinstance(url, str) or not url:
+        return None
+    parts = urlsplit(url)
+    if not parts.netloc:
+        return None
+    return (parts.scheme, parts.netloc.lower())
+
+
+def _stale_credentials_cross_origin(*, connector: PortalConnector, new_config: dict, clear_credentials: bool) -> bool:
+    """True when this update repoints a web_crawler connector's base_url to a
+    different origin while leaving its saved cookies (captured for the old
+    origin) in place. Those cookies must not survive the move - see the
+    caller."""
+    return (
+        connector.connector_type == "web_crawler"
+        and connector.encrypted_credentials is not None
+        and not clear_credentials
+        and "cookies" not in new_config
+        and _origin((connector.config or {}).get("base_url")) != _origin(new_config.get("base_url"))
+    )
+
+
+def _drop_stale_credentials_on_origin_change(
+    *, connector: PortalConnector, new_config: dict, clear_credentials: bool
+) -> None:
+    """Clear ``connector.encrypted_credentials`` when this update repoints a
+    web_crawler connector's base_url to a different origin without supplying
+    fresh cookies - see ``_stale_credentials_cross_origin``. A separate
+    statement (rather than an inline ``if`` in ``update_connector``) so the
+    branch there doesn't push that function over the complexity budget.
+    """
+    if _stale_credentials_cross_origin(connector=connector, new_config=new_config, clear_credentials=clear_credentials):
+        connector.encrypted_credentials = None
+
+
 async def _merge_saved_sensitive_credentials(
     *,
     connector: PortalConnector,
@@ -483,9 +521,22 @@ async def _merge_saved_sensitive_credentials(
     org_id: int,
     db: AsyncSession,
 ) -> dict:
-    """Fill omitted secret fields from encrypted storage for edit requests."""
+    """Fill omitted secret fields from encrypted storage for edit requests.
+
+    Web-crawler cookies are captured for a specific site. If this update also
+    changes ``base_url`` to a different origin, do NOT carry the old cookies
+    forward: a later auth-probe/preview against the new origin would then
+    send the previous site's decrypted session cookies to it. The caller
+    must supply fresh cookies (or ``clear_credentials``) for the new origin.
+    """
     sensitive_fields = _sensitive_fields_for(connector.connector_type)
     missing_fields = sensitive_fields - set(config)
+    if connector.connector_type == "web_crawler" and "cookies" in missing_fields:
+        old_config = connector.config or {}
+        old_origin = _origin(old_config.get("base_url"))
+        new_origin = _origin(config.get("base_url"))
+        if old_origin != new_origin:
+            missing_fields = missing_fields - {"cookies"}
     if not missing_fields or connector.encrypted_credentials is None:
         return config
     if credential_store is None:
@@ -785,6 +836,9 @@ async def update_connector(
                 org_id=perms.org_id,
                 db=db,
             )
+        _drop_stale_credentials_on_origin_change(
+            connector=connector, new_config=body.config, clear_credentials=body.clear_credentials
+        )
         # SPEC-SEC-SSRF-001 REQ-2.1 / AC-8 / AC-20: SSRF + allowlist
         # validation runs before any downstream fingerprint fetch
         # (which would dispatch an HTTP request to the candidate URL).

--- a/klai-portal/backend/tests/test_connector_encryption_api.py
+++ b/klai-portal/backend/tests/test_connector_encryption_api.py
@@ -9,7 +9,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.api.connectors import _connector_out, _cookie_names_from_credentials, _merge_saved_sensitive_credentials
+from app.api.connectors import (
+    _connector_out,
+    _cookie_names_from_credentials,
+    _drop_stale_credentials_on_origin_change,
+    _merge_saved_sensitive_credentials,
+)
 from app.services.connector_credentials import SENSITIVE_FIELDS
 
 # Test-only placeholder values (NOT real credentials)
@@ -163,3 +168,93 @@ async def test_merge_saved_sensitive_credentials_preserves_omitted_json_feed_url
         )
 
     assert merged == {"url": saved_url}
+
+
+@pytest.mark.asyncio
+async def test_merge_saved_sensitive_credentials_drops_cookies_on_origin_change() -> None:
+    """Regression: PATCHing base_url to a different origin must not carry the
+    old cookies forward into this save - they were captured for the old site.
+    Without this, a connector-manage user could repoint base_url and have the
+    real site's decrypted cookies sent to the new origin on the next probe.
+    """
+    connector = MagicMock()
+    connector.connector_type = "web_crawler"
+    connector.encrypted_credentials = b"ENCRYPTED"
+    connector.config = {"base_url": "https://wiki.redcactus.cloud/nl/"}
+
+    with patch("app.api.connectors.credential_store") as mock_store:
+        mock_store.decrypt_credentials = AsyncMock(return_value={"cookies": [{"name": "session", "value": FAKE_TOKEN}]})
+
+        merged = await _merge_saved_sensitive_credentials(
+            connector=connector,
+            config={"base_url": "https://attacker.example.com/"},
+            org_id=8,
+            db=AsyncMock(),
+        )
+
+    assert "cookies" not in merged
+
+
+@pytest.mark.asyncio
+async def test_merge_saved_sensitive_credentials_keeps_cookies_on_same_origin_path_change() -> None:
+    """A base_url edit that stays on the same origin (e.g. adding a path)
+    must still carry the saved cookies forward - only a different origin
+    invalidates them."""
+    connector = MagicMock()
+    connector.connector_type = "web_crawler"
+    connector.encrypted_credentials = b"ENCRYPTED"
+    connector.config = {"base_url": "https://wiki.redcactus.cloud/nl/"}
+    cookies = [{"name": "session", "value": FAKE_TOKEN}]
+
+    with patch("app.api.connectors.credential_store") as mock_store:
+        mock_store.decrypt_credentials = AsyncMock(return_value={"cookies": cookies})
+
+        merged = await _merge_saved_sensitive_credentials(
+            connector=connector,
+            config={"base_url": "https://wiki.redcactus.cloud/nl/login"},
+            org_id=8,
+            db=AsyncMock(),
+        )
+
+    assert merged["cookies"] == cookies
+
+
+class TestDropStaleCredentialsOnOriginChange:
+    """Regression for the same gap, at the point that actually clears storage."""
+
+    def _connector(self, *, base_url: str) -> MagicMock:
+        connector = MagicMock()
+        connector.connector_type = "web_crawler"
+        connector.encrypted_credentials = b"ENCRYPTED"
+        connector.config = {"base_url": base_url}
+        return connector
+
+    def test_clears_on_origin_change_without_fresh_cookies(self) -> None:
+        connector = self._connector(base_url="https://wiki.redcactus.cloud/nl/")
+        _drop_stale_credentials_on_origin_change(
+            connector=connector,
+            new_config={"base_url": "https://attacker.example.com/"},
+            clear_credentials=False,
+        )
+        assert connector.encrypted_credentials is None
+
+    def test_keeps_credentials_when_fresh_cookies_supplied(self) -> None:
+        connector = self._connector(base_url="https://wiki.redcactus.cloud/nl/")
+        _drop_stale_credentials_on_origin_change(
+            connector=connector,
+            new_config={
+                "base_url": "https://attacker.example.com/",
+                "cookies": [{"name": "session", "value": FAKE_TOKEN}],
+            },
+            clear_credentials=False,
+        )
+        assert connector.encrypted_credentials == b"ENCRYPTED"
+
+    def test_keeps_credentials_on_same_origin(self) -> None:
+        connector = self._connector(base_url="https://wiki.redcactus.cloud/nl/")
+        _drop_stale_credentials_on_origin_change(
+            connector=connector,
+            new_config={"base_url": "https://wiki.redcactus.cloud/nl/login"},
+            clear_credentials=False,
+        )
+        assert connector.encrypted_credentials == b"ENCRYPTED"

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-feedback.tsx
@@ -91,7 +91,8 @@ export function PreviewClassificationFeedback({
       break
     case 'requires_javascript':
       message =
-        'Page renders via JavaScript. Configure a wait_for condition or selector for the post-render DOM.'
+        "This page needs JavaScript to load its content, and the preview didn't catch it in time. " +
+        "There's nothing to configure here - save anyway and Klai will index what the full crawl can reach."
       break
     case 'entry_point_empty':
       // The reason from the backend already spells out the fix (paste a

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
@@ -71,7 +71,7 @@ export function CrawlerAuthSetupStep({
     <div className="space-y-4">
       <div className="rounded-lg border border-gray-200 p-4 space-y-3">
         <div className="space-y-1.5">
-          <Label htmlFor="wc-auth-test-url">{m.admin_connectors_webcrawler_test_url()}</Label>
+          <Label htmlFor="wc-auth-test-url">URL to test</Label>
           <Input
             id="wc-auth-test-url"
             type="url"
@@ -79,10 +79,12 @@ export function CrawlerAuthSetupStep({
             value={testUrl}
             onChange={(e) => onTestUrlChange(e.target.value)}
           />
-          <p className="text-xs text-gray-600">{m.admin_connectors_webcrawler_test_url_hint()}</p>
+          <p className="text-xs text-gray-600">
+            Defaults to your base URL. If the login wall lives on a different page, paste that page&apos;s URL here instead.
+          </p>
           {testUrlCrossOrigin && (
             <p className="text-xs text-[var(--color-destructive)]">
-              {m.admin_connectors_webcrawler_test_url_cross_origin()}
+              This URL is on a different domain than your base URL. For safety, cookies can only be tested against the same site.
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary
- crawl4ai >= 0.9's untrusted-config boundary (CVE-2026-57572 hardening) rejects a `cookies` key inside `browser_config.params` with HTTP 400 for every network request — silently breaking authenticated web-crawler connectors (preview AND real sync). Same wall #873 hit for `js_code`. Verified live against our own crawl4ai server: before 400, after 200.
- Cookies now travel via crawl4ai's declarative `add_cookies` hook (`hooks_config`) — the server-validated, currently-supported replacement. Fixed in knowledge-ingest (preview, sync, bulk crawl, BFS job — 4 call sites) and klai-connector (canary-fingerprint computation — a duplicate implementation of the same broken pattern).
- Also closes a related gap found while auditing the credentials path: PATCHing a web_crawler connector's `base_url` to a different origin without supplying fresh cookies used to leave the old cookies in storage, reachable via a later "use saved credentials" probe against the new origin.
- UI fix: the `requires_javascript` preview message told users to "configure a wait_for condition" — a backend-only concept with no UI control. Rewritten to be actionable.

Clean branch off current `main` — an earlier attempt on a reused branch hit CI-triggering and rebase issues against already-merged content from #1364.

## Test plan
- [x] knowledge-ingest: `test_crawl_site_reconcile.py` 106/106 passed; ruff clean
- [x] klai-connector: fingerprint tests 15/15 passed; ruff clean
- [x] portal-backend: connector encryption tests 24/24 passed; ruff clean
- [x] portal-frontend: tsc + eslint clean on changed files
- [x] Live-verified the crawl4ai fix against our own server on core-01 (400 → 200)
- [x] Reviewed by Sol; high-severity findings fixed in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)