### PR TITLE
fix(connector): drop discovery_seed_url that falls outside base_url scope

### DIFF
--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -177,7 +177,8 @@ function AddConnectorPage() {
         if (
           wcPreviewUrl &&
           wcPreviewUrl !== webcrawlerConfig.base_url &&
-          previewResult?.classification === 'success'
+          previewResult?.classification === 'success' &&
+          isWithinBaseUrl(wcPreviewUrl, webcrawlerConfig.base_url)
         ) {
           config.discovery_seed_url = wcPreviewUrl
         }

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -370,7 +370,10 @@ function EditConnectorPage() {
         // is still inside the (possibly edited) base URL scope.
         const base = webcrawlerConfig.base_url
         const validatedSeed =
-          wcPreviewUrl && wcPreviewUrl !== base && previewResult?.classification === 'success'
+          wcPreviewUrl &&
+          wcPreviewUrl !== base &&
+          previewResult?.classification === 'success' &&
+          isWithinBaseUrl(wcPreviewUrl, base)
             ? wcPreviewUrl
             : ''
         const carriedSeed =


### PR DESCRIPTION
## Summary
- Save crashed with a raw 422 (`discovery_seed_url must start with '<base_url>'`) whenever the preview's validated interior page lived under a different path than base_url (e.g. an `/en/` article validated against a `/nl/` base_url — same site, different locale segment).
- The wizard already scope-checked a carried-over stored seed, just not a freshly-validated one from this session — the one case actually reachable via "Run preview → Next → Save" was the one left unchecked.
- Fix: drop the seed instead of sending it out of scope. The connector still saves, just without the discovery-seed fallback for that case.

## Test plan
- [x] `tsc --noEmit` clean
- [x] wizard tests 37/37 passed (existing in-scope seed case still asserts `discovery_seed_url` is sent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)