### PR TITLE
fix(chat-quality): post-deploy migration dropped the wrong constraint name

### DIFF
--- a/klai-portal/backend/alembic/versions/post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql
+++ b/klai-portal/backend/alembic/versions/post_deploy_d3c8b6a5f1e0_conversation_quality_librechat_channel.sql
@@ -32,6 +32,16 @@ END $$;
 -- IF NOT EXISTS for CHECK, so drop-then-add inside the same transaction —
 -- safe: the OLD constraint only accepted 'webchat', which is a subset of
 -- the new allowed set, so no existing row can violate the replacement.
+--
+-- The original CREATE TABLE (post_deploy_b7e4f1a9c3d2) declared this CHECK
+-- inline with no explicit name, so Postgres auto-named it
+-- conversation_quality_judgments_channel_check — NOT ck_cqj_channel (that
+-- name only exists in the SQLAlchemy ORM model's CheckConstraint(), which
+-- was never applied as DDL since portal_api doesn't own this table). Drop
+-- the REAL auto-generated name; ck_cqj_channel here is the constraint this
+-- script is about to (re-)create, not one to look for.
+ALTER TABLE conversation_quality_judgments
+    DROP CONSTRAINT IF EXISTS conversation_quality_judgments_channel_check;
 ALTER TABLE conversation_quality_judgments DROP CONSTRAINT IF EXISTS ck_cqj_channel;
 ALTER TABLE conversation_quality_judgments
     ADD CONSTRAINT ck_cqj_channel CHECK (channel IN ('webchat', 'librechat'));


### PR DESCRIPTION
## Summary
- \`post_deploy_d3c8b6a5f1e0\` looked for a constraint name (\`ck_cqj_channel\`) that never existed in applied DDL — the real, Postgres-auto-generated name from the unnamed inline CHECK in \`post_deploy_b7e4f1a9c3d2\` is \`conversation_quality_judgments_channel_check\`. The DROP silently no-op'd, leaving the old webchat-only constraint active alongside the new widened one.
- Found immediately after deploying PR #1410 by inspecting the live schema on core-01; fixed directly in production and verified the corrected script re-applies idempotently.

## Test plan
- [x] Re-ran the corrected `post_deploy_d3c8b6a5f1e0_*.sql` against production — idempotent no-op on the already-fixed table (`NOTICE: constraint ... does not exist, skipping`)
- [x] `\d conversation_quality_judgments` on core-01 confirms exactly one channel constraint (`ck_cqj_channel`, webchat+librechat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)