### PR TITLE
Keep floating chat widgets within small screens

### DIFF
--- a/.github/workflows/portal-frontend.yml
+++ b/.github/workflows/portal-frontend.yml
@@ -98,6 +98,7 @@ jobs:
         run: |
           npm run i18n:compile
           npm run test:visual
+          npx playwright test e2e/widget-viewport.spec.ts --project=chromium --reporter=line
 
       - name: Upload diff artifacts on failure
         if: failure()

--- a/klai-portal/frontend/e2e/widget-viewport.spec.ts
+++ b/klai-portal/frontend/e2e/widget-viewport.spec.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { test, expect } from '@playwright/test'
+
+const css = readFileSync(new URL('../../../klai-widget/src/styles/widget.css', import.meta.url), 'utf8')
+
+test('floating widget overrides fit a small screen while inline widgets retain their container height', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 600 })
+  await page.setContent('<div id="floating"></div><div id="inline" style="width:200px;height:800px"></div>')
+  await page.evaluate((styles) => {
+    for (const id of ['floating', 'inline']) {
+      const host = document.getElementById(id)!
+      host.style.setProperty('--klai-window-width', '420px')
+      host.style.setProperty('--klai-window-height', '640px')
+      const root = host.attachShadow({ mode: 'open' })
+      const style = document.createElement('style')
+      style.textContent = styles
+      const window = document.createElement('div')
+      window.className = `klai-window${id === 'inline' ? ' klai-window--inline' : ''}`
+      root.append(style, window)
+    }
+  }, css)
+  const floating = await page.locator('#floating .klai-window').boundingBox()
+  expect(floating!.x).toBeGreaterThanOrEqual(0)
+  expect(floating!.y).toBeGreaterThanOrEqual(0)
+  expect(floating!.x + floating!.width).toBeLessThanOrEqual(390)
+  expect(floating!.y + floating!.height).toBeLessThanOrEqual(600)
+  expect((await page.locator('#inline .klai-window').boundingBox())!.height).toBe(800)
+})

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -163,6 +163,11 @@
   color: var(--klai-text-color);
 }
 
+.klai-window:not(.klai-window--inline) {
+  max-width: calc(100vw - 40px);
+  max-height: calc(100dvh - 108px);
+}
+
 /* Header colours can be scoped per widget without changing deployed defaults. */
 .klai-header {
   padding: 14px 14px 16px;


### PR DESCRIPTION
A configured 420px floating widget extended 50px beyond the left edge of a 390px screen. Floating windows now respect the available viewport width and height; inline windows retain their container dimensions.

Validation: browser regression failed at x=-50 before the change and passes afterward, including inline sizing. Widget tests/build/bundle-size checks passed. The browser regression also runs in the existing visual CI job.
