### PR TITLE
fix(widget): correct launcher contrast and separate intro from footer

### DIFF
--- a/klai-widget/src/api/widget-config.ts
+++ b/klai-widget/src/api/widget-config.ts
@@ -7,10 +7,9 @@ export interface WidgetConfig {
   session_expires_at: string;
   // TWD-style empty-state chips. Admin-configured, 0-6 entries.
   conversation_starters?: string[];
-  // White-label flag to hide the AI-accuracy-disclaimer footer. Does NOT
-  // hide the EU AI Act art. 50 notice (labels.aiDisclosure) — that one is
-  // mandatory and always rendered.
+  // Hide the introductory AI notice independently of the footer.
   hide_disclaimer?: boolean;
+  footer_text?: string | null;
   // INTERIM appointment redirect — remove once the chat booking API
   // integration lands. Booking-module URL of the support partner, rendered
   // as the "schedule an appointment" button. The server only delivers
@@ -34,7 +33,7 @@ export interface WidgetConfig {
   name?: string;
   description?: string;
   // Tenant-supplied replacement for the whole AI-notice sentence in the
-  // hero (the mandatory EU AI Act art. 50 notice + the auto-appended
+  // hero (the AI notice + the auto-appended
   // booking sentence). Used verbatim when set. See ChatWindow.tsx.
   ai_disclosure_override?: string;
   // Display toggles: show citation list / meta block under each

--- a/klai-widget/src/components/ChatBubble.tsx
+++ b/klai-widget/src/components/ChatBubble.tsx
@@ -93,6 +93,7 @@ export function ChatBubble(props: ChatBubbleProps = {}) {
           welcomeMessage={chatState.config?.welcome_message}
           bookingUrl={chatState.config?.booking_url}
           aiDisclosureOverride={chatState.config?.ai_disclosure_override}
+          footerText={chatState.config?.footer_text}
           nerdsEnabled={chatState.config?.nerds?.enabled}
           nerdsBookingUrl={chatState.config?.nerds?.booking_url}
           collectUserInfo={chatState.config?.collect_user_info}

--- a/klai-widget/src/components/ChatWindow.tsx
+++ b/klai-widget/src/components/ChatWindow.tsx
@@ -1,4 +1,6 @@
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+import DOMPurify from "dompurify";
+import snarkdown from "snarkdown";
 import { MessageList } from "./MessageList";
 import {
   chatState,
@@ -42,9 +44,9 @@ interface ChatWindowProps {
   onClose: () => void;
   inline?: boolean;
   conversationStarters?: string[];
-  // White-label toggle for the accuracy footer only — it must never hide
-  // the EU AI Act art. 50 notice in the hero.
+  // The introductory AI notice and footer are configured independently.
   hideDisclaimer?: boolean;
+  footerText?: string | null;
   welcomeMessage?: string;
   bookingUrl?: string;
   // Tenant-supplied replacement for the whole AI-notice sentence (the
@@ -52,10 +54,7 @@ interface ChatWindowProps {
   // sentence). Used verbatim, no {name} substitution, nothing auto-appended
   // — the tenant already wrote their own complete sentence, e.g. because
   // they show their own escalation route elsewhere (the nerds footer link).
-  // Unset/empty → the default templated notice, unchanged. The admin UI
-  // must keep telling the tenant this still has to convey "this is an AI
-  // system" — the EU AI Act art. 50 requirement doesn't go away, only the
-  // exact wording becomes theirs.
+  // Unset/empty uses the default notice when the introduction is enabled.
   aiDisclosureOverride?: string;
   // Nerds booking panel (Voys-specific). The server only delivers
   // enabled=true together with an absolute http(s) booking_url
@@ -69,10 +68,10 @@ interface ChatWindowProps {
 
 // TWD-pattern widget chrome:
 //   header  → primary-color bg, avatar + title, close
-//   hero    → centered icon + welcome line + mandatory AI notice +
+//   hero    → centered icon + welcome line + optional AI notice +
 //             starter chips (only when the conversation hasn't started yet)
 //   input   → pill textarea + small primary-color send button
-//   footer  → AI accuracy disclaimer (white-label toggle hides it)
+//   footer  → customer Markdown, or the existing default footer
 export function ChatWindow(props: ChatWindowProps) {
   const [inputValue, setInputValue] = createSignal("");
   const [visitorName, setVisitorName] = createSignal(chatState.visitorName);
@@ -107,14 +106,27 @@ export function ChatWindow(props: ChatWindowProps) {
     const notice = botName
       ? t().aiDisclosure.replace("{name}", botName)
       : t().aiDisclosureNoOrg;
-    // The AI notice is unconditional — it is the Article 50 requirement. The
-    // appointment sentence is not: it only holds where a booking route is
+    // The appointment sentence only holds where a booking route is
     // actually configured. Appending it everywhere would promise every other
     // tenant's visitors a person they have no way to reach.
     const booking = props.bookingUrl ? t().aiDisclosureBooking : "";
     setAiDisclosureText(notice + booking);
   }, 150);
   onCleanup(() => window.clearTimeout(disclosureTimer));
+
+  const footerHtml = () => {
+    const template = document.createElement("template");
+    template.innerHTML = DOMPurify.sanitize(snarkdown(props.footerText?.trim() ?? ""), {
+      ALLOWED_TAGS: ["a", "p", "br", "strong", "em"],
+      ALLOWED_ATTR: ["href", "title"],
+    });
+    for (const link of template.content.querySelectorAll("a")) {
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.className = "klai-disclaimer-link";
+    }
+    return template.innerHTML;
+  };
 
   // ── Nerds booking panel (Voys-specific) ────────────────────────────
   // The panel replaces the widget's contents with an iframe on the Nerds
@@ -647,18 +659,11 @@ export function ChatWindow(props: ChatWindowProps) {
           <p class="klai-hero-title">
             {props.welcomeMessage?.trim() || props.title}
           </p>
-          {/* EU AI Act art. 50 notice: visitors must know they are talking
-              to an AI system, perceptibly, at first interaction. Deliberately
-              NOT gated on hide_disclaimer — that flag is a white-label toggle
-              for the accuracy footer ("AI-antwoorden kunnen fouten bevatten…")
-              and a legal disclosure cannot be switched off per widget. It also
-              sits NEXT TO the configurable welcome_message rather than inside
-              it, so a customer can rewrite the greeting without ever dropping
-              the notice. role="status" + the deferred fill above announce it
-              to screen readers when the window opens. */}
-          <p class="klai-hero-ai-disclosure" role="status" aria-live="polite">
-            {aiDisclosureText()}
-          </p>
+          <Show when={!props.hideDisclaimer}>
+            <p class="klai-hero-ai-disclosure" role="status" aria-live="polite">
+              {aiDisclosureText()}
+            </p>
+          </Show>
           <Show when={(props.conversationStarters?.length ?? 0) > 0}>
             <div class="klai-starters">
               {props.conversationStarters!.map((s) => (
@@ -868,23 +873,11 @@ export function ChatWindow(props: ChatWindowProps) {
         </Show>
       </div>
 
-      {/* With the nerds integration on, the client's own disclosure
-          sentence replaces the plain accuracy footer — same place, but NOT
-          the same white-label gate. hideDisclaimer only white-labels the
-          generic accuracy wording; the nerds escape route is the visitor's
-          one permanent way to reach a human (the booking bar above is
-          already hidden once nerds is active) and must survive that toggle,
-          so it renders whenever nerds is configured, hideDisclaimer or not.
-          "onze nerds" opens the same booking panel the in-conversation
-          appointment button opens. The fragments render as JSX text/a
-          button, never as raw HTML. */}
+      {/* Keep existing booking behavior until a customer supplies a footer. */}
+      <Show when={props.footerText?.trim()} fallback={
       <Show
         when={nerdsActive()}
-        fallback={
-          <Show when={!props.hideDisclaimer}>
-            <p class="klai-disclaimer">{t().disclaimer}</p>
-          </Show>
-        }
+        fallback={<p class="klai-disclaimer">{t().disclaimer}</p>}
       >
         <p class="klai-disclaimer">
           {t().nerdsDisclosureBefore}
@@ -897,6 +890,9 @@ export function ChatWindow(props: ChatWindowProps) {
           </button>
           {t().nerdsDisclosureAfter}
         </p>
+      </Show>
+      }>
+        <div class="klai-disclaimer" innerHTML={footerHtml()} />
       </Show>
 
       {/* Nerds booking panel: overlay covering the chat while open. The

--- a/klai-widget/src/main.ts
+++ b/klai-widget/src/main.ts
@@ -68,6 +68,19 @@ function parsePreviewPrimaryColor(value: string | null): string | null {
   return null;
 }
 
+function previewPrimaryTextColor(primaryColor: string): string {
+  const hex = primaryColor.slice(1);
+  const rgb = (hex.length === 3 ? [...hex].map((digit) => digit + digit).join("") : hex)
+    .slice(0, 6)
+    .match(/.{2}/g)!
+    .map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+  const luminance = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+  return luminance > 0.179 ? "#191918" : "#ffffff";
+}
+
 // css_variables from config as custom properties overrides
 function cssVariableOverrides(config: WidgetConfig): string {
   return Object.entries(config.css_variables)
@@ -151,6 +164,7 @@ async function bootstrap(): Promise<void> {
         welcomeMessage: config.welcome_message,
         bookingUrl: config.booking_url,
         aiDisclosureOverride: config.ai_disclosure_override,
+        footerText: config.footer_text,
         nerdsEnabled: config.nerds?.enabled,
         nerdsBookingUrl: config.nerds?.booking_url,
         collectUserInfo: config.collect_user_info,
@@ -180,7 +194,7 @@ async function bootstrap(): Promise<void> {
     scriptTag.getAttribute("data-primary-color"),
   );
   styleEl.textContent = previewColor
-    ? `${widgetCss}\n:host { --klai-primary-color: ${previewColor}; }`
+    ? `${widgetCss}\n:host { --klai-primary-color: ${previewColor}; --klai-primary-text-color: ${previewPrimaryTextColor(previewColor)}; }`
     : widgetCss;
   shadowRoot.appendChild(styleEl);
 

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -49,6 +49,7 @@
   height: var(--klai-bubble-size);
   border-radius: 50%;
   background-color: var(--klai-primary-color);
+  color: var(--klai-primary-text-color);
   border: 1px solid var(--klai-border-color);
   cursor: pointer;
   display: flex;
@@ -70,7 +71,7 @@
 .klai-bubble svg {
   width: 24px;
   height: 24px;
-  fill: var(--klai-primary-text-color);
+  fill: none;
 }
 
 /* Facade loading state — spinner replacing the glyph inside the
@@ -79,8 +80,8 @@
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  border: 2.5px solid color-mix(in srgb, var(--klai-primary-text-color) 30%, transparent);
-  border-top-color: var(--klai-primary-text-color);
+  border: 2.5px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-top-color: currentColor;
   animation: klai-spin 0.7s linear infinite;
 }
 
@@ -216,6 +217,7 @@
 .klai-header-actions {
   display: flex;
   align-items: center;
+  align-self: center;
   gap: 4px;
   flex-shrink: 0;
 }
@@ -288,6 +290,7 @@
   padding: 4px;
   display: flex;
   align-items: center;
+  align-self: center;
   justify-content: center;
   border-radius: 4px;
   opacity: 0.75;

--- a/klai-widget/tests/booking-bar.test.tsx
+++ b/klai-widget/tests/booking-bar.test.tsx
@@ -89,8 +89,34 @@ describe("permanent booking bar", () => {
     expect(link!.textContent).toBe(t().nerdsDisclosureLink);
   });
 
-  it("still hides the plain accuracy footer via hideDisclaimer when nerds is off", () => {
+  it("hides the AI introduction while preserving the footer", () => {
     const { container } = renderWindow({ hideDisclaimer: true });
-    expect(container.querySelector(".klai-disclaimer")).toBeNull();
+    expect(container.querySelector(".klai-hero-ai-disclosure")).toBeNull();
+    expect(container.querySelector(".klai-disclaimer")!.textContent).toBe(t().disclaimer);
+  });
+
+  it("renders the customer's footer and appointment link independently of the AI introduction", () => {
+    const { container } = renderWindow({
+      hideDisclaimer: true,
+      nerdsEnabled: true,
+      nerdsBookingUrl: BOOKING_URL,
+      footerText: `Onze AI kan fouten maken. Plan bij [onze nerds](${BOOKING_URL}).`,
+    });
+    const footer = container.querySelector(".klai-disclaimer")!;
+    expect(footer.textContent).toBe("Onze AI kan fouten maken. Plan bij onze nerds.");
+    const link = footer.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe(BOOKING_URL);
+    expect(link.target).toBe("_blank");
+    expect(link.rel).toBe("noopener noreferrer");
+    expect(container.querySelector(".klai-hero-ai-disclosure")).toBeNull();
+  });
+
+  it("does not execute HTML or script links supplied in a customer footer", () => {
+    const { container } = renderWindow({
+      footerText: 'Footer <img src=x onerror="alert(1)"> [unsafe](javascript:alert) <script>alert(1)</script>',
+    });
+    const footer = container.querySelector(".klai-disclaimer")!;
+    expect(footer.textContent).toContain("Footer");
+    expect(footer.querySelector("script, img, [onerror], a[href^='javascript:']")).toBeNull();
   });
 });

--- a/klai-widget/tests/widget-shell.test.tsx
+++ b/klai-widget/tests/widget-shell.test.tsx
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { cleanup, render } from "@solidjs/testing-library";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatBubble } from "../src/components/ChatBubble";
+
+const widgetCss = readFileSync(join(process.cwd(), "src/styles/widget.css"), "utf8");
+
+afterEach(() => {
+  cleanup();
+  document.head.innerHTML = "";
+  document.querySelectorAll("#klai-widget-root").forEach((node) => node.remove());
+  vi.resetModules();
+});
+
+describe("widget shell", () => {
+  it("keeps launcher artwork unfilled and centers the header actions", () => {
+    const { container } = render(() => <ChatBubble />);
+    const bubble = container.querySelector(".klai-bubble") as HTMLButtonElement;
+    const icon = bubble.querySelector("svg") as SVGElement;
+
+    expect(icon.getAttribute("stroke")).toBe("currentColor");
+    expect(widgetCss).toMatch(/\.klai-bubble\s*{[^}]*color:\s*var\(--klai-primary-text-color\)/s);
+    expect(widgetCss).toMatch(/\.klai-bubble svg\s*{[^}]*fill:\s*none/s);
+    expect(widgetCss).toMatch(/\.klai-header-actions\s*{[^}]*align-self:\s*center/s);
+    expect(widgetCss).toMatch(/\.klai-close-btn\s*{[^}]*align-self:\s*center/s);
+  });
+
+  it("renders the Voys facade icon white before fetching config", async () => {
+    const script = document.createElement("script");
+    script.src = "https://my.getklai.com/widget/klai-chat.js";
+    script.setAttribute("data-widget-id", "wgt_voys");
+    script.setAttribute("data-primary-color", "#270697");
+    document.head.appendChild(script);
+
+    await import("../src/main");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const root = document.getElementById("klai-widget-root")!;
+    const style = root.shadowRoot!.querySelector("style")!;
+    expect(style.textContent).toContain("--klai-primary-color: #270697");
+    expect(style.textContent).toContain("--klai-primary-text-color: #ffffff");
+    expect(root.shadowRoot!.querySelector("button.klai-bubble svg")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
The floating launcher now uses readable icon contrast before configuration loads, and header controls align vertically. The intro visibility toggle preserves an independently configurable, sanitized Markdown footer. Existing theme defaults and booking fallbacks remain intact. Validation: 23 widget tests, production build, bundle-size gate, and a Playwright click-through on the help site using the built bundle passed.