### PR TITLE
feat(chat-quality): confine the judge loop to an off-peak UTC window

### DIFF
--- a/klai-portal/backend/app/core/config.py
+++ b/klai-portal/backend/app/core/config.py
@@ -285,6 +285,14 @@ class Settings(BaseSettings):
     # reason RAGAS faithfulness moved off klai-fast (Mistral Small truncates
     # multi-field structured JSON). Tier-named, no role-specific alias.
     conversation_judge_model: str = "klai-medium"
+    # SPEC-CHAT-QUALITY-LOOP-001: the judge makes one LLM call per unjudged
+    # conversation on the same LiteLLM/Mistral capacity that serves live
+    # chat traffic. Confine it to an off-peak UTC window so a large backlog
+    # never competes with peak-hour user traffic for rate-limit headroom.
+    # Default 01:00-06:00 UTC. Non-wrapping (start < end); PORTAL_API_
+    # CONVERSATION_JUDGE_WINDOW_START_HOUR/_END_HOUR override per env.
+    conversation_judge_window_start_hour: int = 1
+    conversation_judge_window_end_hour: int = 6
 
     # SPEC-INFRA-TENANT-DELETE-001: Garage S3 for Scribe artifact deletion.
     # Generate credentials via: garage key new --name portal-api

--- a/klai-portal/backend/app/services/conversation_judge.py
+++ b/klai-portal/backend/app/services/conversation_judge.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
 import httpx
 import structlog
@@ -402,32 +403,56 @@ async def _judge_run_once() -> dict[str, int]:
     return {"org_count": len(org_ids), "judged_count": judged_total}
 
 
+def _within_judge_window(now: datetime) -> bool:
+    """Whether ``now`` (UTC) falls inside the configured off-peak window.
+
+    Both passes make one LLM call per conversation on the same LiteLLM/
+    Mistral capacity that serves live chat traffic, so a large backlog must
+    never compete with peak-hour user traffic. Handles a window that wraps
+    past midnight (e.g. 22-6) as well as the non-wrapping default (1-6).
+    """
+    start = settings.conversation_judge_window_start_hour
+    end = settings.conversation_judge_window_end_hour
+    hour = now.hour
+    if start <= end:
+        return start <= hour < end
+    return hour >= start or hour < end
+
+
 async def conversation_judge_loop() -> None:
     """FastAPI-lifespan-attached conversation quality judge loop.
 
     Sleeps 60 s on startup so the app can finish wiring before the first
-    DB hit. Then runs ``_judge_run_once`` (webchat) followed by
-    ``librechat_judge_run_once`` (REQ-5) every JUDGE_INTERVAL_SECONDS until
-    cancelled. Exceptions are logged and do not abort the loop; each
-    channel's pass has its own try/except so neither one's failure stops
-    the other.
+    DB hit. Every JUDGE_INTERVAL_SECONDS it checks the current UTC hour
+    against the configured off-peak window
+    (``conversation_judge_window_start_hour``/``_end_hour``, default
+    01:00-06:00 UTC): outside that window it skips both passes entirely —
+    no DB read, no LLM call — and only checks again next tick. Inside the
+    window it runs ``_judge_run_once`` (webchat) followed by
+    ``librechat_judge_run_once`` (REQ-5); a large backlog is worked off
+    incrementally across the night rather than in one burst, since each
+    pass is capped at ``_BATCH_SIZE`` per org and the next tick picks up
+    where the last one stopped. Exceptions are logged and do not abort the
+    loop; each channel's pass has its own try/except so neither one's
+    failure stops the other.
     """
     await asyncio.sleep(60)
     while True:
-        try:
-            await _judge_run_once()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("conversation_judge_loop_unexpected_error")
-        try:
-            # Lazy import: librechat_quality_judge reuses helpers from this
-            # module, so a module-level import here would be circular.
-            from app.services.librechat_quality_judge import librechat_judge_run_once
+        if _within_judge_window(datetime.now(UTC)):
+            try:
+                await _judge_run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("conversation_judge_loop_unexpected_error")
+            try:
+                # Lazy import: librechat_quality_judge reuses helpers from this
+                # module, so a module-level import here would be circular.
+                from app.services.librechat_quality_judge import librechat_judge_run_once
 
-            await librechat_judge_run_once()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("librechat_judge_loop_unexpected_error")
+                await librechat_judge_run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("librechat_judge_loop_unexpected_error")
         await asyncio.sleep(JUDGE_INTERVAL_SECONDS)

--- a/klai-portal/backend/tests/test_conversation_judge.py
+++ b/klai-portal/backend/tests/test_conversation_judge.py
@@ -471,6 +471,7 @@ async def test_loop_continues_after_org_failure():
     with (
         patch("app.services.conversation_judge._judge_run_once", side_effect=_raise_then_cancel),
         patch("app.services.conversation_judge.JUDGE_INTERVAL_SECONDS", 0),
+        patch("app.services.conversation_judge._within_judge_window", return_value=True),
         patch("asyncio.sleep", new=AsyncMock()),
     ):
         with pytest.raises(asyncio.CancelledError):
@@ -538,3 +539,67 @@ async def test_litellm_call_uses_triage_pattern():
     assert body["temperature"] == 0.1
     assert body["messages"][0] == {"role": "system", "content": cj.JUDGE_SYSTEM_PROMPT}
     assert body["messages"][1] == {"role": "user", "content": '{"transcript": []}'}
+
+
+# ---------------------------------------------------------------------------
+# Off-peak window gate (Mark, 11 sep 2026): the judge must not compete with
+# live chat traffic for LiteLLM/Mistral capacity during business hours.
+# ---------------------------------------------------------------------------
+
+
+def test_within_judge_window_default_01_to_06_utc():
+    from datetime import UTC, datetime
+
+    from app.services.conversation_judge import _within_judge_window
+
+    assert _within_judge_window(datetime(2026, 9, 11, 0, 59, tzinfo=UTC)) is False
+    assert _within_judge_window(datetime(2026, 9, 11, 1, 0, tzinfo=UTC)) is True
+    assert _within_judge_window(datetime(2026, 9, 11, 5, 59, tzinfo=UTC)) is True
+    assert _within_judge_window(datetime(2026, 9, 11, 6, 0, tzinfo=UTC)) is False
+    assert _within_judge_window(datetime(2026, 9, 11, 14, 0, tzinfo=UTC)) is False, (
+        "must stay off during a peak-hour afternoon"
+    )
+
+
+def test_within_judge_window_handles_midnight_wraparound():
+    from datetime import UTC, datetime
+
+    from app.services.conversation_judge import _within_judge_window
+
+    with (
+        patch("app.services.conversation_judge.settings.conversation_judge_window_start_hour", 22),
+        patch("app.services.conversation_judge.settings.conversation_judge_window_end_hour", 6),
+    ):
+        assert _within_judge_window(datetime(2026, 9, 11, 23, 0, tzinfo=UTC)) is True
+        assert _within_judge_window(datetime(2026, 9, 11, 3, 0, tzinfo=UTC)) is True
+        assert _within_judge_window(datetime(2026, 9, 11, 12, 0, tzinfo=UTC)) is False
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_both_passes_outside_the_window():
+    """During business hours the loop must not touch the DB or the LLM at
+    all — not just skip the writes, skip the calls entirely."""
+    from app.services.conversation_judge import conversation_judge_loop
+
+    webchat = AsyncMock()
+    librechat = AsyncMock()
+    call_count = 0
+
+    async def _sleep_then_cancel(_seconds):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise asyncio.CancelledError
+
+    with (
+        patch("app.services.conversation_judge._judge_run_once", webchat),
+        patch("app.services.librechat_quality_judge.librechat_judge_run_once", librechat),
+        patch("app.services.conversation_judge._within_judge_window", return_value=False),
+        patch("app.services.conversation_judge.JUDGE_INTERVAL_SECONDS", 0),
+        patch("asyncio.sleep", side_effect=_sleep_then_cancel),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await conversation_judge_loop()
+
+    webchat.assert_not_awaited()
+    librechat.assert_not_awaited()

--- a/klai-portal/backend/tests/test_librechat_quality_judge.py
+++ b/klai-portal/backend/tests/test_librechat_quality_judge.py
@@ -538,6 +538,7 @@ async def test_loop_runs_both_channel_passes_independently():
     with (
         patch.object(cj, "_judge_run_once", webchat),
         patch.object(lj, "librechat_judge_run_once", librechat),
+        patch.object(cj, "_within_judge_window", return_value=True),
         patch("asyncio.sleep", new=AsyncMock()),
     ):
         with pytest.raises(asyncio.CancelledError):


### PR DESCRIPTION
## Summary
- The nightly webchat + LibreChat quality judge (SPEC-CHAT-QUALITY-LOOP-001) made one LLM call per unjudged conversation every 30 minutes, around the clock, on the same LiteLLM/Mistral capacity that serves live chat traffic.
- \`conversation_judge_loop\` now only runs both passes inside a configurable off-peak UTC window (\`conversation_judge_window_start_hour\`/\`_end_hour\`, default 01:00-06:00 UTC) — outside it, no DB read and no LLM call happen at all, just a cheap hour check.
- A large backlog still gets worked off incrementally across the night: each pass stays capped at the existing per-org batch size, and the next in-window tick picks up where the last one stopped.

## Test plan
- [x] `uv run pytest tests/ -q` — 4045 passed, 0 failed
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run --with pyright pyright` (repo-scoped, matches CI) — 0 errors
- [x] New unit tests: window boundary (01:00/06:00 UTC edges + a peak-hour afternoon), midnight-wraparound window math, and a loop-level test proving neither pass is even called outside the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)