### PR TITLE
fix(widget): preserve explicit blank presentation text in public config

### DIFF
--- a/klai-portal/backend/app/api/partner.py
+++ b/klai-portal/backend/app/api/partner.py
@@ -3035,16 +3035,15 @@ async def widget_config(
         # presentation field interpreted by the widget.
         "conversation_starters": widget_config_data.get("conversation_starters", []),
         "hide_disclaimer": widget_config_data.get("hide_disclaimer", False),
-        "footer_text": widget_config_data.get("footer_text") or "",
+        "footer_text": widget_config_data.get("footer_text"),
         # Name drives the TWD-pattern header (avatar + title). description
         # is admin-only scope/behaviour config, not rendered to visitors —
         # kept in the response only as a widget-frontend locale hint.
         "name": widget_row.name,
         "description": widget_row.description or "",
-        # Tenant-supplied replacement for the whole AI-notice sentence (the
-        # EU AI Act art. 50 notice + the auto-appended booking sentence).
-        # Used verbatim by the widget when set — see ChatWindow.tsx.
-        "ai_disclosure_override": widget_config_data.get("ai_disclosure_override") or "",
+        # Explicit tenant text preserves empty versus null: empty hides the
+        # introduction, while null keeps the widget's legacy default.
+        "ai_disclosure_override": widget_config_data.get("ai_disclosure_override"),
         "primary_color": widget_config_data.get("primary_color", "#fcaa2d"),
         "theme": widget_config_data.get("theme", "light"),
         "collect_user_info": widget_config_data.get("collect_user_info", False),
@@ -3183,7 +3182,7 @@ async def public_bot_config(
         "session_expires_at": expires_at.isoformat(),
         "conversation_starters": widget_config_data.get("conversation_starters", []),
         "hide_disclaimer": widget_config_data.get("hide_disclaimer", False),
-        "footer_text": widget_config_data.get("footer_text") or "",
+        "footer_text": widget_config_data.get("footer_text"),
         "primary_color": widget_config_data.get("primary_color", "#fcaa2d"),
         "theme": widget_config_data.get("theme", "light"),
         "collect_user_info": widget_config_data.get("collect_user_info", False),
@@ -3198,7 +3197,7 @@ async def public_bot_config(
         "nerds": _widget_nerds_integration(widget_config_data),
         "name": widget_row.name,
         "description": widget_row.description or "",
-        "ai_disclosure_override": widget_config_data.get("ai_disclosure_override") or "",
+        "ai_disclosure_override": widget_config_data.get("ai_disclosure_override"),
         "handoff": {
             "hubspot": {
                 # org is None only if the row vanished between the two queries;

--- a/klai-portal/backend/tests/test_widget_config.py
+++ b/klai-portal/backend/tests/test_widget_config.py
@@ -93,7 +93,8 @@ def _make_db_chain(widget: FakeWidget | None, org: FakeOrg | None, kb_ids: list[
 async def test_widget_config_happy_path():
     """Valid wgt_id + allowed origin returns 200 with session token."""
     widget = FakeWidget()
-    widget.widget_config["footer_text"] = "Lees [meer](https://example.com/help)."
+    widget.widget_config["ai_disclosure_override"] = None
+    widget.widget_config["footer_text"] = None
     org = FakeOrg()
     db = _make_db_chain(widget, org, [1, 2])
     request = _make_request("https://example.com")
@@ -114,7 +115,8 @@ async def test_widget_config_happy_path():
     assert '"session_token": "fake.jwt.token"' in body
     assert '"title": "Chat"' in body
     assert '"page_context_enabled": false' in body
-    assert json.loads(body)["footer_text"] == "Lees [meer](https://example.com/help)."
+    assert json.loads(body)["ai_disclosure_override"] is None
+    assert json.loads(body)["footer_text"] is None
     assert "system_prompt" not in body
 
 
@@ -448,7 +450,8 @@ async def test_public_bot_config_delivers_enabled_nerds_integration():
             "welcome_message": "",
             "system_prompt": "",
             "css_variables": {},
-            "footer_text": "Plan met [onze nerds](https://support.voys.nl/book/voys).",
+            "ai_disclosure_override": "",
+            "footer_text": "",
             **_nerds_config({"enabled": True, "booking_url": "https://support.voys.nl/book/voys?t=abc"}),
         },
     )
@@ -466,7 +469,8 @@ async def test_public_bot_config_delivers_enabled_nerds_integration():
 
     body = json.loads(response.body.decode())
     assert body["nerds"] == {"enabled": True, "booking_url": "https://support.voys.nl/book/voys?t=abc"}
-    assert body["footer_text"] == "Plan met [onze nerds](https://support.voys.nl/book/voys)."
+    assert body["ai_disclosure_override"] == ""
+    assert body["footer_text"] == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Preserve null versus empty introduction and footer values in both public configuration routes so blank fields can hide text without changing defaults for existing widgets. Validation: 43 backend tests and Ruff passed; runtime contract reviewed independently.