### PR TITLE
fix(connector): read the sync-run id before the session that owns it closes

### DIFF
--- a/klai-connector/app/services/scheduler.py
+++ b/klai-connector/app/services/scheduler.py
@@ -145,8 +145,13 @@ class ConnectorScheduler:
             session.add(sync_run)
             await session.commit()
             await session.refresh(sync_run)
+            # Read the id here: leaving the block closes the session and
+            # expires the instance, so the same access one line down raises
+            # DetachedInstanceError -- which is what killed every scheduled
+            # sync on the first night this scheduler ran.
+            sync_run_id = sync_run.id
 
-        task = asyncio.create_task(self._sync_callback(connector_id, sync_run.id))
+        task = asyncio.create_task(self._sync_callback(connector_id, sync_run_id))
         self._sync_tasks.add(task)
         task.add_done_callback(self._sync_tasks.discard)
         logger.info("Scheduled sync triggered for connector %s (org %s)", connector_id, org_id)

--- a/klai-connector/tests/services/test_scheduler.py
+++ b/klai-connector/tests/services/test_scheduler.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 from apscheduler.triggers.cron import CronTrigger
+from sqlalchemy import inspect as sa_inspect
 
 import app.core.database as _db_module
 from app.core.enums import SyncStatus
@@ -68,15 +69,40 @@ def _make_session(existing_running_run: Any | None = None) -> tuple[MagicMock, u
     ``session.execute`` answers the RUNNING-run guard with
     ``existing_running_run``; ``session.refresh`` materialises the ORM
     default id the same way a real flush would.
+
+    Leaving the block expires what it loaded, like the real thing. Without
+    that, this mock answers ``sync_run.id`` forever and the test cannot see
+    the one thing that matters here: whether the caller read the id while
+    the session was still open. Every scheduled sync on 2026-09-11 died on
+    exactly that access, and this file was green throughout.
     """
     sync_run_id = uuid.uuid4()
+    added: list[Any] = []
     sess = MagicMock()
     sess.__aenter__ = AsyncMock(return_value=sess)
+
+    async def _rollback() -> None:
+        # tenant_scoped_session() always rolls back on exit
+        # (_reset_tenant_context), and a rollback expires the identity map.
+        # Reproduced with SQLAlchemy's own expiry so an access afterwards
+        # takes the real code path and raises DetachedInstanceError.
+        for obj in added:
+            state = sa_inspect(obj)
+            state._expire(state.dict, set())
+
     sess.__aexit__ = AsyncMock(return_value=False)
     result = MagicMock()
     result.scalars = MagicMock(return_value=MagicMock(first=lambda: existing_running_run))
     sess.execute = AsyncMock(return_value=result)
-    sess.add = MagicMock()
+
+    def _add(obj: Any) -> None:
+        added.append(obj)
+        # Snapshot now. After close the instance is expired, and reading it
+        # then is the very habit that let the bug through.
+        sess.added_rows.append({"connector_id": obj.connector_id, "org_id": obj.org_id, "status": obj.status})
+
+    sess.added_rows = []
+    sess.add = MagicMock(side_effect=_add)
     sess.commit = AsyncMock()
 
     def _refresh(obj: Any) -> None:
@@ -84,7 +110,7 @@ def _make_session(existing_running_run: Any | None = None) -> tuple[MagicMock, u
 
     sess.refresh = AsyncMock(side_effect=_refresh)
     sess.connection = AsyncMock()
-    sess.rollback = AsyncMock()
+    sess.rollback = AsyncMock(side_effect=_rollback)
     return sess, sync_run_id
 
 
@@ -130,9 +156,7 @@ class TestRefreshReconciliation:
         assert any("scheduled connectors" in record.getMessage() for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_refresh_skips_invalid_cron_and_schedules_the_rest(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_refresh_skips_invalid_cron_and_schedules_the_rest(self, caplog: pytest.LogCaptureFixture) -> None:
         bad = _scheduled(schedule="not a cron")
         good = _scheduled()
         with caplog.at_level(logging.ERROR):
@@ -157,17 +181,20 @@ class TestTriggerSync:
         await scheduler._trigger_sync(connector_id, "org-zitadel-1")
         await asyncio.sleep(0)  # let the create_task'd callback run
 
-        sync_run = sess.add.call_args.args[0]
-        assert sync_run.connector_id == connector_id
-        assert sync_run.org_id == "org-zitadel-1"
-        assert sync_run.status == SyncStatus.RUNNING
+        assert sess.added_rows == [
+            {
+                "connector_id": connector_id,
+                "org_id": "org-zitadel-1",
+                "status": SyncStatus.RUNNING,
+            }
+        ]
         sess.commit.assert_awaited_once()
+        # The id must have been read while the session was open. Passing it
+        # on is the whole point: the callback is what actually syncs.
         callback.assert_awaited_once_with(connector_id, sync_run_id)
 
     @pytest.mark.asyncio
-    async def test_trigger_sync_skips_when_run_already_running(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    async def test_trigger_sync_skips_when_run_already_running(self, caplog: pytest.LogCaptureFixture) -> None:
         scheduler = ConnectorScheduler()
         callback = AsyncMock()
         scheduler._sync_callback = callback


### PR DESCRIPTION
Every scheduled sync in the installation failed last night — the first night the portal-driven scheduler (#1360) ran. All seven Voys connectors fired on time at 02:00–03:00 UTC, wrote their `running` row, and died on the next line:

```
sqlalchemy.orm.exc.DetachedInstanceError: Instance <SyncRun at 0x…> is not
bound to a Session; attribute refresh operation cannot proceed
  File "app/services/scheduler.py", line 149, in _trigger_sync
    task = asyncio.create_task(self._sync_callback(connector_id, sync_run.id))
```

`sync_run.id` was read one line below the `async with tenant_scoped_session` block. Leaving that block runs `_reset_tenant_context`, which rolls back, and a rollback expires the identity map — so the access goes looking for a session that is no longer there. Reading the id inside the block is the whole fix.

## Evidence

| | |
|---|---|
| Runs started 02:00–03:00 UTC | 7 of 7 |
| Still `running` six hours later | 7 of 7, `documents_total = 0` |
| Errors in `klai-connector` logs | 7, all the same traceback at `scheduler.py:149` |
| Stuck `running` rows on any earlier day | 0 — this started with #1360 |

## Why no test caught it

The existing test mocked the session and never expired anything, so it answered `sync_run.id` forever and stayed green. It now expires on `rollback` the way the real session does, through SQLAlchemy's own machinery, and reproduces the production traceback exactly when the fix is removed. Its assertions moved to a snapshot taken at `add` time — reading a closed session's instance afterwards is the habit that hid this.

## Follow-up, not in this PR

The seven `running` rows are still there, and `_trigger_sync` skips a connector that already has a running sync, so tonight would have skipped all seven too. Clearing them is a separate production step. Nothing reaps a sync run that never finishes; that gap is worth its own ticket.

## Gates

- `ruff check` — green
- `ruff format --check` — green
- `pytest` — 499 passed, 1 skipped
- Regression test fails with the production traceback when the fix is reverted

Review: uitgevoerd · gates 3/3 groen · Sol 1 gemeld → 1 bevestigd → 1 gefixt (critical 0, high 0) · ronde 1 · mergeable