### PR TITLE
Use private deployment expectations in the OIDC drift workflow

### DIFF
--- a/.github/workflows/zitadel-oidc-drift.yml
+++ b/.github/workflows/zitadel-oidc-drift.yml
@@ -44,6 +44,7 @@ jobs:
           CORE01_HOST: ${{ secrets.CORE01_HOST }}
           CORE01_DEPLOY_KEY: ${{ secrets.CORE01_DEPLOY_KEY }}
           CORE01_KNOWN_HOSTS: ${{ secrets.CORE01_KNOWN_HOSTS }}
+          EXPECTED_STATIC_SUBDOMAINS: ${{ secrets.EXPECTED_STATIC_SUBDOMAINS }}
         run: |
           eval "$(ssh-agent -s)" > /dev/null
           trap 'ssh-agent -k >/dev/null' EXIT
@@ -53,10 +54,11 @@ jobs:
           set -o pipefail
           set +e
           python3 - <<'PYTHON' > drift-report.json 2> drift-stderr.txt
-          import os, shlex, subprocess, sys
+          import json, os, shlex, subprocess, sys
           bootstrap = r"""
-          import os, sys
+          import json, os, sys
           from pathlib import Path
+          os.environ["EXPECTED_STATIC_SUBDOMAINS"] = json.loads(sys.stdin.readline())
           values = dict(line.split("=", 1) for line in Path("/opt/klai/.env").read_text().splitlines() if "=" in line and not line.startswith("#"))
           for target, source in [("ZITADEL_ADMIN_PAT", "ZITADEL_ADMIN_PAT"), ("ZITADEL_ORG_ID", "ZITADEL_PORTAL_ORG_ID"), ("ZITADEL_PROJECT_ID", "ZITADEL_PROJECT_ID")]:
               os.environ[target] = values.get(source, "").strip().strip("\"'")
@@ -64,7 +66,9 @@ jobs:
           exec(compile(sys.stdin.read(), "drift-check", "exec"))
           """
           with open("scripts/check_zitadel_oidc_drift.py") as source:
-              result = subprocess.run(["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", "-o", "ConnectTimeout=15", "klai@" + os.environ["CORE01_HOST"], "python3 -c " + shlex.quote(bootstrap)], stdin=source)
+              # Keep private inventory off argv and out of public code and logs.
+              payload = json.dumps(os.environ.get("EXPECTED_STATIC_SUBDOMAINS", "")) + "\n" + source.read()
+              result = subprocess.run(["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", "-o", "ConnectTimeout=15", "klai@" + os.environ["CORE01_HOST"], "python3 -c " + shlex.quote(bootstrap)], input=payload, text=True)
           sys.exit(result.returncode)
           PYTHON
           status=$?

--- a/scripts/test_check_zitadel_oidc_drift.py
+++ b/scripts/test_check_zitadel_oidc_drift.py
@@ -302,9 +302,38 @@ def test_workflow_uses_server_credentials_and_managed_context(monkeypatch):
     bootstrap = textwrap.dedent(workflow.split('bootstrap = r"""\n')[1].split('"""')[0])
     monkeypatch.setattr(os, "environ", {"ZITADEL_ADMIN_PAT": "wrong-runner-credential"})
     monkeypatch.setattr(Path, "read_text", lambda p: 'ZITADEL_ADMIN_PAT="server-credential"\nZITADEL_PORTAL_ORG_ID=managed-org\nZITADEL_PROJECT_ID=managed-project')
-    monkeypatch.setattr(sys, "stdin", io.StringIO("pass"))
+    monkeypatch.setattr(sys, "stdin", io.StringIO('\"\"\npass'))
     exec(bootstrap, {})
     assert os.environ["ZITADEL_ADMIN_PAT"] == "server-credential"
     assert os.environ["ZITADEL_ORG_ID"] == "managed-org"
     assert os.environ["ZITADEL_PROJECT_ID"] == "managed-project"
     assert os.environ["GITHUB_OUTPUT"] == "/dev/stdout"
+
+
+@pytest.mark.parametrize("expected", ["service", "", "private-canary'; raise Exception('injected') #"])
+def test_workflow_delivers_private_expectations_to_remote_checker(expected, monkeypatch):
+    import shlex
+
+    workflow = (_SCRIPTS_DIR.parent / ".github/workflows/zitadel-oidc-drift.yml").read_text()
+    runner = textwrap.dedent(workflow.split("2> drift-stderr.txt\n")[1].split("          PYTHON\n")[0])
+    monkeypatch.setenv("EXPECTED_STATIC_SUBDOMAINS", expected)
+    monkeypatch.setenv("CORE01_HOST", "example.invalid")
+
+    def ssh_run(command, **kwargs):
+        if expected:
+            assert expected not in shlex.split(command[-1])[2]
+        # A fresh remote process does not inherit the runner's environment.
+        monkeypatch.setattr(os, "environ", {})
+        monkeypatch.setattr(Path, "read_text", lambda p: "ZITADEL_ADMIN_PAT=synthetic")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(
+            kwargs["input"].split("\n", 1)[0] + "\n"
+            + "assert os.environ.get('EXPECTED_STATIC_SUBDOMAINS') == " + repr(expected)
+        ))
+        exec(shlex.split(command[-1])[2], {})
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", ssh_run)
+    with pytest.raises(SystemExit) as result:
+        exec(runner, {})
+    assert result.value.code == 0
+    assert "EXPECTED_STATIC_SUBDOMAINS: ${{ secrets.EXPECTED_STATIC_SUBDOMAINS }}" in workflow


### PR DESCRIPTION
The remote drift check now receives its deployment expectation through encrypted repository configuration. Pass the value over SSH stdin so the inventory stays out of public source, logs and process arguments. The existing checker retains its classification and failure behavior.

Validation: 37 script/root tests, 128 repository rules tests and 15 hook tests pass; YAML and all four shell blocks validate. Actual remote execution passes. Independent review and a delta review completed; private transport regression fixed. A manual main workflow run will verify the merged change.
