### PR TITLE
fix(widget): improve answer spacing and reveal processing on follow-up

### DIFF
--- a/klai-widget/src/components/MessageList.tsx
+++ b/klai-widget/src/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from "solid-js";
+import { createEffect, For, Show } from "solid-js";
 import DOMPurify from "dompurify";
 import snarkdown from "snarkdown";
 import { TypingIndicator } from "./TypingIndicator";
@@ -178,6 +178,12 @@ export function MessageList(props: MessageListProps) {
       listRef.scrollTop = listRef.scrollHeight;
     }
   };
+
+  createEffect(() => {
+    if (props.isStreaming) {
+      queueMicrotask(scrollToBottom);
+    }
+  });
 
   return (
     <div

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -494,8 +494,12 @@
   padding: 10px 14px;
   border-radius: 14px;
   font-size: 14px;
-  line-height: 1.5;
+  line-height: 1.6;
   word-break: break-word;
+}
+
+.klai-message:not(:first-child) {
+  margin-top: 8px;
 }
 
 .klai-message--user {
@@ -511,6 +515,14 @@
   background-color: var(--klai-card-color);
   color: var(--klai-text-color);
   border-bottom-left-radius: 4px;
+}
+
+.klai-message--assistant {
+  width: 100%;
+  max-width: none;
+  padding: 0;
+  border-radius: 0;
+  background-color: transparent;
 }
 
 .klai-message--agent {
@@ -1186,7 +1198,7 @@
 }
 
 .klai-window--inline .klai-message--assistant {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: transparent;
 }
 
 .klai-window--inline .klai-message--user {

--- a/klai-widget/tests/message-list-scroll.test.tsx
+++ b/klai-widget/tests/message-list-scroll.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MessageList } from "../src/components/MessageList";
+
+afterEach(cleanup);
+
+describe("message list scrolling", () => {
+  it("reveals the typing indicator when a later turn starts", async () => {
+    const [isStreaming, setIsStreaming] = createSignal(false);
+    const [messages, setMessages] = createSignal([
+      { role: "assistant" as const, content: "A long earlier answer" },
+    ]);
+    const { container } = render(() => (
+      <MessageList
+        messages={messages()}
+        isStreaming={isStreaming()}
+        error={null}
+      />
+    ));
+    const list = container.querySelector<HTMLElement>(".klai-messages")!;
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 600 });
+    list.scrollTop = 100;
+
+    setIsStreaming(true);
+    await Promise.resolve();
+
+    expect(container.querySelector(".klai-typing")).not.toBeNull();
+    expect(list.scrollTop).toBe(600);
+
+    list.scrollTop = 200;
+    setMessages([{ role: "assistant", content: "A longer streamed answer" }]);
+    await Promise.resolve();
+    expect(list.scrollTop).toBe(200);
+  });
+});


### PR DESCRIPTION
Assistant answers now use the full message column with more line and turn spacing, while visitor messages retain their brand color. Scroll once when a new response starts so the typing indicator stays visible on follow-up questions; manual scrolling during the response is preserved. Validation: test-first regression, 26 widget tests, build and size check; browser verified full-width answers, expanded sources and the visible indicator after a second question. Default ivory and white override both checked.