### PR TITLE
fix(portal): keep the crawler's "URL to test", instead of asking for it again

### DIFF
--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -100,6 +100,7 @@ class WebcrawlerConfig(BaseModel):
     - XOR: canary_url ↔ canary_fingerprint (both or neither)
     - canary_fingerprint must match ^[0-9a-f]{16}$
     - canary_url must start with base_url + (path_prefix if set)
+    - test_url must share base_url's origin (empty is normalised to unset)
     - login_indicator_selector: non-empty, no angle brackets, no 'script'
     """
 
@@ -121,6 +122,13 @@ class WebcrawlerConfig(BaseModel):
     # homepage/hub the crawler can't follow. Scoped within base_url like
     # canary_url so a fallback can never wander off-site.
     discovery_seed_url: str | None = None
+
+    # The auth-probe "URL to test": the page the operator validated their
+    # login cookies against, persisted so the wizard reopens with it instead
+    # of forcing a retype. Not the crawl scope — validated same-ORIGIN with
+    # base_url (see the validator), not within base_url + path_prefix like
+    # canary_url, because a login wall may sit outside the crawled subtree.
+    test_url: str | None = None
 
     @staticmethod
     def _ssrf_check(field: str, url: str | None) -> None:
@@ -159,11 +167,18 @@ class WebcrawlerConfig(BaseModel):
         malicious URL cannot trigger an internal fingerprint fetch.
         """
 
+        # An empty test_url is "no stored choice", never a deliberate value —
+        # normalise to None so the wizard keeps falling back to the derived
+        # base URL and "" can never be persisted as a choice.
+        if self.test_url is not None and not self.test_url.strip():
+            self.test_url = None
+
         # REQ-2.1 / REQ-2.2 / AC-7: SSRF-validate every URL the crawler fetches
         # — base_url, canary_url, and discovery_seed_url on the same footing.
         self._ssrf_check("base_url", self.base_url)
         self._ssrf_check("canary_url", self.canary_url)
         self._ssrf_check("discovery_seed_url", self.discovery_seed_url)
+        self._ssrf_check("test_url", self.test_url)
 
         url_set = self.canary_url is not None
         fp_set = self.canary_fingerprint is not None
@@ -180,6 +195,15 @@ class WebcrawlerConfig(BaseModel):
         # same-domain crawl, not an escape hatch to a different site.
         self._assert_within_scope("canary_url", self.canary_url)
         self._assert_within_scope("discovery_seed_url", self.discovery_seed_url)
+
+        # test_url must stay on base_url's ORIGIN — the same guard the wizard's
+        # "URL to test" field applies client-side (CrawlerAuthSetupStep):
+        # decrypted saved cookies are sent to this URL, so a stored value must
+        # never point at another site, even when it is replayed unseen. Origin
+        # (not path scope): the login wall may live outside base_url +
+        # path_prefix, which is the whole reason the field exists.
+        if self.test_url is not None and _origin(self.test_url) != _origin(self.base_url):
+            raise ValueError(f"test_url must share base_url's origin, got: {self.test_url!r}")
 
         # login_indicator_selector: non-empty, no angle brackets, no javascript: URI.
         # SPEC intent is to block HTML/JS injection in a CSS selector field. Angle
@@ -477,14 +501,30 @@ def _require_credential_store_for_sensitive_config(connector_type: str, config: 
         )
 
 
-def _origin(url: object) -> tuple[str, str] | None:
-    """``(scheme, netloc.lower())`` for a URL, or ``None`` if not a usable URL."""
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin(url: object) -> tuple[str, str, int | None] | None:
+    """WHATWG-style origin for a URL, or ``None`` if not a usable URL.
+
+    Canonicalised on purpose: the browser's ``URL.origin`` drops a scheme's
+    default port, so ``https://x.test:443`` and ``https://x.test`` are one
+    origin there. Comparing raw netloc made the two differ here, which turned
+    a value the wizard had already accepted into a 422 on save.
+    """
     if not isinstance(url, str) or not url:
         return None
     parts = urlsplit(url)
     if not parts.netloc:
         return None
-    return (parts.scheme, parts.netloc.lower())
+    scheme = parts.scheme.lower()
+    try:
+        port = parts.port
+    except ValueError:  # malformed port; keep it distinct rather than guessing
+        return (scheme, parts.netloc.lower(), None)
+    if port is not None and port == _DEFAULT_PORTS.get(scheme):
+        port = None
+    return (scheme, (parts.hostname or "").lower(), port)
 
 
 def _stale_credentials_cross_origin(*, connector: PortalConnector, new_config: dict, clear_credentials: bool) -> bool:

--- a/klai-portal/backend/tests/routers/test_connectors_canary.py
+++ b/klai-portal/backend/tests/routers/test_connectors_canary.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from klai_image_storage.url_guard import _reset_dns_cache
 from pydantic import ValidationError
 
-from app.api.connectors import WebcrawlerConfig
+from app.api.connectors import WebcrawlerConfig, _validate_connector_config
 
 
 @pytest.fixture(autouse=True)
@@ -299,3 +300,76 @@ class TestWebcrawlerConfigDiscoverySeed:
     def test_no_seed_is_fine(self) -> None:
         cfg = WebcrawlerConfig(base_url="https://wiki.example.com")
         assert cfg.discovery_seed_url is None
+
+
+class TestWebcrawlerConfigTestUrl:
+    """test_url: the persisted auth-probe "URL to test".
+
+    Checked through ``_validate_connector_config`` — the exact save-path
+    contract: it returns the dict stored in ``portal_connectors.config`` and
+    raises HTTPException(422) on rejection. The test URL is the destination
+    decrypted saved cookies travel to, so it must stay on base_url's ORIGIN
+    — deliberately NOT bound to the tighter base_url + path_prefix scope of
+    canary_url: the login wall may sit outside the crawled subtree.
+    """
+
+    def test_offprefix_same_origin_test_url_is_persisted(self) -> None:
+        stored = _validate_connector_config(
+            "web_crawler",
+            {
+                "base_url": "https://wiki.example.com",
+                "path_prefix": "/docs",
+                "test_url": "https://wiki.example.com/nl/inloggen",
+            },
+        )
+        assert stored["test_url"] == "https://wiki.example.com/nl/inloggen"
+
+    def test_cross_origin_test_url_rejected(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_connector_config(
+                "web_crawler",
+                {
+                    "base_url": "https://wiki.example.com",
+                    "test_url": "https://other.example.com/nl/inloggen",
+                },
+            )
+        assert exc_info.value.status_code == 422
+        assert "test_url" in str(exc_info.value.detail)
+
+    def test_empty_test_url_not_stored_as_choice(self) -> None:
+        """Empty means "no stored choice" — the wizard keeps falling back to
+        the derived base URL; a literal "" must not become a persisted value."""
+        stored = _validate_connector_config(
+            "web_crawler",
+            {"base_url": "https://wiki.example.com", "test_url": ""},
+        )
+        assert stored["test_url"] is None
+
+    def test_absent_test_url_defaults_to_none(self) -> None:
+        stored = _validate_connector_config("web_crawler", {"base_url": "https://wiki.example.com"})
+        assert stored["test_url"] is None
+
+    def test_explicit_default_port_is_the_same_origin(self) -> None:
+        """The wizard uses the browser's URL.origin, which drops a scheme's
+        default port. Comparing raw netloc here rejected a value the wizard
+        had just accepted, so the save 422'd on something the operator was
+        told was fine."""
+        stored = _validate_connector_config(
+            "web_crawler",
+            {
+                "base_url": "https://wiki.example.com",
+                "test_url": "https://wiki.example.com:443/nl/inloggen",
+            },
+        )
+        assert stored["test_url"] == "https://wiki.example.com:443/nl/inloggen"
+
+    def test_different_port_is_a_different_origin(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_connector_config(
+                "web_crawler",
+                {
+                    "base_url": "https://wiki.example.com",
+                    "test_url": "https://wiki.example.com:8443/nl/inloggen",
+                },
+            )
+        assert exc_info.value.status_code == 422

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.add-connector.tsx
@@ -39,7 +39,7 @@ import {
 } from './-connector-constants'
 import { PreviewClassificationFeedback } from './-connector-feedback'
 import { AiSelectorStep } from './-connector-shared/AiSelectorStep'
-import { CrawlerAuthSetupStep } from './-connector-shared/CrawlerAuthSetupStep'
+import { CrawlerAuthSetupStep, isSameOrigin } from './-connector-shared/CrawlerAuthSetupStep'
 import { CrawlerAuthStatus, type CrawlerAuthStatusState } from './-connector-shared/CrawlerAuthStatus'
 import {
   buildCrawlerCookies,
@@ -184,6 +184,14 @@ function AddConnectorPage() {
         }
         const cookies = buildCrawlerCookies(wcCookieRows, webcrawlerConfig.base_url)
         if (cookies) config.cookies = cookies
+        // Auth-probe test URL ("URL to test"), persisted so the login-wall
+        // page survives reopening the wizard. Kept only while it stays on
+        // the base URL's origin - it is the destination decrypted saved
+        // cookies travel to. Empty is never stored: the fallback stays the
+        // derived base URL.
+        if (wcTestUrl && isSameOrigin(wcTestUrl, webcrawlerConfig.base_url)) {
+          config.test_url = wcTestUrl
+        }
         // SPEC-CRAWL-004: include auto-detected auth guard values. Source is
         // ``authGuard`` state - initialized from auth-probe at step 4 → 5
         // bridge, refreshed by preview onSuccess, mutated by the operator-

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -20,7 +20,7 @@ import { GoogleDrivePicker } from './$kbSlug/_components/GoogleDrivePicker'
 import { MsDocsFolderPicker } from './$kbSlug/_components/MsDocsFolderPicker'
 import { PreviewClassificationFeedback } from './-connector-feedback'
 import { AiSelectorStep } from './-connector-shared/AiSelectorStep'
-import { CrawlerAuthSetupStep } from './-connector-shared/CrawlerAuthSetupStep'
+import { CrawlerAuthSetupStep, isSameOrigin } from './-connector-shared/CrawlerAuthSetupStep'
 import { CrawlerAuthStatus, type CrawlerAuthStatusState } from './-connector-shared/CrawlerAuthStatus'
 import {
   buildCrawlerCookies,
@@ -239,10 +239,15 @@ function EditConnectorPage() {
       const cfg = connector.config as {
         base_url?: string; path_prefix?: string; max_pages?: number; content_selector?: string
         cookies?: unknown[]; login_indicator_selector?: string; discovery_seed_url?: string
+        test_url?: string
       }
       // Remember any stored discovery seed so a re-save that doesn't re-run the
       // preview does not silently drop it.
       setSavedDiscoverySeedUrl(String(cfg.discovery_seed_url ?? ''))
+      // Restore the stored auth-probe test URL ("URL to test") so the
+      // operator's login-wall page survives reopening the wizard. Unset
+      // stays empty, which keeps falling back to the derived base URL.
+      setWcTestUrl(String(cfg.test_url ?? ''))
       setWebcrawlerConfig({
         base_url: String(cfg.base_url ?? ''),
         path_prefix: String(cfg.path_prefix ?? ''),
@@ -382,6 +387,12 @@ function EditConnectorPage() {
             : ''
         const discoverySeed = validatedSeed || carriedSeed
         if (discoverySeed) config.discovery_seed_url = discoverySeed
+        // Auth-probe test URL ("URL to test"), persisted so the login-wall
+        // page survives reopening the wizard. Kept only while it stays on
+        // the (possibly edited) base URL's origin - it is the destination
+        // decrypted saved cookies travel to. Empty is never stored: the
+        // fallback stays the derived base URL.
+        if (wcTestUrl && isSameOrigin(wcTestUrl, base)) config.test_url = wcTestUrl
         // SPEC-CRAWL-004: auth guard from ``authGuard`` state - initialized from
         // auth-probe at step 4 → 5 bridge, refreshed by preview onSuccess,
         // mutated by the operator-editable form on step 5.
@@ -687,7 +698,11 @@ function EditConnectorPage() {
                       value={webcrawlerConfig.path_prefix}
                       onChange={(e) => {
                         setWebcrawlerConfig((p) => ({ ...p, path_prefix: e.target.value }))
-                        setWcTestUrl('')
+                        // Deliberately NOT clearing wcTestUrl: a path change
+                        // leaves the origin alone, and the login wall often
+                        // sits outside the crawled subtree -- which is the
+                        // whole reason this field can differ from base_url +
+                        // path_prefix. Editing base_url does clear it, above.
                         invalidateAuthProbe()
                         invalidatePreview()
                       }}

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
@@ -30,7 +30,10 @@ type SavedSetupMode = {
 // it's the destination cookies (including decrypted saved ones) get sent
 // to. A cross-origin value would let anyone who can edit the connector
 // exfiltrate its stored session cookies to an arbitrary domain.
-function isSameOrigin(a: string, b: string): boolean {
+// Exported because the wizards apply the same guard before persisting the
+// value; the backend re-validates it (WebcrawlerConfig.test_url), since a
+// stored value is later replayed unseen.
+export function isSameOrigin(a: string, b: string): boolean {
   try {
     return new URL(a).origin === new URL(b).origin
   } catch {

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-connector-wizard.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-connector-wizard.test.tsx
@@ -535,4 +535,56 @@ describe('edit connector wizard characterization', () => {
     expect(screen.getByLabelText('Preview URL')).toBeTruthy()
     expect(screen.queryByText('Is this site behind a login?')).toBeNull()
   })
+
+  it('reopens the auth step with the stored test URL in the field', async () => {
+    connectorFixture = webCrawler({
+      has_saved_credentials: true,
+      config: {
+        base_url: 'https://docs.example.com',
+        path_prefix: '/guide',
+        max_pages: 350,
+        test_url: 'https://docs.example.com/nl/inloggen',
+      },
+    })
+    await renderWizard()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByLabelText<HTMLInputElement>('URL to test').value).toBe(
+      'https://docs.example.com/nl/inloggen',
+    )
+  })
+
+  it('keeps the stored test URL when only the path prefix changes', async () => {
+    // A path change leaves the origin alone, and the login wall often sits
+    // outside the crawled subtree -- which is why this field can differ from
+    // base_url + path_prefix at all. Clearing it here silently threw away the
+    // value the operator had just been given back.
+    connectorFixture = webCrawler({
+      has_saved_credentials: true,
+      config: {
+        base_url: 'https://docs.example.com',
+        path_prefix: '/guide',
+        max_pages: 350,
+        test_url: 'https://docs.example.com/nl/inloggen',
+      },
+    })
+    await renderWizard()
+
+    fireEvent.change(screen.getByLabelText('Path prefix (optional)'), {
+      target: { value: '/handboek' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+
+    expect(screen.getByLabelText<HTMLInputElement>('URL to test').value).toBe(
+      'https://docs.example.com/nl/inloggen',
+    )
+  })
+
+  it('falls back to the derived base URL when no test URL is stored', async () => {
+    await advanceSavedToAuthSetup()
+
+    expect(screen.getByLabelText<HTMLInputElement>('URL to test').value).toBe(
+      'https://docs.example.com/guide/',
+    )
+  })
 })


### PR DESCRIPTION
The auth step's "URL to test" lived in component state and nothing else. Whoever pointed it at the page where the login wall actually sits — the only reason the field exists, since that page is often outside the crawled subtree — lost it the moment the wizard closed, and had to find and retype it next time.

There was no `test_url` anywhere: not in the frontend, not in the backend model, and not in the stored config. Verified on the live RedCactus connector, whose config jsonb holds `base_url, max_depth, max_pages, canary_url, path_prefix, content_selector, canary_fingerprint, discovery_seed_url, login_indicator_selector` and nothing else.

## What it does now

It is stored, and validated on both sides against base_url's **origin** — deliberately not the tighter `base_url + path_prefix` scope `canary_url` uses, because the login wall may legitimately sit outside the crawl.

The server-side check is not decoration. This value is the destination decrypted session cookies are sent to, and a stored value is replayed later without anyone looking at it, so a browser-only guard would be a guard in name only.

An empty field stays empty rather than being persisted as a deliberate choice, so the existing fallback to the derived base URL keeps working.

## Two things review turned up

**Editing `path_prefix` cleared the field.** That would have handed the value back and then thrown it away on the next keystroke in an unrelated input. A path change does not move the origin, so it no longer clears — editing `base_url` still does, which is correct. Regression test proven red by temporarily restoring the old line.

**`_origin()` compared raw netloc** while the wizard compares `URL.origin`, which drops a scheme's default port. So `https://x.test:443` against base `https://x.test` passed client-side and 422'd on save — rejecting a value the operator had just been told was fine. It now canonicalises to (scheme, hostname, effective port).

`_origin` has two other callers, both in `connectors.py`: `_stale_credentials_cross_origin` and the credential-clearing comparison beneath it. Both compare base_url to base_url to decide whether stored credentials must be dropped when the origin changes. Canonicalising makes them agree with the browser too — adding or removing an explicit `:443` no longer counts as moving to another site. No callers outside that file.

## Gates

- frontend: `npm run lint`, `tsc --noEmit`, vitest 97 passed (7 files)
- backend: `ruff check`, pytest 4015 passed / 13 deselected / 1 xfailed

Authored by a Qwen build-m agent against a written brief; diff read, deduplicated and gated here. The agent had duplicated the same-origin helper into both wizards because my file bound kept it out of `CrawlerAuthSetupStep.tsx` — that was my bound, not its mistake, and `isSameOrigin` is now exported from its existing home instead of copied a third time.

Review: uitgevoerd · gates 5/5 groen · Sol 2 gemeld → 2 bevestigd → 2 gefixt (critical 0, high 0) · ronde 1 · mergeable