### PR TITLE
fix(widget): align intro typography and clarify link interaction

### DIFF
--- a/klai-portal/frontend/e2e/widget-viewport.spec.ts
+++ b/klai-portal/frontend/e2e/widget-viewport.spec.ts
@@ -70,7 +70,9 @@ test('preview send button stays clickable while open and the header close leaves
 // --klai-font-family must load the locally bundled 'Klai Widget Geist' face
 // through document.fonts (not merely the computed family) with zero external
 // font requests, and the input/starter/message size variables must apply and
-// clear. Runs the real dist bundle through mountPreview/updateConfig.
+// clear. The AI intro follows the message size/line-height only when they are
+// explicitly configured, and reverts to 12.5px/1.45 when the overrides clear.
+// Runs the real dist bundle through mountPreview/updateConfig.
 test('bundled Geist opt-in loads without external font requests and typography overrides apply and clear', async ({ page }) => {
   const bundle = readFileSync(new URL('../../../klai-widget/dist/klai-chat.js', import.meta.url), 'utf8')
   const fontRequests: string[] = []
@@ -79,6 +81,7 @@ test('bundled Geist opt-in loads without external font requests and typography o
   const opted = { ...base, css_variables: {
     '--klai-font-family': '"Klai Widget Geist", system-ui, sans-serif',
     '--klai-input-font-size': '16.5px', '--klai-starter-font-size': '14.3px', '--klai-message-font-size': '15.4px',
+    '--klai-message-line-height': '1.75',
   } }
   const frameHtml = '<!doctype html><html><body style="margin:0"><div id="klai-preview-host" style="height:100vh"></div><script src="/klai-chat.js" data-widget-id="e2e-preview" data-mode="preview"></script></body></html>'
   await page.route('https://widget.e2e/**', (route) => {
@@ -101,12 +104,18 @@ test('bundled Geist opt-in loads without external font requests and typography o
   await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '12.5px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '14px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('-webkit-font-smoothing', 'auto')
+  // Unset message variables keep the intro on its own CSS defaults.
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('font-size', '12.5px')
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('line-height', '18.125px')
   await frame.evaluate((config) => (window as any).__preview.updateConfig(config), opted)
   await expect(chat.locator('.klai-textarea')).toHaveCSS('font-size', '16.5px')
   await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '14.3px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '15.4px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-family', /Klai Widget Geist/)
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('-webkit-font-smoothing', 'antialiased')
+  // Explicit message size/line-height drive the intro: 15.4px and 15.4×1.75.
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('font-size', '15.4px')
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('line-height', '26.95px')
   const face = await frame.evaluate(() => document.fonts.load('16px "Klai Widget Geist"')
     .then((faces) => ({ count: faces.length, loaded: faces.every((f) => f.status === 'loaded') })))
   expect(face.count).toBeGreaterThan(0)
@@ -116,5 +125,41 @@ test('bundled Geist opt-in loads without external font requests and typography o
   await expect(chat.locator('.klai-starter')).toHaveCSS('font-size', '12.5px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('font-size', '14px')
   await expect(chat.locator('.klai-hero-title')).toHaveCSS('-webkit-font-smoothing', 'auto')
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('font-size', '12.5px')
+  await expect(chat.locator('.klai-hero-ai-disclosure')).toHaveCSS('line-height', '18.125px')
   expect(fontRequests).toEqual([])
+})
+
+// Answer (markdown) and footer (disclaimer) links must show a visible hover
+// state and a keyboard-only focus ring: thicker underline on hover, 2px
+// outline on real Tab navigation (:focus-visible). Source CSS in an isolated
+// shadow root, real markup per class.
+test('answer and footer links emphasize on hover and outline on keyboard focus', async ({ page }) => {
+  await page.setContent('<div id="host"></div>')
+  await page.evaluate((styles) => {
+    const root = document.getElementById('host')!.attachShadow({ mode: 'open' })
+    const style = document.createElement('style')
+    style.textContent = styles
+    const box = document.createElement('div')
+    box.innerHTML =
+      '<div class="klai-markdown"><p><a href="https://example.com/a">answer link</a></p></div>' +
+      '<p class="klai-disclaimer"><a class="klai-disclaimer-link" href="https://example.com/f">footer link</a></p>'
+    root.append(style, box)
+  }, css)
+  const answer = page.locator('#host .klai-markdown a')
+  const footer = page.locator('#host .klai-disclaimer-link')
+  await answer.hover()
+  await expect(answer).toHaveCSS('text-decoration-thickness', '2px')
+  await expect(answer).toHaveCSS('text-underline-offset', '3px')
+  await footer.hover()
+  await expect(footer).toHaveCSS('text-decoration-thickness', '2px')
+  await expect(footer).toHaveCSS('text-underline-offset', '3px')
+  await page.keyboard.press('Tab')
+  await expect(answer).toHaveCSS('outline-width', '2px')
+  await expect(answer).toHaveCSS('outline-style', 'solid')
+  await expect(answer).toHaveCSS('outline-offset', '3px')
+  await page.keyboard.press('Tab')
+  await expect(footer).toHaveCSS('outline-width', '2px')
+  await expect(footer).toHaveCSS('outline-style', 'solid')
+  await expect(footer).toHaveCSS('outline-offset', '3px')
 })

--- a/klai-widget/src/main.ts
+++ b/klai-widget/src/main.ts
@@ -108,7 +108,17 @@ function previewPrimaryTextColor(primaryColor: string): string {
 
 // css_variables from config as custom properties overrides
 function cssVariableOverrides(config: WidgetConfig): string {
-  const overrides = Object.entries(config.css_variables)
+  const variables = { ...config.css_variables };
+  // The AI intro follows explicitly configured body typography. An unset
+  // message variable emits no derived declaration, so widgets without
+  // typography config keep the .klai-hero-ai-disclosure CSS defaults.
+  if (variables["--klai-message-font-size"]) {
+    variables["--klai-intro-font-size"] = variables["--klai-message-font-size"];
+  }
+  if (variables["--klai-message-line-height"]) {
+    variables["--klai-intro-line-height"] = variables["--klai-message-line-height"];
+  }
+  const overrides = Object.entries(variables)
     .map(([key, value]) => `${key}: ${value};`)
     .join(" ");
   // Exact opt-in to the bundled Geist face (config.css_variables is already
@@ -167,6 +177,13 @@ function previewAppearance(config: PreviewConfig): Map<string, string> {
   if (values.get("--klai-font-family") === '"Klai Widget Geist", system-ui, sans-serif') {
     values.set("-webkit-font-smoothing", "antialiased");
   }
+  // Same intro derivation as cssVariableOverrides, judged on the final
+  // tenant/widget merge; the applied-set cleanup clears the derived keys
+  // when the explicit message overrides go away.
+  const messageFontSize = values.get("--klai-message-font-size");
+  if (messageFontSize) values.set("--klai-intro-font-size", messageFontSize);
+  const messageLineHeight = values.get("--klai-message-line-height");
+  if (messageLineHeight) values.set("--klai-intro-line-height", messageLineHeight);
   return values;
 }
 

--- a/klai-widget/src/styles/widget.css
+++ b/klai-widget/src/styles/widget.css
@@ -774,6 +774,8 @@
 .klai-markdown strong { font-weight: 600; }
 .klai-markdown em { font-style: italic; }
 .klai-markdown a { color: var(--klai-link-color); text-decoration: underline; }
+.klai-markdown a:hover { text-decoration-thickness: 2px; text-underline-offset: 3px; }
+.klai-markdown a:focus-visible { outline: 2px solid currentColor; outline-offset: 3px; }
 .klai-markdown a.klai-citation {
   white-space: nowrap;
   font-weight: 600;
@@ -1263,10 +1265,12 @@
 }
 
 /* Optional tenant-editable introduction, in the same muted register as
-   the subtitle. An explicitly empty value renders no introduction. */
+   the subtitle. An explicitly empty value renders no introduction.
+   --klai-intro-* are only set inline when the tenant explicitly configured
+   the message typography; otherwise these defaults stand. */
 .klai-hero-ai-disclosure {
-  font-size: 12.5px;
-  line-height: 1.45;
+  font-size: var(--klai-intro-font-size, 12.5px);
+  line-height: var(--klai-intro-line-height, 1.45);
   color: var(--klai-text-muted);
   margin: 10px 0 0;
   max-width: 300px;
@@ -1532,3 +1536,5 @@
   text-decoration: underline;
   cursor: pointer;
 }
+.klai-disclaimer-link:hover { text-decoration-thickness: 2px; text-underline-offset: 3px; }
+.klai-disclaimer-link:focus-visible { outline: 2px solid currentColor; outline-offset: 3px; }


### PR DESCRIPTION
The widget introduction stayed at 12.5px even when administrators configured larger message text. It now follows explicitly configured message size and line height in the public, inline and preview renderer, while widgets without those overrides keep their existing defaults.

Answer and footer links retain their underline and gain a thicker hover underline plus a visible keyboard focus outline.

Validation: widget tests 30/30; TypeScript/Vite build; gzip size 96.6 kB under 200 kB; Playwright 4/4 with red-before-fix assertions; independent public/inline/default/selected browser matrix and preview tenant inheritance/reset checks. Independent delta review found no issues.
