### PR TITLE
fix(log-utils): widen the redaction set and match through JSON escaping

### DIFF
--- a/klai-libs/log-utils/README.md
+++ b/klai-libs/log-utils/README.md
@@ -158,13 +158,25 @@ Combines `extract_secret_values(settings_obj)` and
 `sanitize_response_body(...)`. The recommended call shape from each
 service's wrapper module.
 
+A body that parses as JSON is decoded before the secrets are matched,
+and re-serialised afterwards. JSON has more than one valid spelling of
+the same string — `/` may be `\/`, a newline `\n` or `\u000a`, and a
+nested payload may be encoded twice — so matching the literal value
+against the raw body misses a secret that arrived escaped. A body that
+is not JSON falls back to literal replacement.
+
 ### `extract_secret_values(settings_obj) -> set[str]`
 
 Walks a Pydantic-Settings instance (`model_fields`) or a plain
 attribute object, returning every non-empty string value whose field
-name matches the regex `(?i)(secret|password|token|pat|api_key)` and
-whose length is ≥ 8 characters. Shorter values are deliberately
+name matches the regex `(?i)(secret|password|token|pat|api_key|_key$)`
+and whose length is ≥ 8 characters. Shorter values are deliberately
 skipped to avoid over-redaction of common substrings.
+
+The `_key` suffix is anchored on purpose: it is how most credentials in
+this codebase are named (`litellm_master_key`, `encryption_key`,
+`github_app_private_key`), while `keyboard_layout` and
+`key_rotation_days` are not credentials and must not match.
 
 ### `verify_shared_secret(header_value, configured) -> bool`
 

--- a/klai-libs/log-utils/log_utils/sanitize.py
+++ b/klai-libs/log-utils/log_utils/sanitize.py
@@ -14,6 +14,7 @@ above that, the body is clipped before scanning.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Iterable
 from typing import Any
 
@@ -38,6 +39,60 @@ def _extract_body(exc_or_response: object) -> str:
     if not isinstance(text, str):
         return ""
     return text
+
+
+def _redact(body: str, secrets: list[str]) -> tuple[str, int]:
+    """Replace every secret in ``body``, whatever escaping it arrived in.
+
+    Upstream bodies are JSON, and JSON has more than one valid way to write
+    the same string: ``/`` may be ``\\/``, a newline may be ``\\n`` or
+    ``\\u000a``, and a nested payload may be encoded twice. Enumerating
+    those forms is a losing game -- one was missed the first time this was
+    fixed. So a body that parses as JSON is decoded first and the secrets
+    are matched against the DECODED strings, where no escaping exists at
+    all; decoding also unwraps a double-encoded payload into a plain string
+    that the same literal match then covers.
+
+    A body that is not JSON falls back to literal replacement, which is what
+    it always was.
+    """
+    try:
+        parsed = json.loads(body)
+    except (ValueError, RecursionError):
+        return _redact_literal(body, secrets)
+
+    count = 0
+
+    def walk(node: Any) -> Any:
+        nonlocal count
+        if isinstance(node, str):
+            cleaned, hits = _redact_literal(node, secrets)
+            count += hits
+            return cleaned
+        if isinstance(node, dict):
+            return {walk(key): walk(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    try:
+        redacted = json.dumps(walk(parsed))
+    except (TypeError, ValueError, RecursionError):
+        # Something in there does not round-trip; the literal pass is still
+        # better than returning the body untouched.
+        return _redact_literal(body, secrets)
+    return redacted, count
+
+
+def _redact_literal(text: str, secrets: list[str]) -> tuple[str, int]:
+    """Straight substring replacement, secrets already ordered longest first."""
+    count = 0
+    for secret in secrets:
+        occurrences = text.count(secret)
+        if occurrences:
+            text = text.replace(secret, _REDACTED)
+            count += occurrences
+    return text, count
 
 
 def sanitize_response_body(
@@ -74,15 +129,18 @@ def sanitize_response_body(
     redaction_count = 0
 
     if secret_values:
-        # Replace longer secrets first so a shorter secret that happens to
-        # be a substring of a longer one cannot corrupt the longer match.
-        for secret in sorted(_dedupe_strings(secret_values), key=len, reverse=True):
-            if not secret or len(secret) < _MIN_REDACTABLE_LEN:
-                continue
-            occurrences = body.count(secret)
-            if occurrences:
-                body = body.replace(secret, _REDACTED)
-                redaction_count += occurrences
+        # Longest first, so a shorter secret that happens to be a substring
+        # of a longer one cannot corrupt the longer match.
+        secrets = sorted(
+            (
+                value
+                for value in _dedupe_strings(secret_values)
+                if value and len(value) >= _MIN_REDACTABLE_LEN
+            ),
+            key=len,
+            reverse=True,
+        )
+        body, redaction_count = _redact(body, secrets)
 
     truncated = body[:max_len]
 

--- a/klai-libs/log-utils/log_utils/settings_scan.py
+++ b/klai-libs/log-utils/log_utils/settings_scan.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# Field-name regex per REQ-4.2: secret/password/token/pat/api_key.
-# Case-insensitive. ``pat`` matches both ``personal_access_token`` and
-# ``github_app_pat``-style names.
-_SECRET_NAME_RE = re.compile(r"(?i)(secret|password|token|pat|api_key)")
+# Field-name regex per REQ-4.2: secret/password/token/pat/api_key, plus any
+# name ending in ``_key``. Case-insensitive. ``pat`` matches both
+# ``personal_access_token`` and ``github_app_pat``-style names.
+#
+# The ``_key`` suffix is not decoration: across the services it is how most
+# credentials are named, and ``api_key`` alone does not match a single one of
+# them. The lower bound of eight characters still applies, so this widens the
+# set without turning short, generic values into redaction bait.
+_SECRET_NAME_RE = re.compile(r"(?i)(secret|password|token|pat|api_key|_key$)")
 _MIN_VALUE_LENGTH = 8  # shorter values are too generic to safely scrub
 
 

--- a/klai-libs/log-utils/tests/test_sanitize.py
+++ b/klai-libs/log-utils/tests/test_sanitize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import httpx
@@ -174,3 +175,95 @@ def test_sanitize_from_settings_uses_settings_secrets() -> None:
     out = sanitize_from_settings(settings, _make_response(body))
     assert "sneakysecret-42abc" not in out
     assert "api.example.com" in out
+
+
+def test_secret_is_redacted_in_its_json_escaped_form() -> None:
+    """Upstream bodies are JSON, and JSON escapes quotes and backslashes.
+
+    A literal-only match leaves such a value fully reconstructable in the
+    log: decode the JSON and the credential is back. That matters most for
+    the persisted path (``sync_run.error_details``), which keeps the body
+    rather than just printing it.
+    """
+    secret = 'abc"def\\ghi-0123456789'
+    escaped = json.dumps(secret)[1:-1]
+    assert escaped != secret, "pick a value JSON actually escapes"
+    body = SimpleNamespace(text=f'{{"detail":"rejected {escaped}"}}')
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert escaped not in cleaned
+    assert secret not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_multiline_key_is_redacted_in_its_escaped_form() -> None:
+    """A PEM private key is the worst case: quotes, backslashes and newlines."""
+    secret = "-----BEGIN KEY-----\nline-one\nline-two\n-----END KEY-----"
+    escaped = json.dumps(secret)[1:-1]
+    body = SimpleNamespace(text=f'{{"error":"upstream echoed {escaped}"}}')
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert "line-one" not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_literal_form_still_redacted_when_the_body_is_not_json() -> None:
+    """Plain-text bodies keep working exactly as before."""
+    secret = "plain-text-secret-value"
+    body = SimpleNamespace(text=f"upstream said {secret} is wrong")
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert secret not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_alternative_json_escapes_are_redacted() -> None:
+    """JSON has more than one valid spelling of the same string.
+
+    A producer may write ``/`` as ``\\/``, a newline as ``\\u000a`` and ``<``
+    as ``\\u003c``. Enumerating those forms is a losing game — one was missed
+    the first time this was fixed — so the body is decoded and the secret is
+    matched where no escaping exists.
+    """
+    secret = "abc/def-ghijklmnop"
+    body = SimpleNamespace(text='{"detail":"rejected abc\\/def-ghijklmnop"}')
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert secret not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_unicode_escaped_secret_is_redacted() -> None:
+    secret = "line-one\nline-two-abcdef"
+    body = SimpleNamespace(text='{"detail":"got line-one\\u000aline-two-abcdef"}')
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert "line-two-abcdef" not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_double_encoded_json_is_redacted() -> None:
+    """A nested payload encoded twice still decodes to a plain string."""
+    secret = "nested-secret-value-123"
+    inner = json.dumps({"cookies": [{"value": secret}]})
+    body = SimpleNamespace(text=json.dumps({"detail": inner}))
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert secret not in cleaned
+    assert "<redacted>" in cleaned
+
+
+def test_secret_in_a_json_key_is_redacted_too() -> None:
+    """Keys are strings as well; an upstream echo can put a value there."""
+    secret = "key-position-secret-123"
+    body = SimpleNamespace(text=json.dumps({secret: "whatever"}))
+
+    cleaned = sanitize_response_body(body, [secret])
+
+    assert secret not in cleaned

--- a/klai-libs/log-utils/tests/test_settings_scan.py
+++ b/klai-libs/log-utils/tests/test_settings_scan.py
@@ -70,3 +70,40 @@ def test_password_field_name_is_caught() -> None:
 def test_token_field_name_is_caught() -> None:
     settings = SimpleNamespace(slack_bot_token="xoxb-aaaaaaaaaaaaa")
     assert "xoxb-aaaaaaaaaaaaa" in extract_secret_values(settings)
+
+
+def test_key_suffixed_field_names_are_recognised() -> None:
+    """Most credentials in this codebase are named ``*_key``, not ``*_api_key``.
+
+    ``api_key`` matches none of litellm_master_key, meili_master_key,
+    encryption_key, github_app_private_key or bff_session_key, so before the
+    suffix was added those values were invisible to the scanner and survived
+    into anything that logged an upstream body.
+    """
+    settings = SimpleNamespace(
+        litellm_master_key="litellm-master-key-value",
+        meili_master_key="meili-master-key-value",
+        encryption_key="disk-encryption-key-value",
+        github_app_private_key="-----BEGIN KEY-----\nabc\n-----END KEY-----",
+        bff_session_key="bff-session-key-value",
+    )
+
+    found = extract_secret_values(settings)
+
+    assert found == set(vars(settings).values())
+
+
+def test_key_suffix_still_respects_the_length_floor() -> None:
+    """The suffix widens which names count, not which values are safe."""
+    settings = SimpleNamespace(short_key="abc", long_key="long-enough-to-scrub")
+
+    assert extract_secret_values(settings) == {"long-enough-to-scrub"}
+
+
+def test_key_in_the_middle_of_a_name_is_not_a_credential() -> None:
+    """Anchored on the suffix: ``keyboard_layout`` is not a secret."""
+    settings = SimpleNamespace(
+        keyboard_layout="azerty-layout-name", key_rotation_days="not-a-secret"
+    )
+
+    assert extract_secret_values(settings) == set()


### PR DESCRIPTION
Two improvements to the shared response-body scrubber, the helper every service uses before an upstream error text reaches a log line or `sync_run.error_details`.

**Field names.** The scanner matched `(secret|password|token|pat|api_key)`. Most credentials in this codebase are named with a `_key` suffix instead, so the set now matches that shape too. Anchored, so `keyboard_layout` and `key_rotation_days` stay out.

**Escaping.** Replacement matched the literal value against the raw body, but upstream bodies are JSON, and JSON has more than one valid spelling of the same string: `/` may be `\/`, a newline `\n` or `
`, and a nested payload may be encoded twice. Enumerating escape forms is a losing game, so a body that parses as JSON is decoded, matched against the decoded strings where no escaping exists, and re-serialised. Non-JSON bodies fall back to literal replacement, unchanged.

Shared helper, so all five suites that depend on it were run after the change: connector (485), portal-api (3998), knowledge-mcp (207), mailer (108), scribe (114). Own suite: 72 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)