### PR TITLE
Run OIDC verification with managed server configuration

### DIFF
--- a/.github/workflows/zitadel-oidc-drift.yml
+++ b/.github/workflows/zitadel-oidc-drift.yml
@@ -17,8 +17,8 @@
 # This is not an escalation policy. Independently monitor failures and stale
 # checks through private monitoring; never publish the detailed report.
 #
-# Required secret: ZITADEL_ADMIN_PAT (IAM_OWNER PAT for klai-admin-sa).
-# Used read-only — the script only calls /apps/_search.
+# Uses existing SSH access; IAM credentials and configuration stay on the server.
+# The script uses the managed admin credential read-only for /apps/_search.
 
 name: zitadel-oidc-drift
 
@@ -41,16 +41,36 @@ jobs:
       - name: Run drift check
         id: drift
         env:
-          ZITADEL_ADMIN_PAT: ${{ secrets.ZITADEL_ADMIN_PAT }}
+          CORE01_HOST: ${{ secrets.CORE01_HOST }}
+          CORE01_DEPLOY_KEY: ${{ secrets.CORE01_DEPLOY_KEY }}
+          CORE01_KNOWN_HOSTS: ${{ secrets.CORE01_KNOWN_HOSTS }}
         run: |
+          eval "$(ssh-agent -s)" > /dev/null
+          trap 'ssh-agent -k >/dev/null' EXIT
+          ssh-add - <<< "$CORE01_DEPLOY_KEY" 2>/dev/null
+          mkdir -p ~/.ssh
+          printf '%s\n' "$CORE01_KNOWN_HOSTS" > ~/.ssh/known_hosts
           set -o pipefail
           set +e
-          python scripts/check_zitadel_oidc_drift.py \
-            > drift-report.json \
-            2> drift-stderr.txt
+          python3 - <<'PYTHON' > drift-report.json 2> drift-stderr.txt
+          import os, shlex, subprocess, sys
+          bootstrap = r"""
+          import os, sys
+          from pathlib import Path
+          values = dict(line.split("=", 1) for line in Path("/opt/klai/.env").read_text().splitlines() if "=" in line and not line.startswith("#"))
+          for target, source in [("ZITADEL_ADMIN_PAT", "ZITADEL_ADMIN_PAT"), ("ZITADEL_ORG_ID", "ZITADEL_PORTAL_ORG_ID"), ("ZITADEL_PROJECT_ID", "ZITADEL_PROJECT_ID")]:
+              os.environ[target] = values.get(source, "").strip().strip("\"'")
+          os.environ["GITHUB_OUTPUT"] = "/dev/stdout"
+          exec(compile(sys.stdin.read(), "drift-check", "exec"))
+          """
+          with open("scripts/check_zitadel_oidc_drift.py") as source:
+              result = subprocess.run(["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", "-o", "ConnectTimeout=15", "klai@" + os.environ["CORE01_HOST"], "python3 -c " + shlex.quote(bootstrap)], stdin=source)
+          sys.exit(result.returncode)
+          PYTHON
           status=$?
           set -e
           echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          sed -n '/^failure_reason=[a-z_]*$/p' drift-report.json >> "$GITHUB_OUTPUT"
           # Do not print live IAM drift details to this public repository's
           # Actions log. Operators can reproduce the report through the private
           # runbook path after the generic failure signal fires.
@@ -91,5 +111,5 @@ jobs:
       - name: Fail — unexpected exit code
         if: steps.drift.outputs.exit_code != '0' && steps.drift.outputs.exit_code != '1' && steps.drift.outputs.exit_code != '2'
         run: |
-          echo "::error::OIDC drift check exited with an unexpected code; treat as not-verified."
+          echo "::error::OIDC drift check could not complete: runner or SSH execution failed; treat as not-verified."
           exit 1

--- a/.github/workflows/zitadel-oidc-drift.yml
+++ b/.github/workflows/zitadel-oidc-drift.yml
@@ -12,10 +12,10 @@
 # Action on drift: fail loudly without publishing the live drift report. The
 # detailed report must be reproduced and handled through a private operator
 # channel; this repository and its Actions logs are public.
-# Human signal: GitHub sends private email/web notifications for a failed
-# scheduled workflow to the workflow creator. Keep Actions failure
-# notifications enabled for that account; the notification links to the
-# generic failure while the detailed report remains private.
+# Human signal: GitHub notifies the creator, latest cron editor, or user who
+# re-enabled the schedule, subject to that account's notification settings.
+# This is not an escalation policy. Independently monitor failures and stale
+# checks through private monitoring; never publish the detailed report.
 #
 # Required secret: ZITADEL_ADMIN_PAT (IAM_OWNER PAT for klai-admin-sa).
 # Used read-only — the script only calls /apps/_search.
@@ -67,8 +67,19 @@ jobs:
       # state, so naming the failure mode here leaks nothing.
       - name: Fail — the check could not run
         if: steps.drift.outputs.exit_code == '1'
+        env:
+          FAILURE_REASON: ${{ steps.drift.outputs.failure_reason }}
         run: |
-          echo "::error::OIDC drift check could NOT RUN (exit 1) — configuration error, most likely a missing or expired ZITADEL_ADMIN_PAT. This is not a drift finding: nothing was verified. Drift is UNKNOWN for as long as this persists."
+          # Only fixed messages may reach public logs, never stderr or API text.
+          case "$FAILURE_REASON" in
+            missing_configuration) reason="ZITADEL_ADMIN_PAT is missing or empty" ;;
+            authentication_rejected) reason="Zitadel rejected authentication or permission (HTTP 401/403)" ;;
+            api_error) reason="Zitadel returned an HTTP error" ;;
+            connection_error) reason="Zitadel could not be reached" ;;
+            invalid_response) reason="Zitadel returned an unreadable or malformed response" ;;
+            *) reason="Unexpected checker failure; investigate through the private operator path" ;;
+          esac
+          echo "::error::OIDC drift check could NOT RUN (exit 1): $reason. Nothing was verified; drift is UNKNOWN."
           exit 1
 
       - name: Fail — drift detected

--- a/.github/workflows/zitadel-oidc-drift.yml
+++ b/.github/workflows/zitadel-oidc-drift.yml
@@ -12,8 +12,8 @@
 # Action on drift: fail loudly without publishing the live drift report. The
 # detailed report must be reproduced and handled through a private operator
 # channel; this repository and its Actions logs are public.
-# Human signal: GitHub notifies the creator, latest cron editor, or user who
-# re-enabled the schedule, subject to that account's notification settings.
+# Human signal: GitHub sends private email/web notifications to the creator,
+# latest cron editor, or user who re-enabled it, subject to account settings.
 # This is not an escalation policy. Independently monitor failures and stale
 # checks through private monitoring; never publish the detailed report.
 #

--- a/scripts/check_zitadel_oidc_drift.py
+++ b/scripts/check_zitadel_oidc_drift.py
@@ -10,7 +10,7 @@ silently rejects every login through that app.
 This script flips the loop: it asks Zitadel for the live OIDC config
 and compares against the local expectation. Drift = exit code 2 plus
 a structured report. The accompanying workflow runs this nightly and
-opens a GitHub issue on drift.
+keeps live IAM details out of public logs.
 
 Inputs
 ------
@@ -52,6 +52,7 @@ import os
 import sys
 import urllib.parse
 import urllib.request
+from typing import NoReturn
 from urllib.error import HTTPError, URLError
 
 # Mirrors `_STATIC_SYSTEM_SUBDOMAINS` in klai-portal/backend/app/api/auth.py.
@@ -70,13 +71,21 @@ DEFAULT_EXPECTED_STATIC: frozenset[str] = frozenset({
 })
 
 
+def _fatal(reason: str, detail: str) -> NoReturn:
+    """Expose only a fixed category to Actions; keep diagnostics on stderr."""
+    if output := os.environ.get("GITHUB_OUTPUT"):
+        with open(output, "a", encoding="utf-8") as stream:
+            stream.write(f"failure_reason={reason}\n")
+    print(f"FATAL: {detail}", file=sys.stderr)
+    sys.exit(1)
+
+
 def _env(name: str, default: str | None = None) -> str:
-    """Read env var; raise on missing+no-default."""
+    """Read env var; reject missing or blank required values."""
     value = os.environ.get(name)
-    if value is None:
+    if value is None or (default is None and not value.strip()):
         if default is None:
-            print(f"FATAL: missing required env var {name}", file=sys.stderr)
-            sys.exit(1)
+            _fatal("missing_configuration", f"missing or empty required env var {name}")
         return default
     return value
 
@@ -102,12 +111,15 @@ def _fetch_oidc_apps(
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
-    except (HTTPError, URLError) as exc:
-        print(f"FATAL: Zitadel API call failed: {exc}", file=sys.stderr)
-        sys.exit(1)
-    except json.JSONDecodeError as exc:
-        print(f"FATAL: Zitadel response not JSON: {exc}", file=sys.stderr)
-        sys.exit(1)
+    except HTTPError as exc:
+        reason = "authentication_rejected" if exc.code in (401, 403) else "api_error"
+        _fatal(reason, f"Zitadel API call failed: {exc}")
+    except (URLError, TimeoutError) as exc:
+        _fatal("connection_error", f"Zitadel API call failed: {exc}")
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        _fatal("invalid_response", f"Zitadel response not JSON: {exc}")
+    if not isinstance(payload, dict) or not isinstance(payload.get("result", []), list):
+        _fatal("invalid_response", "Zitadel response has an unexpected structure")
     return payload.get("result", [])
 
 

--- a/scripts/test_check_zitadel_oidc_drift.py
+++ b/scripts/test_check_zitadel_oidc_drift.py
@@ -295,3 +295,16 @@ def test_main_preserves_verified_and_drift_outcomes(missing, expected_exit, monk
     monkeypatch.setattr(drift, "_fetch_oidc_apps", lambda *args: apps)
     assert drift.main() == expected_exit
     assert json.loads(capsys.readouterr().out)["ok"] is (not missing)
+
+
+def test_workflow_uses_server_credentials_and_managed_context(monkeypatch):
+    workflow = (_SCRIPTS_DIR.parent / ".github/workflows/zitadel-oidc-drift.yml").read_text()
+    bootstrap = textwrap.dedent(workflow.split('bootstrap = r"""\n')[1].split('"""')[0])
+    monkeypatch.setattr(os, "environ", {"ZITADEL_ADMIN_PAT": "wrong-runner-credential"})
+    monkeypatch.setattr(Path, "read_text", lambda p: 'ZITADEL_ADMIN_PAT="server-credential"\nZITADEL_PORTAL_ORG_ID=managed-org\nZITADEL_PROJECT_ID=managed-project')
+    monkeypatch.setattr(sys, "stdin", io.StringIO("pass"))
+    exec(bootstrap, {})
+    assert os.environ["ZITADEL_ADMIN_PAT"] == "server-credential"
+    assert os.environ["ZITADEL_ORG_ID"] == "managed-org"
+    assert os.environ["ZITADEL_PROJECT_ID"] == "managed-project"
+    assert os.environ["GITHUB_OUTPUT"] == "/dev/stdout"

--- a/scripts/test_check_zitadel_oidc_drift.py
+++ b/scripts/test_check_zitadel_oidc_drift.py
@@ -1,9 +1,8 @@
 """Unit tests for the OIDC drift-check script.
 
 The script in `scripts/check_zitadel_oidc_drift.py` runs against live
-Zitadel from the workflow; these tests cover the pure-logic helpers
-(_classify, _extract_first_labels) so we catch regressions in the
-classifier without needing Zitadel access.
+Zitadel from the workflow; these tests cover classification, failure
+handling and the public workflow diagnostics without needing Zitadel access.
 
 Run from repo root:
     python -m pytest scripts/test_check_zitadel_oidc_drift.py -v
@@ -11,14 +10,23 @@ Run from repo root:
 
 from __future__ import annotations
 
+import io
+import json
+import os
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
+
+import pytest
 
 # The script lives in scripts/ alongside this test; add to sys.path so
 # the regular import works without a packaging change.
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import check_zitadel_oidc_drift as drift  # noqa: E402
 
 from check_zitadel_oidc_drift import (  # noqa: E402
     DEFAULT_EXPECTED_STATIC,
@@ -204,3 +212,86 @@ class TestEndToEndScenarios:
             if _classify(label, DEFAULT_EXPECTED_STATIC) == "unknown"
         ]
         assert unclassified == ["staging-api"]
+
+
+@pytest.mark.parametrize("pat", [None, "", "   "])
+def test_unavailable_actions_secret_fails_before_http(pat, monkeypatch, tmp_path):
+    if pat is None:
+        monkeypatch.delenv("ZITADEL_ADMIN_PAT", raising=False)
+    else:
+        monkeypatch.setenv("ZITADEL_ADMIN_PAT", pat)
+    output = tmp_path / "output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    def unexpected_http(*args, **kwargs):
+        pytest.fail("Missing secret must fail before any HTTP request")
+    monkeypatch.setattr(drift.urllib.request, "urlopen", unexpected_http)
+    with pytest.raises(SystemExit) as error:
+        drift.main()
+    assert error.value.code == 1
+    assert output.read_text() == "failure_reason=missing_configuration\n"
+
+
+def _public_failure(reason):
+    workflow = (_SCRIPTS_DIR.parent / ".github/workflows/zitadel-oidc-drift.yml").read_text()
+    step = workflow.split("      - name: Fail — the check could not run\n")[1]
+    shell = step.split("        run: |\n")[1].split("\n      - name:")[0]
+    return subprocess.run(
+        ["bash", "-e", "-c", textwrap.dedent(shell)], capture_output=True, text=True,
+        env={**os.environ, "FAILURE_REASON": reason},
+    )
+
+
+@pytest.mark.parametrize("failure, public_message", [
+    (401, "rejected authentication or permission"),
+    (403, "rejected authentication or permission"),
+    (500, "returned an HTTP error"),
+    ("connection", "could not be reached"),
+    ("timeout", "could not be reached"),
+    (b"private-canary-not-json", "unreadable or malformed response"),
+    (b"[]", "unreadable or malformed response"),
+])
+def test_api_failure_exposes_only_safe_reason(failure, public_message, monkeypatch, tmp_path):
+    output = tmp_path / "output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    def response(*args, **kwargs):
+        if isinstance(failure, int):
+            raise drift.HTTPError("https://private-canary.invalid", failure,
+                                  "private-canary\n::error::injected", {}, None)
+        if failure == "connection":
+            raise drift.URLError("private-canary")
+        if failure == "timeout":
+            raise TimeoutError("private-canary")
+        return io.BytesIO(failure)
+    monkeypatch.setattr(drift.urllib.request, "urlopen", response)
+    with pytest.raises(SystemExit) as error:
+        drift._fetch_oidc_apps("https://example.invalid", "synthetic", "org", "project")
+    assert error.value.code == 1
+    reason = output.read_text().removeprefix("failure_reason=").strip()
+    public = _public_failure(reason)
+    assert public.returncode == 1
+    assert public_message in public.stdout
+    assert "private-canary" not in public.stdout + public.stderr + output.read_text()
+
+
+@pytest.mark.parametrize("reason, expected", [
+    ("missing_configuration", "ZITADEL_ADMIN_PAT is missing or empty"),
+    ("", "Unexpected checker failure"),
+    ("private-canary\n$(echo injected)", "Unexpected checker failure"),
+])
+def test_workflow_never_echoes_unknown_diagnostics(reason, expected):
+    public = _public_failure(reason)
+    assert public.returncode == 1
+    assert expected in public.stdout
+    assert "private-canary" not in public.stdout + public.stderr
+    assert "injected" not in public.stdout + public.stderr
+
+
+@pytest.mark.parametrize("missing, expected_exit", [(False, 0), (True, 2)])
+def test_main_preserves_verified_and_drift_outcomes(missing, expected_exit, monkeypatch, capsys):
+    monkeypatch.setenv("ZITADEL_ADMIN_PAT", "synthetic")
+    monkeypatch.setenv("EXPECTED_STATIC_SUBDOMAINS", "service")
+    monkeypatch.setenv("KLAI_DOMAIN", "example.invalid")
+    apps = [] if missing else [{"oidcConfig": {"redirectUris": ["https://service.example.invalid/cb"]}}]
+    monkeypatch.setattr(drift, "_fetch_oidc_apps", lambda *args: apps)
+    assert drift.main() == expected_exit
+    assert json.loads(capsys.readouterr().out)["ok"] is (not missing)


### PR DESCRIPTION
The OIDC checker now uses the existing SSH connection and server-managed credentials and configuration. Public logs show fixed failure categories while detailed reports remain suppressed; the meanings of exit codes 0, 1 and 2 are preserved.

Validation: 34 Python tests passed, YAML and shell syntax checks passed, and the SSH execution path was exercised. Operational findings are handled privately.