### PR TITLE
Offer bundled Klai typography without an external font service

### DIFF
--- a/klai-portal/backend/app/services/widget_style_overrides.py
+++ b/klai-portal/backend/app/services/widget_style_overrides.py
@@ -18,8 +18,16 @@ COLOR_VARIABLES = frozenset(
         "header-control-background",
     )
 )
+FONT_FAMILY_VALUES = frozenset(
+    {
+        '"Klai Widget Geist", system-ui, sans-serif',
+        "system-ui, sans-serif",
+    }
+)
 SIZE_RANGES = {
     "--klai-message-font-size": (12, 24),
+    "--klai-input-font-size": (12, 24),
+    "--klai-starter-font-size": (12, 24),
     "--klai-message-gap": (0, 40),
     "--klai-content-padding": (0, 40),
     "--klai-border-radius": (0, 32),
@@ -37,6 +45,9 @@ def validate_widget_style_overrides(values: dict[str, str]) -> dict[str, str]:
             match = re.fullmatch(r"(\d+(?:\.\d+)?)px", value)
             lower, upper = SIZE_RANGES[key]
             if match and lower <= float(match[1]) <= upper:
+                continue
+        elif key == "--klai-font-family":
+            if value in FONT_FAMILY_VALUES:
                 continue
         elif key == "--klai-message-line-height":
             if re.fullmatch(r"\d+(?:\.\d+)?", value) and 1.2 <= float(value) <= 2.4:

--- a/klai-portal/backend/tests/test_widget_style_settings.py
+++ b/klai-portal/backend/tests/test_widget_style_settings.py
@@ -36,6 +36,20 @@ async def test_tenant_can_save_clear_and_preserve_widget_style_defaults():
     assert result.widget_css_variables == {}
 
 
+def test_tenant_font_style_overrides_accept_supported_and_reject_arbitrary_values():
+    styles = {
+        "--klai-font-family": '"Klai Widget Geist", system-ui, sans-serif',
+        "--klai-input-font-size": "12px",
+        "--klai-starter-font-size": "24px",
+    }
+    assert OrgSettingsUpdate(widget_css_variables=styles).widget_css_variables == styles
+    assert OrgSettingsUpdate(
+        widget_css_variables={"--klai-font-family": "system-ui, sans-serif"}
+    ).widget_css_variables == {"--klai-font-family": "system-ui, sans-serif"}
+    with pytest.raises(ValidationError):
+        OrgSettingsUpdate(widget_css_variables={"--klai-font-family": "url('https://cdn.example/evil.woff2')"})
+
+
 @pytest.mark.parametrize(
     "styles",
     [

--- a/klai-portal/frontend/e2e/widget-viewport.spec.ts
+++ b/klai-portal/frontend/e2e/widget-viewport.spec.ts
@@ -64,3 +64,54 @@ test('preview send button stays clickable while open and the header close leaves
   await chat.locator('.klai-bubble').click()
   await expect(chat.locator('.klai-window')).toBeVisible()
 })
+
+// Regression: Voys/demo rendered .SF NS although live CSS says Geist, and
+// tenant typography could not be configured. Opting in via
+// --klai-font-family must load the locally bundled 'Klai Widget Geist' face
+// through document.fonts (not merely the computed family) with zero external
+// font requests, and the input/starter/message size variables must apply and
+// clear. Runs the real dist bundle through mountPreview/updateConfig.
+test('bundled Geist opt-in loads without external font requests and typography overrides apply and clear', async ({ page }) => {
+  const bundle = readFileSync(new URL('../../../klai-widget/dist/klai-chat.js', import.meta.url), 'utf8')
+  const fontRequests: string[] = []
+  page.on('request', (r) => { if (/font/i.test(r.url())) fontRequests.push(r.url()) })
+  const base = { ...previewConfig, css_variables: {}, conversation_starters: ['E2E starter'] }
+  const opted = { ...base, css_variables: {
+    '--klai-font-family': '"Klai Widget Geist", system-ui, sans-serif',
+    '--klai-input-font-size': '16.5px', '--klai-starter-font-size': '14.3px', '--klai-message-font-size': '15.4px',
+  } }
+  const frameHtml = '<!doctype html><html><body style="margin:0"><div id="klai-preview-host" style="height:100vh"></div><script src="/klai-chat.js" data-widget-id="e2e-preview" data-mode="preview"></script></body></html>'
+  await page.route('https://widget.e2e/**', (route) => {
+    const url = route.request().url()
+    if (url.endsWith('.js')) return route.fulfill({ contentType: 'text/javascript', body: bundle })
+    if (url.endsWith('/preview-frame')) return route.fulfill({ contentType: 'text/html', body: frameHtml })
+    return route.fulfill({ contentType: 'text/html', body: '<!doctype html><html><body style="margin:0"><iframe src="/preview-frame" width="440" height="650" style="border:0"></iframe></body></html>' })
+  })
+  await page.goto('https://widget.e2e/')
+  const frame = page.frames().find((f) => f.url().endsWith('/preview-frame'))!
+  await frame.waitForFunction('window.KlaiWidget !== undefined')
+  await frame.evaluate((config) => {
+    ;(window as any).__preview = (window as any).KlaiWidget.mountPreview(document.getElementById('klai-preview-host')!, {
+      widgetId: 'e2e-preview', config, fetchConfig: async () => config,
+    })
+  }, base)
+  const chat = page.frameLocator('iframe')
+  // Unset overrides keep the standard CSS: 14 / 12.5 / 14.
+  await expect(chat.locator('.klai-textarea')).toHaveCSS('font-size', '14px')
+  await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '12.5px')
+  await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '14px')
+  await frame.evaluate((config) => (window as any).__preview.updateConfig(config), opted)
+  await expect(chat.locator('.klai-textarea')).toHaveCSS('font-size', '16.5px')
+  await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '14.3px')
+  await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '15.4px')
+  await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-family', /Klai Widget Geist/)
+  const face = await frame.evaluate(() => document.fonts.load('16px "Klai Widget Geist"')
+    .then((faces) => ({ count: faces.length, loaded: faces.every((f) => f.status === 'loaded') })))
+  expect(face.count).toBeGreaterThan(0)
+  expect(face.loaded).toBe(true)
+  await frame.evaluate((config) => (window as any).__preview.updateConfig(config), base)
+  await expect(chat.locator('.klai-textarea')).toHaveCSS('font-size', '14px')
+  await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '12.5px')
+  await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '14px')
+  expect(fontRequests).toEqual([])
+})

--- a/klai-widget/src/main.ts
+++ b/klai-widget/src/main.ts
@@ -17,6 +17,21 @@ import {
 import type { WidgetConfig } from "./api/widget-config";
 import { initLabels } from "./i18n/labels";
 import widgetCss from "./styles/widget.css?inline";
+import geistRegularWoff2 from "../../klai-portal/frontend/public/fonts/geist-regular.woff2?inline";
+
+// Locally bundled Geist, opt-in via the tenant CSS variable
+// --klai-font-family: '"Klai Widget Geist", system-ui, sans-serif'.
+// The face is registered once per widget document from the embedded bytes
+// (data URI decoded via atob) — no external font URL, so no network request
+// and no CORS/CSP surface — and under a distinctly named family so a
+// host-page "Geist" is never shadowed. Module scope covers every mode that
+// loads this bundle: public bubble, inline and the preview iframe.
+// jsdom (widget unit tests) has no FontFace; real browsers always do.
+if (typeof FontFace === "function") {
+  const base64 = geistRegularWoff2.split(",")[1];
+  const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  document.fonts.add(new FontFace("Klai Widget Geist", bytes));
+}
 
 // Find the script tag that loaded this widget
 function findScriptTag(): HTMLScriptElement | null {

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -1126,7 +1126,7 @@
   border-radius: 8px;
   padding: 10px 12px;
   font-family: var(--klai-font-family);
-  font-size: 14px;
+  font-size: var(--klai-input-font-size, 14px);
   line-height: 1.4;
   color: var(--klai-text-color);
   background-color: var(--klai-background-color);
@@ -1247,7 +1247,7 @@
 }
 
 .klai-hero-title {
-  font-size: 14px;
+  font-size: var(--klai-message-font-size);
   font-weight: 400;
   line-height: 1.5;
   color: var(--klai-text-color);
@@ -1290,7 +1290,7 @@
 
 .klai-starter {
   font-family: inherit;
-  font-size: 12.5px;
+  font-size: var(--klai-starter-font-size, 12.5px);
   line-height: 1.35;
   color: var(--klai-text-color);
   background: var(--klai-card-color);

--- a/klai-widget/vitest.config.ts
+++ b/klai-widget/vitest.config.ts
@@ -1,5 +1,13 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import solidPlugin from "vite-plugin-solid";
+
+const widgetRoot = dirname(fileURLToPath(import.meta.url));
+const geistFont = resolve(
+  widgetRoot,
+  "../klai-portal/frontend/public/fonts/geist-regular.woff2",
+);
 
 // Separate from vite.config.ts on purpose: the build config describes one
 // IIFE bundle for a customer's page and must not grow test-only settings.
@@ -11,6 +19,16 @@ export default defineConfig({
   plugins: [solidPlugin()],
   resolve: {
     conditions: ["development", "browser"],
+  },
+  // main.ts inlines the portal's geist-regular.woff2, which lives outside
+  // klai-widget. Setting server.fs.allow replaces the inferred workspace
+  // root, so keep the widget root and add exactly that one font file;
+  // strict mode stays on and every other external path remains denied.
+  server: {
+    fs: {
+      strict: true,
+      allow: [widgetRoot, geistFont, `${geistFont}?inline`],
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Widgets can opt into the existing Geist font using their appearance settings, while existing font defaults remain unchanged. Font bytes are bundled with the widget so preview, floating and inline modes need no external font request. Input and starter text sizes are configurable. Validation: 3998 backend tests, 30 widget tests, fresh build, 96.3 kB bundle size, 3 Playwright regressions and 4 default/opt-in browser checks passed.