### PR TITLE
fix(deploy): give firecrawl the memory 2.11.325 actually needs

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2249,7 +2249,18 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 1G
+          # 1G was enough for the pre-2.11 image and is not enough for this
+          # one: it runs the api, a queue worker, an extract worker, five
+          # nuq workers, a prefetch worker and a reconciler — 21 node
+          # processes — and every one of them got SIGKILLed (exit 137) in a
+          # startup loop on 2026-09-10, so /v2/scrape answered connection
+          # refused. Measured steady state after the raise is well under
+          # this ceiling; the headroom is for the startup peak.
+          #
+          # deploy/tests/firecrawl-contract.sh did not catch it: it runs the
+          # image without a memory limit, which is exactly the difference
+          # between a fresh isolated stack and this deployment.
+          memory: 3G
 
   # ─── Cal.com (self-hosted scheduling) ────────────────────────────────────
   # Deployed at https://cal.getklai.com


### PR DESCRIPTION
Follow-up to #1398, fixing an outage it caused.

firecrawl-api crash-looped on core-01 after the upgrade: `/v2/scrape` answered connection refused, and the logs showed exit 137 — SIGKILL, out of memory — on worker after worker against the 1G ceiling that had been fine for the previous image.

2.11.325 runs the api, a queue worker, an extract worker, five nuq workers, a prefetch worker and a reconciler: 21 node processes. It never reached "All services running".

Raised to 3G. The host has 40G available and steady state sits well under the new ceiling; the headroom is for the startup peak.

The part worth keeping: `deploy/tests/firecrawl-contract.sh` verified the API contract and passed, because it starts the image with no memory limit. A harness that runs the dependency in isolation proves the dependency, not the deployment — "answers correctly" and "answers correctly under our limits" are different claims, and this landed in the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)