### PR TITLE
feat(chat-quality): nightly LLM-as-judge for webchat + LibreChat pilot

### DIFF
--- a/docs/architecture/knowledge-ingest-flow.md
+++ b/docs/architecture/knowledge-ingest-flow.md
@@ -1137,8 +1137,11 @@ dropped — retrieval quality is unaffected.
 
 **Storage:** `portal_retrieval_gaps` table in PostgreSQL, with `org_id`, `query`,
 `gap_type`, `nearest_kb_slug` (populated when a soft gap has a closest matching KB),
-`scores`, and a `created_at` timestamp. Rows are retained for 90 days and then
-automatically purged.
+`scores`, and a `created_at` timestamp. Rows carrying raw (non-redacted) query
+text are purged after 7 days by the daily privacy sweep
+(`app/services/telemetry_purge.py`, SPEC-PRIVACY-QUERY-SHADOW-001); rows whose
+query text is already `[REDACTED:...]` are not time-purged and stay until the
+underlying gap is resolved.
 
 **The `/app/gaps` dashboard** (admin-only):
 

--- a/docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md
+++ b/docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md
@@ -1,0 +1,584 @@
+---
+id: SPEC-CHAT-QUALITY-LOOP-001
+version: "0.4.0"
+status: built (REQ-1 t/m REQ-5), not yet deployed — gates groen, diffs zelf
+  gelezen, post-deploy SQL nog niet tegen een echte database gedraaid. Webchat
+  volledig; LibreChat als Voys-only pilot achter een feature-vlag die nog
+  niemand heeft aangezet (§9.1's cross-tenant zorg is hiermee vermeden, niet
+  opgelost — een tweede tenant vraagt om dezelfde soort afweging opnieuw).
+created: 2026-09-11
+updated: 2026-09-11
+author: Claude (Sonnet 5), commissioned by Mark Vletter
+priority: high
+tenant_scope: platform-wide — both chat channels, every tenant
+related:
+  - SPEC-VOYS-HELPBOT-001 (REQ-1 gap events this SPEC reuses, REQ-5 outcome
+    heuristic this SPEC replaces/enriches — read that SPEC's §3 REQ-5 and §7
+    Open before touching widget_outcome.py)
+  - docs/research/help-page-chatbot-voys.md (§6.2 KPI research, §8 gap
+    analysis — G-6 "geen eval-harness voor path B" is the gap this SPEC
+    closes, G-2 and G-13 are referenced but out of scope here)
+  - klai-knowledge-ingest/knowledge_ingest/eval/ (judge_client.py, RAGAS
+    harness — sibling system: synthetic query suites, not live conversations;
+    this SPEC does not replace it)
+  - app/api/app_gaps.py, PortalRetrievalGap (existing knowledge-gap detection
+    — already spans both channels; this SPEC's output sits next to it, does
+    not rebuild it)
+---
+
+# HISTORY
+
+| Versie | Datum | Wijziging |
+|---|---|---|
+| 0.4.0 | 2026-09-11 | REQ-5 (LibreChat, Voys-only pilot) gebouwd en geverifieerd. Schema-uitbreiding en feature-vlag zelf gedaan (echte productie-RLS-tabel + eerste keer dat dit een klant's eigen interne chatdata raakt); Mongo-leeslogica en de aparte interne-gebruiker-rubric naar Qwen (klasse L, zelfde reden als REQ-2). Berichtenschema niet gegist maar opgehaald van de echte, gepinde LibreChat-broncode (v0.8.7) op GitHub. Twee eigen fouten gevonden en gefixt bij verificatie: een kopieerfout in de SPEC (overtollige `"""`) en de daarvan afgeleide pyright-fouten in Qwen's testbestand (mock-params zonder None-narrowing) — geen van beide een Qwen-fout, beide mijn eigen nasleep. Volledige backend-suite: 4036 passed, `uv run --with pyright pyright` (de echte CI-gate) 0 errors. |
+| 0.3.0 | 2026-09-11 | REQ-2, REQ-3, REQ-4 gebouwd en zelf geverifieerd (diff gelezen, gates herdraaid, niet op Qwen's rapport vertrouwd). REQ-2 moest herclassificeren naar klasse L — Qwen weigerde terecht een eerste M-poging (verbatim-promptregel + volledige widget_outcome-mirror past objectief niet in 200 regels); herissue met Mark's staande "GO" als expliciete L-autorisatie loste dit op. Volledige backend-suite: 4028 passed (was 4012 vóór deze sessie). |
+| 0.2.0 | 2026-09-11 | Mark gaf expliciet "GO" om het hele plan te implementeren. Scope vastgezet op webchat-only (LibreChat blijft §9.1's open spike — niet gebouwd). Retentie-besluit (§6, §9.2) en de kennisgat-zichtbaarheidsopmerking (§9.5) waren al verwerkt. REQ-1 t/m REQ-4 hieronder toegevoegd en REQ-1 gebouwd. |
+| 0.1.0 | 2026-09-11 | Eerste plan, alleen onderzoek + open vragen, niets gebouwd. |
+
+# 0. Wat mij hiertoe bracht
+
+Mark vroeg om een self-learning loop op de webchat (voorbeeld: gesprek #255,
+Voys-tenant), onderzoek naar hoe anderen dat bouwen, en een compleet plan
+voordat er iets gebouwd wordt. Twee kleinere, losstaande stukken zijn al apart
+belegd bij Qwen build-agents (zie § 10) omdat Mark daar expliciet groen licht
+voor gaf. Dit document is het "heel goede en complete plan" voor de rest: de
+nachtelijke kwaliteitsbeoordeling die gesprekken goed categoriseert én weet
+waarom, over alle chatkanalen, en de stap naar zwaardere Mistral-modellen
+die de huidige handmatige heuristiek vervangen. Niets in dit document is
+gebouwd. Het is een leesstuk.
+
+# 1. Waarom
+
+`widget_conversations.outcome` bestaat al (`resolved|escalated|abandoned|
+unknown`), maar wordt afgeleid door een pure heuristiek
+(`app/services/widget_outcome.py`) zonder enige onderbouwing — geen
+"waarom". De module zelf, en SPEC-VOYS-HELPBOT-001 REQ-5, zeggen het met
+zoveel woorden: het grote aandeel `unknown` *is* het argument voor een
+LLM-as-judge pass, niet iets om met een gok te vullen. Die pass bestaat nog
+niet. Het onderliggende gat staat al genoteerd in het Voys-onderzoek als
+**G-6, hoog prioriteit, nog open**: "Geen eval-harness voor path B (widget) —
+alle kwaliteitsmetingen gaan via pad A."
+
+Kennisgat-detectie (retrieval vond niets/te zwak) bestaat wél al, en dekt
+beide kanalen: `app_gaps.py` / `PortalRetrievalGap`, gevoed door zowel de
+LiteLLM-hook op het interne LibreChat-pad als — sinds REQ-1 — het
+widget-pad. Dit plan bouwt dat niet opnieuw; het output van deze nieuwe
+judge-pass komt naast de gap-rijen te staan op hetzelfde soort
+admin-oppervlak, niet in plaats ervan.
+
+Wat wél ontbreekt, op geen van beide kanalen: een oordeel over een heel
+gesprek (niet per losse retrieval-query) met een categorie én een
+onderbouwing die een latere Claude Code-sessie (of een mens) kan gebruiken
+om gericht door te vragen — "waarom scoorden gesprekken over onderwerp X
+deze week slecht?".
+
+# 2. Scope
+
+**In scope:** een nachtelijke LLM-as-judge pass over echte gesprekken op
+**beide** live chatoppervlakken:
+
+- **Webchat widget** — `widget_conversations`/`widget_messages` (Postgres),
+  anonieme bezoekers, geen kennis van het product.
+- **LibreChat** (`/app/chat`, "Klai AI") — `conversations`/`messages`
+  (MongoDB, één database per tenant), ingelogde interne Klai-portal-
+  gebruikers die weten hoe een kennissysteem werkt.
+
+Dit levert per gesprek een gestructureerde categorie + onderbouwing op,
+opgeslagen zodat een dashboard of een latere analyse-pass kan filteren op
+"waarom faalde dit". Bewust **twee aparte rubrics/prompts** (§5) — één
+pijplijn, want de populaties verschillen wezenlijk (naïeve anonieme bezoeker
+vs. kennissysteem-vaardige interne gebruiker), precies het onderscheid dat
+Mark zelf noemde.
+
+**Expliciet buiten scope** (benoemd, niet gebouwd):
+
+| Niet nu | Waarom |
+|---|---|
+| Model fine-tunen/RLHF op deze feedback | Zwaar, past niet bij een RAG-architectuur; zie §8 — de hefboom hier is kennis-curatie, niet gewichten-updates. Onderbouwd met actueel extern onderzoek, zie bronnenlijst onderaan. |
+| Automatisch prompts/retrieval bijsturen op basis van judge-output | Toekomstwerk; heeft pas zin als de judge een tijdje meetgeschiedenis heeft opgebouwd. |
+| Kennisgat-detectie opnieuw bouwen | Bestaat al (`app_gaps.py`). |
+| De losse, kleinere G-6-suggestie uit het Voys-onderzoek ("draai de 41 synthetische chat.yaml-queries ook wekelijks op pad B") | Goedkoop en orthogonaal, mag parallel — maar beantwoordt niet "waarom faalde DIT echte gesprek", dus lost het probleem van dit plan niet op. |
+| LibreChat's Mongo vervangen door Postgres als bron van waarheid | De judge-uitkomst leeft in Postgres en verwijst losjes naar het Mongo-gespreks-id, zoals `portal_feedback_events.conversation_id` dat vandaag al doet voor LibreChat-berichten. |
+| Cross-tenant Klai-admin gespreksbrowser | Dat is een apart, kleiner stuk (Fase 1), al bij Qwen belegd — zie §10. |
+
+# 3. Huidige staat (geverifieerd in de bron, 11 sep 2026)
+
+| Onderdeel | Bestand | Wat het doet | Beperking |
+|---|---|---|---|
+| Outcome-heuristiek | `app/services/widget_outcome.py` | Regel-gebaseerd: `escalated` (handoff-rij of letterlijke weigeringstekst), `abandoned` (laatste beurt is user + stil na quiet-period), `resolved` (alléén expliciete thumbs-up), rest `unknown`. 15-minuten achtergrondlus, alleen widget. | Geen vrije-tekst-analyse, geen reden, alleen widget-kanaal. Eigen docstring noemt dit expliciet als tussenstap richting een LLM-judge. |
+| Kennisgat-detectie | `app/api/app_gaps.py`, `PortalRetrievalGap` | Registreert per zwakke/mislukte retrieval-query een gap-rij, met taxonomie-classificatie. Voedt al een dashboard. Al actief op beide paden (LibreChat-hook + widget sinds REQ-1). Detectie zelf is een doorlopende lus, geen tijdelijke functie. | Per query, niet per gesprek; zegt niets over generatie-fouten (juist opgehaald, verkeerd antwoord). Een dagelijkse privacy-purge (`app/services/telemetry_purge.py`, SPEC-PRIVACY-QUERY-SHADOW-001) verwijdert na 7 dagen ALLEEN de rijen waarvan `query_text` nog ruwe/legacy tekst bevat; rijen met een `[REDACTED:...]`-sentinel blijven staan tot het gat is opgelost. Niet "gap-detectie werkt 7 dagen" — de ruwe queryvraag verdwijnt na 7 dagen bij tenants zonder volledige telemetry-toestemming, het gat zelf niet per se. |
+| Bestaand judge-precedent | `klai-knowledge-ingest/knowledge_ingest/eval/judge_client.py` | RAGAS-gebaseerd, draait op synthetische query/chunk/antwoord-sets uit `eval/suites/*.yaml`, niet op live gesprekken. Faithfulness draait bewust op `klai-medium` omdat `klai-fast` (Small) meerdere-uitspraken-JSON afkapt. | Ander doel (regressie-detectie op vaste suites), geen categorisatie-met-reden op een heel gesprek. |
+| Feedback op berichtniveau | `widget_messages.rating` (thumbsUp/thumbsDown) | Bestaat al, wordt in Fase 0 (§10) pas zichtbaar in de admin-UI. | Geen reden-veld, alleen widget. |
+| Modeltiers (LiteLLM) | `deploy/litellm/config.yaml` | `klai-fast`/`klai-primary` = Mistral Small 2603, `klai-medium` = Mistral Medium 3.5, `klai-large` = Mistral Large 2512. Naamgevingsregel: tier-benoemd, nooit rol-benoemd (geen `klai-eval-judge`-alias toevoegen). | — |
+
+# 4. Welke data nodig is (de kernvraag van Mark)
+
+**Judge-input per gesprek** — wat de judge te lezen krijgt, zodat hij niet
+zelf uit platte tekst hoeft te raden wat al ergens anders vaststaat:
+
+- Volledige transcript, chronologisch (user+assistant-beurten). Voor widget
+  bestaat dit al; voor LibreChat is een Mongo→judge-input-adapter nodig
+  (zie open vraag §9.1).
+- Bestaande signalen als context, niet als iets om te herleiden: rating per
+  assistant-beurt, of er al gap-events vuurden voor dit gesprek (join op
+  `app_gaps`), of er een handoff/escalatie plaatsvond, welke bronnen
+  (`sources`) elk antwoord citeerde — of het ontbreken daarvan. Een
+  citation-firewall-weigering (SPEC-VOYS-HELPBOT-001 §7 Open: antwoorden
+  zonder bron worden vervangen door een vaste weigeringstekst) is een sterk,
+  al bestaand signaal en hoort als input, niet als iets wat de judge zelf
+  uit de tekst moet afleiden.
+- Kanaal-discriminator (webchat / librechat) — bepaalt welke rubric/prompt
+  draait (§5).
+
+**Judge-output** — gestructureerd, geen vrije tekst, ontworpen op het
+patroon uit actueel onderzoek naar LLM-as-judge-schema's (categorie waarvan
+er precies één past, onderbouwing met een citaat uit het gesprek, een
+confidence-band, en het onderscheid retrieval-fout vs. generatie-fout uit de
+gangbare root-cause-taxonomie):
+
+| Veld | Waarden | Doel |
+|---|---|---|
+| `outcome` | `resolved` \| `partially_resolved` \| `unresolved` \| `escalated` \| `out_of_scope` \| `abandoned_early` | Superset van de huidige 4 heuristiek-waarden, blijft uitputtend. Een 5e+ waarde op de bestaande `widget_conversations.outcome`-kolom vraagt een migratie op de CHECK-constraint — zie §6, vandaar een aparte tabel. |
+| `failure_category` (alleen bij niet-resolved) | `retrieval_miss` \| `retrieval_wrong` \| `generation_error` \| `policy_refusal` \| `scope_mismatch` \| `user_confusion` \| `none` | Onderscheidt "niets gevonden" van "verkeerd gevonden" van "goed gevonden, fout antwoord" — precies het onderscheid dat de huidige heuristiek en de gap-events niet maken. |
+| `reasoning` | 1-3 zinnen, verplicht een citaat/verwijzing naar een specifieke beurt | Voorkomt vage "klinkt slecht"-oordelen; dit is het veld waarmee Claude Code straks kan doorvragen. |
+| `confidence` | `high` \| `medium` \| `low` | `low`/`medium` gaat in een steekproef (5-10%) naar menselijke review — vertrouw een judge nooit blind, dat is de expliciete aanbeveling uit het onderzoek. |
+| `suggested_action` | vrije tekst, optioneel | Bv. "KB-gat: facturatie-artikel ontbreekt" — het veld dat een rij direct bruikbaar maakt voor een editorial-vervolgstap, kruislinks met de bestaande gap-taxonomie waar van toepassing. |
+
+# 5. Twee rubrics, één pijplijn
+
+| | Webchat | LibreChat |
+|---|---|---|
+| Publiek | Anoniem, geen productkennis | Ingelogd, kent het kennissysteem |
+| "Resolved" betekent | Vraag beantwoord zonder mensinterventie, expliciete of impliciete tevredenheid | Vraag beantwoord tot bruikbaarheidsniveau van een collega die de tool al kent |
+| Citation firewall | Actief (pad B) — een weigering zonder bron is een hard signaal | Niet op dezelfde manier actief (pad A) — ander beoordelingskader nodig |
+| Escalatiepad | Handoff/booking (SPEC-VOYS-HELPBOT-001 §4) | Geen — interne gebruiker zoekt zelf verder of stelt een vervolgvraag |
+
+Eén pijplijn (zelfde jobvorm, zelfde opslag, zelfde modeltier), twee
+promptvarianten geselecteerd op kanaal — zoals `partner_chat.py` nu al
+meerdere systeemprompt-profielen kiest op basis van widget-instellingen.
+
+# 6. Pijplijn-ontwerp
+
+- **Vorm:** volg het patroon van de bestaande `widget_outcome_loop()`
+  (FastAPI-lifespan achtergrondlus, batches, per-tenant
+  `tenant_scoped_session`) voor het widget-deel. Voor LibreChat is dit een
+  nieuwe stap, want die data staat niet in Postgres — vermoedelijk beter als
+  een aparte nachtelijke job in de stijl van de bestaande
+  `klai-knowledge-ingest`-cron dan als een in-process FastAPI-lus, omdat dat
+  al de plek is waar dit soort niet-realtime batchwerk draait. **Nog niet
+  bevestigd — zie open vraag §9.1.**
+- **Model:** bestaande `klai-medium`-tier (Mistral Medium 3.5) — geen nieuwe
+  alias, want de naamgevingsregel in dit repo staat rol-benoemde aliases
+  ("geen `klai-eval-judge`") expliciet niet toe. Dezelfde tier waar RAGAS'
+  faithfulness-metric al naartoe verhuisde omdat `klai-fast` (Small)
+  meerdere-uitspraken-JSON afkapt — zelfde risico geldt hier, dus zelfde
+  keuze. `klai-large` (Mistral Large 2512) is de volgende stap omhoog als
+  een kleine benchmark (§7) laat zien dat medium categorieën mist die een
+  menselijke reviewer wel ziet.
+- **Opslag:** nieuwe tabel, bv. `conversation_quality_judgments`
+  (`channel`, `external_conversation_id`, `org_id`, `outcome`,
+  `failure_category`, `reasoning`, `confidence`, `suggested_action`,
+  `model_used`, `judged_at`) — een aparte tabel, niet de bestaande
+  4-waarden-CHECK-kolom op `widget_conversations.outcome`, zodat de
+  goedkope realtime heuristiek (§7) gewoon blijft werken als directe
+  fallback en dit een verrijkende nachtelijke laag erbovenop is.
+- **Retentie — Mark's keuze (11 sep 2026):** gesprekken zelf maximaal 7 dagen
+  bewaren, de metadata over gespreksuccess (het judge-oordeel) langer, maar
+  geanonimiseerd. Twee gevolgen, uitgewerkt:
+  1. **Ruwe gesprekken korter bewaren is een bestaande, losse knop, geen
+     nieuwe bouw.** `widget_messages`/`widget_conversations` hebben al een
+     actieve purge-lus (`app/services/widget_messages_retention.py`,
+     SPEC-SEC-CROSS-TENANT-FOLLOWUP-001 REQ-8), gestuurd door
+     `settings.widget_messages_retention_days` (huidige default: **90**,
+     env `PORTAL_API_WIDGET_MESSAGES_RETENTION_DAYS`). Naar 7 dagen zou een
+     config-wijziging zijn, geen nieuwe code. **Dit is een aparte,
+     productiedata-verwijderende beslissing die niet stilzwijgend in dit
+     SPEC hoort** — het verkort nu al hoeveel geschiedenis Fase 1's
+     cross-tenant gespreksbrowser (§10) kan tonen, en het Voys-onderzoek
+     ging uit van wekelijkse handmatige review van transcripts, wat bij 7
+     dagen krapper wordt. Aparte go/no-go vraag, zie §9.2.
+  2. **De nieuwe `conversation_quality_judgments`-tabel moet dan
+     TWEE trapsgewijze vormen hebben, niet één rij die voor altijd
+     hetzelfde blijft:**
+     - **Kort (≤7 dagen, gekoppeld aan het nog levende gesprek):** het volle
+       schema uit §4, inclusief `reasoning` met een citaat uit het gesprek —
+       dit is de vorm die Claude Code direct kan gebruiken om door te
+       vragen.
+     - **Lang (na het verlopen van de gesprek-retentie, geanonimiseerd):**
+       zodra het onderliggende gesprek gepurged is, moet `reasoning` niet
+       langer een citaat bevatten — een citaat uit een verwijderd gesprek is
+       zelf weer identificeerbare inhoud. Wat overblijft: `outcome`,
+       `failure_category`, `confidence`, een gegeneraliseerde (niet-
+       citerende) samenvatting, `org_id`, `channel`, `judged_at`. Dit is het
+       niveau waarop een trenddashboard ("categorie X neemt toe") nog werkt
+       zonder een individueel gesprek te kunnen reconstrueren.
+     Een derde optie — de detailrij gewoon nooit verwijderen maar op t=7d
+     automatisch de citaten uit `reasoning` strippen (in plaats van twee
+     aparte rijen) — is technisch eenvoudiger en waarschijnlijk de betere
+     keuze; genoemd als ontwerprichting, niet als besluit.
+
+# 7. Fase 3-visie: zwaardere Mistral-modellen vervangen de handmatige stap
+
+Mark's vraag: kunnen we dit uiteindelijk op zwaardere Mistral-modellen bouwen
+en daarmee "onze handmatige code stap" vervangen? Concreet is die
+handmatige stap `widget_outcome.py` — de heuristiek noemt zichzelf expliciet
+als kandidaat voor vervanging.
+
+**Actuele Mistral-lijn (gecheckt via webonderzoek, sep 2026, niet uit
+trainingsdata):** Mistral Large 3 (vlaggenschip voor redeneren/agentwerk,
+open-weight MoE, uitgebracht 2 dec 2025, ≈$0,50/$1,50 per miljoen in/uit-
+tokens) en Mistral Medium 3.5 (frontier-class, sterk in agent- en codewerk,
+≈$1,50/$7,50/M). Klai draait beide al in productie als `klai-large`
+(mistral-large-2512) en `klai-medium` (mistral-medium-3.5). "Zwaardere
+Mistral-modellen" is dus geen nieuwe integratie — het is deze judge-calls
+routeren naar een tier die al bestaat.
+
+**Vervangingspad voor `widget_outcome.py`:** de goedkope heuristiek blijft
+bestaan als instant/realtime label (het dashboard heeft een
+zelfde-dag-cijfer nodig, en niet elk gesprek hoeft op een LLM te wachten);
+de nachtelijke judge-pass overschrijft/verrijkt die met het echte oordeel
+zodra beschikbaar — exact het patroon dat `klai-knowledge-ingest` al
+gebruikt voor RAGAS' asynchrone naderhand-scoring.
+
+# 8. Wat "self-learning loop" hier concreet betekent
+
+Judge-uitkomst → aggregatie op een dashboard naast `app_gaps` → KB-auteur of
+een Claude Code-sessie repareert de content → het volgende soortgelijke
+gesprek scoort beter → lus gesloten. Expliciet **geen** model-finetuning
+(§2): actueel extern onderzoek (Anthropic/arXiv-bronnen, Braintrust/Langfuse-
+platformvergelijkingen, zie eerdere onderzoeksronde in deze sessie) bevestigt
+dat producten met deze RAG-vorm meer waarde halen uit een kennis-curatie-
+flywheel dan uit gewichten-updates — en dat matcht wat dit repo al doet:
+`app_gaps.py` bestaat, een trainingspijplijn niet.
+
+# 9. Open vragen voor Mark (vóór goedkeuring / vóór een klai:auto-run)
+
+1. **LibreChat-toegang.** LibreChat's data staat in MongoDB, één database per
+   tenant. Vandaag leest alleen `librechat_chat_context.py` daar iets uit, en
+   dat is in-process, per ingelogde gebruiker, portal-geauthenticeerd. Een
+   nachtelijke BATCH cross-tenant Mongo-read is een nieuw toegangspatroon dat
+   nog niet bewezen veilig/afgeschermd is. Dit verdient een kleine spike
+   vóórdat de LibreChat-helft van dit plan scope krijgt — voorstel: eerst
+   alleen het webchat-deel bouwen, LibreChat als expliciete fase 2b na die
+   spike.
+2. **Retentie — deels beantwoord, één vraag terug.** Je koos: gesprekken max
+   7 dagen, judge-metadata langer maar geanonimiseerd (uitgewerkt in §6).
+   Nog open: mag `widget_messages_retention_days` (nu 90) daadwerkelijk naar
+   7? Dat is een productiedata-verwijderende config-wijziging op een
+   bestaand systeem, los van dit SPEC — bevestig je dat expliciet, en zo ja,
+   geldt 7 dagen voor alle tenants direct, of eerst een pilot-tenant?
+3. **Modeltier om mee te starten:** advies `klai-medium`, met een kleine
+   benchmark tegen `klai-large` voordat we `klai-medium` als definitief
+   aanmerken.
+4. **Dit wordt een eigen SPEC** (`SPEC-CHAT-QUALITY-LOOP-001`) in plaats van
+   een uitbreiding van `SPEC-VOYS-HELPBOT-001`, omdat de scope nu
+   platform-breed + LibreChat is, niet Voys-pilot-specifiek. Akkoord?
+5. **Mark's observatie (11 sep 2026):** de bestaande kennisgat-detectie
+   (§3, `app_gaps.py`) zit vandaag niet goed genoeg in de workflow — hij
+   ervaart het dashboard als verstopt in de UI. Genoteerd, expliciet niet
+   nu oppakken ("wellicht voor later", zijn woorden) — geen scope-wijziging
+   op dit SPEC. Wel relevant voor de volgorde: een judge-verdict dat naast
+   een al-onzichtbaar gap-dashboard komt te staan lost het onderliggende
+   "niemand kijkt ernaar"-probleem niet op. Als losse opvolgvraag, niet in
+   dit plan: verdient het gap-dashboard eerst een zichtbaarheids-fix
+   (bijvoorbeeld een plek in het platform-adminmenu, zie Fase 1 in §10)
+   vóórdat dit SPEC een tweede, vergelijkbaar dashboard toevoegt?
+
+Zodra je hierop antwoord geeft, schrijf ik de requirements (REQ-1, REQ-2, …)
+met acceptatiecriteria uit en gaat dit pas dan naar een build-brief — precies
+zoals SPEC-VOYS-HELPBOT-001 dat deed.
+
+# 10. Wat al loopt (apart belegd, klein genoeg om niet op dit plan te wachten)
+
+- **Fase 0** (klasse S): bestaande `widget_messages.rating` zichtbaar maken
+  in de tenant-admin activity-drawer. Bij Qwen `build-s`, brief in
+  `.context/briefs/fase0-widget-rating.txt`.
+- **Fase 1** (klasse M): Klai-admin cross-tenant gespreksbrowser, als nieuwe
+  tab op de bestaande `/admin/platform/orgs/$orgId`-detailpagina (hergebruikt
+  het cross-tenant `require_platform_admin()`/`cross_org_session()`-patroon
+  uit `app/api/admin/platform.py`). Bij Qwen `build-m`, brief in
+  `.context/briefs/fase1-platform-conversations.txt`.
+
+Beide zijn losstaand van dit plan en hoeven niet op goedkeuring hiervan te
+wachten — ze maken bestaande data zichtbaar, ze bouwen geen nieuw
+oordeel-systeem.
+
+# 11. Requirements (webchat-only, na Mark's GO van 11 sep 2026)
+
+Status legend: **done** = gebouwd, gates gedraaid, diff zelf gelezen;
+**wip** = in uitvoering (Qwen build-agent bezig); **open** = nog niet gestart.
+
+## REQ-1 — Tabel + model voor het judge-verdict · done
+
+`conversation_quality_judgments`, Cat-D RLS, FK naar `widget_conversations`
+(webchat-only scope, geen losse `channel`-tabel nodig zolang er maar één
+kanaal is). Eén rij per gesprek (UNIQUE op `conversation_id`), met
+`reasoning` als het veld dat door de anonimiseringssweep (REQ-4) wordt
+geleegd zodra het onderliggende gesprek is gepurged.
+
+- `alembic/versions/b7e4f1a9c3d2_conversation_quality_judgments.py` (no-op
+  marker, zelfde reden als bij `widget_conversations`: portal_api heeft geen
+  REFERENCES-recht op een klai-owned tabel).
+- `alembic/versions/post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql`
+  (echte DDL, Cat-D policy, mirror van
+  `post_deploy_a4f72e913c8b_widget_conversations_rls.sql`).
+- `app/models/conversation_quality.py` (SQLAlchemy-model).
+- `app/core/rls_guard.py` — tabel toegevoegd aan `RLS_DML_TABLES`.
+- `app/core/config.py` — nieuwe instelling `conversation_judge_model =
+  "klai-medium"` (tier-benoemd, geen rol-alias, zelfde reden als RAGAS
+  faithfulness al op klai-medium draait).
+
+Gate: `uv run pytest tests/test_rls_hygiene.py -q` → 23 passed. Model-import
+handmatig geverifieerd (`ConversationQualityJudgment.__table__.columns.keys()`
+komt exact overeen met de SQL-kolommen).
+
+**Nog niet gedraaid: de post-deploy SQL zelf tegen een echte database.** Dat
+gebeurt pas bij deploy (`scripts/apply_post_deploy_sql.sh` of handmatig als
+klai-superuser), net als bij elke eerdere klai-owned-tabel-migratie in dit
+repo — dat hoort niet in een worktree-sessie te draaien.
+
+## REQ-2 — Judge-service + nachtelijke lus · done
+
+Nieuw bestand `app/services/conversation_judge.py`, structuur mirrort
+`app/services/widget_outcome.py` (per-org batch, cross-org discovery,
+FastAPI-lifespan-lus) en de LiteLLM-aanroep mirrort exact
+`app/klai_feedback/triage.py::_call_triage_llm` (httpx naar
+`{settings.litellm_base_url}/v1/chat/completions`, `Authorization: Bearer
+{settings.litellm_master_key}`, `get_trace_headers()`).
+
+**Selectie:** gesprekken met een NIET-NULL `widget_conversations.outcome`
+(de heuristiek heeft het gesprek al als "afgerond" gelabeld — hergebruikt
+`widget_outcome.py`'s quiet-period-logica in plaats van die te dupliceren)
+EN nog geen rij in `conversation_quality_judgments` (LEFT JOIN … WHERE
+cqj.id IS NULL). `is_preview`-gesprekken worden overgeslagen, zelfde
+uitzondering als `widget_outcome.py` en de gap-events.
+
+**Judge-prompt (exact, niet vrij te ontwerpen door de bouwer):**
+
+System:
+```
+You are a quality judge for a webchat AI assistant conversation. You will be
+shown a full conversation transcript (visitor + assistant turns) plus known
+signals, and must output a single JSON object evaluating the conversation.
+
+Known signals given to you (trust these, do not re-derive them):
+- explicit_rating: the visitor's thumbs rating on the last assistant answer,
+  if any ("thumbsUp" / "thumbsDown" / null)
+- had_citation_refusal: whether any assistant answer was the fixed
+  "no sources found" refusal
+- had_handoff: whether the conversation was escalated to a human/booking flow
+
+Output EXACTLY one JSON object, no other text, matching this schema:
+{
+  "outcome": one of "resolved" | "partially_resolved" | "unresolved" |
+    "escalated" | "out_of_scope" | "abandoned_early",
+  "failure_category": one of "retrieval_miss" | "retrieval_wrong" |
+    "generation_error" | "policy_refusal" | "scope_mismatch" |
+    "user_confusion" | "none" (use "none" only when outcome is "resolved"),
+  "reasoning": 1-3 sentences in the conversation's own language, MUST quote
+    or closely paraphrase a specific turn as evidence. Never invent evidence
+    not present in the transcript.
+  "confidence": one of "high" | "medium" | "low" — use "low" whenever the
+    visitor gave no explicit signal and the transcript alone is ambiguous.
+  "suggested_action": a short actionable note for a knowledge-base editor,
+    or null if none applies.
+}
+
+Category definitions:
+- retrieval_miss: the assistant found no relevant source and said so (or
+  gave the fixed refusal).
+- retrieval_wrong: the assistant cited a source, but it does not actually
+  answer the visitor's question.
+- generation_error: the right source was cited, but the assistant's answer
+  is wrong, incomplete, or hallucinated beyond the source.
+- policy_refusal: the assistant correctly declined per policy (e.g.
+  broad-mode consent, pricing/contract commitment ban) — not a knowledge gap.
+- scope_mismatch: the question is entirely outside what this product/company
+  does.
+- user_confusion: the visitor's own question was unclear or
+  self-contradictory, not a system fault.
+- none: only for outcome "resolved".
+
+Trust explicit_rating over your own read of tone when they conflict: an
+explicit thumbsUp always yields "resolved" outcome with high confidence; an
+explicit thumbsDown never yields "resolved".
+```
+
+User content: JSON-encoded transcript (`role`, `content`, `sources` per
+turn) + the three known signals, `json.dumps(..., ensure_ascii=False)`
+zoals `_build_triage_prompt`.
+
+**Opslag:** `INSERT ... ON CONFLICT (conversation_id) DO UPDATE SET
+outcome=…, failure_category=…, reasoning=…, confidence=…,
+suggested_action=…, model_used=…, judged_at=NOW()` — idempotent, geen
+model-versiegeschiedenis nodig (in tegenstelling tot feedback-triage's
+`model_key`-patroon; hier is er maar één actueel verdict per gesprek).
+
+**Fail-open bij parse-fouten:** ongeldige JSON of een schema-mismatch →
+`logger.warning(..., exc_info=True)`, gesprek overslaan, volgende cyclus
+probeert opnieuw (zelfde patroon als `_safe_ascore()` in
+`judge_client.py` — nooit een stille "success", altijd zichtbaar in logs).
+
+Model: `settings.conversation_judge_model` (= `klai-medium`, al toegevoegd
+in REQ-1).
+
+**Gate (opgegeven aan de bouwer):**
+```
+cd klai-portal/backend && uv run pytest tests/test_conversation_judge.py -q
+```
+Nieuw testbestand, mirror van `tests/test_widget_outcome.py`'s mock-stijl
+voor de selectiequery + een gemockte httpx-response voor de LiteLLM-call
+(geen echte netwerkaanroep in tests).
+
+## REQ-3 — Judge-verdict zichtbaar in de admin-UI · done
+
+Toon `outcome`/`failure_category`/`reasoning`/`confidence` uit REQ-2 als een
+klein paneel/badge bij een gesprek, op zowel de tenant-admin
+`ActivityTab.tsx` (Fase 0) als de platform cross-tenant
+`ConversationsSection` (Fase 1) — beide renderen al de transcript-drawer,
+dit voegt alleen een leesveld toe naast de bestaande rating-badge. Geen
+nieuwe route.
+
+## REQ-5 — LibreChat-pilot, alleen Voys, achter een feature-vlag · done
+
+Mark vroeg op 11 sep om ook LibreChat-gesprekken te kunnen monitoren, maar
+beperkt tot één tenant (Voys) zodat het risico van een nieuw cross-tenant
+Mongo-toegangspatroon (§9.1) niet hoeft te worden opgelost — verbinden met
+precies één, al-bekende tenant-database is geen nieuw patroon, het is
+`librechat_chat_context.py`'s bestaande aanpak nog een keer.
+
+**Schema (al gebouwd, zelf gedaan, zelfde reden als REQ-1):**
+Nieuwe migratie `d3c8b6a5f1e0`: `channel`-CHECK verbreed naar
+`('webchat', 'librechat')`, nieuwe nullable kolom
+`external_conversation_id TEXT` (uniek) voor LibreChat-rijen — een
+LibreChat-gesprek heeft geen Postgres-rij om naar te FK'en (Mongo
+ObjectId-string, geen widget_conversations.id), dus een aparte kolom i.p.v.
+de bestaande `conversation_id` hergebruiken.
+
+**Feature-vlag (al gebouwd):** nieuwe key `librechat_quality_judge` in
+`KNOWN_FEATURES` (`app/core/extensions_registry.py`) — standaard uit voor
+elke tenant, alleen aan te zetten via het bestaande platform-unlocks-
+mechanisme (`PATCH /api/admin/orgs/{slug}/platform-unlocks`), zelfde
+mechanisme als `widgets`/`partner_api`. Geen hardcoded tenant-check —
+expliciet de les uit SPEC-VOYS-HELPBOT-001 REQ-10 toegepast.
+
+**Geverifieerd LibreChat-schema (echt Mongoose-schema, gepinde tag v0.8.7,
+`packages/data-schemas/src/schema/message.ts` — niet afgeleid, opgehaald
+van danny-avila/LibreChat op GitHub):** relevante velden op een
+`messages`-document: `conversationId`, `isCreatedByUser` (bool — het echte
+rolveld), `text`, `content` (mixed array, alleen voor rijkere content),
+`sender`, `createdAt`, `unfinished`/`error` (bool — platformeigen
+foutsignalen), `feedback: {rating: 'thumbsUp'|'thumbsDown', tag, text}`.
+**Geen citaten/bronnen-veld** — LibreChat's Klai-fork parseert bronnen uit
+de gestreamde tekst maar bewaart ze niet gestructureerd in Mongo. De
+LibreChat-rubric gebruikt dus GEEN `had_citation_refusal`-signaal (bestaat
+niet voor dit kanaal); in plaats daarvan `had_error` op basis van het echte
+`error`-veld.
+
+**Tweede rubric (interne, kennissysteem-vaardige gebruiker — het
+onderscheid dat Mark vanaf het begin vroeg):**
+
+System (LETTERLIJK over te nemen, niet te herschrijven):
+```
+You are a quality judge for an internal AI knowledge assistant conversation.
+The user is an authenticated employee who already knows how to use this
+tool and how to talk to a knowledge system — unlike an anonymous public
+visitor, they can rephrase, drill down, and are not put off by a
+clarifying question. You will be shown a full conversation transcript
+(user + assistant turns) plus known signals, and must output a single JSON
+object evaluating the conversation.
+
+Known signals given to you (trust these, do not re-derive them):
+- explicit_rating: the user's thumbs rating on the last assistant answer,
+  if any ("thumbsUp" / "thumbsDown" / null)
+- had_error: whether any assistant turn was flagged as a system/generation
+  error by the platform itself
+
+Output EXACTLY one JSON object, no other text, matching this schema:
+{
+  "outcome": one of "resolved" | "partially_resolved" | "unresolved" |
+    "escalated" | "out_of_scope" | "abandoned_early",
+  "failure_category": one of "retrieval_miss" | "retrieval_wrong" |
+    "generation_error" | "policy_refusal" | "scope_mismatch" |
+    "user_confusion" | "none" (use "none" only when outcome is "resolved"),
+  "reasoning": 1-3 sentences in the conversation's own language, MUST quote
+    or closely paraphrase a specific turn as evidence. Never invent evidence
+    not present in the transcript.
+  "confidence": one of "high" | "medium" | "low" — use "low" whenever the
+    user gave no explicit signal and the transcript alone is ambiguous.
+  "suggested_action": a short actionable note for a knowledge-base editor,
+    or null if none applies.
+}
+
+Category definitions (adjusted for this internal audience):
+- retrieval_miss: the assistant found no relevant source and said so, or
+  answered generically without grounding in this organisation's own
+  knowledge base.
+- retrieval_wrong: the assistant referenced material that does not answer
+  what the user actually asked.
+- generation_error: the right information was available, but the
+  assistant's answer is wrong, incomplete, or hallucinated beyond it — or
+  had_error is true.
+- policy_refusal: not typically applicable to this internal audience; use
+  only if the assistant explicitly declined for a stated policy reason.
+- scope_mismatch: the question is entirely outside what this
+  organisation's knowledge base could ever cover.
+- user_confusion: the user's own question was unclear or
+  self-contradictory, not a system fault.
+- none: only for outcome "resolved".
+
+There is no escalation/handoff concept on this channel and no
+citation-firewall — judge the answer on its own merits, not on whether a
+source was formally cited. Trust explicit_rating over your own read of
+tone when they conflict: an explicit thumbsUp always yields "resolved"
+outcome with high confidence; an explicit thumbsDown never yields
+"resolved".
+```
+
+**Selectie:** per org waarvoor `librechat_quality_judge` unlocked is
+(`org.platform_unlocked_features`), resolve `org.slug` →
+`provisioning_names_for_slug(slug).mongodb_database` (patroon:
+`librechat-{slug}`), verbind met dezelfde root-credentials en timeouts als
+`librechat_chat_context.py::_sync_recent_conversations` (host
+`settings.mongodb_container_name`, poort 27017, `authSource="admin"`, 2s
+timeouts), sync `pymongo.MongoClient` binnen `asyncio.to_thread` — geen
+nieuw verbindingspatroon, exacte kopie. Sluit gesprekken uit waarvan
+`external_conversation_id` al een rij heeft in
+`conversation_quality_judgments` (eerst ophalen uit Postgres, dan filteren
+in Python — bij pilotschaal van één tenant geen probleem).
+
+**Opslag:** zelfde tabel, `channel='librechat'`,
+`external_conversation_id` gevuld, `conversation_id` NULL. UPSERT op
+`external_conversation_id` (aparte unieke constraint, al gebouwd).
+
+**Loop:** geen nieuwe FastAPI-lifespan-taak — de bestaande
+`conversation_judge_loop()` roept na de webchat-pas ook de nieuwe
+LibreChat-pas aan, zodat er geen tweede achtergrondlus met eigen interval
+nodig is.
+
+## REQ-4 — Anonimiseringssweep · done
+
+Nieuwe stap in `widget_messages_retention.py::_retention_run_once`, VÓÓR de
+bestaande DELETE op `widget_messages`: voor elke conversation_id die zo
+meteen gepurged gaat worden, `UPDATE conversation_quality_judgments SET
+reasoning = NULL, anonymized_at = NOW() WHERE conversation_id = ANY(:ids)
+AND reasoning IS NOT NULL`. De FK is `ON DELETE SET NULL` (gefixt in REQ-1,
+was per ongeluk `CASCADE`), dus de judgment-rij zelf overleeft de latere
+purge van `widget_conversations` — alleen `conversation_id` wordt dan NULL.
+Resultaat: `outcome`, `failure_category`, `confidence`, `suggested_action`,
+`org_id`, `judged_at`, `anonymized_at` blijven bruikbaar voor een
+trenddashboard, zonder citaat uit een inmiddels verwijderd gesprek.
+
+---
+
+# Bronnen (webonderzoek, sep 2026)
+
+- [Agent-in-the-Loop: A Data Flywheel for Continuous Improvement in LLM-based Customer Support](https://arxiv.org/pdf/2510.06674)
+- [Reinforcement Learning for Optimizing RAG for Domain Chatbots](https://arxiv.org/pdf/2401.06800)
+- [8 best human-in-the-loop LLM evaluation platforms in 2026 — Braintrust](https://www.braintrust.dev/articles/best-human-in-the-loop-llm-evaluation-platforms-2026)
+- [Top LLM Observability and Evaluation Platforms in 2026 — MarkTechPost](https://www.marktechpost.com/2026/08/09/top-llm-observability-and-evaluation-platforms-in-2026-langfuse-langsmith-braintrust-arize-and-more-compared/)
+- [LLM-as-a-Judge — Langfuse](https://langfuse.com/docs/evaluation/evaluation-methods/llm-as-a-judge)
+- [Auto-Flag Problematic LLM Conversations Without Classifiers — Latitude](https://latitude.so/blog/auto-flag-problematic-conversations)
+- [Every Mistral AI Model Explained and Compared (Sep 2026) — Second Talent](https://www.secondtalent.com/resources/every-mistral-ai-model-explained-compared/)
+- [Mistral API Pricing (September 2026) — BenchLM.ai](https://benchlm.ai/mistral/api-pricing)
+- Intern: `docs/research/help-page-chatbot-voys.md` §6.2 (Zendesk verifieert "resolved"-labels achteraf met een LLM, juist om opgeblazen cijfers te voorkomen — dezelfde reden als hier), §8 (G-6, G-2, G-13)

--- a/klai-portal/backend/alembic/versions/b7e4f1a9c3d2_conversation_quality_judgments.py
+++ b/klai-portal/backend/alembic/versions/b7e4f1a9c3d2_conversation_quality_judgments.py
@@ -1,0 +1,45 @@
+"""conversation_quality_judgments — SPEC-CHAT-QUALITY-LOOP-001 REQ-1
+
+Adds one table storing the nightly LLM-as-judge verdict for a webchat
+conversation: outcome, failure category, evidence-grounded reasoning,
+confidence and a suggested follow-up action. Sits next to
+``widget_conversations`` as an enrichment layer on top of the existing
+heuristic ``widget_conversations.outcome`` column — that column is
+unchanged and keeps serving as the cheap same-day fallback.
+
+Scope is webchat-only for now (REQ-1 ties directly to
+``widget_conversations`` via FK); LibreChat is explicitly deferred pending
+the cross-tenant Mongo-read spike in SPEC-CHAT-QUALITY-LOOP-001 §9.1.
+
+Tables live in the public schema next to ``widget_conversations``, same
+klai-owned + Cat-D RLS shape (per
+``.claude/rules/klai/projects/portal-security.md``). RLS policies are NOT
+created here — ``portal_api`` is not the table owner. They are applied
+post-deploy via
+``post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql`` as the
+``klai`` superuser, same pattern as
+``post_deploy_a4f72e913c8b_widget_conversations_rls.sql``.
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision: str = "b7e4f1a9c3d2"
+down_revision: str | None = "e81c2f93a640"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    # No-op: portal_api lacks REFERENCES privilege on `widget_conversations`
+    # (owned by klai), so CREATE TABLE ... FOREIGN KEY(conversation_id)
+    # REFERENCES widget_conversations(id) fails with 42501 when alembic
+    # runs as portal_api. All DDL for this revision lives in
+    # post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql,
+    # applied by an operator (or scripts/apply_post_deploy_sql.sh) as klai
+    # superuser AFTER alembic upgrade head completes successfully.
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/klai-portal/backend/alembic/versions/d3c8b6a5f1e0_conversation_quality_librechat_channel.py
+++ b/klai-portal/backend/alembic/versions/d3c8b6a5f1e0_conversation_quality_librechat_channel.py
@@ -1,0 +1,37 @@
+"""conversation_quality_judgments: add librechat channel — SPEC-CHAT-QUALITY-LOOP-001 REQ-5
+
+Widens the ``channel`` CHECK constraint to allow ``'librechat'`` alongside
+``'webchat'``, and adds a nullable ``external_conversation_id`` column for
+LibreChat rows: a LibreChat conversation lives in a per-tenant MongoDB
+database and is identified by a Mongo ObjectId string, not a row in
+``widget_conversations`` — the existing ``conversation_id`` FK cannot
+represent it. Webchat rows keep using ``conversation_id`` (FK'd,
+NOT NULL for that channel by convention, enforced at the application layer
+since a CHECK across channel is awkward with the existing NULL-for-
+anonymization design on that same column); LibreChat rows use
+``external_conversation_id`` instead and leave ``conversation_id`` NULL.
+
+Same klai-owned + Cat-D RLS shape as the rest of this table. RLS policies
+are NOT touched here — the existing tenant_isolation policy already covers
+new columns on the same table without a policy change. DDL runs post-deploy
+as the ``klai`` superuser via
+``post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql``.
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision: str = "d3c8b6a5f1e0"
+down_revision: str | None = "b7e4f1a9c3d2"
+branch_labels: tuple[str, ...] | None = None
+depends_on: tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    # No-op, same reason as every prior revision on this klai-owned table:
+    # portal_api lacks ALTER privilege on conversation_quality_judgments.
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/klai-portal/backend/alembic/versions/post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql
@@ -1,0 +1,73 @@
+-- Post-deploy SQL for revision b7e4f1a9c3d2 (conversation_quality_judgments).
+-- SPEC-CHAT-QUALITY-LOOP-001 REQ-1.
+--
+-- portal_api lacks REFERENCES privilege on `widget_conversations` (owned by
+-- klai), so CREATE TABLE with FK(conversation_id) REFERENCES
+-- widget_conversations(id) inside an alembic migration fails with 42501.
+-- The migration's upgrade() is a no-op; all DDL lives here and runs as
+-- klai superuser.
+--
+-- Apply with:
+--   ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+--       'psql -U \$POSTGRES_USER -d \$POSTGRES_DB' \
+--   < klai-portal/backend/alembic/versions/post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql"
+--
+-- Idempotent: every CREATE/ALTER uses IF NOT EXISTS so re-runs are safe.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS conversation_quality_judgments (
+    id BIGSERIAL PRIMARY KEY,
+    org_id INTEGER NOT NULL REFERENCES portal_orgs(id) ON DELETE CASCADE,
+    -- Nullable + SET NULL (not CASCADE): the whole point of this table is
+    -- to outlive the conversation it judged, anonymized. CASCADE would
+    -- delete the row the moment widget_messages_retention purges the
+    -- conversation, which is exactly when it should start its longer,
+    -- anonymized life. The anonymization sweep (REQ-4) nulls `reasoning`
+    -- before that purge runs; SET NULL then clears the now-dangling FK.
+    conversation_id BIGINT REFERENCES widget_conversations(id) ON DELETE SET NULL,
+    channel VARCHAR(16) NOT NULL DEFAULT 'webchat'
+        CHECK (channel IN ('webchat')),
+    outcome VARCHAR(24) NOT NULL
+        CHECK (outcome IN ('resolved', 'partially_resolved', 'unresolved',
+                            'escalated', 'out_of_scope', 'abandoned_early')),
+    failure_category VARCHAR(24)
+        CHECK (failure_category IN ('retrieval_miss', 'retrieval_wrong',
+                                     'generation_error', 'policy_refusal',
+                                     'scope_mismatch', 'user_confusion', 'none')),
+    -- Evidence-grounded judge reasoning, may quote the conversation. Set to
+    -- NULL by the anonymization sweep once the underlying conversation is
+    -- purged (widget_messages_retention_days) — a quote from a deleted
+    -- conversation is itself identifiable content, see SPEC-CHAT-QUALITY-
+    -- LOOP-001 §6. anonymized_at records when that happened.
+    reasoning TEXT,
+    confidence VARCHAR(8) NOT NULL
+        CHECK (confidence IN ('high', 'medium', 'low')),
+    suggested_action TEXT,
+    model_used VARCHAR(64) NOT NULL,
+    judged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    anonymized_at TIMESTAMPTZ,
+    CONSTRAINT uq_conversation_quality_judgments_conversation UNIQUE (conversation_id)
+);
+CREATE INDEX IF NOT EXISTS ix_conversation_quality_judgments_org_judged
+    ON conversation_quality_judgments (org_id, judged_at DESC);
+CREATE INDEX IF NOT EXISTS ix_conversation_quality_judgments_outcome
+    ON conversation_quality_judgments (outcome);
+
+-- Grant DML to portal_api so the runtime can SELECT / INSERT / UPDATE via
+-- SQLAlchemy. RLS Cat-D enforces tenant isolation on top.
+GRANT SELECT, INSERT, UPDATE, DELETE ON conversation_quality_judgments TO portal_api;
+GRANT USAGE, SELECT ON SEQUENCE conversation_quality_judgments_id_seq TO portal_api;
+
+-- RLS Cat-D strict policy (per portal-security.md): every access path must
+-- SET app.current_org_id; missing GUC = raise (helper returns NULL -> first
+-- OR clause skipped, fallback strict check fires). Mirrors
+-- widget_conversations / widget_messages.
+ALTER TABLE conversation_quality_judgments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE conversation_quality_judgments FORCE  ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS tenant_isolation ON conversation_quality_judgments;
+CREATE POLICY tenant_isolation ON conversation_quality_judgments
+    USING (_rls_current_org_id() IS NULL OR org_id = _rls_current_org_id())
+    WITH CHECK (org_id = _rls_current_org_id());
+
+COMMIT;

--- a/klai-portal/backend/alembic/versions/post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql
@@ -1,0 +1,39 @@
+-- Post-deploy SQL for revision d3c8b6a5f1e0 (LibreChat channel support on
+-- conversation_quality_judgments). SPEC-CHAT-QUALITY-LOOP-001 REQ-5.
+--
+-- Apply with:
+--   ssh core-01 "docker exec klai-core-postgres-1 sh -c \
+--       'psql -U \$POSTGRES_USER -d \$POSTGRES_DB' \
+--   < klai-portal/backend/alembic/versions/post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql"
+--
+-- Idempotent: guarded with IF NOT EXISTS / DO blocks so re-runs are safe.
+
+BEGIN;
+
+ALTER TABLE conversation_quality_judgments
+    ADD COLUMN IF NOT EXISTS external_conversation_id TEXT;
+
+-- One judgment per LibreChat conversation, same idempotency guarantee the
+-- existing UNIQUE(conversation_id) gives webchat rows. NULLs (all webchat
+-- rows) are not considered duplicates by Postgres, so this coexists cleanly.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'uq_conversation_quality_judgments_external_conversation'
+    ) THEN
+        ALTER TABLE conversation_quality_judgments
+            ADD CONSTRAINT uq_conversation_quality_judgments_external_conversation
+            UNIQUE (external_conversation_id);
+    END IF;
+END $$;
+
+-- Widen channel CHECK to allow 'librechat'. Postgres has no ADD CONSTRAINT
+-- IF NOT EXISTS for CHECK, so drop-then-add inside the same transaction —
+-- safe: the OLD constraint only accepted 'webchat', which is a subset of
+-- the new allowed set, so no existing row can violate the replacement.
+ALTER TABLE conversation_quality_judgments DROP CONSTRAINT IF EXISTS ck_cqj_channel;
+ALTER TABLE conversation_quality_judgments
+    ADD CONSTRAINT ck_cqj_channel CHECK (channel IN ('webchat', 'librechat'));
+
+COMMIT;

--- a/klai-portal/backend/app/api/admin/platform.py
+++ b/klai-portal/backend/app/api/admin/platform.py
@@ -29,6 +29,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import and_, bindparam, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.admin_widgets import (
+    ConversationDetail,
+    ConversationListItem,
+    ConversationQualityRead,
+    WidgetMessageItem,
+)
 from app.core.database import cross_org_session
 from app.core.permissions import UserPermissions, require_platform_admin
 from app.klai_feedback.models import FeedbackItem, FeedbackItemLink, FeedbackSubmission, FeedbackTriageSuggestion
@@ -944,6 +950,193 @@ async def platform_bots(
         )
         for r in rows
     ]
+
+
+async def _platform_widget_or_404(db: AsyncSession, widget_id: str) -> str:
+    """Resolve a public widget UUID with NO org filter — this endpoint group
+    is deliberately cross-tenant; the platform-admin gate is the only boundary.
+    Soft-deleted widgets stay readable (REQ-16, mirrors admin_widgets)."""
+    result = await db.execute(
+        text("SELECT id FROM widgets WHERE id = CAST(:widget_id AS uuid)"),
+        {"widget_id": widget_id},
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Widget not found")
+    return str(row.id)
+
+
+@router.get("/bots/{widget_id}/conversations", response_model=list[ConversationListItem])
+async def platform_bot_conversations(
+    widget_id: str,
+    cursor: str | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> list[ConversationListItem]:
+    """Cross-tenant conversation list for one widget.
+
+    Mirrors ``admin_widgets.list_widget_conversations`` minus the org
+    restriction — platform staff can inspect any tenant's webchat history.
+    """
+    await _audit(perms, "bot-conversations", widget_id)
+    params: dict[str, object] = {"widget_id": widget_id, "limit": limit}
+    if cursor:
+        try:
+            params["cursor"] = datetime.fromisoformat(cursor.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="invalid cursor") from exc
+
+    async with cross_org_session() as db:
+        wid = await _platform_widget_or_404(db, widget_id)
+        params["widget_id"] = wid
+        if cursor:
+            result = await db.execute(
+                text(
+                    "SELECT id, started_at, last_message_at, message_count, "
+                    "first_user_query, language_detected "
+                    "FROM widget_conversations "
+                    "WHERE widget_id = CAST(:widget_id AS uuid) "
+                    "AND started_at < :cursor "
+                    "ORDER BY started_at DESC LIMIT :limit"
+                ),
+                params,
+            )
+        else:
+            result = await db.execute(
+                text(
+                    "SELECT id, started_at, last_message_at, message_count, "
+                    "first_user_query, language_detected "
+                    "FROM widget_conversations "
+                    "WHERE widget_id = CAST(:widget_id AS uuid) "
+                    "ORDER BY started_at DESC LIMIT :limit"
+                ),
+                params,
+            )
+        rows = result.all()
+
+    return [
+        ConversationListItem(
+            id=row.id,
+            started_at=row.started_at,
+            last_message_at=row.last_message_at,
+            message_count=row.message_count,
+            first_user_query=row.first_user_query,
+            language_detected=row.language_detected,
+        )
+        for row in rows
+    ]
+
+
+@router.get("/bots/{widget_id}/conversations/{conv_id}", response_model=ConversationDetail)
+async def platform_bot_conversation(
+    widget_id: str,
+    conv_id: int,
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> ConversationDetail:
+    """Cross-tenant transcript of one conversation, messages chronological.
+
+    Mirrors ``admin_widgets.get_widget_conversation`` minus the org restriction.
+    """
+    await _audit(perms, "bot-conversations", widget_id)
+
+    async with cross_org_session() as db:
+        wid = await _platform_widget_or_404(db, widget_id)
+        conv_result = await db.execute(
+            text(
+                """
+                SELECT id, started_at, last_message_at, message_count,
+                       first_user_query, language_detected
+                  FROM widget_conversations
+                 WHERE id = :conv_id
+                   AND widget_id = CAST(:widget_id AS uuid)
+                """
+            ),
+            {"conv_id": conv_id, "widget_id": wid},
+        )
+        conv_row = conv_result.first()
+        if conv_row is None:
+            raise HTTPException(status_code=404, detail="conversation not found")
+
+        msg_result = await db.execute(
+            text(
+                """
+                SELECT id, role, content, sources, created_at, sequence, rating
+                  FROM widget_messages
+                 WHERE conversation_id = :conv_id
+                 ORDER BY sequence ASC
+                """
+            ),
+            {"conv_id": conv_id},
+        )
+        messages = [
+            WidgetMessageItem(
+                id=m.id,
+                role=m.role,  # type: ignore[arg-type]
+                content=m.content,
+                sources=m.sources,
+                created_at=m.created_at,
+                sequence=m.sequence,
+                rating=m.rating,
+            )
+            for m in msg_result.all()
+        ]
+
+    return ConversationDetail(
+        id=conv_row.id,
+        started_at=conv_row.started_at,
+        last_message_at=conv_row.last_message_at,
+        message_count=conv_row.message_count,
+        first_user_query=conv_row.first_user_query,
+        language_detected=conv_row.language_detected,
+        messages=messages,
+    )
+
+
+@router.get(
+    "/bots/{widget_id}/conversations/{conv_id}/quality",
+    response_model=ConversationQualityRead,
+)
+async def platform_bot_conversation_quality(
+    widget_id: str,
+    conv_id: int,
+    perms: UserPermissions = Depends(require_platform_admin()),
+) -> ConversationQualityRead:
+    """Cross-tenant judge verdict for one conversation (REQ-3,
+    SPEC-CHAT-QUALITY-LOOP-001).
+
+    Mirrors ``admin_widgets.get_widget_conversation_quality`` without the org
+    restriction — conversation_id is unique, so no org filter is needed under
+    the RLS-bypassing cross_org_session; the platform-admin gate is the only
+    boundary. No row → 404 ("not judged yet" renders as nothing).
+    """
+    await _audit(perms, "bot-conversations", widget_id)
+
+    async with cross_org_session() as db:
+        await _platform_widget_or_404(db, widget_id)
+        result = await db.execute(
+            text(
+                """
+                SELECT outcome, failure_category, reasoning, confidence,
+                       suggested_action, judged_at
+                  FROM conversation_quality_judgments
+                 WHERE conversation_id = :conv_id
+                """
+            ),
+            {"conv_id": conv_id},
+        )
+        row = result.first()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="conversation not judged yet")
+
+    return ConversationQualityRead(
+        outcome=row.outcome,
+        failure_category=row.failure_category,
+        reasoning=row.reasoning,
+        confidence=row.confidence,
+        suggested_action=row.suggested_action,
+        judged_at=row.judged_at,
+    )
 
 
 @router.get("/knowledge-bases", response_model=list[PlatformKB])

--- a/klai-portal/backend/app/api/admin_widgets.py
+++ b/klai-portal/backend/app/api/admin_widgets.py
@@ -1049,9 +1049,7 @@ async def get_widget_conversation(
     )
 
 
-@router.get(
-    "/{widget_id}/conversations/{conv_id}/quality", response_model=ConversationQualityRead
-)
+@router.get("/{widget_id}/conversations/{conv_id}/quality", response_model=ConversationQualityRead)
 async def get_widget_conversation_quality(
     widget_id: str,
     conv_id: int,

--- a/klai-portal/backend/app/api/admin_widgets.py
+++ b/klai-portal/backend/app/api/admin_widgets.py
@@ -854,10 +854,25 @@ class WidgetMessageItem(BaseModel):
     sources: list[dict] | None
     created_at: datetime
     sequence: int
+    rating: Literal["thumbsUp", "thumbsDown"] | None
 
 
 class ConversationDetail(ConversationListItem):
     messages: list[WidgetMessageItem]
+
+
+class ConversationQualityRead(BaseModel):
+    """Read-only sidecar for one conversation's judge verdict (REQ-3,
+    SPEC-CHAT-QUALITY-LOOP-001). Separate model on purpose: the existing
+    transcript responses stay untouched. Deliberately omits ``model_used``
+    and ``anonymized_at`` — internals the admin UI never shows."""
+
+    outcome: str
+    failure_category: str | None = None
+    reasoning: str | None = None
+    confidence: str
+    suggested_action: str | None = None
+    judged_at: datetime
 
 
 class TopQuery(BaseModel):
@@ -1002,7 +1017,7 @@ async def get_widget_conversation(
     msg_result = await db.execute(
         text(
             """
-            SELECT id, role, content, sources, created_at, sequence
+            SELECT id, role, content, sources, created_at, sequence, rating
               FROM widget_messages
              WHERE conversation_id = :conv_id
              ORDER BY sequence ASC
@@ -1018,6 +1033,7 @@ async def get_widget_conversation(
             sources=m.sources,
             created_at=m.created_at,
             sequence=m.sequence,
+            rating=m.rating,
         )
         for m in msg_result.all()
     ]
@@ -1030,6 +1046,50 @@ async def get_widget_conversation(
         first_user_query=conv_row.first_user_query,
         language_detected=conv_row.language_detected,
         messages=messages,
+    )
+
+
+@router.get(
+    "/{widget_id}/conversations/{conv_id}/quality", response_model=ConversationQualityRead
+)
+async def get_widget_conversation_quality(
+    widget_id: str,
+    conv_id: int,
+    perms: UserPermissions = Depends(get_caller_at_least(ProfileRole.ADMIN)),
+    _platform: UserPermissions = Depends(require_platform_unlocked("widgets")),
+    db: AsyncSession = Depends(get_db),
+) -> ConversationQualityRead:
+    """Nightly judge verdict for one conversation (REQ-3, SPEC-CHAT-QUALITY-LOOP-001).
+
+    Read-only sidecar to the transcript drawer; the conversation_id lookup is
+    tenant-scoped by the Cat-D RLS policy on conversation_quality_judgments
+    (same session as the transcript route above). No row → 404: "not judged
+    yet" is a normal state the frontend renders as nothing.
+    """
+    await _get_widget_or_404(widget_id, perms.org_id, db, include_deleted=True)
+
+    result = await db.execute(
+        text(
+            """
+            SELECT outcome, failure_category, reasoning, confidence,
+                   suggested_action, judged_at
+              FROM conversation_quality_judgments
+             WHERE conversation_id = :conv_id
+            """
+        ),
+        {"conv_id": conv_id},
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="conversation not judged yet")
+
+    return ConversationQualityRead(
+        outcome=row.outcome,
+        failure_category=row.failure_category,
+        reasoning=row.reasoning,
+        confidence=row.confidence,
+        suggested_action=row.suggested_action,
+        judged_at=row.judged_at,
     )
 
 

--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -281,6 +281,10 @@ class Settings(BaseSettings):
     extraction_model: str = "klai-fast"
     synthesis_model: str = "klai-primary"
     feedback_triage_model: str = "klai-fast"
+    # SPEC-CHAT-QUALITY-LOOP-001 REQ-2: klai-medium, not klai-fast — same
+    # reason RAGAS faithfulness moved off klai-fast (Mistral Small truncates
+    # multi-field structured JSON). Tier-named, no role-specific alias.
+    conversation_judge_model: str = "klai-medium"
 
     # SPEC-INFRA-TENANT-DELETE-001: Garage S3 for Scribe artifact deletion.
     # Generate credentials via: garage key new --name portal-api
@@ -367,7 +371,9 @@ class Settings(BaseSettings):
 
     # REQ-8 (SPEC-SEC-CROSS-TENANT-FOLLOWUP-001): widget_messages retention.
     # Rows older than this many days are deleted daily by the background loop.
-    widget_messages_retention_days: int = 90  # PORTAL_API_WIDGET_MESSAGES_RETENTION_DAYS
+    # Lowered from 90 to 7 (SPEC-CHAT-QUALITY-LOOP-001 open item #2, decided
+    # 2026-09-11): global, all tenants, no per-org override exists today.
+    widget_messages_retention_days: int = 7  # PORTAL_API_WIDGET_MESSAGES_RETENTION_DAYS
 
     # Conversations quiet for at least this many minutes get an outcome
     # label ('resolved' / 'escalated' / 'abandoned' / 'unknown') by the

--- a/klai-portal/backend/app/core/extensions_registry.py
+++ b/klai-portal/backend/app/core/extensions_registry.py
@@ -34,6 +34,10 @@ KNOWN_FEATURES: frozenset[str] = frozenset(
         "custom_mcps",
         "scribe",
         "docs",
+        # SPEC-CHAT-QUALITY-LOOP-001 REQ-5: per-org opt-in for the nightly
+        # LLM-as-judge pass on LibreChat conversations. Default off; Klai
+        # staff turn it on per tenant here, not in code (Voys is the pilot).
+        "librechat_quality_judge",
     }
 )
 

--- a/klai-portal/backend/app/core/rls_guard.py
+++ b/klai-portal/backend/app/core/rls_guard.py
@@ -49,6 +49,7 @@ logger = logging.getLogger(__name__)
 #     and tenant context is always bound by that point.
 RLS_DML_TABLES: frozenset[str] = frozenset(
     {
+        "conversation_quality_judgments",  # SPEC-CHAT-QUALITY-LOOP-001 Cat-D
         "partner_api_key_kb_access",
         "partner_api_keys",
         "portal_connectors",

--- a/klai-portal/backend/app/main.py
+++ b/klai-portal/backend/app/main.py
@@ -49,6 +49,7 @@ from app.middleware.logging_context import LoggingContextMiddleware
 from app.middleware.session import SessionMiddleware
 from app.middleware.tenant_host import KlaiTenantHostMiddleware
 from app.services.bot_poller import poll_loop
+from app.services.conversation_judge import conversation_judge_loop
 from app.services.events import _pending as _event_tasks
 from app.services.kb_upload_poller import run_poll_loop as run_kb_upload_poll_loop
 from app.services.password_policy_guard import assert_zitadel_password_policy_compatible
@@ -299,6 +300,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     widget_outcome_task = asyncio.create_task(widget_outcome_loop())
     logger.info("Widget conversation outcome loop started")
 
+    # SPEC-CHAT-QUALITY-LOOP-001 REQ-2: LLM-as-judge verdicts for finished,
+    # unjudged conversations (reads the outcome labels set above).
+    conversation_judge_task = asyncio.create_task(conversation_judge_loop())
+    logger.info("Conversation quality judge loop started")
+
     imap_task: asyncio.Task[None] | None = None
     if settings.imap_host and settings.imap_username:
         from app.services.imap_listener import start_imap_listener
@@ -316,6 +322,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     telemetry_purge_task.cancel()
     widget_messages_retention_task.cancel()
     widget_outcome_task.cancel()
+    conversation_judge_task.cancel()
     if imap_task is not None:
         imap_task.cancel()
     if _event_tasks:

--- a/klai-portal/backend/app/models/conversation_quality.py
+++ b/klai-portal/backend/app/models/conversation_quality.py
@@ -50,8 +50,7 @@ class ConversationQualityJudgment(Base):
     __table_args__ = (
         CheckConstraint("channel IN ('webchat', 'librechat')", name="ck_cqj_channel"),
         CheckConstraint(
-            "outcome IN ('resolved','partially_resolved','unresolved',"
-            "'escalated','out_of_scope','abandoned_early')",
+            "outcome IN ('resolved','partially_resolved','unresolved','escalated','out_of_scope','abandoned_early')",
             name="ck_cqj_outcome",
         ),
         CheckConstraint(
@@ -62,17 +61,13 @@ class ConversationQualityJudgment(Base):
         ),
         CheckConstraint("confidence IN ('high','medium','low')", name="ck_cqj_confidence"),
         UniqueConstraint("conversation_id", name="uq_conversation_quality_judgments_conversation"),
-        UniqueConstraint(
-            "external_conversation_id", name="uq_conversation_quality_judgments_external_conversation"
-        ),
+        UniqueConstraint("external_conversation_id", name="uq_conversation_quality_judgments_external_conversation"),
         Index("ix_conversation_quality_judgments_org_judged", "org_id", "judged_at"),
         Index("ix_conversation_quality_judgments_outcome", "outcome"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    org_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("portal_orgs.id", ondelete="CASCADE"), nullable=False
-    )
+    org_id: Mapped[int] = mapped_column(Integer, ForeignKey("portal_orgs.id", ondelete="CASCADE"), nullable=False)
     # Nullable + SET NULL, not CASCADE: this row must outlive the purged
     # conversation, anonymized (see post_deploy SQL comment + SPEC §6).
     conversation_id: Mapped[int | None] = mapped_column(
@@ -90,7 +85,5 @@ class ConversationQualityJudgment(Base):
     confidence: Mapped[str] = mapped_column(String(8), nullable=False)
     suggested_action: Mapped[str | None] = mapped_column(Text, nullable=True)
     model_used: Mapped[str] = mapped_column(String(64), nullable=False)
-    judged_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
-    )
+    judged_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     anonymized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/klai-portal/backend/app/models/conversation_quality.py
+++ b/klai-portal/backend/app/models/conversation_quality.py
@@ -1,0 +1,96 @@
+"""ConversationQualityJudgment ORM model — SPEC-CHAT-QUALITY-LOOP-001 REQ-1/REQ-5.
+
+Nightly LLM-as-judge verdict for a finished conversation, webchat or
+LibreChat, enriching (not replacing) the cheap real-time heuristic in
+``widget_conversations.outcome`` (``app/services/widget_outcome.py``) for
+the webchat case. One row per conversation:
+
+- ``channel='webchat'`` rows key off ``conversation_id`` (FK into
+  ``widget_conversations``, UPSERT on that column).
+- ``channel='librechat'`` rows key off ``external_conversation_id`` (the
+  Mongo ObjectId string — LibreChat lives in a per-tenant MongoDB, not
+  Postgres, so there is no local row to foreign-key against) and leave
+  ``conversation_id`` NULL. REQ-5 gates this per org via the
+  ``librechat_quality_judge`` platform-unlock feature (default off; Voys is
+  the pilot).
+
+``reasoning`` may quote the conversation and is nulled out by the retention
+sweep once the underlying ``widget_conversations``/``widget_messages`` rows
+are purged (``widget_messages_retention_days``) — a quote surviving past the
+conversation it came from is itself identifiable content. See
+SPEC-CHAT-QUALITY-LOOP-001 §6.
+
+DDL lives in
+``post_deploy_b7e4f1a9c3d2_conversation_quality_judgments_rls.sql``
+(klai-owned table, Cat-D RLS) — this class only describes the shape for the
+ORM layer.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class ConversationQualityJudgment(Base):
+    __tablename__ = "conversation_quality_judgments"
+    __table_args__ = (
+        CheckConstraint("channel IN ('webchat', 'librechat')", name="ck_cqj_channel"),
+        CheckConstraint(
+            "outcome IN ('resolved','partially_resolved','unresolved',"
+            "'escalated','out_of_scope','abandoned_early')",
+            name="ck_cqj_outcome",
+        ),
+        CheckConstraint(
+            "failure_category IS NULL OR failure_category IN "
+            "('retrieval_miss','retrieval_wrong','generation_error',"
+            "'policy_refusal','scope_mismatch','user_confusion','none')",
+            name="ck_cqj_failure_category",
+        ),
+        CheckConstraint("confidence IN ('high','medium','low')", name="ck_cqj_confidence"),
+        UniqueConstraint("conversation_id", name="uq_conversation_quality_judgments_conversation"),
+        UniqueConstraint(
+            "external_conversation_id", name="uq_conversation_quality_judgments_external_conversation"
+        ),
+        Index("ix_conversation_quality_judgments_org_judged", "org_id", "judged_at"),
+        Index("ix_conversation_quality_judgments_outcome", "outcome"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    org_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("portal_orgs.id", ondelete="CASCADE"), nullable=False
+    )
+    # Nullable + SET NULL, not CASCADE: this row must outlive the purged
+    # conversation, anonymized (see post_deploy SQL comment + SPEC §6).
+    conversation_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("widget_conversations.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    channel: Mapped[str] = mapped_column(String(16), nullable=False, default="webchat")
+    # Mongo ObjectId string for channel='librechat' rows; NULL for webchat
+    # rows (which use conversation_id instead). See module docstring.
+    external_conversation_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    outcome: Mapped[str] = mapped_column(String(24), nullable=False)
+    failure_category: Mapped[str | None] = mapped_column(String(24), nullable=True)
+    reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+    confidence: Mapped[str] = mapped_column(String(8), nullable=False)
+    suggested_action: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model_used: Mapped[str] = mapped_column(String(64), nullable=False)
+    judged_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    anonymized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/klai-portal/backend/app/services/conversation_judge.py
+++ b/klai-portal/backend/app/services/conversation_judge.py
@@ -1,0 +1,441 @@
+"""LLM-as-judge quality verdicts for finished webchat conversations.
+
+SPEC-CHAT-QUALITY-LOOP-001 REQ-2. The heuristic in ``widget_outcome.py``
+labels conversations resolved/escalated/abandoned/unknown from stored
+signals, and says honestly in its own docstring that a large 'unknown'
+share is the argument for a judge that can READ a transcript. This is that
+judge: a background pass sends each finished conversation plus its three
+known signals (explicit_rating, had_citation_refusal, had_handoff) to an
+LLM and stores the verdict in ``conversation_quality_judgments`` (one row
+per conversation, UPSERT).
+
+Selection reuses the heuristic's finish signal instead of re-deriving one:
+a conversation enters the queue when ``widget_conversations.outcome`` is
+non-NULL (the quiet-period labeller already decided it is done) and no
+judgment row exists yet. Preview conversations are skipped, same exception
+as every other widget background pass.
+
+Worker design mirrors ``widget_outcome.py`` exactly: per-tenant batches run
+in a ``tenant_scoped_session(org_id)`` so RLS Cat-D stays enforced on every
+read and write; only the org-discovery query runs cross-org. The LiteLLM
+call mirrors ``app.klai_feedback.triage._call_triage_llm``. Verdicts are
+written with raw SQL ``INSERT … ON CONFLICT … DO UPDATE`` because the
+SQLAlchemy ORM appends an implicit RETURNING that breaks on RLS Cat-D
+tables under an insert/update-role mismatch (see
+``.claude/rules/klai/projects/portal-backend.md``, "SQLAlchemy + RLS").
+
+**Fail-open per conversation, never per batch.** An unparsable or
+schema-violating judge response logs ``conversation_judge_parse_failed``
+with ``exc_info=True`` and skips only that conversation — the same shape as
+``_safe_ascore()`` in knowledge-ingest's ``judge_client.py``. A transient
+LLM or DB error likewise costs one conversation or one tenant, never the
+pass; the next cycle retries (nothing was written, so the row stays
+queued). One deliberate difference from the upstream pattern: the judge
+returns a fresh verdict for the same prompt, and the UPSERT overwrites —
+there is no model_key-style version history here by design (SPEC REQ-2:
+exactly one current verdict per conversation).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import httpx
+import structlog
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.database import cross_org_session, tenant_scoped_session
+from app.services.widget_outcome import _SUPPORT_REFERRAL_TEXTS
+from app.trace import get_trace_headers
+
+logger = structlog.get_logger()
+
+# 30-minute cadence: unlike the heuristic labeller this makes an LLM call per
+# conversation, and quality verdicts do not need to be fresh within minutes.
+JUDGE_INTERVAL_SECONDS = 30 * 60
+# Conversations judged per tenant per pass — bounds the pass's wall time and
+# LiteLLM load; the next pass picks up where this one stopped. Deliberately
+# smaller than widget_outcome's 500: a pass here is ~50 network calls, not
+# ~500 UPDATEs.
+_BATCH_SIZE = 50
+
+# Enum sets mirrored from the ck_cqj_* CHECK constraints on
+# conversation_quality_judgments (app/models/conversation_quality.py) — a
+# verdict outside them would fail at INSERT time anyway, so reject it as a
+# parse failure instead and keep the conversation queued for a retry.
+_OUTCOMES = frozenset(
+    {"resolved", "partially_resolved", "unresolved", "escalated", "out_of_scope", "abandoned_early"}
+)
+_FAILURE_CATEGORIES = frozenset(
+    {
+        "retrieval_miss",
+        "retrieval_wrong",
+        "generation_error",
+        "policy_refusal",
+        "scope_mismatch",
+        "user_confusion",
+        "none",
+    }
+)
+_CONFIDENCES = frozenset({"high", "medium", "low"})
+
+# Verbatim from docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md § REQ-2
+# ("Judge-prompt (exact, niet vrij te ontwerpen door de bouwer)"). The test
+# suite diffs this string against the spec file byte for byte — do not edit
+# the wording here, edit the spec and regenerate.
+JUDGE_SYSTEM_PROMPT = """You are a quality judge for a webchat AI assistant conversation. You will be
+shown a full conversation transcript (visitor + assistant turns) plus known
+signals, and must output a single JSON object evaluating the conversation.
+
+Known signals given to you (trust these, do not re-derive them):
+- explicit_rating: the visitor's thumbs rating on the last assistant answer,
+  if any ("thumbsUp" / "thumbsDown" / null)
+- had_citation_refusal: whether any assistant answer was the fixed
+  "no sources found" refusal
+- had_handoff: whether the conversation was escalated to a human/booking flow
+
+Output EXACTLY one JSON object, no other text, matching this schema:
+{
+  "outcome": one of "resolved" | "partially_resolved" | "unresolved" |
+    "escalated" | "out_of_scope" | "abandoned_early",
+  "failure_category": one of "retrieval_miss" | "retrieval_wrong" |
+    "generation_error" | "policy_refusal" | "scope_mismatch" |
+    "user_confusion" | "none" (use "none" only when outcome is "resolved"),
+  "reasoning": 1-3 sentences in the conversation's own language, MUST quote
+    or closely paraphrase a specific turn as evidence. Never invent evidence
+    not present in the transcript.
+  "confidence": one of "high" | "medium" | "low" — use "low" whenever the
+    visitor gave no explicit signal and the transcript alone is ambiguous.
+  "suggested_action": a short actionable note for a knowledge-base editor,
+    or null if none applies.
+}
+
+Category definitions:
+- retrieval_miss: the assistant found no relevant source and said so (or
+  gave the fixed refusal).
+- retrieval_wrong: the assistant cited a source, but it does not actually
+  answer the visitor's question.
+- generation_error: the right source was cited, but the assistant's answer
+  is wrong, incomplete, or hallucinated beyond the source.
+- policy_refusal: the assistant correctly declined per policy (e.g.
+  broad-mode consent, pricing/contract commitment ban) — not a knowledge gap.
+- scope_mismatch: the question is entirely outside what this product/company
+  does.
+- user_confusion: the visitor's own question was unclear or
+  self-contradictory, not a system fault.
+- none: only for outcome "resolved".
+
+Trust explicit_rating over your own read of tone when they conflict: an
+explicit thumbsUp always yields "resolved" outcome with high confidence; an
+explicit thumbsDown never yields "resolved"."""
+
+
+@dataclass(frozen=True)
+class JudgeTurn:
+    """One stored widget message, as the judge sees it."""
+
+    role: str  # 'user' | 'assistant'
+    content: str
+    sources: list | dict | str | None  # citation payload stored on the row
+    rating: str | None  # 'thumbsUp' / 'thumbsDown' / None — assistant rows only
+
+
+def _derive_signals(turns: list[JudgeTurn], *, had_handoff: bool) -> dict:
+    """The three known signals the SPEC hands to the judge, from stored data.
+
+    ``explicit_rating``: rating of the LAST assistant turn (a rating moved to
+    a later answer does not retroactively rate the earlier one).
+    ``had_citation_refusal``: any assistant turn is verbatim the fixed
+    no-citable-sources refusal — the same ``_SUPPORT_REFERRAL_TEXTS`` set
+    ``widget_outcome.derive_outcome`` matches against, not a re-invention.
+    ``had_handoff``: passed in by the caller from widget_handoff_sessions,
+    same existence check as widget_outcome.
+    """
+    last_assistant = next((t for t in reversed(turns) if t.role == "assistant"), None)
+    return {
+        "explicit_rating": last_assistant.rating if last_assistant is not None else None,
+        "had_citation_refusal": any(
+            t.role == "assistant" and t.content.strip() in _SUPPORT_REFERRAL_TEXTS for t in turns
+        ),
+        "had_handoff": had_handoff,
+    }
+
+
+def _build_user_prompt(
+    turns: list[JudgeTurn],
+    *,
+    explicit_rating: str | None,
+    had_citation_refusal: bool,
+    had_handoff: bool,
+) -> str:
+    """JSON-encoded transcript (role, content, sources per turn) + the three
+    signals — same ``json.dumps(..., ensure_ascii=False)`` shape as
+    ``triage._build_triage_prompt``."""
+    return json.dumps(
+        {
+            "transcript": [
+                {"role": t.role, "content": t.content, "sources": t.sources} for t in turns
+            ],
+            "signals": {
+                "explicit_rating": explicit_rating,
+                "had_citation_refusal": had_citation_refusal,
+                "had_handoff": had_handoff,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+async def _call_judge_llm(
+    *, model: str, user: str, system: str = JUDGE_SYSTEM_PROMPT
+) -> str:
+    """One LiteLLM chat completion — mirrors ``triage._call_triage_llm``.
+
+    ``system`` defaults to the webchat rubric; the LibreChat pass (REQ-5)
+    passes its own verbatim rubric, the rest of the call is channel-agnostic.
+    """
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            f"{settings.litellm_base_url}/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {settings.litellm_master_key}",
+                **get_trace_headers(),
+            },
+            json={
+                "model": model,
+                "temperature": 0.1,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+            },
+        )
+        resp.raise_for_status()
+        return str(resp.json()["choices"][0]["message"]["content"])
+
+
+def _parse_verdict(raw: str) -> dict:
+    """Validate the judge's JSON against the SPEC schema.
+
+    Raises on anything the storage CHECK constraints would reject (invalid
+    enum, wrong shape, non-string required field) so the caller's fail-open
+    path sees one catch-all; never returns a partially trusted dict.
+    """
+    stripped = raw.strip()
+    if stripped.startswith("```"):
+        stripped = stripped.split("\n", 1)[1].rsplit("```", 1)[0]
+    data = json.loads(stripped)
+    if not isinstance(data, dict):
+        raise TypeError(f"judge response is not a JSON object: {type(data).__name__}")
+
+    outcome = data.get("outcome")
+    confidence = data.get("confidence")
+    failure_category = data.get("failure_category")
+    reasoning = data.get("reasoning")
+    suggested_action = data.get("suggested_action")
+
+    if not isinstance(outcome, str) or outcome not in _OUTCOMES:
+        raise ValueError(f"invalid outcome: {outcome!r}")
+    if not isinstance(confidence, str) or confidence not in _CONFIDENCES:
+        raise ValueError(f"invalid confidence: {confidence!r}")
+    if failure_category is not None and (
+        not isinstance(failure_category, str) or failure_category not in _FAILURE_CATEGORIES
+    ):
+        raise ValueError(f"invalid failure_category: {failure_category!r}")
+    if not isinstance(reasoning, str) or not reasoning.strip():
+        raise ValueError(f"invalid reasoning: {reasoning!r}")
+    if suggested_action is not None and not isinstance(suggested_action, str):
+        raise ValueError(f"invalid suggested_action: {suggested_action!r}")
+
+    return {
+        "outcome": outcome,
+        "failure_category": failure_category,
+        "reasoning": reasoning.strip(),
+        "confidence": confidence,
+        "suggested_action": suggested_action.strip() if suggested_action else None,
+    }
+
+
+# Raw SQL, not ORM: the INSERT/UPDATE role combination on this Cat-D RLS
+# table breaks on SQLAlchemy's implicit RETURNING (portal-backend rule
+# "SQLAlchemy + RLS"), same reason widget_audit/widget_handoff UPSERT raw.
+_UPSERT_SQL = """
+INSERT INTO conversation_quality_judgments
+      (org_id, conversation_id, channel, outcome, failure_category,
+       reasoning, confidence, suggested_action, model_used, judged_at)
+VALUES (:org_id, :conversation_id, :channel, :outcome, :failure_category,
+        :reasoning, :confidence, :suggested_action, :model_used, NOW())
+ON CONFLICT (conversation_id) DO UPDATE SET
+    outcome = EXCLUDED.outcome,
+    failure_category = EXCLUDED.failure_category,
+    reasoning = EXCLUDED.reasoning,
+    confidence = EXCLUDED.confidence,
+    suggested_action = EXCLUDED.suggested_action,
+    model_used = EXCLUDED.model_used,
+    judged_at = NOW()
+"""
+
+
+async def _judge_org(org_id: int) -> int:
+    """Judge finished, not-yet-judged conversations of one tenant. Returns count.
+
+    Everything after the org_id filter runs inside a tenant-scoped session,
+    so RLS Cat-D enforces the boundary even if the WHERE clause regressed.
+    """
+    judged = 0
+    async with tenant_scoped_session(org_id) as db:
+        conv_result = await db.execute(
+            text(
+                """
+                SELECT wc.id
+                  FROM widget_conversations wc
+                  LEFT JOIN conversation_quality_judgments cqj
+                         ON cqj.conversation_id = wc.id
+                 WHERE wc.org_id = :org_id
+                   AND wc.outcome IS NOT NULL
+                   AND wc.is_preview = false
+                   AND cqj.id IS NULL
+                 ORDER BY wc.last_message_at
+                 LIMIT :batch_size
+                """
+            ),
+            {"org_id": org_id, "batch_size": _BATCH_SIZE},
+        )
+        conv_ids = [row.id for row in conv_result.all()]
+        if not conv_ids:
+            return 0
+
+        msg_result = await db.execute(
+            text(
+                """
+                SELECT conversation_id, role, content, sources, rating
+                  FROM widget_messages
+                 WHERE conversation_id = ANY(CAST(:conv_ids AS bigint[]))
+                 ORDER BY conversation_id, sequence ASC
+                """
+            ),
+            {"conv_ids": conv_ids},
+        )
+        turns_by_conv: dict[int, list[JudgeTurn]] = {cid: [] for cid in conv_ids}
+        for row in msg_result.all():
+            turns_by_conv[row.conversation_id].append(
+                JudgeTurn(
+                    role=row.role, content=row.content, sources=row.sources, rating=row.rating
+                )
+            )
+
+        handoff_result = await db.execute(
+            text(
+                """
+                SELECT DISTINCT conversation_id
+                  FROM widget_handoff_sessions
+                 WHERE conversation_id = ANY(CAST(:conv_ids AS bigint[]))
+                """
+            ),
+            {"conv_ids": conv_ids},
+        )
+        handoff_ids = {row.conversation_id for row in handoff_result.all()}
+
+        for conv_id in conv_ids:
+            turns = turns_by_conv[conv_id]
+            signals = _derive_signals(turns, had_handoff=conv_id in handoff_ids)
+            user_prompt = _build_user_prompt(turns, **signals)
+            try:
+                raw = await _call_judge_llm(model=settings.conversation_judge_model, user=user_prompt)
+            except Exception:
+                # One tenant's flaky LLM call costs this conversation, not
+                # the batch; nothing was written so the next pass retries.
+                logger.warning("conversation_judge_llm_failed", conversation_id=conv_id, exc_info=True)
+                continue
+            try:
+                verdict = _parse_verdict(raw)
+            except Exception:
+                logger.warning("conversation_judge_parse_failed", conversation_id=conv_id, exc_info=True)
+                continue
+            # conversation_id is NULLABLE on the table only for the later
+            # anonymization sweep (REQ-4); rows written here always set it.
+            await db.execute(
+                text(_UPSERT_SQL),
+                {
+                    "org_id": org_id,
+                    "conversation_id": conv_id,
+                    "channel": "webchat",
+                    **verdict,
+                    "model_used": settings.conversation_judge_model,
+                },
+            )
+            judged += 1
+
+        await db.commit()
+
+    if judged:
+        logger.info("conversation_quality_judged", org_id=org_id, judged_count=judged)
+    return judged
+
+
+async def _judge_run_once() -> dict[str, int]:
+    """One pass: discover orgs with unjudged finished conversations, judge each.
+
+    Returns ``{"org_count": …, "judged_count": …}``.
+    """
+    async with cross_org_session() as db:
+        org_result = await db.execute(
+            text(
+                """
+                SELECT DISTINCT wc.org_id
+                  FROM widget_conversations wc
+                  LEFT JOIN conversation_quality_judgments cqj
+                         ON cqj.conversation_id = wc.id
+                 WHERE wc.outcome IS NOT NULL
+                   AND wc.is_preview = false
+                   AND cqj.id IS NULL
+                 ORDER BY wc.org_id
+                """
+            ),
+        )
+        org_ids = list(org_result.scalars().all())
+
+    judged_total = 0
+    for org_id in org_ids:
+        # One tenant's failure must not strand the other tenants' verdicts;
+        # the pass continues and the next cycle retries.
+        try:
+            judged_total += await _judge_org(org_id)
+        except Exception:
+            logger.exception("conversation_judge_org_failed", org_id=org_id)
+
+    return {"org_count": len(org_ids), "judged_count": judged_total}
+
+
+async def conversation_judge_loop() -> None:
+    """FastAPI-lifespan-attached conversation quality judge loop.
+
+    Sleeps 60 s on startup so the app can finish wiring before the first
+    DB hit. Then runs ``_judge_run_once`` (webchat) followed by
+    ``librechat_judge_run_once`` (REQ-5) every JUDGE_INTERVAL_SECONDS until
+    cancelled. Exceptions are logged and do not abort the loop; each
+    channel's pass has its own try/except so neither one's failure stops
+    the other.
+    """
+    await asyncio.sleep(60)
+    while True:
+        try:
+            await _judge_run_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("conversation_judge_loop_unexpected_error")
+        try:
+            # Lazy import: librechat_quality_judge reuses helpers from this
+            # module, so a module-level import here would be circular.
+            from app.services.librechat_quality_judge import librechat_judge_run_once
+
+            await librechat_judge_run_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("librechat_judge_loop_unexpected_error")
+        await asyncio.sleep(JUDGE_INTERVAL_SECONDS)

--- a/klai-portal/backend/app/services/conversation_judge.py
+++ b/klai-portal/backend/app/services/conversation_judge.py
@@ -66,9 +66,7 @@ _BATCH_SIZE = 50
 # conversation_quality_judgments (app/models/conversation_quality.py) — a
 # verdict outside them would fail at INSERT time anyway, so reject it as a
 # parse failure instead and keep the conversation queued for a retry.
-_OUTCOMES = frozenset(
-    {"resolved", "partially_resolved", "unresolved", "escalated", "out_of_scope", "abandoned_early"}
-)
+_OUTCOMES = frozenset({"resolved", "partially_resolved", "unresolved", "escalated", "out_of_scope", "abandoned_early"})
 _FAILURE_CATEGORIES = frozenset(
     {
         "retrieval_miss",
@@ -176,9 +174,7 @@ def _build_user_prompt(
     ``triage._build_triage_prompt``."""
     return json.dumps(
         {
-            "transcript": [
-                {"role": t.role, "content": t.content, "sources": t.sources} for t in turns
-            ],
+            "transcript": [{"role": t.role, "content": t.content, "sources": t.sources} for t in turns],
             "signals": {
                 "explicit_rating": explicit_rating,
                 "had_citation_refusal": had_citation_refusal,
@@ -189,9 +185,7 @@ def _build_user_prompt(
     )
 
 
-async def _call_judge_llm(
-    *, model: str, user: str, system: str = JUDGE_SYSTEM_PROMPT
-) -> str:
+async def _call_judge_llm(*, model: str, user: str, system: str = JUDGE_SYSTEM_PROMPT) -> str:
     """One LiteLLM chat completion — mirrors ``triage._call_triage_llm``.
 
     ``system`` defaults to the webchat rubric; the LibreChat pass (REQ-5)
@@ -322,9 +316,7 @@ async def _judge_org(org_id: int) -> int:
         turns_by_conv: dict[int, list[JudgeTurn]] = {cid: [] for cid in conv_ids}
         for row in msg_result.all():
             turns_by_conv[row.conversation_id].append(
-                JudgeTurn(
-                    role=row.role, content=row.content, sources=row.sources, rating=row.rating
-                )
+                JudgeTurn(role=row.role, content=row.content, sources=row.sources, rating=row.rating)
             )
 
         handoff_result = await db.execute(

--- a/klai-portal/backend/app/services/librechat_quality_judge.py
+++ b/klai-portal/backend/app/services/librechat_quality_judge.py
@@ -231,9 +231,7 @@ def _turns_from_messages(docs: list[dict]) -> list[dict]:
         content = _message_text(doc)
         if not content.strip():
             continue
-        turns.append(
-            {"role": "user" if doc.get("isCreatedByUser") else "assistant", "content": content}
-        )
+        turns.append({"role": "user" if doc.get("isCreatedByUser") else "assistant", "content": content})
     return turns
 
 

--- a/klai-portal/backend/app/services/librechat_quality_judge.py
+++ b/klai-portal/backend/app/services/librechat_quality_judge.py
@@ -1,0 +1,366 @@
+"""LLM-as-judge quality verdicts for LibreChat conversations (SPEC-CHAT-QUALITY-LOOP-001 REQ-5).
+
+Second rubric on top of the webchat judge (``conversation_judge.py``, REQ-2):
+the same verdict schema, aimed at an internal, knowledge-system-fluent
+audience instead of an anonymous web visitor. Gated per org on the
+``librechat_quality_judge`` platform unlock (``portal_orgs.platform_unlocked_features``,
+default off; Voys is the pilot) — no hardcoded tenant check, the same lesson
+as SPEC-VOYS-HELPBOT-001 REQ-10.
+
+LibreChat lives in a per-tenant MongoDB, not Postgres, so there is no local
+row to foreign-key a judgment against: rows are stored in the same
+``conversation_quality_judgments`` table with ``channel='librechat'`` and
+``external_conversation_id`` (the Mongo conversationId string) as the UPSERT
+key; ``conversation_id`` stays NULL.
+
+Mongo access mirrors ``librechat_chat_context.py`` exactly — same root
+credentials, same 2 s timeouts, sync ``pymongo`` inside ``asyncio.to_thread``,
+database name derived from the org slug via ``provisioning_names_for_slug``.
+Scoping is enforced in code: one org, its own database, one pass at a time.
+``_call_judge_llm`` and ``_parse_verdict`` are reused from
+``conversation_judge.py`` via import (channel-agnostic apart from the rubric,
+which this pass overrides through its ``system`` argument).
+
+Per-conversation fail-open, per-org isolation and the raw-SQL UPSERT mirror
+the webchat pass, including the RLS Cat-D reason for raw SQL (see
+``.claude/rules/klai/projects/portal-backend.md``, "SQLAlchemy + RLS").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pymongo
+import structlog
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.database import cross_org_session, tenant_scoped_session
+from app.core.provisioning_names import provisioning_names_for_slug
+from app.services.conversation_judge import _call_judge_llm, _parse_verdict
+
+logger = structlog.get_logger()
+
+# Platform-unlock key from KNOWN_FEATURES (app/core/extensions_registry.py).
+_FEATURE = "librechat_quality_judge"
+# Conversations fetched per org per pass — same cap as the webchat batch;
+# the newest come first, already-judged ones are filtered out afterwards.
+_BATCH_SIZE = 50
+# Same constructor values as librechat_chat_context.py::_sync_recent_conversations.
+_MONGO_TIMEOUT_MS = 2000
+
+# Verbatim from docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md § REQ-5
+# ("System (LETTERLIJK over te nemen, niet te herschrijven)"). The test suite
+# diffs this string against the spec file byte for byte — do not edit the
+# wording here, edit the spec and regenerate.
+LIBRECHAT_JUDGE_SYSTEM_PROMPT = """You are a quality judge for an internal AI knowledge assistant conversation.
+The user is an authenticated employee who already knows how to use this
+tool and how to talk to a knowledge system — unlike an anonymous public
+visitor, they can rephrase, drill down, and are not put off by a
+clarifying question. You will be shown a full conversation transcript
+(user + assistant turns) plus known signals, and must output a single JSON
+object evaluating the conversation.
+
+Known signals given to you (trust these, do not re-derive them):
+- explicit_rating: the user's thumbs rating on the last assistant answer,
+  if any ("thumbsUp" / "thumbsDown" / null)
+- had_error: whether any assistant turn was flagged as a system/generation
+  error by the platform itself
+
+Output EXACTLY one JSON object, no other text, matching this schema:
+{
+  "outcome": one of "resolved" | "partially_resolved" | "unresolved" |
+    "escalated" | "out_of_scope" | "abandoned_early",
+  "failure_category": one of "retrieval_miss" | "retrieval_wrong" |
+    "generation_error" | "policy_refusal" | "scope_mismatch" |
+    "user_confusion" | "none" (use "none" only when outcome is "resolved"),
+  "reasoning": 1-3 sentences in the conversation's own language, MUST quote
+    or closely paraphrase a specific turn as evidence. Never invent evidence
+    not present in the transcript.
+  "confidence": one of "high" | "medium" | "low" — use "low" whenever the
+    user gave no explicit signal and the transcript alone is ambiguous.
+  "suggested_action": a short actionable note for a knowledge-base editor,
+    or null if none applies.
+}
+
+Category definitions (adjusted for this internal audience):
+- retrieval_miss: the assistant found no relevant source and said so, or
+  answered generically without grounding in this organisation's own
+  knowledge base.
+- retrieval_wrong: the assistant referenced material that does not answer
+  what the user actually asked.
+- generation_error: the right information was available, but the
+  assistant's answer is wrong, incomplete, or hallucinated beyond it — or
+  had_error is true.
+- policy_refusal: not typically applicable to this internal audience; use
+  only if the assistant explicitly declined for a stated policy reason.
+- scope_mismatch: the question is entirely outside what this
+  organisation's knowledge base could ever cover.
+- user_confusion: the user's own question was unclear or
+  self-contradictory, not a system fault.
+- none: only for outcome "resolved".
+
+There is no escalation/handoff concept on this channel and no
+citation-firewall — judge the answer on its own merits, not on whether a
+source was formally cited. Trust explicit_rating over your own read of
+tone when they conflict: an explicit thumbsUp always yields "resolved"
+outcome with high confidence; an explicit thumbsDown never yields
+"resolved"."""
+
+_ORG_SQL = """
+                SELECT id, slug
+                  FROM portal_orgs
+                 WHERE deleted_at IS NULL
+                   AND :feature = ANY(platform_unlocked_features)
+                 ORDER BY id
+"""
+
+_EXCLUDE_SQL = """
+                SELECT external_conversation_id
+                  FROM conversation_quality_judgments
+                 WHERE channel = 'librechat'
+                   AND org_id = :org_id
+"""
+
+# Raw SQL for the same RLS Cat-D reason as the webchat UPSERT; conflict
+# target is the separate unique key on external_conversation_id (migration
+# d3c8b6a5f1e0). channel is pinned to 'librechat' in the SQL text, and
+# conversation_id is never written — it stays NULL for this channel.
+_UPSERT_SQL = """
+INSERT INTO conversation_quality_judgments
+      (org_id, channel, external_conversation_id, outcome, failure_category,
+       reasoning, confidence, suggested_action, model_used, judged_at)
+VALUES (:org_id, 'librechat', :external_conversation_id, :outcome, :failure_category,
+        :reasoning, :confidence, :suggested_action, :model_used, NOW())
+ON CONFLICT (external_conversation_id) DO UPDATE SET
+    outcome = EXCLUDED.outcome,
+    failure_category = EXCLUDED.failure_category,
+    reasoning = EXCLUDED.reasoning,
+    confidence = EXCLUDED.confidence,
+    suggested_action = EXCLUDED.suggested_action,
+    model_used = EXCLUDED.model_used,
+    judged_at = NOW()
+"""
+
+
+def _mongo_client() -> pymongo.MongoClient:
+    """Exact copy of librechat_chat_context.py's constructor — root
+    credentials, per-tenant database chosen in code."""
+    return pymongo.MongoClient(
+        host=settings.mongodb_container_name,
+        port=27017,
+        username=settings.mongo_root_username,
+        password=settings.mongo_root_password,
+        authSource="admin",
+        serverSelectionTimeoutMS=_MONGO_TIMEOUT_MS,
+        connectTimeoutMS=_MONGO_TIMEOUT_MS,
+        socketTimeoutMS=_MONGO_TIMEOUT_MS,
+    )
+
+
+def _sync_fetch_conversations(db_name: str, limit: int) -> list[dict]:
+    """The tenant's most recent LibreChat conversations, newest first."""
+    with _mongo_client() as client:
+        cursor = (
+            client[db_name]
+            .conversations.find(
+                {},
+                {"conversationId": 1, "title": 1, "updatedAt": 1, "_id": 0},
+            )
+            .sort("updatedAt", pymongo.DESCENDING)
+            .limit(limit)
+        )
+        return list(cursor)
+
+
+def _sync_fetch_messages(db_name: str, conversation_ids: list[str]) -> dict[str, list[dict]]:
+    """All messages of the given conversations, grouped and ordered by createdAt.
+
+    Field set verified against the pinned LibreChat fork (v0.8.7,
+    packages/data-schemas/src/schema/message.ts); there is no structured
+    sources field on this channel, hence no had_citation_refusal signal.
+    """
+    projection = {
+        "conversationId": 1,
+        "isCreatedByUser": 1,
+        "text": 1,
+        "content": 1,
+        "sender": 1,
+        "createdAt": 1,
+        "unfinished": 1,
+        "error": 1,
+        "feedback": 1,
+        "_id": 0,
+    }
+    with _mongo_client() as client:
+        cursor = (
+            client[db_name]
+            .messages.find({"conversationId": {"$in": conversation_ids}}, projection)
+            .sort("createdAt", pymongo.ASCENDING)
+        )
+        grouped: dict[str, list[dict]] = {}
+        for doc in cursor:
+            cid = doc.get("conversationId")
+            if isinstance(cid, str):
+                grouped.setdefault(cid, []).append(doc)
+        return grouped
+
+
+def _message_text(doc: dict) -> str:
+    """Message body: ``text`` is the primary field; ``content`` is LibreChat's
+    mixed array (or plain string) of parts — flatten its text parts. Anything
+    else yields an empty string, which the caller drops instead of judging."""
+    text_value = doc.get("text")
+    if isinstance(text_value, str) and text_value.strip():
+        return text_value
+    content = doc.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [p["text"] for p in content if isinstance(p, dict) and isinstance(p.get("text"), str)]
+        return "\n".join(parts)
+    return ""
+
+
+def _turns_from_messages(docs: list[dict]) -> list[dict]:
+    """Judge transcript: role from the real ``isCreatedByUser`` field; messages
+    with no usable text are skipped instead of becoming empty turns."""
+    turns = []
+    for doc in docs:
+        content = _message_text(doc)
+        if not content.strip():
+            continue
+        turns.append(
+            {"role": "user" if doc.get("isCreatedByUser") else "assistant", "content": content}
+        )
+    return turns
+
+
+def _derive_signals(docs: list[dict]) -> dict:
+    """The two known signals of the REQ-5 rubric, from stored data.
+
+    ``explicit_rating``: ``feedback.rating`` of the LAST assistant message
+    (same last-answer rule as the webchat pass).
+    ``had_error``: any assistant message flagged ``error: true`` by the
+    platform itself.
+    """
+    assistant_docs = [d for d in docs if not d.get("isCreatedByUser")]
+    explicit_rating = None
+    if assistant_docs:
+        feedback = assistant_docs[-1].get("feedback")
+        if isinstance(feedback, dict) and isinstance(feedback.get("rating"), str):
+            explicit_rating = feedback["rating"]
+    return {
+        "explicit_rating": explicit_rating,
+        "had_error": any(d.get("error") for d in assistant_docs),
+    }
+
+
+def _build_user_prompt(turns: list[dict], *, explicit_rating: str | None, had_error: bool) -> str:
+    """JSON-encoded transcript (role/content per turn) plus the two signals —
+    same ``json.dumps(..., ensure_ascii=False)`` shape as the webchat pass;
+    this channel has no sources field to carry."""
+    return json.dumps(
+        {
+            "transcript": turns,
+            "signals": {
+                "explicit_rating": explicit_rating,
+                "had_error": had_error,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+async def _judge_org(org_id: int, slug: str) -> int:
+    """Judge recent, not-yet-judged LibreChat conversations of one org.
+
+    The exclude query and the UPSERT run inside a tenant-scoped session so
+    RLS Cat-D enforces the org boundary even if the WHERE clause regressed;
+    Mongo and the LLM are reached per conversation with fail-open.
+    """
+    db_name = provisioning_names_for_slug(slug, domain=settings.domain).mongodb_database
+    judged = 0
+    async with tenant_scoped_session(org_id) as db:
+        excl_result = await db.execute(text(_EXCLUDE_SQL), {"org_id": org_id})
+        excluded = {row.external_conversation_id for row in excl_result.all()}
+
+        conversations = await asyncio.to_thread(_sync_fetch_conversations, db_name, _BATCH_SIZE)
+        todo = [
+            conv["conversationId"]
+            for conv in conversations
+            if isinstance(conv.get("conversationId"), str)
+            and conv["conversationId"]
+            and conv["conversationId"] not in excluded
+        ]
+        if not todo:
+            return 0
+
+        messages_by_cid = await asyncio.to_thread(_sync_fetch_messages, db_name, todo)
+
+        for cid in todo:
+            docs = messages_by_cid.get(cid, [])
+            turns = _turns_from_messages(docs)
+            if not turns:
+                # Nothing to judge (e.g. an empty chat); skipping without a
+                # row keeps it eligible once it has real content.
+                logger.debug("librechat_judge_no_usable_turns", org_id=org_id, conversation_id=cid)
+                continue
+            signals = _derive_signals(docs)
+            user_prompt = _build_user_prompt(turns, **signals)
+            try:
+                raw = await _call_judge_llm(
+                    model=settings.conversation_judge_model,
+                    user=user_prompt,
+                    system=LIBRECHAT_JUDGE_SYSTEM_PROMPT,
+                )
+            except Exception:
+                # One flaky LLM call costs this conversation, not the batch;
+                # nothing was written so the next pass retries.
+                logger.warning("librechat_judge_llm_failed", conversation_id=cid, exc_info=True)
+                continue
+            try:
+                verdict = _parse_verdict(raw)
+            except Exception:
+                logger.warning("librechat_judge_parse_failed", conversation_id=cid, exc_info=True)
+                continue
+            await db.execute(
+                text(_UPSERT_SQL),
+                {
+                    "org_id": org_id,
+                    "external_conversation_id": cid,
+                    **verdict,
+                    "model_used": settings.conversation_judge_model,
+                },
+            )
+            judged += 1
+
+        await db.commit()
+
+    if judged:
+        logger.info("librechat_quality_judged", org_id=org_id, judged_count=judged)
+    return judged
+
+
+async def librechat_judge_run_once() -> dict[str, int]:
+    """One pass: discover orgs with the platform unlock, judge each.
+
+    Returns ``{"org_count": …, "judged_count": …}`` like the webchat pass.
+    Called by ``conversation_judge_loop`` after the webchat pass — there is
+    deliberately no second lifespan task with its own interval.
+    """
+    async with cross_org_session() as db:
+        org_result = await db.execute(text(_ORG_SQL), {"feature": _FEATURE})
+        orgs = [(row.id, row.slug) for row in org_result.all()]
+
+    judged_total = 0
+    for org_id, slug in orgs:
+        # One tenant's Mongo or DB failure must not strand the other tenants'
+        # verdicts; the pass continues and the next cycle retries.
+        try:
+            judged_total += await _judge_org(org_id, slug)
+        except Exception:
+            logger.exception("librechat_judge_org_failed", org_id=org_id)
+
+    return {"org_count": len(orgs), "judged_count": judged_total}

--- a/klai-portal/backend/app/services/widget_messages_retention.py
+++ b/klai-portal/backend/app/services/widget_messages_retention.py
@@ -3,7 +3,9 @@ Widget message retention worker.
 
 Background loop that runs every 24 hours and deletes widget_messages rows
 older than ``settings.widget_messages_retention_days`` days in chunks of
-10 000 rows.
+10 000 rows. Before each delete pass it anonymizes the
+``conversation_quality_judgments.reasoning`` of the purged conversations
+(REQ-4, SPEC-CHAT-QUALITY-LOOP-001 §11).
 
 Design mirrors ``telemetry_purge.py``:
 - cross-org: retention is platform-wide, not per-tenant.
@@ -38,11 +40,18 @@ _CHUNK_SIZE = 10_000
 async def _retention_run_once() -> dict[str, int]:
     """Delete expired widget_messages rows in chunks.
 
+    REQ-4 (SPEC-CHAT-QUALITY-LOOP-001 §11): before each DELETE pass, nulls
+    ``conversation_quality_judgments.reasoning`` (and stamps ``anonymized_at``)
+    for the conversations whose messages are being purged — a judge quote may
+    not outlive the conversation it came from, while the judgment row itself
+    survives (FK is SET NULL, not CASCADE).
+
     Returns a dict with ``deleted_count`` (total rows removed) and
     ``chunk_count`` (number of DELETE passes executed).
     """
     cutoff = datetime.now(UTC) - timedelta(days=settings.widget_messages_retention_days)
     deleted_total = 0
+    anonymized_total = 0
     chunk_count = 0
 
     while True:
@@ -50,7 +59,7 @@ async def _retention_run_once() -> dict[str, int]:
             candidate_result = await db.execute(
                 text(
                     """
-                    SELECT id FROM widget_messages
+                    SELECT id, conversation_id FROM widget_messages
                     WHERE created_at < :cutoff
                     ORDER BY id
                     LIMIT :chunk_size
@@ -58,9 +67,27 @@ async def _retention_run_once() -> dict[str, int]:
                 ),
                 {"cutoff": cutoff, "chunk_size": _CHUNK_SIZE},
             )
-            message_ids = list(candidate_result.scalars().all())
-            if not message_ids:
+            rows = list(candidate_result.all())
+            if not rows:
                 break
+            message_ids = [row[0] for row in rows]
+
+            # Anonymize first, in this same transaction: batched per chunk,
+            # keyed off the messages we are about to delete (no separate
+            # cutoff computation on widget_conversations).
+            conversation_ids = sorted({row[1] for row in rows})
+            anon_result = await db.execute(
+                text(
+                    """
+                    UPDATE conversation_quality_judgments
+                    SET reasoning = NULL, anonymized_at = NOW()
+                    WHERE conversation_id = ANY(CAST(:conversation_ids AS bigint[]))
+                      AND reasoning IS NOT NULL
+                    """
+                ),
+                {"conversation_ids": conversation_ids},
+            )
+            anonymized_total += anon_result.rowcount or 0  # type: ignore[attr-defined]
 
             result = await db.execute(
                 text(
@@ -83,6 +110,7 @@ async def _retention_run_once() -> dict[str, int]:
     logger.info(
         "widget_messages.retention_deleted",
         deleted_count=deleted_total,
+        anonymized_judgments=anonymized_total,
         chunk_count=chunk_count,
         cutoff=cutoff.isoformat(),
         retention_days=settings.widget_messages_retention_days,

--- a/klai-portal/backend/tests/test_admin_extensions.py
+++ b/klai-portal/backend/tests/test_admin_extensions.py
@@ -37,7 +37,14 @@ class TestListExtensions:
 
         result = await list_extensions(perms=perms, db=db)
         keys = {item.key for item in result.extensions}
-        assert keys == {"partner_api", "widgets", "custom_mcps", "scribe", "docs"}
+        assert keys == {
+            "partner_api",
+            "widgets",
+            "custom_mcps",
+            "scribe",
+            "docs",
+            "librechat_quality_judge",
+        }
         enabled = {item.key for item in result.extensions if item.enabled}
         assert enabled == {"scribe", "docs"}
 

--- a/klai-portal/backend/tests/test_conversation_judge.py
+++ b/klai-portal/backend/tests/test_conversation_judge.py
@@ -1,0 +1,542 @@
+"""LLM-as-judge quality pass over finished webchat conversations (REQ-2).
+
+Covers the three acceptance scenarios of SPEC-CHAT-QUALITY-LOOP-001 §11 REQ-2:
+  (a) a conversation with a non-NULL widget_conversations.outcome and no
+      existing judgment row is selected, judged through the LiteLLM call and
+      UPSERTed into conversation_quality_judgments with every field filled;
+  (b) a conversation whose outcome is still NULL is never selected;
+  (c) an invalid judge JSON response logs ``conversation_judge_parse_failed``,
+      skips that conversation and never crashes the batch — the other
+      conversations in the same pass are still judged.
+
+Plus the structural mirrors of widget_outcome: the selection query text
+(outcome IS NOT NULL / is_preview = false / LEFT JOIN … cqj.id IS NULL), the
+UPSERT shape (ON CONFLICT (conversation_id) DO UPDATE, judged_at=NOW()) and
+per-org RLS isolation (every read and write of a tenant runs through that
+tenant's scoped session only).
+
+# @MX:SPEC: SPEC-CHAT-QUALITY-LOOP-001 REQ-2
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _verdict_raw(**overrides) -> str:
+    """A valid judge response: one JSON object matching the SPEC schema."""
+    verdict = {
+        "outcome": "resolved",
+        "failure_category": "none",
+        "reasoning": "De helpverlener antwoordde correct op de vraag over retourtermijnen.",
+        "confidence": "high",
+        "suggested_action": None,
+    }
+    verdict.update(overrides)
+    return json.dumps(verdict, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Signal derivation — the three known signals handed to the judge
+# ---------------------------------------------------------------------------
+
+
+def _turn(role, content="", sources=None, rating=None):
+    from app.services.conversation_judge import JudgeTurn
+
+    return JudgeTurn(role=role, content=content, sources=sources, rating=rating)
+
+
+def test_signals_rating_of_last_assistant_and_refusal_detection():
+    """explicit_rating comes from the LAST assistant turn (a rating on an
+    earlier turn is withdrawn/overridden); had_citation_refusal is True when
+    ANY assistant turn is exactly the fixed helpdesk refusal — the same
+    detection set widget_outcome uses, not a re-invented one."""
+    from app.services.conversation_judge import _derive_signals
+    from app.services.widget_outcome import _SUPPORT_REFERRAL_TEXTS
+
+    refusal = next(iter(_SUPPORT_REFERRAL_TEXTS))
+    turns = [
+        _turn("user", "retour?"),
+        _turn("assistant", "30 dagen", rating="thumbsDown"),
+        _turn("user", "en ik?"),
+        _turn("assistant", refusal, rating="thumbsUp"),
+    ]
+    assert _derive_signals(turns, had_handoff=True) == {
+        "explicit_rating": "thumbsUp",
+        "had_citation_refusal": True,
+        "had_handoff": True,
+    }
+
+    quiet = [_turn("user", "prijs?"), _turn("assistant", "€10", sources=[{"title": "p"}])]
+    assert _derive_signals(quiet, had_handoff=False) == {
+        "explicit_rating": None,
+        "had_citation_refusal": False,
+        "had_handoff": False,
+    }
+
+
+def test_user_prompt_carries_transcript_and_signals_json():
+    """User content is JSON-encoded (ensure_ascii=False) with role/content/
+    sources per turn plus the three signals, like _build_triage_prompt."""
+    from app.services.conversation_judge import _build_user_prompt
+
+    turns = [_turn("user", "waar is Café?"), _turn("assistant", "Bij de bron [1]", sources=[{"n": 1}])]
+    payload = json.loads(
+        _build_user_prompt(
+            turns,
+            explicit_rating="thumbsUp",
+            had_citation_refusal=False,
+            had_handoff=True,
+        )
+    )
+    assert payload["transcript"] == [
+        {"role": "user", "content": "waar is Café?", "sources": None},
+        {"role": "assistant", "content": "Bij de bron [1]", "sources": [{"n": 1}]},
+    ]
+    assert payload["signals"] == {
+        "explicit_rating": "thumbsUp",
+        "had_citation_refusal": False,
+        "had_handoff": True,
+    }
+    # Non-ASCII is embedded literally, not escaped.
+    assert "waar is Café?" in _build_user_prompt(
+        turns, explicit_rating=None, had_citation_refusal=False, had_handoff=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test doubles for the loop — same mock-session style as test_widget_outcome
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OrgDb:
+    """One tenant's RLS-scoped session over widget tables.
+
+    Simulates the selection contract: a conversation is a candidate only when
+    its stored ``outcome`` is non-NULL, ``is_preview`` is False and no
+    judgment row exists yet (the cqj.id IS NULL join). Records every UPSERT;
+    raises if asked to write another org's row.
+    """
+
+    org_id: int
+    outcome: dict[int, str | None] = field(default_factory=dict)
+    preview: set[int] = field(default_factory=set)
+    judged: set[int] = field(default_factory=set)
+    messages: dict[int, list[tuple]] = field(default_factory=dict)
+    handoffs: set[int] = field(default_factory=set)
+    inserts: dict[int, dict] = field(default_factory=dict)
+    other_org_judged: set[int] = field(default_factory=set)
+
+    def _result(self, rows):
+        res = MagicMock()
+        res.all.return_value = rows
+        res.rowcount = len(rows)
+        return res
+
+    async def commit(self):
+        pass
+
+    async def execute(self, stmt, params=None, **kwargs):
+        sql = str(stmt)
+        if "SELECT wc.id" in sql:
+            assert params["org_id"] == self.org_id, "candidate SELECT leaked another org's id"
+            rows = [
+                MagicMock(id=cid)
+                for cid in sorted(self.outcome)
+                if self.outcome[cid] is not None
+                and cid not in self.preview
+                and cid not in self.judged
+                and cid not in self.other_org_judged
+            ]
+            return self._result(rows[: params["batch_size"]])
+        if "SELECT conversation_id, role, content, sources, rating" in sql:
+            ids = params["conv_ids"]
+            assert all(i in self.outcome for i in ids), "cross-org message read"
+            rows = []
+            for cid in ids:
+                for role, content, sources, rating in self.messages.get(cid, []):
+                    rows.append(
+                        MagicMock(
+                            conversation_id=cid, role=role, content=content, sources=sources, rating=rating
+                        )
+                    )
+            return self._result(rows)
+        if "SELECT DISTINCT conversation_id" in sql:  # handoff
+            ids = params["conv_ids"]
+            assert all(i in self.outcome for i in ids), "cross-org handoff read"
+            return self._result([MagicMock(conversation_id=cid) for cid in ids if cid in self.handoffs])
+        if "INSERT INTO conversation_quality_judgments" in sql:
+            assert params["org_id"] == self.org_id, "UPSERT leaked another org's id"
+            conv_id = params["conversation_id"]
+            assert conv_id in self.outcome, f"UPSERT {conv_id} not owned by org {self.org_id}"
+            self.inserts[conv_id] = dict(params)
+            res = MagicMock()
+            res.rowcount = 1
+            return res
+        raise AssertionError(f"unexpected SQL in tenant session:\n{sql}")
+
+
+def _cross_org_returning(org_ids: list[int]):
+    @asynccontextmanager
+    async def _cross():
+        db = AsyncMock()
+
+        async def _exec(stmt, params=None, **kwargs):
+            assert "conversation_quality_judgments" in str(stmt), "discovery must skip already-judged orgs"
+            res = MagicMock()
+            res.scalars.return_value.all.return_value = org_ids
+            return res
+
+        db.execute = _exec
+        yield db
+
+    return _cross
+
+
+_Q = "app.services.conversation_judge"
+
+
+# ---------------------------------------------------------------------------
+# (a) selected, judged and written with the right fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finished_conversation_is_judged_and_upserted():
+    from app.core.config import settings
+    from app.services import conversation_judge as cj
+
+    org = _OrgDb(
+        org_id=1,
+        outcome={100: "resolved"},
+        messages={100: [("user", "vraag", None, None), ("assistant", "antwoord", [{"t": "bron"}], "thumbsUp")]},
+    )
+
+    @asynccontextmanager
+    async def _tenant(org_id):
+        assert org_id == 1
+        yield org
+
+    captured: dict = {}
+
+    async def _fake_llm(*, model: str, user: str) -> str:
+        captured["model"] = model
+        captured["user"] = user
+        return _verdict_raw()
+
+    with (
+        patch.object(cj, "tenant_scoped_session", _tenant),
+        patch.object(cj, "cross_org_session", _cross_org_returning([1])),
+        patch.object(cj, "_call_judge_llm", _fake_llm),
+    ):
+        result = await cj._judge_run_once()
+
+    assert result == {"org_count": 1, "judged_count": 1}
+    # Model comes from settings; the user prompt carries transcript + signals.
+    assert captured["model"] == settings.conversation_judge_model
+    prompt_payload = json.loads(captured["user"])
+    assert prompt_payload["signals"] == {
+        "explicit_rating": "thumbsUp",
+        "had_citation_refusal": False,
+        "had_handoff": False,
+    }
+    row = org.inserts[100]
+    assert row["conversation_id"] == 100
+    assert row["org_id"] == 1
+    assert row["channel"] == "webchat"
+    assert row["outcome"] == "resolved"
+    assert row["failure_category"] == "none"
+    assert row["reasoning"].startswith("De helpverlener")
+    assert row["confidence"] == "high"
+    assert row["suggested_action"] is None
+    assert row["model_used"] == settings.conversation_judge_model
+
+
+@pytest.mark.asyncio
+async def test_selection_query_requires_outcome_and_skips_preview_and_judged():
+    """The contract of the candidate SELECT: outcome IS NOT NULL (the heuristic
+    already labelled it), is_preview = false, and no existing judgment row via
+    LEFT JOIN … cqj.id IS NULL."""
+    from app.services import conversation_judge as cj
+
+    org = _OrgDb(
+        org_id=1,
+        outcome={1: "resolved", 2: None, 3: "unknown", 4: "resolved"},
+        preview={3},
+        other_org_judged={4},  # simulates "cqj row already exists"
+        messages={1: [("user", "q", None, None)], 2: [], 3: [], 4: []},
+    )
+
+    @asynccontextmanager
+    async def _tenant(org_id):
+        yield org
+
+    judged_first: list[str] = []
+
+    async def _only_first_may_reach_judge(*, model: str, user: str) -> str:
+        judged_first.append(json.loads(user)["transcript"][0]["content"])
+        return _verdict_raw()
+
+    with (
+        patch.object(cj, "tenant_scoped_session", _tenant),
+        patch.object(cj, "_call_judge_llm", _only_first_may_reach_judge),
+    ):
+        judged = await cj._judge_org(1)
+
+    assert judged == 1
+    assert set(org.inserts) == {1}
+    assert judged_first == ["q"]  # conversations 2-4 never reached the judge
+
+    # And the SQL text itself carries the three filters.
+    captured_sql: list[str] = []
+
+    @asynccontextmanager
+    async def _tenant_capturing(org_id):
+        db = AsyncMock()
+
+        async def _exec(stmt, params=None, **kwargs):
+            captured_sql.append(str(stmt))
+            res = MagicMock()
+            res.all.return_value = []
+            return res
+
+        db.execute = _exec
+        yield db
+
+    with patch.object(cj, "tenant_scoped_session", _tenant_capturing):
+        await cj._judge_org(1)
+
+    select_sql = captured_sql[0]
+    assert "outcome IS NOT NULL" in select_sql
+    assert "is_preview = false" in select_sql
+    assert "LEFT JOIN conversation_quality_judgments cqj" in select_sql
+    assert "cqj.id IS NULL" in select_sql
+
+
+@pytest.mark.asyncio
+async def test_upsert_overwrites_and_never_duplicates():
+    """Storage is INSERT … ON CONFLICT (conversation_id) DO UPDATE with
+    judged_at=NOW() — idempotent by the uq_conversation_quality_judgments
+    _conversation unique key, so a re-judge can never create a second row."""
+    from app.services import conversation_judge as cj
+
+    upsert = cj._UPSERT_SQL
+    assert "INSERT INTO conversation_quality_judgments" in upsert
+    assert "ON CONFLICT (conversation_id) DO UPDATE SET" in upsert
+    for field_name in (
+        "outcome",
+        "failure_category",
+        "reasoning",
+        "confidence",
+        "suggested_action",
+        "model_used",
+    ):
+        assert f"{field_name} = EXCLUDED.{field_name}" in upsert
+    assert "judged_at = NOW()" in upsert
+
+
+# ---------------------------------------------------------------------------
+# (b) outcome IS NULL is never selected — enforced by the SELECT contract
+# above; here: the org-level session only ever sees its own rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_judges_only_the_owning_org():
+    from app.services import conversation_judge as cj
+
+    org1 = _OrgDb(org_id=1, outcome={100: "unknown"}, messages={100: [("user", "vraag", None, None)]})
+    org2 = _OrgDb(org_id=2, outcome={})  # nothing of org 2 to judge
+
+    dbs = {1: org1, 2: org2}
+
+    @asynccontextmanager
+    async def _tenant(org_id):
+        yield dbs[org_id]
+
+    async def _fake_llm(*, model: str, user: str) -> str:
+        return _verdict_raw(outcome="unresolved", failure_category="retrieval_miss", confidence="low")
+
+    with (
+        patch.object(cj, "tenant_scoped_session", _tenant),
+        patch.object(cj, "cross_org_session", _cross_org_returning([1, 2])),
+        patch.object(cj, "_call_judge_llm", _fake_llm),
+    ):
+        result = await cj._judge_run_once()
+
+    assert set(org1.inserts) == {100}
+    assert org2.inserts == {}
+    assert org1.inserts[100]["outcome"] == "unresolved"
+    assert org1.inserts[100]["failure_category"] == "retrieval_miss"
+    assert result["judged_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# (c) invalid judge JSON → warning log, conversation skipped, batch continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_judge_json_is_skipped_and_batch_continues():
+    from app.services import conversation_judge as cj
+
+    org = _OrgDb(
+        org_id=1,
+        outcome={100: "resolved", 101: "escalated"},
+        messages={
+            100: [("user", "q1", None, None), ("assistant", "a1", None, None)],
+            101: [("user", "q2", None, None), ("assistant", "a2", None, None)],
+        },
+    )
+
+    @asynccontextmanager
+    async def _tenant(org_id):
+        yield org
+
+    async def _llm_returns_garbage_first(*, model: str, user: str) -> str:
+        payload = json.loads(user)
+        if payload["transcript"][0]["content"] == "q1":
+            return "this is definitely not the JSON the schema asked for"
+        return _verdict_raw(outcome="escalated", failure_category="none", confidence="medium")
+
+    warn = MagicMock()
+    with (
+        patch.object(cj, "tenant_scoped_session", _tenant),
+        patch.object(cj, "cross_org_session", _cross_org_returning([1])),
+        patch.object(cj, "_call_judge_llm", _llm_returns_garbage_first),
+        patch.object(cj.logger, "warning", warn),
+    ):
+        result = await cj._judge_run_once()
+
+    warn.assert_called_once()
+    assert warn.call_args.args[0] == "conversation_judge_parse_failed"
+    assert warn.call_args.kwargs["conversation_id"] == 100
+    assert warn.call_args.kwargs["exc_info"] is True
+    # The bad conversation is skipped, the good one in the same batch lands.
+    assert set(org.inserts) == {101}
+    assert result["judged_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_schema_mismatch_is_skipped():
+    """Valid JSON but an enum value outside the SPEC schema is a schema
+    failure: skipped with the same warning, never written."""
+    from app.services import conversation_judge as cj
+
+    org = _OrgDb(org_id=1, outcome={100: "resolved"}, messages={100: [("user", "q", None, None)]})
+
+    @asynccontextmanager
+    async def _tenant(org_id):
+        yield org
+
+    warn = MagicMock()
+    with (
+        patch.object(cj, "tenant_scoped_session", _tenant),
+        patch.object(cj, "cross_org_session", _cross_org_returning([1])),
+        patch.object(cj, "_call_judge_llm", AsyncMock(return_value=_verdict_raw(outcome="fixed"))),
+        patch.object(cj.logger, "warning", warn),
+    ):
+        result = await cj._judge_run_once()
+
+    assert warn.call_args.args[0] == "conversation_judge_parse_failed"
+    assert org.inserts == {}
+    assert result["judged_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Loop resilience + verbatim SPEC prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loop_continues_after_org_failure():
+    """conversation_judge_loop does not abort when one pass raises."""
+    from app.services.conversation_judge import conversation_judge_loop
+
+    call_count = 0
+
+    async def _raise_then_cancel():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient DB error")
+        raise asyncio.CancelledError
+
+    with (
+        patch("app.services.conversation_judge._judge_run_once", side_effect=_raise_then_cancel),
+        patch("app.services.conversation_judge.JUDGE_INTERVAL_SECONDS", 0),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await conversation_judge_loop()
+
+    assert call_count >= 2, "Loop did not retry after the exception"
+
+
+def test_system_prompt_matches_spec_verbatim():
+    """REQ-2 fixes the judge prompt: it must equal the fenced block in
+    docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md byte for byte."""
+    import re
+    from pathlib import Path
+
+    from app.services.conversation_judge import JUDGE_SYSTEM_PROMPT
+
+    spec = Path(__file__).resolve().parents[3] / "docs" / "specs" / "SPEC-CHAT-QUALITY-LOOP-001" / "spec.md"
+    text = spec.read_text()
+    section = text.split("## REQ-2", 1)[1].split("## REQ-3", 1)[0]
+    block = re.search(r"System:\n```\n(.*?)\n```", section, re.DOTALL).group(1)
+    assert JUDGE_SYSTEM_PROMPT == block
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_uses_triage_pattern():
+    """Same endpoint, auth header, trace headers, temperature 0.1 and payload
+    shape as triage._call_triage_llm — verified against a mocked httpx client
+    (no real network in tests)."""
+    from app.core.config import settings
+    from app.services import conversation_judge as cj
+
+    posted: dict = {}
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, headers=None, json=None):
+            posted["url"] = url
+            posted["headers"] = headers
+            posted["json"] = json
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+            return resp
+
+    with (
+        patch("httpx.AsyncClient", _Client),
+        patch.object(cj, "get_trace_headers", lambda: {"x-trace": "t"}),
+    ):
+        out = await cj._call_judge_llm(model="klai-medium", user='{"transcript": []}')
+
+    assert out == "ok"
+    assert posted["url"] == f"{settings.litellm_base_url}/v1/chat/completions"
+    assert posted["headers"]["Authorization"] == f"Bearer {settings.litellm_master_key}"
+    assert posted["headers"]["x-trace"] == "t"
+    body = posted["json"]
+    assert body["model"] == "klai-medium"
+    assert body["temperature"] == 0.1
+    assert body["messages"][0] == {"role": "system", "content": cj.JUDGE_SYSTEM_PROMPT}
+    assert body["messages"][1] == {"role": "user", "content": '{"transcript": []}'}

--- a/klai-portal/backend/tests/test_conversation_judge.py
+++ b/klai-portal/backend/tests/test_conversation_judge.py
@@ -164,9 +164,7 @@ class _OrgDb:
             for cid in ids:
                 for role, content, sources, rating in self.messages.get(cid, []):
                     rows.append(
-                        MagicMock(
-                            conversation_id=cid, role=role, content=content, sources=sources, rating=rating
-                        )
+                        MagicMock(conversation_id=cid, role=role, content=content, sources=sources, rating=rating)
                     )
             return self._result(rows)
         if "SELECT DISTINCT conversation_id" in sql:  # handoff

--- a/klai-portal/backend/tests/test_conversation_quality_endpoints.py
+++ b/klai-portal/backend/tests/test_conversation_quality_endpoints.py
@@ -1,0 +1,163 @@
+"""Regression tests for the per-conversation quality-judgment read endpoints.
+
+SPEC-CHAT-QUALITY-LOOP-001 REQ-3: the nightly judge (REQ-2) writes one row
+per conversation into ``conversation_quality_judgments``; the tenant admin
+(`/api/admin/widgets/{widget_id}/conversations/{conv_id}/quality`) and the
+platform console
+(`/api/admin/platform/bots/{widget_id}/conversations/{conv_id}/quality`)
+expose it as a read-only sidecar. A missing row is a 404 — "not judged yet"
+is a normal state the frontend renders as nothing, never an error dialog.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from tests.conftest import make_perms
+
+WIDGET_UUID = "5112f9ad-3768-4b76-9a13-5b74e9165bc3"
+
+
+class AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class TextRows:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+    def scalar_one_or_none(self):
+        return self.rows[0] if self.rows else None
+
+
+def _platform_perms():
+    return make_perms(
+        role="admin",
+        user_id="platform-admin",
+        org_id=1,
+        org_slug="getklai",
+        is_platform_admin=True,
+    )
+
+
+def _tenant_admin_perms():
+    """Ordinary tenant admin: ADMIN role, own org 42, NOT a platform admin."""
+    return make_perms(
+        role="admin",
+        user_id="tenant-admin",
+        org_id=42,
+        org_slug="voys",
+        is_platform_admin=False,
+    )
+
+
+def _judgment_row():
+    return SimpleNamespace(
+        org_id=42,
+        outcome="escalated",
+        failure_category="retrieval_miss",
+        reasoning="De bot kende het actuele prijsplan niet.",
+        confidence="high",
+        suggested_action="Prijs-KB opnieuw in de index opnemen.",
+        judged_at=datetime(2026, 9, 11, 2, 0, tzinfo=UTC),
+    )
+
+
+def _widget_row():
+    return SimpleNamespace(id=WIDGET_UUID, org_id=42)
+
+
+@pytest.mark.asyncio
+async def test_tenant_quality_route_returns_judgment_fields() -> None:
+    from app.api.admin_widgets import get_widget_conversation_quality
+
+    row = _judgment_row()
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[TextRows([_widget_row()]), TextRows([row])])
+
+    judgment = await get_widget_conversation_quality(
+        widget_id=WIDGET_UUID, conv_id=7, perms=_tenant_admin_perms(), db=db
+    )
+
+    assert judgment.outcome == "escalated"
+    assert judgment.failure_category == "retrieval_miss"
+    assert judgment.reasoning == "De bot kende het actuele prijsplan niet."
+    assert judgment.confidence == "high"
+    assert judgment.suggested_action == "Prijs-KB opnieuw in de index opnemen."
+    assert judgment.judged_at == row.judged_at
+
+
+@pytest.mark.asyncio
+async def test_tenant_quality_route_404_when_conversation_not_judged() -> None:
+    from app.api.admin_widgets import get_widget_conversation_quality
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[TextRows([_widget_row()]), TextRows([])])
+
+    with pytest.raises(HTTPException) as exc:
+        await get_widget_conversation_quality(
+            widget_id=WIDGET_UUID, conv_id=7, perms=_tenant_admin_perms(), db=db
+        )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_platform_quality_route_reads_other_org_judgment() -> None:
+    from app.api.admin.platform import platform_bot_conversation_quality
+
+    # Judgment belongs to org 42; the platform admin lives in org 1.
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[TextRows([_widget_row()]), TextRows([_judgment_row()])])
+
+    with (
+        patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform._audit", new=AsyncMock()) as audit,
+    ):
+        judgment = await platform_bot_conversation_quality(
+            widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms()
+        )
+
+    assert judgment.outcome == "escalated"
+    assert judgment.reasoning == "De bot kende het actuele prijsplan niet."
+    # Cross-tenant read: the query must NOT carry an org restriction — the
+    # platform-admin gate plus cross_org_session() is the only boundary.
+    for call in db.execute.await_args_list:
+        assert "org_id" not in str(call.args[0])
+    audit.assert_awaited_once()
+    assert audit.await_args.args[1:] == ("bot-conversations", WIDGET_UUID)
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_gets_403_on_platform_quality_route() -> None:
+    from app.api.admin.platform import router
+    from app.core.permissions import get_caller
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_caller] = _tenant_admin_perms
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations/7/quality")
+
+    assert resp.status_code == 403

--- a/klai-portal/backend/tests/test_conversation_quality_endpoints.py
+++ b/klai-portal/backend/tests/test_conversation_quality_endpoints.py
@@ -114,9 +114,7 @@ async def test_tenant_quality_route_404_when_conversation_not_judged() -> None:
     db.execute = AsyncMock(side_effect=[TextRows([_widget_row()]), TextRows([])])
 
     with pytest.raises(HTTPException) as exc:
-        await get_widget_conversation_quality(
-            widget_id=WIDGET_UUID, conv_id=7, perms=_tenant_admin_perms(), db=db
-        )
+        await get_widget_conversation_quality(widget_id=WIDGET_UUID, conv_id=7, perms=_tenant_admin_perms(), db=db)
     assert exc.value.status_code == 404
 
 
@@ -132,9 +130,7 @@ async def test_platform_quality_route_reads_other_org_judgment() -> None:
         patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
         patch("app.api.admin.platform._audit", new=AsyncMock()) as audit,
     ):
-        judgment = await platform_bot_conversation_quality(
-            widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms()
-        )
+        judgment = await platform_bot_conversation_quality(widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms())
 
     assert judgment.outcome == "escalated"
     assert judgment.reasoning == "De bot kende het actuele prijsplan niet."
@@ -155,9 +151,7 @@ async def test_tenant_admin_gets_403_on_platform_quality_route() -> None:
     app.include_router(router)
     app.dependency_overrides[get_caller] = _tenant_admin_perms
 
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations/7/quality")
 
     assert resp.status_code == 403

--- a/klai-portal/backend/tests/test_librechat_quality_judge.py
+++ b/klai-portal/backend/tests/test_librechat_quality_judge.py
@@ -1,0 +1,547 @@
+"""LLM-as-judge quality pass over LibreChat conversations (SPEC-CHAT-QUALITY-LOOP-001 REQ-5).
+
+Covers the acceptance scenarios of §11 REQ-5:
+  (a) an org without the ``librechat_quality_judge`` platform unlock is never
+      selected and no Mongo client is ever constructed;
+  (b) an org with the unlock: a LibreChat conversation with at least one user
+      and one assistant message is judged through the LiteLLM call and
+      UPSERTed with channel='librechat', external_conversation_id filled and
+      no conversation_id (NULL);
+  (c) a conversation whose external id already has a judgment row is filtered
+      out before the LLM is called — a second cycle neither duplicates nor
+      re-judges;
+  (d) ``isCreatedByUser`` drives the turn role, ``feedback.rating`` of the
+      last assistant message becomes ``explicit_rating``, an assistant
+      ``error: true`` becomes ``had_error``;
+  (e) an invalid judge response logs and skips only that conversation, the
+      rest of the batch still lands.
+
+Mock style mirrors tests/test_conversation_judge.py: fake DB sessions that
+simulate the SQL contract, a fake pymongo.MongoClient patched in THIS
+module's namespace, no real network, no real Mongo.
+
+# @MX:SPEC: SPEC-CHAT-QUALITY-LOOP-001 REQ-5
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_CREATED = dt.datetime(2026, 9, 11, 10, 0, 0)
+
+
+def _verdict_raw(**overrides) -> str:
+    """A valid judge response: one JSON object matching the SPEC schema."""
+    verdict = {
+        "outcome": "resolved",
+        "failure_category": "none",
+        "reasoning": "De kennisassistent antwoordde correct op de vraag.",
+        "confidence": "high",
+        "suggested_action": None,
+    }
+    verdict.update(overrides)
+    return json.dumps(verdict, ensure_ascii=False)
+
+
+def _conv(conversation_id: str, *, minutes: int = 0) -> dict:
+    return {"conversationId": conversation_id, "updatedAt": _CREATED + dt.timedelta(minutes=minutes)}
+
+
+def _msg(
+    conversation_id: str,
+    *,
+    user: bool,
+    minutes: int,
+    text: str | None = None,
+    content=None,
+    feedback: dict | None = None,
+    error: bool | None = None,
+    unfinished: bool | None = None,
+) -> dict:
+    doc = {
+        "conversationId": conversation_id,
+        "isCreatedByUser": user,
+        "createdAt": _CREATED + dt.timedelta(minutes=minutes),
+    }
+    if text is not None:
+        doc["text"] = text
+    if content is not None:
+        doc["content"] = content
+    if feedback is not None:
+        doc["feedback"] = feedback
+    if error is not None:
+        doc["error"] = error
+    if unfinished is not None:
+        doc["unfinished"] = unfinished
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# Fake pymongo — patched as app.services.librechat_quality_judge.pymongo.MongoClient
+# ---------------------------------------------------------------------------
+
+
+class _Cursor:
+    def __init__(self, docs):
+        self._docs = list(docs)
+
+    def sort(self, key, direction):
+        self._docs.sort(key=lambda d: d.get(key), reverse=direction < 0)
+        return self
+
+    def limit(self, n):
+        self._docs = self._docs[:n]
+        return self
+
+    def __iter__(self):
+        return iter(self._docs)
+
+
+class _FakeMongo:
+    """Stands in for pymongo.MongoClient: records connect kwargs and find
+    calls, serves fixed per-database conversations/messages documents."""
+
+    def __init__(self, dbs: dict[str, dict[str, list[dict]]] | None = None):
+        self.dbs = dbs or {}
+        self.connect_kwargs: list[dict] = []
+        self.finds: list[tuple[str, str, dict]] = []
+
+    def client(self, **kwargs):
+        self.connect_kwargs.append(kwargs)
+        return _FakeClient(self)
+
+
+class _FakeClient:
+    def __init__(self, mongo: _FakeMongo):
+        self._mongo = mongo
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def __getitem__(self, db_name: str):
+        return _FakeDb(self._mongo, db_name)
+
+
+class _FakeDb:
+    def __init__(self, mongo: _FakeMongo, db_name: str):
+        self._mongo = mongo
+        self._db_name = db_name
+        docs = mongo.dbs.get(db_name, {})
+        self.conversations = _FakeCollection(mongo, db_name, "conversations", docs.get("conversations", []))
+        self.messages = _FakeCollection(mongo, db_name, "messages", docs.get("messages", []))
+
+
+class _FakeCollection:
+    def __init__(self, mongo: _FakeMongo, db_name: str, name: str, docs: list[dict]):
+        self._mongo = mongo
+        self._db_name = db_name
+        self._name = name
+        self._docs = docs
+
+    def find(self, flt=None, projection=None):
+        self._mongo.finds.append((self._db_name, self._name, flt or {}))
+        docs = self._docs
+        cid_filter = (flt or {}).get("conversationId")
+        if isinstance(cid_filter, dict) and "$in" in cid_filter:
+            wanted = set(cid_filter["$in"])
+            docs = [d for d in docs if d.get("conversationId") in wanted]
+        return _Cursor(docs)
+
+
+# ---------------------------------------------------------------------------
+# Fake DB sessions — same mock-session style as test_conversation_judge
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OrgDb:
+    """One tenant's RLS-scoped session over the judgment table.
+
+    Simulates the exclude query: rows listed in ``judged_external`` already
+    have a judgment row for this org and channel. Records every UPSERT;
+    raises if asked to read or write another org's rows.
+    """
+
+    org_id: int
+    judged_external: set[str] = field(default_factory=set)
+    inserts: dict[str, dict] = field(default_factory=dict)
+    sql_log: list[str] = field(default_factory=list)
+
+    def _result(self, rows):
+        res = MagicMock()
+        res.all.return_value = rows
+        res.rowcount = len(rows)
+        return res
+
+    async def commit(self):
+        pass
+
+    async def execute(self, stmt, params: dict | None = None, **kwargs):
+        sql = str(stmt)
+        self.sql_log.append(sql)
+        assert params is not None, "every query in this fake session expects params"
+        if "SELECT external_conversation_id" in sql:
+            assert "channel = 'librechat'" in sql, "exclude query must scope to the librechat channel"
+            assert params["org_id"] == self.org_id, "exclude SELECT leaked another org's id"
+            rows = [MagicMock(external_conversation_id=e) for e in sorted(self.judged_external)]
+            return self._result(rows)
+        if "INSERT INTO conversation_quality_judgments" in sql:
+            assert "'librechat'" in sql, "UPSERT must pin channel='librechat'"
+            assert params["org_id"] == self.org_id, "UPSERT leaked another org's id"
+            self.inserts[params["external_conversation_id"]] = dict(params)
+            res = MagicMock()
+            res.rowcount = 1
+            return res
+        raise AssertionError(f"unexpected SQL in tenant session:\n{sql}")
+
+
+def _cross_org_returning(orgs: list[tuple[int, str, list[str]]]):
+    """Discovery session over portal_orgs. Simulates the WHERE clause: only
+    orgs whose platform_unlocked_features contain the requested feature are
+    returned, so a missing flag must cost zero Mongo connections downstream."""
+
+    @asynccontextmanager
+    async def _cross():
+        db = AsyncMock()
+
+        async def _exec(stmt, params: dict | None = None, **kwargs):
+            sql = str(stmt)
+            assert "portal_orgs" in sql, "discovery must read portal_orgs"
+            assert "platform_unlocked_features" in sql, "discovery must filter on the platform unlock"
+            assert params is not None
+            feature = params["feature"]
+            res = MagicMock()
+            res.all.return_value = [
+                MagicMock(id=org_id, slug=slug) for org_id, slug, features in orgs if feature in features
+            ]
+            return res
+
+        db.execute = _exec
+        yield db
+
+    return _cross
+
+
+def _tenant_returning(org: _OrgDb):
+    @asynccontextmanager
+    async def _tenant(org_id):
+        assert org_id == org.org_id
+        yield org
+
+    return _tenant
+
+
+_LJ = "app.services.librechat_quality_judge"
+
+
+# ---------------------------------------------------------------------------
+# (a) org without the feature flag: skipped, zero Mongo connections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_org_without_feature_flag_makes_no_mongo_call():
+    from app.core.extensions_registry import KNOWN_FEATURES
+    from app.services import librechat_quality_judge as lj
+
+    mongo = _FakeMongo()
+    org = _OrgDb(org_id=1)
+
+    with (
+        patch(f"{_LJ}.pymongo.MongoClient", mongo.client),
+        patch.object(lj, "cross_org_session", _cross_org_returning([(1, "voys", ["widgets", "partner_api"])])),
+        patch.object(lj, "tenant_scoped_session", _tenant_returning(org)),
+    ):
+        result = await lj.librechat_judge_run_once()
+
+    assert result == {"org_count": 0, "judged_count": 0}
+    assert mongo.connect_kwargs == [], "no-flag org must never open a Mongo connection"
+    assert mongo.finds == []
+    # The flag name the pass queries on is a real platform feature.
+    assert "librechat_quality_judge" in KNOWN_FEATURES
+
+
+# ---------------------------------------------------------------------------
+# (b) org with the flag: conversation judged and stored on the librechat channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unlocked_org_conversation_is_judged_and_stored():
+    from app.core.config import settings
+    from app.core.provisioning_names import provisioning_names_for_slug
+    from app.services import librechat_quality_judge as lj
+
+    db_name = provisioning_names_for_slug("voys", domain=settings.domain).mongodb_database
+    mongo = _FakeMongo(
+        {
+            db_name: {
+                "conversations": [_conv("c-new", minutes=5)],
+                "messages": [
+                    _msg("c-new", user=True, minutes=0, text="hoe regel ik een vergoeding?"),
+                    _msg(
+                        "c-new",
+                        user=False,
+                        minutes=1,
+                        text="Dat kan via het portaal [1].",
+                        feedback={"rating": "thumbsUp"},
+                    ),
+                ],
+            }
+        }
+    )
+    org = _OrgDb(org_id=7)
+
+    captured: dict = {}
+
+    async def _fake_llm(*, model: str, user: str, system: str) -> str:
+        captured["model"] = model
+        captured["user"] = user
+        captured["system"] = system
+        return _verdict_raw()
+
+    with (
+        patch(f"{_LJ}.pymongo.MongoClient", mongo.client),
+        patch.object(lj, "cross_org_session", _cross_org_returning([(7, "voys", ["librechat_quality_judge"])])),
+        patch.object(lj, "tenant_scoped_session", _tenant_returning(org)),
+        patch.object(lj, "_call_judge_llm", _fake_llm),
+    ):
+        result = await lj.librechat_judge_run_once()
+
+    assert result == {"org_count": 1, "judged_count": 1}
+    # Connection mirrors librechat_chat_context.py's constructor exactly.
+    assert mongo.connect_kwargs and mongo.connect_kwargs[0] == {
+        "host": settings.mongodb_container_name,
+        "port": 27017,
+        "username": settings.mongo_root_username,
+        "password": settings.mongo_root_password,
+        "authSource": "admin",
+        "serverSelectionTimeoutMS": 2000,
+        "connectTimeoutMS": 2000,
+        "socketTimeoutMS": 2000,
+    }
+    # The second (internal-audience) rubric is what reaches the model.
+    assert captured["system"] == lj.LIBRECHAT_JUDGE_SYSTEM_PROMPT
+    assert captured["model"] == settings.conversation_judge_model
+    payload = json.loads(captured["user"])
+    assert payload["signals"] == {"explicit_rating": "thumbsUp", "had_error": False}
+
+    row = org.inserts["c-new"]
+    assert row["org_id"] == 7
+    assert row["external_conversation_id"] == "c-new"
+    # conversation_id stays NULL for this channel: the UPSERT never binds it.
+    assert "conversation_id" not in row
+    assert row["outcome"] == "resolved"
+    assert row["confidence"] == "high"
+    assert row["model_used"] == settings.conversation_judge_model
+
+
+# ---------------------------------------------------------------------------
+# (c) already-judged conversation: excluded before the LLM, no duplicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_already_judged_conversation_is_not_rejudged():
+    from app.services import librechat_quality_judge as lj
+
+    mongo = _FakeMongo(
+        {
+            "librechat-voys": {
+                "conversations": [_conv("c-old", minutes=5)],
+                "messages": [_msg("c-old", user=True, minutes=0, text="vraag")],
+            }
+        }
+    )
+    org = _OrgDb(org_id=7, judged_external={"c-old"})
+    llm = AsyncMock()
+
+    with (
+        patch(f"{_LJ}.pymongo.MongoClient", mongo.client),
+        patch.object(lj, "cross_org_session", _cross_org_returning([(7, "voys", ["librechat_quality_judge"])])),
+        patch.object(lj, "tenant_scoped_session", _tenant_returning(org)),
+        patch.object(lj, "_call_judge_llm", llm),
+    ):
+        result = await lj.librechat_judge_run_once()
+
+    llm.assert_not_awaited()
+    assert org.inserts == {}
+    assert result == {"org_count": 1, "judged_count": 0}
+
+
+# ---------------------------------------------------------------------------
+# (d) isCreatedByUser → role, feedback.rating → explicit_rating, error → had_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roles_and_signals_come_from_the_real_librechat_fields():
+    from app.services import librechat_quality_judge as lj
+
+    mongo = _FakeMongo(
+        {
+            "librechat-voys": {
+                "conversations": [_conv("c1", minutes=5)],
+                "messages": [
+                    _msg("c1", user=True, minutes=0, text="vraag één"),
+                    _msg("c1", user=False, minutes=1, text="antwoord met fout", error=True),
+                    _msg("c1", user=True, minutes=2, text=""),  # no text, no content → dropped
+                    _msg("c1", user=False, minutes=3, content=[{"type": "text", "text": "via content"}]),
+                    _msg("c1", user=True, minutes=4, text="opvolger", feedback={"rating": "thumbsDown"}),
+                    _msg("c1", user=False, minutes=5, text="laatste antwoord", feedback={"rating": "thumbsDown"}),
+                ],
+            }
+        }
+    )
+    org = _OrgDb(org_id=7)
+
+    captured: dict = {}
+
+    async def _fake_llm(*, model: str, user: str, system: str) -> str:
+        captured["user"] = user
+        return _verdict_raw(outcome="unresolved", failure_category="generation_error", confidence="medium")
+
+    with (
+        patch(f"{_LJ}.pymongo.MongoClient", mongo.client),
+        patch.object(lj, "cross_org_session", _cross_org_returning([(7, "voys", ["librechat_quality_judge"])])),
+        patch.object(lj, "tenant_scoped_session", _tenant_returning(org)),
+        patch.object(lj, "_call_judge_llm", _fake_llm),
+    ):
+        await lj.librechat_judge_run_once()
+
+    payload = json.loads(captured["user"])
+    assert [t["role"] for t in payload["transcript"]] == ["user", "assistant", "assistant", "user", "assistant"]
+    assert payload["transcript"][2]["content"] == "via content"  # text empty → content parts flattened
+    # empty user message never reached the transcript as an empty turn
+    assert all(t["content"].strip() for t in payload["transcript"])
+    # explicit_rating = feedback of the LAST assistant message; had_error from
+    # any assistant error:true. The user-message feedback above must not count.
+    assert payload["signals"] == {"explicit_rating": "thumbsDown", "had_error": True}
+    assert org.inserts["c1"]["outcome"] == "unresolved"
+
+
+# ---------------------------------------------------------------------------
+# (e) invalid judge JSON: conversation skipped, batch continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_judge_json_is_skipped_and_batch_continues():
+    from app.services import librechat_quality_judge as lj
+
+    mongo = _FakeMongo(
+        {
+            "librechat-voys": {
+                "conversations": [_conv("c1", minutes=5), _conv("c2", minutes=6)],
+                "messages": [
+                    _msg("c1", user=True, minutes=0, text="q1"),
+                    _msg("c1", user=False, minutes=1, text="a1"),
+                    _msg("c2", user=True, minutes=2, text="q2"),
+                    _msg("c2", user=False, minutes=3, text="a2"),
+                ],
+            }
+        }
+    )
+    org = _OrgDb(org_id=7)
+
+    async def _llm_returns_garbage_for_c1(*, model: str, user: str, system: str) -> str:
+        payload = json.loads(user)
+        if payload["transcript"][0]["content"] == "q1":
+            return "this is definitely not the JSON the schema asked for"
+        return _verdict_raw(outcome="escalated", failure_category="none", confidence="medium")
+
+    warn = MagicMock()
+    with (
+        patch(f"{_LJ}.pymongo.MongoClient", mongo.client),
+        patch.object(lj, "cross_org_session", _cross_org_returning([(7, "voys", ["librechat_quality_judge"])])),
+        patch.object(lj, "tenant_scoped_session", _tenant_returning(org)),
+        patch.object(lj, "_call_judge_llm", _llm_returns_garbage_for_c1),
+        patch.object(lj.logger, "warning", warn),
+    ):
+        result = await lj.librechat_judge_run_once()
+
+    warn.assert_called_once()
+    assert warn.call_args.args[0] == "librechat_judge_parse_failed"
+    assert warn.call_args.kwargs["conversation_id"] == "c1"
+    assert warn.call_args.kwargs["exc_info"] is True
+    assert set(org.inserts) == {"c2"}
+    assert result["judged_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Structural: UPSERT shape, verbatim SPEC rubric, loop wiring
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_overwrites_by_external_id_and_never_duplicates():
+    """Storage is INSERT … ON CONFLICT (external_conversation_id) DO UPDATE
+    with channel pinned to 'librechat' — the separate unique key from
+    migration d3c8b6a5f1e0, so a re-judge can never create a second row."""
+    from app.services import librechat_quality_judge as lj
+
+    upsert = lj._UPSERT_SQL
+    assert "INSERT INTO conversation_quality_judgments" in upsert
+    assert "ON CONFLICT (external_conversation_id) DO UPDATE SET" in upsert
+    for field_name in (
+        "outcome",
+        "failure_category",
+        "reasoning",
+        "confidence",
+        "suggested_action",
+        "model_used",
+    ):
+        assert f"{field_name} = EXCLUDED.{field_name}" in upsert
+    assert "judged_at = NOW()" in upsert
+    # conversation_id is not written at all — it stays NULL for this channel.
+    assert "conversation_id" not in upsert.replace("external_conversation_id", "")
+
+
+def test_system_prompt_matches_spec_verbatim():
+    """REQ-5 fixes the second rubric: it must equal the fenced System block in
+    docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md byte for byte."""
+    import re
+    from pathlib import Path
+
+    from app.services.librechat_quality_judge import LIBRECHAT_JUDGE_SYSTEM_PROMPT
+
+    spec = Path(__file__).resolve().parents[3] / "docs" / "specs" / "SPEC-CHAT-QUALITY-LOOP-001" / "spec.md"
+    text = spec.read_text()
+    section = text.split("## REQ-5", 1)[1].split("## REQ-4", 1)[0]
+    match = re.search(r"System \(LETTERLIJK[^)]*\):\n```\n(.*?)\n```", section, re.DOTALL)
+    assert match is not None, "spec.md is missing the REQ-5 verbatim System block"
+    assert LIBRECHAT_JUDGE_SYSTEM_PROMPT == match.group(1)
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_both_channel_passes_independently():
+    """conversation_judge_loop runs the LibreChat pass after the webchat pass
+    every cycle; a failure on either channel is logged and never stops the
+    other channel's pass in the same or a later cycle."""
+    from app.services import conversation_judge as cj
+    from app.services import librechat_quality_judge as lj
+
+    # Cycle 1: webchat pass fails → LibreChat pass must still run, and fails.
+    # Cycle 2: webchat pass runs again → LibreChat raises CancelledError to end the loop.
+    webchat = AsyncMock(side_effect=[RuntimeError("webchat DB hiccup"), {}])
+    librechat = AsyncMock(side_effect=[RuntimeError("mongo down"), asyncio.CancelledError()])
+
+    with (
+        patch.object(cj, "_judge_run_once", webchat),
+        patch.object(lj, "librechat_judge_run_once", librechat),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await cj.conversation_judge_loop()
+
+    assert webchat.await_count == 2, "LibreChat failure stopped the webchat pass"
+    assert librechat.await_count == 2, "webchat failure stopped the LibreChat pass"

--- a/klai-portal/backend/tests/test_platform_bot_conversations.py
+++ b/klai-portal/backend/tests/test_platform_bot_conversations.py
@@ -92,9 +92,7 @@ async def test_platform_admin_reads_other_org_conversation_list_without_org_filt
         patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
         patch("app.api.admin.platform._audit", new=AsyncMock()) as audit,
     ):
-        result = await platform_bot_conversations(
-            widget_id=WIDGET_UUID, cursor=None, limit=20, perms=_platform_perms()
-        )
+        result = await platform_bot_conversations(widget_id=WIDGET_UUID, cursor=None, limit=20, perms=_platform_perms())
 
     # Cross-tenant read: org 42's conversation served to a platform-admin in org 1.
     assert [c.id for c in result] == [7]
@@ -114,7 +112,9 @@ async def test_platform_admin_reads_conversation_transcript_with_rating() -> Non
 
     now = datetime(2026, 9, 1, 12, 0, 0)
     msg_rows = [
-        SimpleNamespace(id=1, role="user", content="Wat kost Klai?", sources=None, created_at=now, sequence=1, rating=None),
+        SimpleNamespace(
+            id=1, role="user", content="Wat kost Klai?", sources=None, created_at=now, sequence=1, rating=None
+        ),
         SimpleNamespace(
             id=2,
             role="assistant",
@@ -138,9 +138,7 @@ async def test_platform_admin_reads_conversation_transcript_with_rating() -> Non
         patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
         patch("app.api.admin.platform._audit", new=AsyncMock()),
     ):
-        detail = await platform_bot_conversation(
-            widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms()
-        )
+        detail = await platform_bot_conversation(widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms())
 
     assert detail.id == 7
     assert [m.id for m in detail.messages] == [1, 2]
@@ -157,9 +155,7 @@ async def test_tenant_admin_gets_403_on_platform_conversation_endpoints() -> Non
     app.include_router(router)
     app.dependency_overrides[get_caller] = _tenant_admin_perms
 
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
         listing = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations")
         detail = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations/7")
 

--- a/klai-portal/backend/tests/test_platform_bot_conversations.py
+++ b/klai-portal/backend/tests/test_platform_bot_conversations.py
@@ -1,0 +1,167 @@
+"""Regression tests for platform-admin cross-tenant widget conversation reads.
+
+The platform console must let Klai staff read ANY tenant's webchat
+conversations via /platform/bots/{widget_id}/conversations*, gated solely on
+require_platform_admin() — an ordinary tenant admin gets 403, never another
+tenant's transcript.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from tests.conftest import make_perms
+
+WIDGET_UUID = "5112f9ad-3768-4b76-9a13-5b74e9165bc3"
+
+
+class AsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class TextRows:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def first(self):
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+
+def _platform_perms():
+    return make_perms(
+        role="admin",
+        user_id="platform-admin",
+        org_id=1,
+        org_slug="getklai",
+        is_platform_admin=True,
+    )
+
+
+def _tenant_admin_perms():
+    """Ordinary tenant admin: ADMIN role, own org 42, NOT a platform admin."""
+    return make_perms(
+        role="admin",
+        user_id="tenant-admin",
+        org_id=42,
+        org_slug="voys",
+        is_platform_admin=False,
+    )
+
+
+def _conv_row():
+    now = datetime(2026, 9, 1, 12, 0, 0)
+    return SimpleNamespace(
+        id=7,
+        started_at=now,
+        last_message_at=now,
+        message_count=2,
+        first_user_query="Wat kost Klai?",
+        language_detected="nl",
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_reads_other_org_conversation_list_without_org_filter() -> None:
+    from app.api.admin.platform import platform_bot_conversations
+
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            TextRows([SimpleNamespace(id=WIDGET_UUID, org_id=42)]),
+            TextRows([_conv_row()]),
+        ]
+    )
+
+    with (
+        patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform._audit", new=AsyncMock()) as audit,
+    ):
+        result = await platform_bot_conversations(
+            widget_id=WIDGET_UUID, cursor=None, limit=20, perms=_platform_perms()
+        )
+
+    # Cross-tenant read: org 42's conversation served to a platform-admin in org 1.
+    assert [c.id for c in result] == [7]
+    assert result[0].first_user_query == "Wat kost Klai?"
+    # The platform query must NOT carry an org restriction — the platform-admin
+    # gate plus cross_org_session() is the only boundary (mirrors platform_bots).
+    for call in db.execute.await_args_list:
+        assert "org_id" not in str(call.args[0])
+    # Every cross-tenant read writes an audit event, no exceptions.
+    audit.assert_awaited_once()
+    assert audit.await_args.args[1:] == ("bot-conversations", WIDGET_UUID)
+
+
+@pytest.mark.asyncio
+async def test_platform_admin_reads_conversation_transcript_with_rating() -> None:
+    from app.api.admin.platform import platform_bot_conversation
+
+    now = datetime(2026, 9, 1, 12, 0, 0)
+    msg_rows = [
+        SimpleNamespace(id=1, role="user", content="Wat kost Klai?", sources=None, created_at=now, sequence=1, rating=None),
+        SimpleNamespace(
+            id=2,
+            role="assistant",
+            content="Dat hangt van het plan af.",
+            sources=[{"label": "1", "title": "Prijzen", "url": "https://getklai.com/prijzen"}],
+            created_at=now,
+            sequence=2,
+            rating="thumbsUp",
+        ),
+    ]
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[
+            TextRows([SimpleNamespace(id=WIDGET_UUID, org_id=42)]),
+            TextRows([_conv_row()]),
+            TextRows(msg_rows),
+        ]
+    )
+
+    with (
+        patch("app.api.admin.platform.cross_org_session", return_value=AsyncContext(db)),
+        patch("app.api.admin.platform._audit", new=AsyncMock()),
+    ):
+        detail = await platform_bot_conversation(
+            widget_id=WIDGET_UUID, conv_id=7, perms=_platform_perms()
+        )
+
+    assert detail.id == 7
+    assert [m.id for m in detail.messages] == [1, 2]
+    assert detail.messages[1].rating == "thumbsUp"
+    assert detail.messages[1].sources[0]["url"] == "https://getklai.com/prijzen"
+
+
+@pytest.mark.asyncio
+async def test_tenant_admin_gets_403_on_platform_conversation_endpoints() -> None:
+    from app.api.admin.platform import router
+    from app.core.permissions import get_caller
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_caller] = _tenant_admin_perms
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        listing = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations")
+        detail = await client.get(f"/platform/bots/{WIDGET_UUID}/conversations/7")
+
+    assert listing.status_code == 403
+    assert detail.status_code == 403

--- a/klai-portal/backend/tests/test_widget_messages_retention.py
+++ b/klai-portal/backend/tests/test_widget_messages_retention.py
@@ -261,7 +261,7 @@ async def test_retention_run_once_skips_delete_when_no_candidates():
         result = await _retention_run_once()
 
     assert result == {"deleted_count": 0, "chunk_count": 0}
-    assert any("SELECT id FROM widget_messages" in sql for sql in captured_sql)
+    assert any("SELECT id, conversation_id FROM widget_messages" in sql for sql in captured_sql)
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +344,82 @@ async def test_retention_run_once_uses_settings_retention_days():
 
     # The SQL must have been called with a cutoff param
     assert captured_params, "No SQL params captured — DELETE not issued"
+
+
+# ---------------------------------------------------------------------------
+# REQ-4 (SPEC-CHAT-QUALITY-LOOP-001 §11) — anonymize judgment reasoning on purge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_anonymizes_judgment_reasoning_before_deleting_messages():
+    """Purging a conversation's messages NULLs its judgment's reasoning first.
+
+    The UPDATE runs BEFORE the DELETE, in the same session/transaction, and
+    only for the DISTINCT conversation_ids of the messages deleted in that
+    chunk — a conversation that is not purged keeps its judgment untouched.
+    outcome/confidence/judged_at are not in the SET list, so they survive.
+    """
+    from app.services.widget_messages_retention import _retention_run_once
+
+    session_id = 0
+    calls: list[tuple[int, str, dict]] = []
+    db = AsyncMock()
+
+    async def _execute(stmt, params=None, **kwargs):
+        sql = str(stmt)
+        calls.append((session_id, sql, dict(params or {})))
+        result = MagicMock()
+        if "FROM widget_messages" in sql and sql.lstrip().startswith("SELECT"):
+            # 3 expired messages across conversations 7, 7 and 9
+            result.all.return_value = [(101, 7), (102, 7), (103, 9)]
+        elif "UPDATE conversation_quality_judgments" in sql:
+            result.rowcount = 2
+        else:
+            result.rowcount = 3
+        return result
+
+    db.execute = _execute
+    db.commit = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_session():
+        nonlocal session_id
+        session_id += 1
+        yield db
+
+    import structlog.testing
+
+    with (
+        patch("app.services.widget_messages_retention.cross_org_session", _fake_session),
+        patch("app.services.widget_messages_retention.settings") as mock_settings,
+        structlog.testing.capture_logs() as captured,
+    ):
+        mock_settings.widget_messages_retention_days = 7
+        result = await _retention_run_once()
+
+    update_idx = next(
+        i for i, (_, sql, _) in enumerate(calls)
+        if "UPDATE conversation_quality_judgments" in sql
+    )
+    delete_idx = next(
+        i for i, (_, sql, _) in enumerate(calls) if "DELETE FROM widget_messages" in sql
+    )
+    assert update_idx < delete_idx, "reasoning must be nulled before the messages are deleted"
+
+    _, update_sql, update_params = calls[update_idx]
+    assert "SET reasoning = NULL" in update_sql
+    assert "anonymized_at = NOW()" in update_sql
+    assert "conversation_id = ANY(CAST(:conversation_ids AS bigint[]))" in update_sql
+    assert "reasoning IS NOT NULL" in update_sql
+    assert update_params["conversation_ids"] == [7, 9]
+
+    # Same cross_org_session as the DELETE (no second session/transaction).
+    assert calls[update_idx][0] == calls[delete_idx][0]
+
+    assert result["deleted_count"] == 3
+    audit = [e for e in captured if e.get("event") == "widget_messages.retention_deleted"]
+    assert audit[0]["anonymized_judgments"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/klai-portal/backend/tests/test_widget_messages_retention.py
+++ b/klai-portal/backend/tests/test_widget_messages_retention.py
@@ -398,13 +398,8 @@ async def test_retention_anonymizes_judgment_reasoning_before_deleting_messages(
         mock_settings.widget_messages_retention_days = 7
         result = await _retention_run_once()
 
-    update_idx = next(
-        i for i, (_, sql, _) in enumerate(calls)
-        if "UPDATE conversation_quality_judgments" in sql
-    )
-    delete_idx = next(
-        i for i, (_, sql, _) in enumerate(calls) if "DELETE FROM widget_messages" in sql
-    )
+    update_idx = next(i for i, (_, sql, _) in enumerate(calls) if "UPDATE conversation_quality_judgments" in sql)
+    delete_idx = next(i for i, (_, sql, _) in enumerate(calls) if "DELETE FROM widget_messages" in sql)
     assert update_idx < delete_idx, "reasoning must be nulled before the messages are deleted"
 
     _, update_sql, update_params = calls[update_idx]

--- a/klai-portal/frontend/messages/en.json
+++ b/klai-portal/frontend/messages/en.json
@@ -2667,5 +2667,7 @@
   "klai_assistant_submitting": "Sending...",
   "klai_assistant_error": "Sending failed. Please try again.",
   "klai_assistant_add_another": "Send another",
-  "klai_assistant_disclaimer": "AI answers can contain mistakes. Always verify important information at the source."
+  "klai_assistant_disclaimer": "AI answers can contain mistakes. Always verify important information at the source.",
+  "admin_extension_librechat_quality_judge_label": "Conversation quality (LibreChat)",
+  "admin_extension_librechat_quality_judge_description": "Let the nightly quality judge also evaluate this tenant's LibreChat conversations (separate from webchat)."
 }

--- a/klai-portal/frontend/messages/nl.json
+++ b/klai-portal/frontend/messages/nl.json
@@ -2667,5 +2667,7 @@
   "klai_assistant_submitting": "Versturen...",
   "klai_assistant_error": "Versturen mislukt. Probeer het opnieuw.",
   "klai_assistant_add_another": "Nog iets doorgeven",
-  "klai_assistant_disclaimer": "AI-antwoorden kunnen fouten bevatten. Controleer belangrijke informatie altijd bij de bron."
+  "klai_assistant_disclaimer": "AI-antwoorden kunnen fouten bevatten. Controleer belangrijke informatie altijd bij de bron.",
+  "admin_extension_librechat_quality_judge_label": "Gespreksbeoordeling (LibreChat)",
+  "admin_extension_librechat_quality_judge_description": "Laat de nachtelijke kwaliteitsbeoordeling ook LibreChat-gesprekken van deze tenant beoordelen (los van webchat)."
 }

--- a/klai-portal/frontend/src/routes/admin/platform/-components/OrgDetailSections.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/-components/OrgDetailSections.tsx
@@ -539,11 +539,14 @@ export function UsersSection({
 
 export function BotsSection({
   bots,
+  orgId,
   fmtDate,
 }: {
   bots: PlatformBot[]
+  orgId: string
   fmtDate: (s: string | null) => string
 }) {
+  const navigate = useNavigate()
   return (
     <section>
       <h2 className="mb-3 text-[0.6875rem] font-semibold uppercase tracking-[0.06em] text-gray-600">
@@ -558,6 +561,7 @@ export function BotsSection({
               <DataTableHead>{m.platform_col_bot()}</DataTableHead>
               <DataTableHead>{m.platform_col_knowledge_bases()}</DataTableHead>
               <DataTableHead>{m.platform_col_created()}</DataTableHead>
+              <DataTableHead className="w-24">&nbsp;</DataTableHead>
             </DataTableRow>
           </DataTableHeader>
           <DataTableBody>
@@ -579,6 +583,24 @@ export function BotsSection({
                 <DataTableCell className="tabular-nums">{b.kb_count}</DataTableCell>
                 <DataTableCell className="whitespace-nowrap tabular-nums text-gray-600">
                   {fmtDate(b.created_at)}
+                </DataTableCell>
+                <DataTableCell className="text-right">
+                  {/* Cross-tenant conversation browser (platform staff only) */}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      void navigate({
+                        to: '/admin/platform/orgs/$orgId',
+                        params: { orgId },
+                        search: { tab: 'conversations', widgetId: b.id },
+                      })
+                    }}
+                  >
+                    Gesprekken
+                  </Button>
                 </DataTableCell>
               </DataTableRow>
             ))}

--- a/klai-portal/frontend/src/routes/admin/platform/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/platform/-types.ts
@@ -170,6 +170,31 @@ export interface PlatformBot {
   created_at: string
 }
 
+// Cross-tenant widget conversation reads (GET /platform/bots/{id}/conversations*).
+// Shapes mirror admin/widgets/-types.ts deliberately — no cross-directory import.
+export interface PlatformBotConversationItem {
+  id: number
+  started_at: string
+  last_message_at: string
+  message_count: number
+  first_user_query: string | null
+  language_detected: string | null
+}
+
+export interface PlatformBotConversationMessage {
+  id: number
+  role: 'user' | 'assistant'
+  content: string
+  sources: { label: string; title: string; url: string }[] | null
+  created_at: string
+  sequence: number
+  rating: 'thumbsUp' | 'thumbsDown' | null
+}
+
+export interface PlatformBotConversationDetail extends PlatformBotConversationItem {
+  messages: PlatformBotConversationMessage[]
+}
+
 export interface PlatformChatError {
   id: number
   org_id: number

--- a/klai-portal/frontend/src/routes/admin/platform/orgs.$orgId.tsx
+++ b/klai-portal/frontend/src/routes/admin/platform/orgs.$orgId.tsx
@@ -1,4 +1,6 @@
 import { createFileRoute, useNavigate, useParams } from '@tanstack/react-router'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import {
   AlertTriangle,
   ArrowLeft,
@@ -6,14 +8,22 @@ import {
   BookOpen,
   FileText,
   Loader2,
+  MessageSquare,
   Settings,
   BarChart3,
+  ThumbsDown,
+  ThumbsUp,
   Users,
+  X,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { QueryErrorState } from '@/components/ui/query-error-state'
+import { Select } from '@/components/ui/select'
 import { Tabs, type TabItem } from '@/components/ui/tabs'
+import { useAuth } from '@/lib/auth'
+import { apiFetch } from '@/lib/apiFetch'
 import { getLocale } from '@/paraglide/runtime'
 import { datetime } from '@/paraglide/registry'
 import * as m from '@/paraglide/messages'
@@ -28,15 +38,32 @@ import {
   UsersSection,
 } from './-components/OrgDetailSections'
 import { UsageSection } from './-components/stats/UsageSection'
-import type { PlatformUsageRange } from './-types'
+import type {
+  PlatformBot,
+  PlatformBotConversationDetail,
+  PlatformBotConversationItem,
+  PlatformUsageRange,
+} from './-types'
 import { PageContainer } from '@/components/ui/page-container'
+// REQ-9 (Finding B-9): reuse the tested URL-scheme allowlist for conversation
+// source links rather than re-implementing it here.
+import { _isSafeHttpUrl } from '../widgets/_components/tabs/ActivityTab'
 
-type TabId = 'features' | 'users' | 'bots' | 'knowledge-bases' | 'templates' | 'usage' | 'danger'
+type TabId =
+  | 'features'
+  | 'users'
+  | 'bots'
+  | 'conversations'
+  | 'knowledge-bases'
+  | 'templates'
+  | 'usage'
+  | 'danger'
 
 const VALID_TABS = new Set<TabId>([
   'features',
   'users',
   'bots',
+  'conversations',
   'knowledge-bases',
   'templates',
   'usage',
@@ -46,6 +73,7 @@ const VALID_TABS = new Set<TabId>([
 type DetailSearch = {
   tab?: TabId
   range?: PlatformUsageRange
+  widgetId?: string
 }
 
 export const Route = createFileRoute('/admin/platform/orgs/$orgId')({
@@ -56,6 +84,10 @@ export const Route = createFileRoute('/admin/platform/orgs/$orgId')({
     range:
       search.range === '7d' || search.range === '30d' || search.range === '90d'
         ? search.range
+        : undefined,
+    widgetId:
+      typeof search.widgetId === 'string' && search.widgetId
+        ? search.widgetId
         : undefined,
   }),
   component: PlatformOrgDetailPage,
@@ -121,6 +153,11 @@ function PlatformOrgDetailPage() {
       label: m.platform_tab_bots(),
       icon: Bot,
       count: data.bots.length,
+    },
+    {
+      id: 'conversations',
+      label: m.admin_widgets_activity_recent_conversations_title(),
+      icon: MessageSquare,
     },
     {
       id: 'knowledge-bases',
@@ -209,7 +246,12 @@ function PlatformOrgDetailPage() {
       {activeTab === 'users' && (
         <UsersSection orgId={orgId} users={data.users} />
       )}
-      {activeTab === 'bots' && <BotsSection bots={data.bots} fmtDate={fmtDate} />}
+      {activeTab === 'bots' && (
+        <BotsSection bots={data.bots} orgId={orgId} fmtDate={fmtDate} />
+      )}
+      {activeTab === 'conversations' && (
+        <ConversationsSection bots={data.bots} initialWidgetId={search.widgetId} />
+      )}
       {activeTab === 'knowledge-bases' && (
         <KnowledgeBasesSection
           knowledgeBases={data.knowledge_bases}
@@ -224,5 +266,306 @@ function PlatformOrgDetailPage() {
       )}
       {activeTab === 'danger' && <TenantDangerZone org={data.org} />}
     </PageContainer>
+  )
+}
+
+// Cross-tenant widget conversation browser for platform staff. Mirrors the
+// tenant-side ActivityTab pattern (row list + transcript drawer — a deliberate
+// exception to the "admin detail = separate route" rule, valid for chat
+// transcripts; see SPEC-WIDGET-ACTIVITY-001).
+
+function ConversationsSection({
+  bots,
+  initialWidgetId,
+}: {
+  bots: PlatformBot[]
+  initialWidgetId?: string
+}) {
+  const auth = useAuth()
+  const [selected, setSelected] = useState(
+    () => bots.find((b) => b.id === initialWidgetId)?.id ?? bots[0]?.id ?? '',
+  )
+  const [openConvId, setOpenConvId] = useState<number | null>(null)
+
+  const convsQuery = useQuery({
+    queryKey: ['platform-bot-conversations', selected],
+    queryFn: async () =>
+      apiFetch<PlatformBotConversationItem[]>(
+        `/api/admin/platform/bots/${selected}/conversations?limit=50`,
+      ),
+    enabled: auth.isAuthenticated && !!selected,
+  })
+  const conversations = Array.isArray(convsQuery.data) ? convsQuery.data : []
+
+  if (bots.length === 0) {
+    return (
+      <p className="text-sm text-gray-600">{m.platform_no_bots()}</p>
+    )
+  }
+
+  return (
+    <section className="space-y-4">
+      {bots.length > 1 && (
+        <div className="max-w-sm space-y-1.5">
+          <Label htmlFor="platform-bot-select">{m.platform_col_bot()}</Label>
+          <Select
+            id="platform-bot-select"
+            value={selected}
+            onChange={(e) => {
+              setSelected(e.target.value)
+              setOpenConvId(null)
+            }}
+          >
+            {bots.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </Select>
+        </div>
+      )}
+
+      {convsQuery.isLoading && (
+        <p className="text-sm text-gray-600">
+          <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+          {m.admin_shared_loading()}
+        </p>
+      )}
+      {convsQuery.isError && (
+        <p className="text-sm text-[var(--color-destructive)]">
+          Kon gesprekken niet laden.
+        </p>
+      )}
+      {!convsQuery.isLoading && conversations.length === 0 && !convsQuery.isError && (
+        <p className="text-sm text-gray-600">
+          Nog geen gesprekken voor deze bot.
+        </p>
+      )}
+      {conversations.length > 0 && (
+        <ul className="divide-y divide-gray-200 border-t border-b border-gray-200">
+          {conversations.map((c) => (
+            <li key={c.id}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpenConvId(c.id)}
+                className="klai-hover h-auto w-full justify-start rounded-none px-2 py-3.5 text-left"
+              >
+                <MessageSquare className="h-4 w-4 mt-0.5 text-gray-500 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm text-gray-900">
+                    {c.first_user_query || (
+                      <span className="text-gray-600 italic">
+                        (geen vraag opgeslagen)
+                      </span>
+                    )}
+                  </p>
+                  <p className="mt-0.5 flex items-center gap-2 text-xs text-gray-600">
+                    <span>{fmtDate(c.started_at)}</span>
+                    <span>·</span>
+                    <span>
+                      {c.message_count === 1
+                        ? '1 bericht'
+                        : `${c.message_count} berichten`}
+                    </span>
+                    {c.language_detected && (
+                      <>
+                        <span>·</span>
+                        <span className="uppercase">{c.language_detected}</span>
+                      </>
+                    )}
+                  </p>
+                </div>
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {openConvId !== null && (
+        <PlatformConversationDrawer
+          widgetId={selected}
+          convId={openConvId}
+          onClose={() => setOpenConvId(null)}
+        />
+      )}
+    </section>
+  )
+}
+
+/**
+ * REQ-3 (SPEC-CHAT-QUALITY-LOOP-001): the nightly judge's verdict via the
+ * platform cross-tenant sidecar endpoint. Local shape, mirroring the
+ * tenant-side drawer in widgets/…/ActivityTab.tsx — deliberately not shared.
+ */
+interface PlatformConversationQuality {
+  outcome: string
+  failure_category: string | null
+  reasoning: string | null
+  confidence: string | null
+  suggested_action: string | null
+  judged_at: string | null
+}
+
+/** Outcome → existing Badge semantic variant; no ad-hoc colors. */
+const OUTCOME_BADGE_VARIANT: Record<string, 'success' | 'warning' | 'secondary'> = {
+  resolved: 'success',
+  partially_resolved: 'success',
+  escalated: 'warning',
+  unresolved: 'secondary',
+  abandoned_early: 'secondary',
+  out_of_scope: 'secondary',
+}
+
+/** Judge verdict panel. Renders only when a judgment exists — a 404
+ * ("not judged yet") is normal and shows nothing. */
+function QualityPanel({ quality }: { quality: PlatformConversationQuality }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+      <Badge variant={OUTCOME_BADGE_VARIANT[quality.outcome] ?? 'secondary'}>
+        {quality.outcome}
+      </Badge>
+      {quality.reasoning && (
+        <p className="mt-2 text-xs leading-5 text-gray-600">{quality.reasoning}</p>
+      )}
+      {quality.suggested_action && (
+        <p className="mt-1.5 text-xs leading-5 text-gray-700">{quality.suggested_action}</p>
+      )}
+    </div>
+  )
+}
+
+function PlatformConversationDrawer({
+  widgetId,
+  convId,
+  onClose,
+}: {
+  widgetId: string
+  convId: number
+  onClose: () => void
+}) {
+  const auth = useAuth()
+  const query = useQuery({
+    queryKey: ['platform-bot-conversation', widgetId, convId],
+    queryFn: async () =>
+      apiFetch<PlatformBotConversationDetail>(
+        `/api/admin/platform/bots/${widgetId}/conversations/${convId}`,
+      ),
+    enabled: auth.isAuthenticated,
+  })
+  // 404 = not judged yet (normal state): retry off, error never surfaced.
+  const qualityQuery = useQuery({
+    queryKey: ['platform-bot-conversation-quality', widgetId, convId],
+    queryFn: () =>
+      apiFetch<PlatformConversationQuality>(
+        `/api/admin/platform/bots/${widgetId}/conversations/${convId}/quality`,
+      ),
+    enabled: !!convId && auth.isAuthenticated,
+    retry: false,
+  })
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex justify-end">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden />
+      <div className="relative h-full w-full max-w-lg bg-white overflow-y-auto">
+        <div className="sticky top-0 z-10 flex items-center justify-between gap-3 border-b border-gray-200 bg-white px-5 py-3.5">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-900 truncate">
+              Gesprek #{convId}
+            </p>
+            {query.data && (
+              <p className="text-xs text-gray-600">
+                {fmtDate(query.data.started_at)} ·{' '}
+                {query.data.message_count === 1
+                  ? '1 bericht'
+                  : `${query.data.message_count} berichten`}
+              </p>
+            )}
+          </div>
+          <Button
+            type="button"
+            onClick={onClose}
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 text-gray-500"
+            aria-label="Sluiten"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div className="px-5 py-4 space-y-3">
+          {qualityQuery.data && <QualityPanel quality={qualityQuery.data} />}
+          {query.isLoading && (
+            <p className="text-sm text-gray-600">
+              <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
+              Laden…
+            </p>
+          )}
+          {query.error && (
+            <p className="text-sm text-[var(--color-destructive)]">
+              Kon gesprek niet laden.
+            </p>
+          )}
+          {query.data?.messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={
+                msg.role === 'user'
+                  ? 'ml-auto max-w-[85%] rounded-2xl rounded-br-md bg-gray-900 px-4 py-2.5 text-sm text-white whitespace-pre-wrap'
+                  : 'mr-auto max-w-[85%] rounded-2xl rounded-bl-md bg-[var(--color-rl-cream)] px-4 py-2.5 text-sm text-gray-900 whitespace-pre-wrap'
+              }
+            >
+              {msg.content}
+              {msg.role === 'assistant' &&
+                msg.sources &&
+                msg.sources.length > 0 && (
+                  <ul className="mt-2 flex flex-wrap gap-1.5">
+                    {msg.sources.map((s) => (
+                      <li key={`${msg.id}-${s.label}`}>
+                        {/* REQ-9: only http/https schemes render as anchors */}
+                        {_isSafeHttpUrl(s.url) ? (
+                          <a
+                            href={s.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={s.title}
+                            className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[0.6875rem] text-gray-700 klai-hover"
+                          >
+                            <span className="font-medium">({s.label})</span>
+                            <span className="truncate max-w-[12rem]">{s.title}</span>
+                          </a>
+                        ) : (
+                          <span
+                            title={s.title}
+                            className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[0.6875rem] text-gray-700"
+                          >
+                            <span className="font-medium">({s.label})</span>
+                            <span className="truncate max-w-[12rem]">{s.title}</span>
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              {msg.role === 'assistant' && msg.rating && (
+                msg.rating === 'thumbsUp' ? (
+                  <ThumbsUp
+                    role="img"
+                    aria-label="Door klant beoordeeld met duim omhoog"
+                    className="mt-2 h-3.5 w-3.5 text-[var(--color-success-text)]"
+                  />
+                ) : (
+                  <ThumbsDown
+                    role="img"
+                    aria-label="Door klant beoordeeld met duim omlaag"
+                    className="mt-2 h-3.5 w-3.5 text-[var(--color-destructive)]"
+                  />
+                )
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/klai-portal/frontend/src/routes/admin/widgets/-types.ts
+++ b/klai-portal/frontend/src/routes/admin/widgets/-types.ts
@@ -177,6 +177,7 @@ export interface WidgetMessageItem {
   sources: MessageSourceItem[] | null
   created_at: string
   sequence: number
+  rating: 'thumbsUp' | 'thumbsDown' | null
 }
 
 export interface ConversationDetail extends ConversationListItem {

--- a/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/ActivityTab.tsx
+++ b/klai-portal/frontend/src/routes/admin/widgets/_components/tabs/ActivityTab.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
-import { Loader2, MessageSquare, X } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { Loader2, MessageSquare, ThumbsDown, ThumbsUp, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { apiFetch } from '@/lib/apiFetch'
 import * as m from '@/paraglide/messages'
 import {
   useWidgetConversations,
@@ -340,6 +343,48 @@ function HourlySparkline({ data }: { data: number[] | undefined }) {
   )
 }
 
+/**
+ * REQ-3 (SPEC-CHAT-QUALITY-LOOP-001): the nightly judge's verdict, read from
+ * its own sidecar endpoint so the transcript types stay untouched. Local
+ * shape on purpose — duplicated in the platform drawer, no shared module.
+ */
+interface ConversationQuality {
+  outcome: string
+  failure_category: string | null
+  reasoning: string | null
+  confidence: string | null
+  suggested_action: string | null
+  judged_at: string | null
+}
+
+/** Outcome → existing Badge semantic variant; no ad-hoc colors. */
+const OUTCOME_BADGE_VARIANT: Record<string, 'success' | 'warning' | 'secondary'> = {
+  resolved: 'success',
+  partially_resolved: 'success',
+  escalated: 'warning',
+  unresolved: 'secondary',
+  abandoned_early: 'secondary',
+  out_of_scope: 'secondary',
+}
+
+/** Judge verdict panel for a conversation drawer. Renders only when a
+ * judgment exists — a 404 ("not judged yet") is normal and shows nothing. */
+function QualityPanel({ quality }: { quality: ConversationQuality }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+      <Badge variant={OUTCOME_BADGE_VARIANT[quality.outcome] ?? 'secondary'}>
+        {quality.outcome}
+      </Badge>
+      {quality.reasoning && (
+        <p className="mt-2 text-xs leading-5 text-gray-600">{quality.reasoning}</p>
+      )}
+      {quality.suggested_action && (
+        <p className="mt-1.5 text-xs leading-5 text-gray-700">{quality.suggested_action}</p>
+      )}
+    </div>
+  )
+}
+
 function ConversationDrawer({
   widgetId,
   convId,
@@ -350,6 +395,16 @@ function ConversationDrawer({
   onClose: () => void
 }) {
   const query = useWidgetConversation(widgetId, convId)
+  // 404 = not judged yet (normal state): retry off, error never surfaced.
+  const qualityQuery = useQuery({
+    queryKey: ['widget-conversation-quality', widgetId, convId],
+    queryFn: () =>
+      apiFetch<ConversationQuality>(
+        `/api/admin/widgets/${widgetId}/conversations/${convId}/quality`,
+      ),
+    enabled: !!convId,
+    retry: false,
+  })
   return (
     <div
       role="dialog"
@@ -389,6 +444,7 @@ function ConversationDrawer({
         </div>
 
         <div className="px-5 py-4 space-y-3">
+          {qualityQuery.data && <QualityPanel quality={qualityQuery.data} />}
           {query.isLoading && (
             <p className="text-sm text-gray-600">
               <Loader2 className="inline h-4 w-4 animate-spin mr-2" />
@@ -438,6 +494,21 @@ function ConversationDrawer({
                     </li>
                   ))}
                 </ul>
+              )}
+              {msg.role === 'assistant' && msg.rating && (
+                msg.rating === 'thumbsUp' ? (
+                  <ThumbsUp
+                    role="img"
+                    aria-label="Door klant beoordeeld met duim omhoog"
+                    className="mt-2 h-3.5 w-3.5 text-[var(--color-success-text)]"
+                  />
+                ) : (
+                  <ThumbsDown
+                    role="img"
+                    aria-label="Door klant beoordeeld met duim omlaag"
+                    className="mt-2 h-3.5 w-3.5 text-[var(--color-destructive)]"
+                  />
+                )
               )}
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Self-learning conversation quality loop: nightly LLM-as-judge (klai-medium) categorizes finished webchat conversations (outcome, failure category, evidence-grounded reasoning, confidence, suggested action) into a new `conversation_quality_judgments` table, enriching the existing real-time `widget_outcome.py` heuristic without replacing it.
- Existing thumbs-rating now surfaces in both the tenant-admin activity drawer and a new Klai-admin cross-tenant conversation browser (platform console → org detail → Conversations tab).
- LibreChat conversations can be judged too, but only for a tenant with the new `librechat_quality_judge` platform-unlock explicitly turned on (default off everywhere) — Voys is the intended pilot, reusing the existing per-tenant Mongo connection pattern rather than a new cross-tenant read.
- `widget_messages_retention_days` lowered from 90 to 7 (global); a new anonymization sweep strips judge `reasoning` before a conversation is purged, so quality metadata (outcome/category/confidence) outlives the raw conversation, anonymized.
- Doc fix: knowledge-ingest-flow.md's retention note for `portal_retrieval_gaps` corrected from a flat "90 days" to the actual privacy-driven 7-day sweep behavior.

Full design, requirement history and open questions: `docs/specs/SPEC-CHAT-QUALITY-LOOP-001/spec.md`.

## Test plan
- [x] `uv run pytest tests/ -q` — 4036 passed, 0 failed (klai-portal/backend)
- [x] `uv run ruff check .` — clean
- [x] `uv run --with pyright pyright` — 0 errors
- [x] `npx tsc -b --noEmit` and `npx eslint .` (klai-portal/frontend) — clean
- [x] Judge system prompts verified byte-identical to the SPEC (both webchat and LibreChat rubrics), programmatically
- [ ] Post-deploy SQL (`post_deploy_b7e4f1a9c3d2_*.sql`, `post_deploy_d3c8b6a5f1e0_*.sql`) applied against production by an operator — required before the new endpoints/loop can run without erroring on the missing table
- [ ] `librechat_quality_judge` platform-unlock turned on for Voys — deliberately left off; a separate admin action after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)