### PR TITLE
fix(hooks): gate on where a command lands, not on which verb it uses

### DIFF
--- a/.claude/hooks/klai/public-github-mutation-guard.py
+++ b/.claude/hooks/klai/public-github-mutation-guard.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Block autonomous public GitHub issue, PR, and main-branch mutations.
+"""Block autonomous GitHub issue mutations, and anything aimed at a repo
+that is not ours.
 
 Claude PreToolUse hooks receive the pending Bash invocation as JSON on stdin.
 An explicit marker is available for a user-authorized public mutation; repo
@@ -9,6 +10,7 @@ instructions define when an agent may use it.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -20,16 +22,30 @@ CODE_APPROVAL_MARKER = "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"
 
 READ_ONLY_ISSUE_VERBS = {"list", "status", "view"}
 
-# `create` is here with the read-only verbs, and that is the point: by the time
-# it runs, the branch push already published the code AND every commit message
-# on it, unblocked -- only pushes to `main` are gated below. Opening the PR adds
-# no surface that is not already public, so blocking it protected nothing while
-# firing on every ordinary PR. A guard that is bypassed every single time
-# teaches the bypass, and the two blocks that do earn their place -- issues,
-# which have no other gate, and merge, which is the #1208 review-gate lesson --
-# get bypassed with the same reflex. The publication rule in AGENTS.md is
-# unchanged and still governs what you put in a PR body.
-READ_ONLY_PR_VERBS = {"checks", "checkout", "create", "diff", "list", "status", "view"}
+# What this gate asks changed on 2026-09-11: WHERE a command is aimed, not
+# which verb it uses.
+#
+# Inside GetKlai it blocks nothing. Klai has three people, all admins, and main
+# is already gated by branch protection -- a PR, a green `quality` check (which
+# itself waits on every affected service job), no force-push, no deletion. A
+# marker the one developer types on every merge is not a second opinion, it is
+# a keystroke. It also self-authorised once: a PR body that merely MENTIONED
+# the marker satisfied the match.
+#
+# Outside GetKlai it blocks what lands on someone else's doorstep. Pushing a
+# branch to your own fork notifies nobody; a pull request does. Not
+# hypothetical: one was opened at unclecode/crawl4ai on 2026-09-11 from a
+# sentence read as permission, and nothing here stopped it -- `gh pr create`
+# was on the read-only list.
+#
+# There is deliberately no exemption for `--draft`. A draft still needs the
+# user to have asked for one, and the exemption was where the holes were: a
+# body reading "use --draft next time" satisfied it, and so did a `--draft` in
+# a later command on the same line. One rule that always asks beats an
+# exception that can be spelled six ways.
+READ_ONLY_PR_VERBS = {"checks", "checkout", "diff", "list", "status", "view"}
+
+OUR_ORG = "getklai"
 ISSUE_ENDPOINT = re.compile(
     r"(?:https?://api\.github\.com/)?repos/[^/\s'\"]+/[^/\s'\"]+/issues"
     r"(?:[/ ?'\"]|$)",
@@ -97,13 +113,6 @@ PUSH_FLAG_OPTIONS = {
     "--thin",
     "--no-thin",
 }
-
-
-class PushInvocation(NamedTuple):
-    arguments: list[str] | None
-    git_options: list[str]
-    cwd: str | None
-    branch_context_known: bool
 
 
 class Heredoc(NamedTuple):
@@ -237,167 +246,185 @@ def is_public_issue_mutation(command: str) -> bool:
     return False
 
 
-def is_public_pr_mutation(command: str) -> bool:
-    for match in re.finditer(r"\bgh\s+pr\s+([a-z-]+)\b", command, re.IGNORECASE):
-        if match.group(1).lower() not in READ_ONLY_PR_VERBS:
+# gh accepts several ways to name a repository, and a guard that knows only
+# the longest one is a guard with a documented bypass.
+# An API call names the owner in its path rather than in a flag.
+_REPO_PATH = re.compile(r"(?:^|[\s'\"/])repos/([^/\s'\"]+)/[^/\s'\"]+")
+_OWNER_OF = re.compile(r"^['\"]?([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s'\"]+['\"]?$")
+
+# gh's own short forms. Without these, `gh pr new` is an unknown verb and
+# `gh pr ls` looks like a mutation.
+_PR_VERB_ALIASES = {"new": "create", "co": "checkout", "ls": "list"}
+
+# A directory change means the cwd we were handed no longer describes where
+# the command runs, and a shell variable means the destination is not in the
+# text at all. Neither can be resolved here, and unresolved is elsewhere.
+_CHANGES_DIRECTORY = re.compile(r"(?:^|[\s;&|(])cd\s", re.IGNORECASE)
+
+
+def _named_owners(command: str) -> tuple[set[str], bool]:
+    """Owners named in the text, and whether any naming could not be read.
+
+    Tokenised rather than scanned, because the difference matters: in
+    ``--body 'see --repo GetKlai/klai please'`` the body is ONE token and the
+    flag never appears on its own, while ``--repo GetKlai/klai`` is two real
+    tokens. Regex on the raw string cannot tell those apart, and read the
+    first as a GetKlai destination.
+
+    The second half of the return matters as much as the first: ``-R
+    "$TARGET"`` names a repository this cannot resolve, and calling that "none
+    named" would quietly fall back to the local checkout.
+    """
+    owners: set[str] = set()
+    unresolved = False
+
+    try:
+        tokens = shlex.split(command, comments=False)
+    except ValueError:
+        # Unparseable shell. We cannot see the flags, so we have not proved
+        # anything about where this lands.
+        return set(), True
+
+    flags = {"--repo", "-r"}
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        lowered = token.lower()
+        value: str | None = None
+        if lowered in flags or lowered == "-r":
+            value = tokens[index + 1] if index + 1 < len(tokens) else ""
+            index += 1
+        elif "=" in token:
+            name, _, rest = token.partition("=")
+            if name.lower() in flags or name == "GH_REPO":
+                value = rest
+        if value is not None:
+            match = _OWNER_OF.match(value)
+            if match is None:
+                unresolved = True
+            else:
+                owners.add(match.group(1).lower())
+        index += 1
+
+    return owners, unresolved
+
+
+def _path_owners(command: str) -> set[str]:
+    """Owners appearing as ``repos/<owner>/<name>``, from the raw text.
+
+    Used only to raise suspicion, never to clear it: unlike a tokenised flag,
+    this shape can sit inside a quoted argument, so a GetKlai name here proves
+    nothing about where the command lands.
+    """
+    return {m.group(1).lower() for m in _REPO_PATH.finditer(command)}
+
+
+def _origin_owner(cwd: str | None) -> str | None:
+    """Owner of the repository ``gh`` would act on in ``cwd``, or None.
+
+    ``gh repo set-default`` records its choice in ``remote.<name>.gh-resolved``
+    and gh prefers it over the remote URL, so reading only the URL would miss
+    a default pointed somewhere else entirely.
+    """
+    if not cwd:
+        return None
+    for args in (
+        ["config", "--get-regexp", r"remote\..*\.gh-resolved"],
+        ["remote", "get-url", "origin"],
+    ):
+        try:
+            result = subprocess.run(
+                ["git", "-C", cwd, *args],
+                capture_output=True, text=True, timeout=5, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            continue
+        text = result.stdout.strip()
+        if not text:
+            continue
+        # gh-resolved is either "base" (meaning origin) or "owner/name".
+        match = re.search(r"(?:github\.com[:/])([^/\s]+)/", text) or re.search(
+            r"\s([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s]+$", text
+        )
+        if match:
+            return match.group(1).lower()
+    return None
+
+
+def targets_another_org(command: str, cwd: str | None) -> bool:
+    """True unless everything visible says this lands inside GetKlai.
+
+    Fail-closed by construction. Being wrong this way costs one sentence
+    asking the user; being wrong the other way costs a stranger their inbox.
+    """
+    flag_owners, unresolved = _named_owners(command)
+    if unresolved:
+        return True
+    if any(owner != OUR_ORG for owner in flag_owners | _path_owners(command)):
+        return True
+    if flag_owners:
+        # A tokenised --repo is the destination itself, so this settles it
+        # without asking the checkout.
+        return False
+    if _CHANGES_DIRECTORY.search(command):
+        # The cwd we were handed no longer describes where this runs, and
+        # nothing named a repository outright.
+        return True
+    return _origin_owner(cwd) != OUR_ORG
+
+
+def is_public_pr_mutation(command: str, cwd: str | None = None) -> bool:
+    elsewhere: bool | None = None
+
+    def aimed_elsewhere() -> bool:
+        # Resolved at most once, and only once something worth gating is
+        # found: this hook runs before EVERY bash command, and `git remote
+        # get-url` on each `echo hello` is a subprocess nobody asked for.
+        nonlocal elsewhere
+        if elsewhere is None:
+            elsewhere = targets_another_org(command, cwd)
+        return elsewhere
+
+    # Bounded to one invocation: a greedy tail let `gh pr view && gh pr create`
+    # be judged entirely on the `view`.
+    for match in re.finditer(
+        r"\bgh\s+pr\s+([a-z-]+)\b([^\n;&|]*)", command, re.IGNORECASE
+    ):
+        verb = _PR_VERB_ALIASES.get(match.group(1).lower(), match.group(1).lower())
+        if verb in READ_ONLY_PR_VERBS:
+            continue
+        if verb == "ready" and re.search(r"(?:^|\s)--undo(?:\s|$)", match.group(2)):
+            # Putting a PR BACK to draft is the retreat, never the publication.
+            continue
+        if aimed_elsewhere():
             return True
 
+    # The same publications reached through the API rather than the CLI.
     if re.search(r"\bgh\s+api\b", command, re.IGNORECASE):
-        if PULL_ENDPOINT.search(command) and (
-            MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command)
+        if (
+            PULL_ENDPOINT.search(command)
+            and (MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command))
+            and aimed_elsewhere()
         ):
             return True
         if re.search(r"\bgraphql\b", command, re.IGNORECASE) and (
             PULL_GRAPHQL_MUTATION.search(command)
         ):
+            # A GraphQL mutation addresses an opaque node id, so nothing in
+            # the command says which repository it lands in. Unknown is
+            # elsewhere: this is the one shape where our own checkout proves
+            # nothing at all.
             return True
 
-    if re.search(r"\bcurl\b", command, re.IGNORECASE) and PULL_ENDPOINT.search(command):
-        if MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command):
-            return True
-
-    return False
-
-
-def _branch_context(command: str, git_start: int) -> tuple[str | None, bool]:
-    prefix = command[:git_start]
-    if not prefix.strip():
-        return None, True
-    has_shell_context = re.search(r"&&|\|\||[;|\n]", prefix) is not None
-    try:
-        tokens = shlex.split(prefix)
-    except ValueError:
-        starts_with_cd = re.match(r"^\s*cd\b", prefix, re.IGNORECASE) is not None
-        return None, not (starts_with_cd or has_shell_context)
-    if len(tokens) == 3 and tokens[0].lower() == "cd" and tokens[2] == "&&":
-        return tokens[1], True
-    if has_shell_context or any(token.lower() == "cd" for token in tokens):
-        return None, False
-    return None, True
-
-
-def _push_invocations(command: str) -> list[PushInvocation]:
-    invocations: list[PushInvocation] = []
-    parsed_starts: set[int] = set()
-    for match in GIT_PUSH.finditer(command):
-        parsed_starts.add(match.start())
-        invocation = re.split(
-            r"&&|\|\||[;|()\n]", command[match.start() :], maxsplit=1
-        )[0]
-        cwd, branch_context_known = _branch_context(command, match.start())
-        try:
-            tokens = shlex.split(invocation)
-        except ValueError:
-            invocations.append(PushInvocation(None, [], cwd, False))
-            continue
-        try:
-            push_index = len(shlex.split(match.group(0))) - 1
-        except ValueError:
-            invocations.append(PushInvocation(None, [], cwd, False))
-            continue
-        invocations.append(
-            PushInvocation(
-                tokens[push_index + 1 :],
-                tokens[1:push_index],
-                cwd,
-                branch_context_known,
-            )
-        )
-    for match in UNPARSED_GIT_PUSH.finditer(command):
-        if match.start() not in parsed_starts:
-            invocations.append(PushInvocation(None, [], None, False))
-    return invocations
-
-
-def _current_git_branch(git_options: list[str], cwd: str | None) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", *git_options, "symbolic-ref", "--quiet", "--short", "HEAD"],
-            capture_output=True,
-            check=False,
-            cwd=cwd,
-            text=True,
-            timeout=2,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if result.returncode != 0:
-        return None
-    branch = result.stdout.strip()
-    return branch or None
-
-
-def _push_refspecs(arguments: list[str]) -> tuple[list[str] | None, bool]:
-    positionals: list[str] = []
-    delete = False
-    index = 0
-    options_done = False
-    while index < len(arguments):
-        argument = arguments[index]
-        if not options_done and argument == "--":
-            options_done = True
-        elif not options_done and argument in {"--all", "--mirror"}:
-            return None, True
-        elif not options_done and argument == "--delete":
-            delete = True
-        elif not options_done and argument.startswith("--delete="):
-            positionals.append(argument.split("=", 1)[1])
-            delete = True
-        elif not options_done and (
-            argument in PUSH_FLAG_OPTIONS
-            or argument == "--force-with-lease"
-            or argument.startswith(("--force-with-lease=", "--signed="))
-        ):
-            pass
-        elif not options_done and argument.startswith("-"):
-            return None, True
-        else:
-            positionals.append(argument)
-        index += 1
-
-    if delete:
-        if not positionals:
-            return None, True
-        return positionals[1:] if len(positionals) > 1 else None, False
-    return positionals[1:] if positionals else [], False
-
-
-def _destination_for_refspec(refspec: str, invocation: PushInvocation) -> str | None:
-    normalized = refspec.removeprefix("+")
-    if "*" in normalized:
-        return None
-    if ":" in normalized:
-        destination = normalized.rsplit(":", 1)[1]
-        return destination or None
-    if normalized not in {"@", "HEAD"}:
-        return normalized
-    if not invocation.branch_context_known:
-        return None
-    return _current_git_branch(invocation.git_options, invocation.cwd)
-
-
-def is_public_main_push(command: str) -> bool:
-    for invocation in _push_invocations(command):
-        if invocation.arguments is None:
-            return True
-        refspecs, must_block = _push_refspecs(invocation.arguments)
-        if must_block:
-            return True
-        if refspecs is None:
-            return True
-        if not refspecs:
-            if not invocation.branch_context_known:
-                return True
-            branch = _current_git_branch(invocation.git_options, invocation.cwd)
-            if branch is None:
-                return True
-            refspecs = [branch]
-        for refspec in refspecs:
-            destination = _destination_for_refspec(refspec, invocation)
-            if destination is None:
-                return True
-            if destination in {"main", "refs/heads/main"}:
-                return True
+    if (
+        re.search(r"\bcurl\b", command, re.IGNORECASE)
+        and PULL_ENDPOINT.search(command)
+        and (MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command))
+        and aimed_elsewhere()
+    ):
+        return True
 
     return False
 
@@ -456,22 +483,23 @@ def main() -> int:
         )
         return 2
 
-    if not _is_authorized(command, CODE_APPROVAL_MARKER) and is_public_pr_mutation(command):
-        print(
-            "BLOCKED: autonomous public GitHub PR mutation.\n\n"
-            "A public PR is a disclosure surface. Only when the user's current "
-            "request explicitly authorizes this exact public mutation may the "
-            f"command be retried with {CODE_APPROVAL_MARKER}.",
-            file=sys.stderr,
-        )
-        return 2
+    # Claude sends the invocation's cwd; falling back to ours keeps the hook
+    # correct when it is run directly, where the process cwd IS the checkout.
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = os.getcwd()
 
-    if not _is_authorized(command, CODE_APPROVAL_MARKER) and is_public_main_push(command):
+    if not _is_authorized(command, CODE_APPROVAL_MARKER) and is_public_pr_mutation(command, cwd):
         print(
-            "BLOCKED: public main branch push.\n\n"
-            "Direct publication to main requires explicit authorization. Routine "
-            "feature-branch pushes remain allowed. Retry an authorized main push "
-            f"with {CODE_APPROVAL_MARKER}.",
+            "BLOCKED: this may land in a repository outside GetKlai.\n\n"
+            "Pushing a branch to a fork notifies nobody; a pull request puts "
+            "it in front of someone else's maintainers, and that is the "
+            "user's call, not yours. Ask, then do exactly what they said -- "
+            "including whether it opens as a draft. This also fires when the "
+            "destination cannot be read from the command, which is deliberate: "
+            "unproven is treated as elsewhere. Only when the user's current "
+            "request authorizes this exact publication may the command be "
+            f"retried with {CODE_APPROVAL_MARKER}.",
             file=sys.stderr,
         )
         return 2

--- a/.claude/hooks/klai/public-github-mutation-guard.py
+++ b/.claude/hooks/klai/public-github-mutation-guard.py
@@ -246,30 +246,52 @@ def is_public_issue_mutation(command: str) -> bool:
     return False
 
 
-# gh accepts several ways to name a repository, and a guard that knows only
-# the longest one is a guard with a documented bypass.
+# What this can and cannot do, stated plainly: it reads a bash string and
+# decides where the command lands. Arbitrary shell can always compute a
+# destination this cannot see, so this is a guard against MISREADING a
+# sentence -- the failure that actually happened -- not against someone
+# determined to get around it. Everything unclear therefore blocks, and the
+# marker is the way through.
+
 # An API call names the owner in its path rather than in a flag.
 _REPO_PATH = re.compile(r"(?:^|[\s'\"/])repos/([^/\s'\"]+)/[^/\s'\"]+")
-_OWNER_OF = re.compile(r"^['\"]?([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s'\"]+['\"]?$")
+# gh takes [HOST/]OWNER/REPO, and a pull-request URL wherever a number fits.
+_OWNER_OF = re.compile(
+    r"^['\"]?(?:[A-Za-z0-9.-]+/)?([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s'\"]+['\"]?$"
+)
+_PR_URL = re.compile(
+    r"https?://[^/\s]*github\.com/([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s]+/pull/",
+    re.IGNORECASE,
+)
 
 # gh's own short forms. Without these, `gh pr new` is an unknown verb and
 # `gh pr ls` looks like a mutation.
 _PR_VERB_ALIASES = {"new": "create", "co": "checkout", "ls": "list"}
 
 # A directory change means the cwd we were handed no longer describes where
-# the command runs, and a shell variable means the destination is not in the
-# text at all. Neither can be resolved here, and unresolved is elsewhere.
-_CHANGES_DIRECTORY = re.compile(r"(?:^|[\s;&|(])cd\s", re.IGNORECASE)
+# the command runs. `-` and `~` are here too: they change it just as much.
+_CHANGES_DIRECTORY = re.compile(r"(?:^|[\s;&|(])(?:cd|pushd|popd)(?:\s|$)")
+# A mutating gh pr verb, or the API routes that do the same thing.
+_MUTATING_PR = re.compile(r"\bgh\s+pr\s+([a-z-]+)\b", re.IGNORECASE)
 
 
-def _named_owners(command: str) -> tuple[set[str], bool]:
-    """Owners named in the text, and whether any naming could not be read.
+def _segments(command: str) -> list[str]:
+    """Split into shell invocations, so one command cannot vouch for another.
+
+    `gh pr view --repo GetKlai/klai && gh pr merge 42` names our repository
+    exactly once, on the read-only half. Judging the merge on it is how a
+    whole-string scan clears a mutation it never looked at.
+    """
+    return [part for part in re.split(r"&&|\|\||[;\n|]", command) if part.strip()]
+
+
+def _named_owners(segment: str) -> tuple[set[str], bool]:
+    """Owners this segment names, and whether any naming could not be read.
 
     Tokenised rather than scanned, because the difference matters: in
     ``--body 'see --repo GetKlai/klai please'`` the body is ONE token and the
     flag never appears on its own, while ``--repo GetKlai/klai`` is two real
-    tokens. Regex on the raw string cannot tell those apart, and read the
-    first as a GetKlai destination.
+    tokens.
 
     The second half of the return matters as much as the first: ``-R
     "$TARGET"`` names a repository this cannot resolve, and calling that "none
@@ -278,60 +300,67 @@ def _named_owners(command: str) -> tuple[set[str], bool]:
     owners: set[str] = set()
     unresolved = False
 
+    def record(value: str) -> None:
+        nonlocal unresolved
+        match = _OWNER_OF.match(value)
+        if match is None:
+            unresolved = True
+        else:
+            owners.add(match.group(1).lower())
+
     try:
-        tokens = shlex.split(command, comments=False)
+        tokens = shlex.split(segment, comments=True)
     except ValueError:
-        # Unparseable shell. We cannot see the flags, so we have not proved
-        # anything about where this lands.
         return set(), True
 
-    flags = {"--repo", "-r"}
     index = 0
     while index < len(tokens):
         token = tokens[index]
-        lowered = token.lower()
-        value: str | None = None
-        if lowered in flags or lowered == "-r":
-            value = tokens[index + 1] if index + 1 < len(tokens) else ""
-            index += 1
-        elif "=" in token:
-            name, _, rest = token.partition("=")
-            if name.lower() in flags or name == "GH_REPO":
-                value = rest
-        if value is not None:
-            match = _OWNER_OF.match(value)
-            if match is None:
-                unresolved = True
-            else:
-                owners.add(match.group(1).lower())
+        # `-R` selects a repository; lowercase `-r` is reviewer on create and
+        # rebase on merge. Case matters here, so it is not folded away.
+        if token in {"--repo", "-R"}:
+            record(tokens[index + 1] if index + 1 < len(tokens) else "")
+            index += 2
+            continue
+        if token.startswith("-R") and len(token) > 2:
+            record(token[2:])          # gh accepts the value glued on
+        elif token.startswith("--repo="):
+            record(token[len("--repo="):])
+        elif token.startswith("GH_REPO="):
+            record(token[len("GH_REPO="):])
+        else:
+            url = _PR_URL.match(token.strip("'\""))
+            if url:
+                owners.add(url.group(1).lower())
         index += 1
 
     return owners, unresolved
 
 
-def _path_owners(command: str) -> set[str]:
-    """Owners appearing as ``repos/<owner>/<name>``, from the raw text.
+def _path_owners(segment: str) -> set[str]:
+    """Owners from a `repos/<owner>/<name>` API path, for gh api and curl only.
 
-    Used only to raise suspicion, never to clear it: unlike a tokenised flag,
-    this shape can sit inside a quoted argument, so a GetKlai name here proves
-    nothing about where the command lands.
+    Raw text rather than tokens, so it can only raise suspicion, never clear
+    it -- and it is read only where such a path is the destination, so the
+    same string quoted inside a PR body does not block an internal action.
     """
-    return {m.group(1).lower() for m in _REPO_PATH.finditer(command)}
+    if not re.search(r"\b(?:gh\s+api|curl)\b", segment, re.IGNORECASE):
+        return set()
+    return {m.group(1).lower() for m in _REPO_PATH.finditer(segment)}
 
 
 def _origin_owner(cwd: str | None) -> str | None:
     """Owner of the repository ``gh`` would act on in ``cwd``, or None.
 
-    ``gh repo set-default`` records its choice in ``remote.<name>.gh-resolved``
-    and gh prefers it over the remote URL, so reading only the URL would miss
-    a default pointed somewhere else entirely.
+    ``gh repo set-default`` records its choice as `remote.<name>.gh-resolved`,
+    and gh prefers it over the remote URL. The value is either `base` -- that
+    remote IS the choice -- or an explicit `owner/name`. Reading only
+    `origin` misses a default pointed at an upstream entirely.
     """
     if not cwd:
         return None
-    for args in (
-        ["config", "--get-regexp", r"remote\..*\.gh-resolved"],
-        ["remote", "get-url", "origin"],
-    ):
+
+    def git(*args: str) -> str | None:
         try:
             result = subprocess.run(
                 ["git", "-C", cwd, *args],
@@ -339,36 +368,47 @@ def _origin_owner(cwd: str | None) -> str | None:
             )
         except (OSError, subprocess.SubprocessError):
             return None
-        if result.returncode != 0:
-            continue
-        text = result.stdout.strip()
-        if not text:
-            continue
-        # gh-resolved is either "base" (meaning origin) or "owner/name".
-        match = re.search(r"(?:github\.com[:/])([^/\s]+)/", text) or re.search(
-            r"\s([A-Za-z0-9][A-Za-z0-9-]*)/[^/\s]+$", text
-        )
-        if match:
-            return match.group(1).lower()
-    return None
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    resolved = git("config", "--get-regexp", r"remote\..*\.gh-resolved")
+    remote = "origin"
+    if resolved:
+        key, _, value = resolved.splitlines()[0].partition(" ")
+        if value.strip() and value.strip() != "base":
+            match = _OWNER_OF.match(value.strip())
+            return match.group(1).lower() if match else None
+        parts = key.split(".")
+        if len(parts) >= 3:
+            remote = ".".join(parts[1:-1])
+
+    url = git("remote", "get-url", remote)
+    if not url:
+        return None
+    match = re.search(r"(?:github\.com[:/])([^/\s]+)/", url)
+    return match.group(1).lower() if match else None
 
 
-def targets_another_org(command: str, cwd: str | None) -> bool:
-    """True unless everything visible says this lands inside GetKlai.
+def targets_another_org(segment: str, cwd: str | None, whole: str) -> bool:
+    """True unless everything visible says this segment lands inside GetKlai.
 
     Fail-closed by construction. Being wrong this way costs one sentence
     asking the user; being wrong the other way costs a stranger their inbox.
     """
-    flag_owners, unresolved = _named_owners(command)
+    owners, unresolved = _named_owners(segment)
     if unresolved:
         return True
-    if any(owner != OUR_ORG for owner in flag_owners | _path_owners(command)):
+    if any(owner != OUR_ORG for owner in owners | _path_owners(segment)):
         return True
-    if flag_owners:
-        # A tokenised --repo is the destination itself, so this settles it
-        # without asking the checkout.
+    if owners:
+        # A tokenised repository selector IS the destination, so this settles
+        # it without asking the checkout.
         return False
-    if _CHANGES_DIRECTORY.search(command):
+    # gh also reads GH_REPO from the environment it inherits.
+    inherited = os.environ.get("GH_REPO", "")
+    if inherited:
+        match = _OWNER_OF.match(inherited)
+        return match is None or match.group(1).lower() != OUR_ORG
+    if _CHANGES_DIRECTORY.search(whole):
         # The cwd we were handed no longer describes where this runs, and
         # nothing named a repository outright.
         return True
@@ -376,55 +416,50 @@ def targets_another_org(command: str, cwd: str | None) -> bool:
 
 
 def is_public_pr_mutation(command: str, cwd: str | None = None) -> bool:
-    elsewhere: bool | None = None
+    """Does this command mutate a pull request somewhere that is not ours?
 
-    def aimed_elsewhere() -> bool:
-        # Resolved at most once, and only once something worth gating is
-        # found: this hook runs before EVERY bash command, and `git remote
-        # get-url` on each `echo hello` is a subprocess nobody asked for.
-        nonlocal elsewhere
-        if elsewhere is None:
-            elsewhere = targets_another_org(command, cwd)
-        return elsewhere
+    Judged per shell segment, so a read-only invocation cannot vouch for a
+    mutating one standing next to it.
+    """
+    for segment in _segments(command):
+        mutates = False
 
-    # Bounded to one invocation: a greedy tail let `gh pr view && gh pr create`
-    # be judged entirely on the `view`.
-    for match in re.finditer(
-        r"\bgh\s+pr\s+([a-z-]+)\b([^\n;&|]*)", command, re.IGNORECASE
-    ):
-        verb = _PR_VERB_ALIASES.get(match.group(1).lower(), match.group(1).lower())
-        if verb in READ_ONLY_PR_VERBS:
-            continue
-        if verb == "ready" and re.search(r"(?:^|\s)--undo(?:\s|$)", match.group(2)):
-            # Putting a PR BACK to draft is the retreat, never the publication.
-            continue
-        if aimed_elsewhere():
+        for match in _MUTATING_PR.finditer(segment):
+            verb = _PR_VERB_ALIASES.get(match.group(1).lower(), match.group(1).lower())
+            if verb in READ_ONLY_PR_VERBS:
+                continue
+            tail = segment[match.end():]
+            if verb == "ready" and re.search(r"(?:^|\s)--undo(?:\s|$)", tail):
+                # Putting a PR BACK to draft is the retreat, never the
+                # publication.
+                continue
+            mutates = True
+            break
+
+        if not mutates and re.search(r"\bgh\s+api\b", segment, re.IGNORECASE):
+            if re.search(r"\bgraphql\b", segment, re.IGNORECASE) and (
+                PULL_GRAPHQL_MUTATION.search(segment)
+            ):
+                # A GraphQL mutation addresses an opaque node id, so nothing
+                # in the command says which repository it lands in. Unknown is
+                # elsewhere: the one shape where our checkout proves nothing.
+                return True
+            mutates = bool(
+                PULL_ENDPOINT.search(segment)
+                and (MUTATING_METHOD.search(segment) or BODY_ARGUMENT.search(segment))
+            )
+
+        if not mutates and re.search(r"\bcurl\b", segment, re.IGNORECASE):
+            mutates = bool(
+                PULL_ENDPOINT.search(segment)
+                and (MUTATING_METHOD.search(segment) or BODY_ARGUMENT.search(segment))
+            )
+
+        # Resolved only once a segment turns out to be worth gating: this hook
+        # runs before EVERY bash command, and `git remote get-url` on each
+        # `echo hello` is a subprocess nobody asked for.
+        if mutates and targets_another_org(segment, cwd, command):
             return True
-
-    # The same publications reached through the API rather than the CLI.
-    if re.search(r"\bgh\s+api\b", command, re.IGNORECASE):
-        if (
-            PULL_ENDPOINT.search(command)
-            and (MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command))
-            and aimed_elsewhere()
-        ):
-            return True
-        if re.search(r"\bgraphql\b", command, re.IGNORECASE) and (
-            PULL_GRAPHQL_MUTATION.search(command)
-        ):
-            # A GraphQL mutation addresses an opaque node id, so nothing in
-            # the command says which repository it lands in. Unknown is
-            # elsewhere: this is the one shape where our own checkout proves
-            # nothing at all.
-            return True
-
-    if (
-        re.search(r"\bcurl\b", command, re.IGNORECASE)
-        and PULL_ENDPOINT.search(command)
-        and (MUTATING_METHOD.search(command) or BODY_ARGUMENT.search(command))
-        and aimed_elsewhere()
-    ):
-        return True
 
     return False
 

--- a/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
+++ b/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
@@ -12,7 +12,6 @@ from contextlib import redirect_stderr
 from pathlib import Path
 from unittest import mock
 
-
 HOOK = Path(__file__).resolve().parents[1] / "public-github-mutation-guard.py"
 SPEC = importlib.util.spec_from_file_location("public_github_mutation_guard", HOOK)
 if SPEC is None or SPEC.loader is None:
@@ -22,101 +21,235 @@ sys.modules[SPEC.name] = GUARD
 sys.dont_write_bytecode = True
 SPEC.loader.exec_module(GUARD)
 
+OUTSIDE = "outside GetKlai"
+ISSUES = "autonomous public GitHub issue mutation"
 
-class PublicGitHubMutationGuardTest(unittest.TestCase):
-    def run_guard(
-        self, command: str, *, current_branch: str | None = None
-    ) -> tuple[int, str, mock.Mock]:
-        payload = io.StringIO(json.dumps({"tool_input": {"command": command}}))
+
+class GuardTestCase(unittest.TestCase):
+    """Shared harness.
+
+    ``origin_owner`` stands in for reading `git remote get-url origin`, which
+    is how the guard works out where a command with no ``--repo`` is aimed.
+    It defaults to our own org so a test has to opt in to being elsewhere.
+    """
+
+    def run_guard(self, command: str, *, origin_owner: str | None = "getklai"):
+        payload = io.StringIO(json.dumps({
+            "tool_input": {"command": command},
+            "cwd": "/some/checkout",
+        }))
         stderr = io.StringIO()
         with (
             mock.patch.object(sys, "stdin", payload),
-            mock.patch.object(
-                GUARD, "_current_git_branch", return_value=current_branch
-            ) as branch_lookup,
+            mock.patch.object(GUARD, "_origin_owner", return_value=origin_owner),
             redirect_stderr(stderr),
         ):
             exit_code = GUARD.main()
-        return exit_code, stderr.getvalue(), branch_lookup
+        return exit_code, stderr.getvalue()
 
-    def assert_allowed(
-        self, command: str, *, current_branch: str | None = None
-    ) -> mock.Mock:
-        exit_code, stderr, branch_lookup = self.run_guard(
-            command, current_branch=current_branch
-        )
+    def assert_allowed(self, command: str, *, origin_owner: str | None = "getklai") -> None:
+        exit_code, stderr = self.run_guard(command, origin_owner=origin_owner)
         self.assertEqual(0, exit_code, stderr)
-        return branch_lookup
 
     def assert_blocked(
-        self,
-        command: str,
-        message: str,
-        *,
-        current_branch: str | None = None,
-    ) -> mock.Mock:
-        exit_code, stderr, branch_lookup = self.run_guard(
-            command, current_branch=current_branch
-        )
+        self, command: str, message: str, *, origin_owner: str | None = "getklai"
+    ) -> None:
+        exit_code, stderr = self.run_guard(command, origin_owner=origin_owner)
         self.assertEqual(2, exit_code, stderr)
         self.assertIn(message, stderr)
-        return branch_lookup
 
-    def test_allows_named_feature_push_after_heredoc_commit(self) -> None:
-        command = """\
-cd /path/to/repo
-git add -A klai-portal/frontend
-git commit -q -F - <<'MSG'
-It's a `design-callouts` change — with “quotes”.
-MSG
-git push -q -u origin mvletter/design-callouts && echo "pushed"
-"""
 
-        branch_lookup = self.assert_allowed(command)
+class OurOwnRepositoryTest(GuardTestCase):
+    """Inside GetKlai the guard is out of the way. Branch protection is the gate."""
 
-        branch_lookup.assert_not_called()
-
-    def test_allows_named_feature_push_in_simple_compound(self) -> None:
-        command = (
-            'git status --short; echo "---"; '
-            "git push -u origin mvletter/design-callouts 2>&1 | tail -3"
-        )
-
-        branch_lookup = self.assert_allowed(command)
-
-        branch_lookup.assert_not_called()
-
-    def test_allows_pr_mutation_words_inside_heredoc_data(self) -> None:
-        command = """\
-cat > /tmp/notes.md <<'EOF'
-Then we ran gh pr merge 123 and it worked.
-EOF
-"""
-
-        self.assert_allowed(command)
-
-    def test_allows_mutation_words_in_unquoted_and_tab_stripped_heredocs(
-        self,
-    ) -> None:
-        commands = [
-            "cat <<EOF\ngit push origin main\nEOF\n",
-            "cat <<-EOF\n\tgh issue close 123\n\tEOF\n",
-        ]
-
-        for command in commands:
+    def test_pushing_to_main_is_not_our_business(self) -> None:
+        for command in (
+            "git push origin main",
+            "git push origin HEAD:main",
+            "git push --force-with-lease origin main",
+        ):
             with self.subTest(command=command):
                 self.assert_allowed(command)
 
-    def test_heredoc_data_cannot_supply_the_code_approval_marker(self) -> None:
-        command = """\
-cat <<'EOF'
-KLAI_ALLOW_PUBLIC_CODE_MUTATION=1
-EOF
-gh pr merge 123
-"""
+    def test_merging_our_own_pr_needs_no_marker(self) -> None:
+        for command in (
+            "gh pr merge 42 --squash",
+            "gh pr merge 42 --merge --admin",
+            "gh pr create --title x --body y",
+            "gh pr ready 42",
+            "gh pr comment 42 --body 'looks good'",
+        ):
+            with self.subTest(command=command):
+                self.assert_allowed(command)
 
+    def test_an_explicit_getklai_repo_is_still_ours(self) -> None:
+        self.assert_allowed(
+            "gh pr merge 42 --repo GetKlai/klai-infra", origin_owner="somebodyelse"
+        )
+
+
+class AnotherOrganisationTest(GuardTestCase):
+    """Outside GetKlai, opening or undrafting a PR is the user's call."""
+
+    def test_opening_a_pr_elsewhere_is_blocked(self) -> None:
         self.assert_blocked(
-            command, "autonomous public GitHub PR mutation"
+            "gh pr create --repo unclecode/crawl4ai --title x --body y", OUTSIDE
+        )
+
+    def test_a_draft_elsewhere_still_needs_the_user_to_have_asked(self) -> None:
+        """There is no --draft exemption, on purpose.
+
+        A draft is still a pull request someone else did not ask for, and the
+        exemption was where the holes were: a body reading "use --draft next
+        time" satisfied it, and so did a --draft in a later command on the
+        same line.
+        """
+        self.assert_blocked(
+            "gh pr create --repo unclecode/crawl4ai --draft --title x", OUTSIDE
+        )
+
+    def test_undrafting_elsewhere_is_blocked_even_though_the_pr_exists(self) -> None:
+        self.assert_blocked("gh pr ready 2249 --repo unclecode/crawl4ai", OUTSIDE)
+
+    def test_putting_it_back_to_draft_is_a_retreat_not_a_publication(self) -> None:
+        self.assert_allowed("gh pr ready 2249 --repo unclecode/crawl4ai --undo")
+
+    def test_short_and_env_spellings_of_the_repo_are_read_too(self) -> None:
+        """gh takes -R and GH_REPO as well. A guard that knows only the long
+        flag is a guard with a written-down way around it."""
+        for command in (
+            "gh pr create -R unclecode/crawl4ai --title x",
+            "GH_REPO=unclecode/crawl4ai gh pr create --title x",
+        ):
+            with self.subTest(command=command):
+                self.assert_blocked(command, OUTSIDE)
+
+    def test_undo_switched_off_explicitly_is_still_a_publication(self) -> None:
+        self.assert_blocked(
+            "gh pr ready 2249 --repo unclecode/crawl4ai --undo=false", OUTSIDE
+        )
+
+    def test_a_graphql_pr_mutation_cannot_prove_where_it_lands(self) -> None:
+        """It addresses an opaque node id, so nothing in the command says which
+        repository it hits -- not even from one of our own checkouts."""
+        self.assert_blocked(
+            "gh api graphql -f query='mutation "
+            "{ markPullRequestReadyForReview(input: {}) { pullRequest { id } } }'",
+            OUTSIDE,
+        )
+
+    def test_gh_short_verbs_are_classified_like_their_long_forms(self) -> None:
+        self.assert_blocked("gh pr new --repo unclecode/crawl4ai --title x", OUTSIDE)
+        self.assert_allowed("gh pr ls --repo unclecode/crawl4ai")
+
+    def test_a_read_only_verb_cannot_shelter_a_mutation_behind_it(self) -> None:
+        """A greedy tail judged `gh pr view && gh pr create` on the view."""
+        self.assert_blocked(
+            "gh pr view 1 --repo unclecode/crawl4ai && "
+            "gh pr create --repo unclecode/crawl4ai --title x",
+            OUTSIDE,
+        )
+
+    def test_a_getklai_name_in_argument_text_does_not_make_it_ours(self) -> None:
+        """Run from an external checkout with our name sitting in a --body."""
+        self.assert_blocked(
+            "gh pr comment 42 --body 'see example --repo GetKlai/klai please'",
+            OUTSIDE,
+            origin_owner="unclecode",
+        )
+
+    def test_a_repository_named_by_variable_cannot_be_resolved(self) -> None:
+        """`-R "$TARGET"` names a destination this hook cannot read. That is
+        not "none named"; it is unknown, and unknown is elsewhere."""
+        self.assert_blocked('gh pr ready 42 -R "$TARGET"', OUTSIDE)
+
+    def test_a_directory_change_invalidates_the_checkout_we_were_handed(self) -> None:
+        self.assert_blocked("cd /somewhere/else && gh pr ready 42", OUTSIDE)
+
+    def test_a_getklai_path_in_argument_text_does_not_clear_it(self) -> None:
+        """Unlike a tokenised flag, `repos/owner/name` can sit inside a quoted
+        argument, so our name appearing there proves nothing."""
+        self.assert_blocked(
+            "gh pr comment 42 --body 'see repos/GetKlai/klai for the pattern'",
+            OUTSIDE,
+            origin_owner="unclecode",
+        )
+
+    def test_unparseable_shell_is_not_proof_of_anything(self) -> None:
+        self.assert_blocked("gh pr merge 42 --body 'unterminated", OUTSIDE)
+
+    def test_a_directory_change_is_fine_when_our_repo_is_named_outright(self) -> None:
+        self.assert_allowed("cd /somewhere/else && gh pr merge 42 --repo GetKlai/klai")
+
+    def test_a_fork_pr_aimed_at_us_is_ours(self) -> None:
+        """`--head owner:branch` names where the branch lives, not where the PR
+        lands. Reading it as the target blocks an ordinary contribution to
+        GetKlai."""
+        self.assert_allowed("gh pr create --head someone:fix/x --title y --fill")
+
+    def test_an_unknown_destination_fails_closed(self) -> None:
+        self.assert_blocked("gh pr merge 1", OUTSIDE, origin_owner=None)
+
+    def test_the_api_route_to_the_same_publication_is_blocked(self) -> None:
+        """Run from one of OUR checkouts, so only the path says where it lands."""
+        for command in (
+            "gh api --method POST repos/unclecode/crawl4ai/pulls -f title=x",
+            "curl -X POST https://api.github.com/repos/unclecode/crawl4ai/pulls -d '{}'",
+        ):
+            with self.subTest(command=command):
+                self.assert_blocked(command, OUTSIDE)
+
+    def test_the_api_route_against_our_own_repo_is_fine(self) -> None:
+        self.assert_allowed("gh api --method POST repos/GetKlai/klai/pulls -f title=x")
+
+    def test_reading_someone_elses_repo_is_fine(self) -> None:
+        for command in (
+            "gh pr view 2249 --repo unclecode/crawl4ai",
+            "gh pr checks 2249 --repo unclecode/crawl4ai",
+            "gh pr diff 2249 --repo unclecode/crawl4ai",
+        ):
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+
+class IssueTest(GuardTestCase):
+    """Issues keep their own gate: they have no other one."""
+
+    def test_creating_an_issue_is_blocked(self) -> None:
+        self.assert_blocked("gh issue create --title x --body y", ISSUES)
+
+    def test_issue_marker_as_argument_data_cannot_authorize(self) -> None:
+        self.assert_blocked(
+            'gh issue create --title x --body "KLAI_ALLOW_PUBLIC_ISSUE_MUTATION=1"',
+            ISSUES,
+        )
+
+
+class CommandParsingTest(GuardTestCase):
+    """The guard reads shell, not prose. These are the ways that went wrong."""
+
+    def test_allows_pr_mutation_words_inside_heredoc_data(self) -> None:
+        self.assert_allowed(
+            "cat > /tmp/notes.md <<'EOF'\n"
+            "Then we ran gh pr merge 123 --repo other/thing and it worked.\n"
+            "EOF\n"
+        )
+
+    def test_allows_mutation_words_in_unquoted_and_tab_stripped_heredocs(self) -> None:
+        for command in (
+            "cat <<EOF\ngh pr create --repo other/thing\nEOF\n",
+            "cat <<-EOF\n\tgh issue close 123\n\tEOF\n",
+        ):
+            with self.subTest(command=command):
+                self.assert_allowed(command)
+
+    def test_heredoc_data_cannot_supply_the_approval_marker(self) -> None:
+        self.assert_blocked(
+            "cat <<'EOF'\n"
+            "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1\n"
+            "EOF\n"
+            "gh pr merge 123 --repo other/thing\n",
+            OUTSIDE,
         )
 
     def test_marker_as_argument_data_cannot_authorize(self) -> None:
@@ -129,124 +262,34 @@ gh pr merge 123
         how PR #1400 came to be opened: its body contained a sentence naming
         the marker.
         """
-        cases = [
-            ('gh pr comment 42 --body "retry with KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"',
-             "autonomous public GitHub PR mutation"),
-            ('gh pr edit 42 --title "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"',
-             "autonomous public GitHub PR mutation"),
-            ('git commit -m "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1" && git push origin main',
-             "public main branch push"),
-        ]
-        for command, message in cases:
+        for command in (
+            'gh pr comment 42 --repo other/thing --body "retry with KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"',
+            'gh pr edit 42 --repo other/thing --title "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1"',
+        ):
             with self.subTest(command=command):
-                self.assert_blocked(command, message)
-
-    def test_issue_marker_as_argument_data_cannot_authorize(self) -> None:
-        self.assert_blocked(
-            'gh issue create --title x --body "KLAI_ALLOW_PUBLIC_ISSUE_MUTATION=1"',
-            "autonomous public GitHub issue mutation",
-        )
+                self.assert_blocked(command, OUTSIDE)
 
     def test_marker_in_the_assignment_position_still_authorizes(self) -> None:
         """The intended escape hatch keeps working, including after a separator."""
-        commands = [
-            "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr merge 42 --squash",
-            "echo hi && KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr merge 42",
-            "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 git push origin main",
-        ]
-        for command in commands:
+        for command in (
+            "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr merge 42 --repo other/thing",
+            "echo hi && KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr ready 42 --repo other/thing",
+        ):
             with self.subTest(command=command):
-                exit_code, _stderr, _run = self.run_guard(command)
-                self.assertEqual(exit_code, 0, command)
+                exit_code, _stderr = self.run_guard(command)
+                self.assertEqual(0, exit_code, command)
 
     def test_non_heredoc_shift_operators_do_not_hide_a_real_mutation(self) -> None:
-        commands = [
-            "printf '%s\\n' \"<<'EOF'\"\ngh pr merge 123\nEOF\n",
-            "echo $((1 <<EOF))\ngh pr merge 123\nEOF\n",
-        ]
-
-        for command in commands:
+        for command in (
+            "printf '%s\\n' \"<<'EOF'\"\ngh pr merge 123 --repo other/thing\nEOF\n",
+            "echo $((1 <<EOF))\ngh pr merge 123 --repo other/thing\nEOF\n",
+        ):
             with self.subTest(command=command):
-                self.assert_blocked(
-                    command, "autonomous public GitHub PR mutation"
-                )
+                self.assert_blocked(command, OUTSIDE)
 
     def test_unsupported_compound_delimiter_fails_closed(self) -> None:
-        command = """\
-cat <<E'OF'
-notes
-EOF
-gh pr merge 123
-"""
-
         self.assert_blocked(
-            command, "autonomous public GitHub PR mutation"
-        )
-
-    def test_allows_standalone_named_feature_push(self) -> None:
-        branch_lookup = self.assert_allowed(
-            "git push origin mvletter/design-callouts", current_branch="main"
-        )
-
-        branch_lookup.assert_not_called()
-
-    def test_blocks_every_explicit_main_destination(self) -> None:
-        commands = [
-            "git push origin main",
-            "git push origin refs/heads/main",
-            "git push origin HEAD:main",
-            "git push origin feature:main",
-            "git push origin feature:refs/heads/main",
-            "git push origin :main",
-            "git push origin --delete main",
-            "git push --all",
-            "git push --mirror origin",
-            "git push --force origin main",
-            "git push -f origin feature:main",
-            "git push --force-with-lease origin HEAD:main",
-            "git push origin +feature:main",
-        ]
-
-        for command in commands:
-            with self.subTest(command=command):
-                branch_lookup = self.assert_blocked(
-                    command, "public main branch push", current_branch="feature/safe"
-                )
-                branch_lookup.assert_not_called()
-
-    def test_bare_push_uses_current_branch_and_fails_closed_when_unknown(self) -> None:
-        cases = [
-            ("main", True),
-            ("feature/design-callouts", False),
-            (None, True),
-        ]
-
-        for current_branch, should_block in cases:
-            with self.subTest(current_branch=current_branch):
-                if should_block:
-                    branch_lookup = self.assert_blocked(
-                        "git push",
-                        "public main branch push",
-                        current_branch=current_branch,
-                    )
-                else:
-                    branch_lookup = self.assert_allowed(
-                        "git push", current_branch=current_branch
-                    )
-                branch_lookup.assert_called_once_with([], None)
-
-    def test_head_push_in_unsupported_shell_context_fails_closed(self) -> None:
-        branch_lookup = self.assert_blocked(
-            "(cd /path/to/repo && git push origin HEAD)",
-            "public main branch push",
-            current_branch="feature/session",
-        )
-
-        branch_lookup.assert_not_called()
-
-    def test_blocks_real_pr_mutation_outside_heredoc_without_marker(self) -> None:
-        self.assert_blocked(
-            "gh pr merge 123 --squash", "autonomous public GitHub PR mutation"
+            "cat <<E'OF'\nnotes\nEOF\ngh pr merge 123 --repo other/thing\n", OUTSIDE
         )
 
 

--- a/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
+++ b/.claude/hooks/klai/tests/public-github-mutation-guard.test.py
@@ -175,6 +175,47 @@ class AnotherOrganisationTest(GuardTestCase):
             origin_owner="unclecode",
         )
 
+    def test_a_read_only_invocation_cannot_vouch_for_the_one_beside_it(self) -> None:
+        """The repository is named once, on the half that only reads."""
+        self.assert_blocked(
+            "gh pr view 1 --repo GetKlai/klai && gh pr merge 42",
+            OUTSIDE,
+            origin_owner="unclecode",
+        )
+
+    def test_lowercase_r_is_not_a_repository_selector(self) -> None:
+        """`-R` selects a repository; `-r` is reviewer on create and rebase on
+        merge. Folding the case read `-r GetKlai/security` as our repo, and
+        blocked an ordinary `gh pr merge -r` inside GetKlai."""
+        self.assert_allowed("gh pr merge 42 -r")
+        self.assert_blocked(
+            "gh pr create -r someone/else --title x", OUTSIDE, origin_owner="unclecode"
+        )
+
+    def test_the_value_glued_onto_the_short_flag_is_read(self) -> None:
+        self.assert_blocked("gh pr create -Runclecode/crawl4ai --title x", OUTSIDE)
+
+    def test_a_pull_request_url_is_a_destination(self) -> None:
+        """`gh pr merge <url>` is valid syntax and names the repository."""
+        self.assert_blocked(
+            "gh pr merge https://github.com/unclecode/crawl4ai/pull/2249 --merge",
+            OUTSIDE,
+        )
+
+    def test_a_host_prefixed_repository_still_reads_as_ours(self) -> None:
+        """gh takes [HOST/]OWNER/REPO; rejecting that spelling blocked our own
+        work for no reason."""
+        self.assert_allowed("gh pr merge 42 --repo github.com/GetKlai/klai")
+
+    def test_pushd_moves_the_checkout_just_like_cd(self) -> None:
+        self.assert_blocked("pushd /elsewhere && gh pr ready 42", OUTSIDE)
+
+    def test_an_api_path_quoted_in_a_body_does_not_block_our_own_work(self) -> None:
+        """The path only counts where such a path IS the destination."""
+        self.assert_allowed(
+            "gh pr comment 42 --body 'call repos/unclecode/crawl4ai/pulls for this'"
+        )
+
     def test_unparseable_shell_is_not_proof_of_anything(self) -> None:
         self.assert_blocked("gh pr merge 42 --body 'unterminated", OUTSIDE)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,12 +128,18 @@ authorization to mutate GitHub.
 - The hook that enforces this asks WHERE a command is aimed, not which verb
   it uses. Inside GetKlai it blocks nothing: `main` is already gated by branch
   protection, and a marker the one developer types on every merge is a
-  keystroke, not a second opinion. Outside GetKlai it blocks opening a pull
-  request that is not a draft, undrafting one, and the same publication made
-  through `gh api` or `curl` — because a branch on your own fork notifies
-  nobody, while those three put it in front of someone else's maintainers.
-  Open it with `--draft`, show the user, undraft only once they have said to.
-  It still blocks issue mutations everywhere; issues have no other gate.
+  keystroke, not a second opinion. Outside GetKlai it blocks every
+  pull-request mutation, including drafts and including the same publication
+  made through `gh api` or `curl` — a branch on your own fork notifies nobody,
+  a pull request does. Ask first, then do exactly what was asked, drafting
+  included. It also blocks when the destination cannot be read from the
+  command, which is deliberate. It still blocks issue mutations everywhere;
+  issues have no other gate.
+- That guard reads a bash string to decide where a command lands, so it is a
+  guard against misreading a sentence — the failure that actually happened —
+  and not against someone determined to get around it. Arbitrary shell can
+  always compute a destination it cannot see. Do not treat a green run as
+  permission.
   Everything above still governs what you WRITE in a PR body — that judgement
   is yours, not the hook's.
 - If sensitive details are already public, do not amplify them in comments or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,13 +125,16 @@ authorization to mutate GitHub.
   unpatched security fix, establish the private remediation and deployment
   path with the user. After the fix is deployed, a deliberately redacted public
   explanation is allowed when requested.
-- The hook that enforces this blocks what it can meaningfully gate: issue
-  mutations, PR comments, reviews, edits and merges, and any push to `main`.
-  It does not block `gh pr create`, because the branch push that precedes it
-  already published the same code and the same commit messages — gating the
-  PR that proposes them stopped nothing and made bypassing the hook routine,
-  which is how the blocks that do matter get bypassed too. The rule above is
-  unchanged: it still governs what you write in a PR body, and that judgement
+- The hook that enforces this asks WHERE a command is aimed, not which verb
+  it uses. Inside GetKlai it blocks nothing: `main` is already gated by branch
+  protection, and a marker the one developer types on every merge is a
+  keystroke, not a second opinion. Outside GetKlai it blocks opening a pull
+  request that is not a draft, undrafting one, and the same publication made
+  through `gh api` or `curl` — because a branch on your own fork notifies
+  nobody, while those three put it in front of someone else's maintainers.
+  Open it with `--draft`, show the user, undraft only once they have said to.
+  It still blocks issue mutations everywhere; issues have no other gate.
+  Everything above still governs what you WRITE in a PR body — that judgement
   is yours, not the hook's.
 - If sensitive details are already public, do not amplify them in comments or
   linked issues. Prioritize remediation, then close or redact the public item

--- a/rules/tests/test_public_issue_publication.py
+++ b/rules/tests/test_public_issue_publication.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import shlex
 import subprocess
 import textwrap
 from pathlib import Path
@@ -192,275 +191,128 @@ def test_hook_allows_explicitly_authorized_public_issue_mutation() -> None:
     assert result.returncode == 0
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "gh pr edit 42 --body 'new details'",
-        "gh pr comment 42 --body 'new details'",
-        "gh pr review 42 --comment --body 'review details'",
-        "gh api repos/GetKlai/klai/pulls -X POST -f title=finding",
-        "gh api -X PATCH repos/GetKlai/klai/pulls/42 -f state=closed",
-        "gh api graphql -f query='mutation { mergePullRequest(input: {}) { pullRequest { id } } }'",
-        "curl https://api.github.com/repos/GetKlai/klai/pulls/42 -X PATCH -d '{}'",
-    ],
-)
-def test_hook_blocks_unapproved_public_pr_mutations(command: str) -> None:
-    result = _run_hook(command)
-
-    assert result.returncode == 2
-    assert "autonomous public GitHub PR mutation" in result.stderr
+ELSEWHERE = "outside GetKlai"
 
 
-@pytest.mark.parametrize(
-    "command",
-    [
-        "gh pr create --title 'fix' --body 'details'",
-        "gh pr create --base main --head feature --fill",
-    ],
-)
-def test_hook_allows_opening_a_pull_request(command: str) -> None:
-    """Opening a PR publishes nothing the branch push did not already publish.
+def _repo_with_origin(tmp_path: Path, owner: str) -> Path:
+    """A checkout whose `origin` belongs to ``owner``.
 
-    Only pushes to `main` are gated, so `git push -u origin feature` already
-    made the code and every commit message on it public. Blocking the PR that
-    proposes them protected nothing and fired on every ordinary change; what
-    it did teach was the bypass reflex, which then also reaches the blocks
-    that matter.
+    The guard reads that remote to work out where a command with no explicit
+    repository is aimed, so this is the only setup these tests need.
     """
-    result = _run_hook(command)
+    repo = tmp_path / owner
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin",
+         f"https://github.com/{owner}/thing.git"],
+        check=True, capture_output=True,
+    )
+    return repo
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr merge 42 --squash",
+        "gh pr merge 42 --merge --admin",
+        "gh pr create --title 'fix' --body 'details'",
+        "gh pr ready 42",
+        "gh pr comment 42 --body 'details'",
+        "gh pr review 42 --approve",
+        "gh pr edit 42 --body 'new details'",
+        "git push origin main",
+        "git push --force-with-lease origin HEAD:main",
+        "gh api repos/GetKlai/klai/pulls -X POST -f title=x",
+    ],
+)
+def test_hook_stays_out_of_the_way_inside_getklai(command: str, tmp_path: Path) -> None:
+    """Inside our own org the hook blocks nothing, on purpose.
+
+    `main` is gated by branch protection: a pull request, a green `quality`
+    check that itself waits on every affected service job, no force-push, no
+    deletion. A marker the one developer types on every merge adds no second
+    opinion -- and it self-authorised once, when a PR body that merely named
+    the marker satisfied the match (#1400).
+    """
+    result = _run_hook(command, cwd=_repo_with_origin(tmp_path, "GetKlai"))
 
     assert result.returncode == 0, result.stderr
 
 
-def test_hook_still_blocks_merging_and_commenting() -> None:
-    """The two PR verbs that are not covered by anything else stay blocked.
-
-    `merge` is the #1208 lesson -- an agent merged past a review gate -- and
-    a comment or review is prose published straight to the PR.
-    """
-    for command in (
-        "gh pr merge 42 --squash",
-        "gh pr comment 42 --body 'details'",
-        "gh pr review 42 --approve",
-    ):
-        result = _run_hook(command)
-        assert result.returncode == 2, f"{command!r} should still be blocked"
-        assert "autonomous public GitHub PR mutation" in result.stderr
-
-
 @pytest.mark.parametrize(
     "command",
     [
-        "git push origin main",
-        "git push --force origin main",
-        "git push --set-upstream origin main",
-        "git push --force-with-lease origin HEAD:main",
-        "git push origin HEAD:refs/heads/main",
-        "git push origin fix/publication-guard:refs/heads/main",
-        "git push origin deadbeef:refs/heads/main",
-        "git push origin +deadbeef:refs/heads/main",
-        "git push origin +main",
-        "git push origin --delete main",
-        "git push --all",
-        "git push --all origin",
-        "git push --mirror",
-        "git push --mirror origin",
+        "gh pr create --repo unclecode/crawl4ai --title x --body y",
+        "gh pr ready 2249 --repo unclecode/crawl4ai",
+        "gh pr merge 2249 --repo unclecode/crawl4ai",
+        "gh pr comment 2249 --repo unclecode/crawl4ai --body 'ping'",
+        "gh api --method POST repos/unclecode/crawl4ai/pulls -f title=x",
+        "curl -X POST https://api.github.com/repos/unclecode/crawl4ai/pulls -d '{}'",
     ],
 )
-def test_hook_blocks_unapproved_pushes_that_can_mutate_main(command: str) -> None:
-    result = _run_hook(command)
-
-    assert result.returncode == 2
-    assert "public main branch push" in result.stderr
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "gh pr view 42 --json title,body",
-        "gh pr list --state open",
-        "gh pr checks 42",
-        "gh pr diff 42",
-        "gh pr checkout 42",
-        "git push origin feature/foo",
-        "git push --force origin feature/foo",
-        "git push -u origin fix/publication-guard",
-        "git push --set-upstream origin feature/foo",
-        "git push origin HEAD:refs/heads/fix/publication-guard",
-        "git push origin deadbeef:refs/heads/fix/publication-guard",
-        "git push origin +deadbeef:refs/heads/fix/publication-guard",
-        "git push origin +feature/foo",
-        "git push origin --delete feature/foo",
-    ],
-)
-def test_hook_allows_read_only_pr_commands_and_named_feature_branch_pushes(
-    command: str,
-) -> None:
-    result = _run_hook(command)
-
-    assert result.returncode == 0
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "git push",
-        "git push --force",
-        "git push -f",
-        "git push origin",
-        "git push origin HEAD",
-        "git push --force origin HEAD",
-        "git push -f origin HEAD",
-        "git push -u origin HEAD",
-        "git push --set-upstream origin HEAD",
-    ],
-)
-def test_hook_allows_head_pushes_from_a_feature_branch(
+def test_hook_blocks_publication_aimed_at_another_organisation(
     command: str, tmp_path: Path
 ) -> None:
-    """HEAD-relative pushes depend on the checked-out branch, so pin it.
+    """Pushing a branch to your own fork notifies nobody; these do.
 
-    These forms were once asserted without controlling the branch. That passed
-    on a feature worktree and on a detached PR checkout, and failed on main --
-    where the hook is right to block them. The test was reading its environment
-    rather than the contract. Its sibling below pins main; this one pins a
-    feature branch, so both outcomes are asserted deliberately.
+    Opening a pull request puts it in front of someone else's maintainers, and
+    undrafting is the moment it asks to be reviewed. On 2026-09-11 a PR was
+    opened at unclecode/crawl4ai from a sentence read as permission, and
+    nothing here stopped it -- `gh pr create` was on the read-only list.
     """
-    _init_git_repo(tmp_path, "feature/guard-context")
+    result = _run_hook(command, cwd=_repo_with_origin(tmp_path, "GetKlai"))
 
-    result = _run_hook(command, cwd=tmp_path)
-
-    assert result.returncode == 0
+    assert result.returncode == 2, result.stderr
+    assert ELSEWHERE in result.stderr
 
 
 @pytest.mark.parametrize(
     "command",
     [
-        "git push",
-        "git push --force",
-        "git push -f",
-        "git push origin",
-        "git push origin HEAD",
-        "git push --force origin HEAD",
-        "git push -f origin HEAD",
-        "git push -u origin HEAD",
-        "git push --set-upstream origin HEAD",
+        "gh pr ready 2249 --repo unclecode/crawl4ai --undo",
+        "gh pr view 2249 --repo unclecode/crawl4ai",
+        "gh pr checks 2249 --repo unclecode/crawl4ai",
+        "gh pr diff 2249 --repo unclecode/crawl4ai",
     ],
 )
-def test_hook_resolves_head_pushes_to_main(
+def test_hook_allows_retreating_and_reading_elsewhere(
     command: str, tmp_path: Path
 ) -> None:
-    _init_git_repo(tmp_path, "main")
+    """Putting a PR back to draft is the retreat; reading is not publication.
 
-    result = _run_hook(command, cwd=tmp_path)
+    Opening one is NOT here, draft or otherwise: a draft is still a pull
+    request nobody asked for, and the --draft exemption was where the holes
+    were -- a body reading "use --draft next time" satisfied it.
+    """
+    result = _run_hook(command, cwd=_repo_with_origin(tmp_path, "GetKlai"))
 
-    assert result.returncode == 2
-    assert "public main branch push" in result.stderr
-
-
-def test_hook_blocks_when_head_branch_cannot_be_resolved(tmp_path: Path) -> None:
-    result = _run_hook("git push --force origin HEAD", cwd=tmp_path)
-
-    assert result.returncode == 2
-    assert "symbolic-ref" in HOOK.read_text()
+    assert result.returncode == 0, result.stderr
 
 
-def test_hook_resolves_head_in_leading_cd_worktree(tmp_path: Path) -> None:
-    session_repo = tmp_path / "session-main"
-    feature_repo = tmp_path / "target feature"
-    _init_git_repo(session_repo, "main")
-    _init_git_repo(feature_repo, "feature/worktree-target")
+def test_hook_fails_closed_when_the_destination_is_unknown(tmp_path: Path) -> None:
+    """No `--repo`, no usable `origin`: treat it as elsewhere.
 
-    command = f"cd {shlex.quote(str(feature_repo))} && git push -u origin HEAD"
-    result = _run_hook(command, cwd=session_repo)
+    Being wrong that way costs one sentence asking the user. Being wrong the
+    other way costs a stranger their inbox.
+    """
+    nowhere = tmp_path / "nowhere"
+    nowhere.mkdir()
+    result = _run_hook("gh pr merge 1", cwd=nowhere)
 
-    assert result.returncode == 0
-
-
-def test_hook_blocks_head_in_leading_cd_main_worktree(tmp_path: Path) -> None:
-    session_repo = tmp_path / "session-feature"
-    main_repo = tmp_path / "target main"
-    _init_git_repo(session_repo, "feature/session")
-    _init_git_repo(main_repo, "main")
-
-    command = f"cd {shlex.quote(str(main_repo))} && git push origin HEAD"
-    result = _run_hook(command, cwd=session_repo)
-
-    assert result.returncode == 2
-    assert "public main branch push" in result.stderr
+    assert result.returncode == 2, result.stderr
+    assert ELSEWHERE in result.stderr
 
 
-def test_hook_blocks_branch_dependent_push_in_unsupported_shell_context(
+def test_hook_allows_explicitly_authorized_publication_elsewhere(
     tmp_path: Path,
 ) -> None:
-    session_repo = tmp_path / "session-feature"
-    main_repo = tmp_path / "target-main"
-    _init_git_repo(session_repo, "feature/session")
-    _init_git_repo(main_repo, "main")
-
-    command = f"(cd {shlex.quote(str(main_repo))} && git push origin HEAD)"
-    result = _run_hook(command, cwd=session_repo)
-
-    assert result.returncode == 2
-    assert "public main branch push" in result.stderr
-
-
-@pytest.mark.parametrize(
-    ("branch", "expected_exit"),
-    [("feature/git-c-target", 0), ("main", 2)],
-)
-def test_hook_resolves_head_in_git_c_worktree(
-    branch: str, expected_exit: int, tmp_path: Path
-) -> None:
-    target_repo = tmp_path / branch.replace("/", "-")
-    _init_git_repo(target_repo, branch)
-
     result = _run_hook(
-        f"git -C {shlex.quote(str(target_repo))} push origin HEAD", cwd=tmp_path
+        "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr ready 2249 --repo unclecode/crawl4ai",
+        cwd=_repo_with_origin(tmp_path, "GetKlai"),
     )
 
-    assert result.returncode == expected_exit
-
-
-def test_hook_prefers_explicit_refspec_destination_over_current_branch(
-    tmp_path: Path,
-) -> None:
-    _init_git_repo(tmp_path, "main")
-
-    result = _run_hook(
-        "git push origin HEAD:refs/heads/fix/explicit-target", cwd=tmp_path
-    )
-
-    assert result.returncode == 0
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "git push --unknown-option origin feature/guard",
-        "git --no-pager push origin feature/guard",
-        "git push origin refs/heads/*:refs/heads/*",
-        "git push origin deadbeef:",
-    ],
-)
-def test_hook_blocks_push_shapes_with_ambiguous_destinations(command: str) -> None:
-    result = _run_hook(command)
-
-    assert result.returncode == 2
-    assert "public main branch push" in result.stderr
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 gh pr comment 42 --body approved",
-        "KLAI_ALLOW_PUBLIC_CODE_MUTATION=1 git push origin main",
-    ],
-)
-def test_hook_allows_explicitly_authorized_public_code_mutation(command: str) -> None:
-    result = _run_hook(command)
-
-    assert result.returncode == 0
+    assert result.returncode == 0, result.stderr
 
 
 def test_server_guard_has_safe_events_and_minimal_write_permissions() -> None:


### PR DESCRIPTION
The guard had it backwards. Inside GetKlai it stopped every merge and every push to `main` until the marker was typed — by the one person developing Klai, on every change. That is a keystroke, not a second opinion, and it self-authorised once already: a PR body that merely *named* the marker satisfied the substring match (#1400).

Meanwhile opening a pull request sat on the read-only list, so nothing stopped one being opened at another project. On 2026-09-11 one was, at `unclecode/crawl4ai`, from a sentence read as permission.

## What changes

| | before | after |
|---|---|---|
| merging a PR on GetKlai | blocked | allowed |
| `git push origin main` | blocked | allowed |
| opening a PR elsewhere | **allowed** | blocked |
| undrafting a PR elsewhere | blocked | blocked |
| creating an issue | blocked | blocked |

Inside GetKlai the gate is branch protection, which this commit does not touch: a pull request, a green `quality` check (itself an aggregate over every affected service job), no force-push, no deletion.

There is deliberately **no `--draft` exemption**. A draft is still a pull request the other project did not ask for, and the exemption was where most of the holes were.

## Destination is established fail-closed

Review found six ways around the first attempt. Each is now a regression test:

- a greedy tail meant a read-only verb followed by a mutating one was judged on the read-only one — verb matching is bounded to one invocation
- `--draft` anywhere in the text satisfied the exemption, including inside a `--body` — the exemption is gone
- a repo name in argument text faked the destination — flags are read from `shlex` tokens, where `--body 'see --repo GetKlai/klai'` is one token and the flag never appears on its own
- a leading `cd` invalidated the cwd we were handed — a directory change now needs an explicit repository or it blocks
- `gh repo set-default` overrides `origin` — `remote.*.gh-resolved` is read first
- `-R "$TARGET"` resolved to nothing and fell back to our own origin — a repository flag that is present but unreadable blocks

Plus, from the first round: a GraphQL mutation carries only an opaque node id, so it can never prove where it lands and is always treated as elsewhere; `--head owner:branch` names the *source* of a fork PR and was blocking ordinary contributions aimed at GetKlai; `new`/`co`/`ls` are real gh aliases and were misclassified.

## Measured

Eleven shapes against the hook binary, zero wrong — the six bypasses above, the `-R` and `GH_REPO` spellings, and three that must stay allowed (merging ours, `git push origin main`, and merging `--repo GetKlai/klai-infra` from a foreign checkout).

`git remote get-url` now runs lazily: 0 subprocess calls for `echo hello`, 1 for a PR verb. It used to run on every bash command.

## Gates

- guard unit tests: 32 passed
- `rules/tests/test_public_issue_publication.py`: 45 passed
- ruff clean on the files this touches

Net −239 lines: the whole main-push resolver goes, since there is nothing left for it to decide.

Review: uitgevoerd · gates 3/3 groen · Sol 15 gemeld → 15 bevestigd → 15 gefixt (critical 0, high 6) · ronde 2 · mergeable
