### PR TITLE
fix(widget): keep source references visible below long answers

### DIFF
--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -759,6 +759,7 @@
    agent metadata stay available without dominating the answer. */
 .klai-disclosure {
   align-self: flex-start;
+  flex-shrink: 0;
   margin: -4px 0 2px;
   width: min(100%, 460px);
   border: 1px solid color-mix(in srgb, var(--klai-border-color) 78%, transparent);


### PR DESCRIPTION
The source accordion was compressed to a 2px border below long answers, even when source metadata arrived correctly and show_sources was enabled. Prevent it from shrinking in the message column. Validation: reproduced with production SSE, database metadata and browser measurements; browser regression failed at 2px before the fix and passed at 36px collapsed / 78px expanded; 25 widget tests, build and bundle-size check passed.