### PR TITLE
fix(portal): replacing one expired cookie no longer deletes the others

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -2341,8 +2341,7 @@ async def _resolve_web_crawler_probe_cookies(
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=(
-                        f"No saved value to keep for cookie {cookie.get('name')!r}. "
-                        "Paste its value, or remove the row."
+                        f"No saved value to keep for cookie {cookie.get('name')!r}. Paste its value, or remove the row."
                     ),
                 )
             resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})

--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -2321,6 +2321,32 @@ async def _resolve_web_crawler_probe_cookies(
         )
     if use_saved_credentials:
         return await _load_saved_web_crawler_cookies(kb, connector_id, org_id, db, probe_url)
+    if cookies and any(isinstance(c, dict) and not c.get("value") for c in cookies):
+        # A row with a name and no value means "keep the stored one", which is
+        # how one expired cookie gets replaced without re-reading the others.
+        # Resolve it HERE as well as on save: a probe that tests a different
+        # set than the one being stored is worth less than no probe, and
+        # crawl4ai rejects a cookie with no value outright.
+        saved = await _load_saved_web_crawler_cookies(kb, connector_id, org_id, db, probe_url)
+        by_name = {c["name"]: c for c in (saved or []) if isinstance(c, dict) and c.get("name")}
+        resolved: list[dict] = []
+        for cookie in cookies:
+            if not isinstance(cookie, dict):
+                continue
+            if cookie.get("value"):
+                resolved.append(cookie)
+                continue
+            kept = by_name.get(cookie.get("name"))
+            if kept is None or not kept.get("value"):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"No saved value to keep for cookie {cookie.get('name')!r}. "
+                        "Paste its value, or remove the row."
+                    ),
+                )
+            resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})
+        return resolved
     return cookies
 
 

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -82,10 +82,19 @@ _CANARY_FINGERPRINT_RE = re.compile(r"^[0-9a-f]{16}$")
 
 
 class CookieEntry(BaseModel):
-    """A single browser cookie for webcrawler auth injection."""
+    """A single browser cookie for webcrawler auth injection.
+
+    ``value`` is optional so one expired cookie can be replaced without
+    re-reading the others out of DevTools: an entry with a name and no value
+    means "keep the value already saved for this name", and is resolved in
+    ``_merge_saved_credentials`` before anything is stored. A blank value is
+    never persisted as a cookie -- a crawl carrying one answers HTTP 200 and
+    fetches the logged-out page, which is the failure class that stayed
+    invisible here for four weeks.
+    """
 
     name: str
-    value: str
+    value: str | None = None
     domain: str = ""
     path: str = "/"
 
@@ -577,7 +586,18 @@ async def _merge_saved_sensitive_credentials(
         new_origin = _origin(config.get("base_url"))
         if old_origin != new_origin:
             missing_fields = missing_fields - {"cookies"}
-    if not missing_fields or connector.encrypted_credentials is None:
+    needs_kept_cookies = connector.connector_type == "web_crawler" and any(
+        isinstance(cookie, dict) and not cookie.get("value")
+        for cookie in (config.get("cookies") or [])
+    )
+    if (not missing_fields and not needs_kept_cookies) or connector.encrypted_credentials is None:
+        if needs_kept_cookies:
+            # Nothing stored to keep a value from, so the blank rows cannot be
+            # resolved. Fail loudly rather than store a cookie with no value.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="No saved cookies to keep values from. Paste every cookie value.",
+            )
         return config
     if credential_store is None:
         raise HTTPException(
@@ -594,7 +614,73 @@ async def _merge_saved_sensitive_credentials(
     for field in missing_fields:
         if field in saved_credentials:
             merged[field] = saved_credentials[field]
+    if needs_kept_cookies:
+        merged["cookies"] = _resolve_kept_cookies(config, saved_credentials)
     return merged
+
+
+def _assert_no_valueless_cookies(config: dict) -> None:
+    """A cookie with no value must never reach the vault.
+
+    ``CookieEntry.value`` is optional so a blank row can mean "keep the stored
+    one", and ``_resolve_kept_cookies`` fills those in on update. Create has no
+    stored value to fill from, and a direct API call can reach either path, so
+    the invariant is asserted here -- once, immediately before encryption --
+    rather than trusted to hold at every call site.
+
+    Storing one would not raise anywhere later: the crawl carries a blank
+    cookie, the site serves the logged-out page, and crawl4ai answers HTTP 200.
+    """
+    for cookie in config.get("cookies") or []:
+        if isinstance(cookie, dict) and not cookie.get("value"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"Cookie {cookie.get('name')!r} has no value. Paste one, or "
+                    "remove the row."
+                ),
+            )
+
+
+def _resolve_kept_cookies(config: dict, saved_credentials: dict) -> list[dict]:
+    """Fill in the cookies the caller left blank from what is already stored.
+
+    The wizard prefills the saved cookie NAMES with empty values, so replacing
+    one expired cookie means typing one value and leaving the rest alone. Until
+    this existed those blank rows were dropped before the request and the whole
+    stored set was replaced by the single cookie that had been typed -- so
+    refreshing one cookie silently deleted the others.
+
+    A name that is not in the vault cannot be kept, and saying so beats
+    storing a cookie with no value: that crawls logged out and still answers
+    HTTP 200.
+    """
+    incoming = config.get("cookies") or []
+    saved_by_name = {
+        cookie["name"]: cookie
+        for cookie in (saved_credentials.get("cookies") or [])
+        if isinstance(cookie, dict) and cookie.get("name")
+    }
+
+    resolved: list[dict] = []
+    for cookie in incoming:
+        if not isinstance(cookie, dict):
+            continue
+        if cookie.get("value"):
+            resolved.append(cookie)
+            continue
+        name = cookie.get("name")
+        kept = saved_by_name.get(name)
+        if kept is None or not kept.get("value"):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"No saved value to keep for cookie {name!r}. "
+                    "Paste its value, or remove the row."
+                ),
+            )
+        resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})
+    return resolved
 
 
 def _connector_out(c: PortalConnector) -> ConnectorOut:
@@ -751,6 +837,7 @@ async def create_connector(
     encrypted_blob = None
     _require_credential_store_for_sensitive_config(body.connector_type, config_for_save)
     if credential_store is not None:
+        _assert_no_valueless_cookies(config_for_save)
         encrypted_blob, config_to_store = await credential_store.encrypt_credentials(
             org_id=perms.org_id,
             connector_type=body.connector_type,
@@ -887,6 +974,7 @@ async def update_connector(
         config_for_save = await _auto_fill_canary_fingerprint(validated_config)
         _require_credential_store_for_sensitive_config(connector.connector_type, config_for_save)
         if credential_store is not None:
+            _assert_no_valueless_cookies(config_for_save)
             encrypted_blob, stripped_config = await credential_store.encrypt_credentials(
                 org_id=perms.org_id,
                 connector_type=connector.connector_type,

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -587,8 +587,7 @@ async def _merge_saved_sensitive_credentials(
         if old_origin != new_origin:
             missing_fields = missing_fields - {"cookies"}
     needs_kept_cookies = connector.connector_type == "web_crawler" and any(
-        isinstance(cookie, dict) and not cookie.get("value")
-        for cookie in (config.get("cookies") or [])
+        isinstance(cookie, dict) and not cookie.get("value") for cookie in (config.get("cookies") or [])
     )
     if (not missing_fields and not needs_kept_cookies) or connector.encrypted_credentials is None:
         if needs_kept_cookies:
@@ -635,10 +634,7 @@ def _assert_no_valueless_cookies(config: dict) -> None:
         if isinstance(cookie, dict) and not cookie.get("value"):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"Cookie {cookie.get('name')!r} has no value. Paste one, or "
-                    "remove the row."
-                ),
+                detail=(f"Cookie {cookie.get('name')!r} has no value. Paste one, or remove the row."),
             )
 
 
@@ -674,10 +670,7 @@ def _resolve_kept_cookies(config: dict, saved_credentials: dict) -> list[dict]:
         if kept is None or not kept.get("value"):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"No saved value to keep for cookie {name!r}. "
-                    "Paste its value, or remove the row."
-                ),
+                detail=(f"No saved value to keep for cookie {name!r}. Paste its value, or remove the row."),
             )
         resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})
     return resolved

--- a/klai-portal/backend/tests/routers/test_connectors_canary.py
+++ b/klai-portal/backend/tests/routers/test_connectors_canary.py
@@ -19,7 +19,12 @@ from fastapi import HTTPException
 from klai_image_storage.url_guard import _reset_dns_cache
 from pydantic import ValidationError
 
-from app.api.connectors import WebcrawlerConfig, _validate_connector_config
+from app.api.connectors import (
+    WebcrawlerConfig,
+    _assert_no_valueless_cookies,
+    _resolve_kept_cookies,
+    _validate_connector_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -373,3 +378,81 @@ class TestWebcrawlerConfigTestUrl:
                 },
             )
         assert exc_info.value.status_code == 422
+
+
+class TestReplaceOneCookie:
+    """Refreshing one expired cookie must not delete the others.
+
+    The wizard prefills the saved cookie NAMES with empty values, so replacing
+    one means typing one value and leaving the rest alone. Those blank rows
+    used to be dropped before the request, and the backend then replaced the
+    whole stored set with the single cookie that had been typed.
+    """
+
+    @staticmethod
+    def _saved(*pairs: tuple[str, str]) -> dict:
+        return {"cookies": [{"name": n, "value": v, "domain": "w.example.com", "path": "/"} for n, v in pairs]}
+
+    def test_a_blank_row_keeps_the_stored_value(self) -> None:
+        resolved = _resolve_kept_cookies(
+            {
+                "cookies": [
+                    {"name": "sess", "value": "new1", "domain": "w.example.com", "path": "/"},
+                    {"name": "xsrf", "domain": "w.example.com", "path": "/"},
+                ]
+            },
+            self._saved(("sess", "old1"), ("xsrf", "old2")),
+        )
+
+        assert [(c["name"], c["value"]) for c in resolved] == [
+            ("sess", "new1"),
+            ("xsrf", "old2"),
+        ]
+
+    def test_a_removed_row_removes_the_cookie(self) -> None:
+        """The x in the wizard drops the row, so the name never arrives."""
+        resolved = _resolve_kept_cookies(
+            {"cookies": [{"name": "sess", "value": "new1", "domain": "w.example.com", "path": "/"}]},
+            self._saved(("sess", "old1"), ("xsrf", "old2")),
+        )
+
+        assert [c["name"] for c in resolved] == ["sess"]
+
+    def test_a_blank_row_for_an_unknown_name_is_refused(self) -> None:
+        """Storing a cookie with no value would crawl logged out and still
+        answer HTTP 200, which is the failure that hid here for four weeks."""
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_kept_cookies(
+                {"cookies": [{"name": "typo", "domain": "w.example.com", "path": "/"}]},
+                self._saved(("sess", "old1")),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "typo" in str(exc_info.value.detail)
+
+    def test_a_blank_row_never_becomes_an_empty_cookie(self) -> None:
+        resolved = _resolve_kept_cookies(
+            {"cookies": [{"name": "sess", "domain": "w.example.com", "path": "/"}]},
+            self._saved(("sess", "old1")),
+        )
+
+        assert all(c["value"] for c in resolved)
+
+    def test_a_valueless_cookie_never_reaches_the_vault(self) -> None:
+        """Create has nothing stored to fill a blank row from, and a direct API
+        call reaches the same model. Asserted once, right before encryption,
+        rather than trusted to hold at every call site -- storing one raises
+        nowhere later: the crawl carries a blank cookie, the site serves the
+        logged-out page, and crawl4ai answers HTTP 200."""
+        with pytest.raises(HTTPException) as exc_info:
+            _assert_no_valueless_cookies(
+                {"cookies": [{"name": "sid", "domain": "w.example.com", "path": "/"}]}
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "sid" in str(exc_info.value.detail)
+
+    def test_cookies_with_values_pass_the_vault_check(self) -> None:
+        _assert_no_valueless_cookies(
+            {"cookies": [{"name": "sid", "value": "x", "domain": "w.example.com", "path": "/"}]}
+        )

--- a/klai-portal/backend/tests/routers/test_connectors_canary.py
+++ b/klai-portal/backend/tests/routers/test_connectors_canary.py
@@ -445,9 +445,7 @@ class TestReplaceOneCookie:
         nowhere later: the crawl carries a blank cookie, the site serves the
         logged-out page, and crawl4ai answers HTTP 200."""
         with pytest.raises(HTTPException) as exc_info:
-            _assert_no_valueless_cookies(
-                {"cookies": [{"name": "sid", "domain": "w.example.com", "path": "/"}]}
-            )
+            _assert_no_valueless_cookies({"cookies": [{"name": "sid", "domain": "w.example.com", "path": "/"}]})
 
         assert exc_info.value.status_code == 422
         assert "sid" in str(exc_info.value.detail)

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/api.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/api.ts
@@ -17,9 +17,15 @@ export type CrawlerPreviewRequest = CrawlerAuthPayload & {
   try_ai?: boolean
 }
 
+// A row with a name but no value means "keep the one already saved", which is
+// how you replace ONE expired cookie without fetching the others out of
+// DevTools again. Dropping those rows here is what made the backend replace
+// the whole set with whatever you happened to type, silently losing the rest.
+// Removing a row with its x still removes the cookie: the name is then gone.
 export function buildCrawlerCookies(rows: CookieRow[], baseUrl: string): unknown[] | undefined {
-  const filled = rows.filter((row) => row.name.trim() && row.value.trim())
-  if (filled.length === 0) return undefined
+  const named = rows.filter((row) => row.name.trim())
+  if (named.length === 0) return undefined
+  if (named.every((row) => !row.value.trim())) return undefined
 
   const domain = (() => {
     try {
@@ -29,12 +35,12 @@ export function buildCrawlerCookies(rows: CookieRow[], baseUrl: string): unknown
     }
   })()
 
-  return filled.map((row) => ({
-    name: row.name.trim(),
-    value: row.value.trim(),
-    domain,
-    path: '/',
-  }))
+  // Key order is kept as it was: a row WITH a value serialises exactly like
+  // before, so nothing downstream sees this change unless a value is blank.
+  return named.map((row) => {
+    const value = row.value.trim()
+    return { name: row.name.trim(), ...(value ? { value } : {}), domain, path: '/' }
+  })
 }
 
 function savedCredentialFields(
@@ -48,7 +54,11 @@ function savedCredentialFields(
   const useSavedCredentials = payload.use_saved_credentials === true
   return {
     cookies: useSavedCredentials ? null : (payload.cookies || null),
-    connector_id: useSavedCredentials ? connectorId : null,
+    // Always sent, not only with use_saved_credentials: a row left blank means
+    // "keep the stored value", and the server cannot look that up without
+    // knowing which connector. It stays the server's decision what to hand
+    // back -- the same-origin check on the probe URL is enforced there.
+    connector_id: connectorId,
     use_saved_credentials: useSavedCredentials,
   }
 }

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, expect, it } from 'vitest'
+
+import { buildCrawlerCookies } from '../-connector-shared/api'
 import {
   isWithinBaseUrl,
   joinSeedUrl,
@@ -111,5 +113,43 @@ describe('isWithinBaseUrl', () => {
   it('rejects a different site and a look-alike host', () => {
     expect(isWithinBaseUrl('https://y.com/docs', 'https://x.com')).toBe(false)
     expect(isWithinBaseUrl('https://x.com.evil.test/docs', 'https://x.com')).toBe(false)
+  })
+})
+
+describe('buildCrawlerCookies', () => {
+  const base = 'https://wiki.example.com/'
+
+  it('passes a named row with no value through, so the backend can keep it', () => {
+    // The wizard prefills saved cookie NAMES with empty values. Dropping those
+    // rows here is what made refreshing one cookie delete the others.
+    const rows = [
+      { name: 'sess', value: 'new1' },
+      { name: 'xsrf', value: '' },
+    ]
+
+    expect(buildCrawlerCookies(rows, base)).toEqual([
+      { name: 'sess', value: 'new1', domain: 'wiki.example.com', path: '/' },
+      { name: 'xsrf', domain: 'wiki.example.com', path: '/' },
+    ])
+  })
+
+  it('drops a row with no name at all', () => {
+    const rows = [
+      { name: 'sess', value: 'new1' },
+      { name: '  ', value: 'orphan' },
+    ]
+
+    expect(buildCrawlerCookies(rows, base)).toHaveLength(1)
+  })
+
+  it('sends nothing when every row is blank', () => {
+    // Not "replace them all with nothing" but "do not touch the cookies",
+    // which is what opening the wizard and saving without editing must do.
+    const rows = [
+      { name: 'sess', value: '' },
+      { name: 'xsrf', value: '' },
+    ]
+
+    expect(buildCrawlerCookies(rows, base)).toBeUndefined()
   })
 })

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-connector-wizard.test.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/edit-connector-wizard.test.tsx
@@ -282,7 +282,7 @@ describe('edit connector wizard characterization', () => {
     expect(screen.getByText('Saved authentication configured')).toBeTruthy()
   })
 
-  it('Replace cookies prefills only saved cookie names and posts replacement values', async () => {
+  it('Replace cookies keeps the rows you left blank instead of dropping them', async () => {
     await advanceSavedToAuthSetup()
     await waitFor(() => {
       expect(apiFetchMock.mock.calls.some(([url]) => String(url).endsWith('/credential-metadata'))).toBe(
@@ -300,6 +300,10 @@ describe('edit connector wizard characterization', () => {
     const authCall = apiFetchMock.mock.calls.find(([url]) =>
       String(url).endsWith('/auth-probe'),
     )
+    // `csrf` was left blank and is still here, carrying no value: that is the
+    // request to keep the stored one. It used to be dropped, and the backend
+    // then replaced the whole set with `sessionid` alone -- so refreshing one
+    // expired cookie silently deleted the other.
     expect(JSON.parse((authCall?.[1] as RequestInit).body as string)).toEqual({
       url: 'https://docs.example.com/guide/',
       cookies: [
@@ -309,8 +313,16 @@ describe('edit connector wizard characterization', () => {
           domain: 'docs.example.com',
           path: '/',
         },
+        {
+          name: 'csrf',
+          domain: 'docs.example.com',
+          path: '/',
+        },
       ],
-      connector_id: null,
+      // Sent even though use_saved_credentials is false: without it the
+      // server cannot look up the value the blank `csrf` row is asking to
+      // keep, and the probe would 400.
+      connector_id: 'connector-1',
       use_saved_credentials: false,
     })
   })


### PR DESCRIPTION
The wizard prefills the saved cookie **names** with empty values, so refreshing a session looks like it should be: type the one that expired, leave the rest alone.

It was not. `buildCrawlerCookies` dropped every row whose value was blank, the backend then saw a cookies list *with content*, and replaced the whole stored set with the single cookie that had been typed. RedCactus has two cookies; updating one silently removed the other, and the next crawl ran logged out while still answering HTTP 200.

## Three controls, three meanings

| in the wizard | means |
|---|---|
| a row with a value | use the new value |
| a row left blank | keep the stored value for that name |
| a row removed with its × | that cookie goes |

Blank rows are resolved on the **probe** as well as on save. A "Test authentication" that tests a different set than the one being stored is worth less than no probe at all — and that exact mismatch is what hid the last cookie bug.

## Two things review caught, both of which would have broken this in practice

**The wizard sends `connector_id` only when using saved credentials.** The server cannot look up the value a blank row is asking to keep without it, so every partial replacement would have failed at the probe with a 400. Worse, the frontend test asserted that same `null` while mocking a successful response — a mock agreeing with a broken contract, which is the pattern that cost four weeks here. The id is now sent whenever we have one; the same-origin check on the probe URL is unchanged and still the enforcement point.

**`value` became optional for create as well as update**, while only update resolves blanks — so a direct API call could store a cookie with no value. There is now one assertion immediately before encryption, on both paths, rather than a check trusted to hold at every call site. A stored blank raises nowhere later: the crawl carries it, the site serves the logged-out page, and crawl4ai answers 200.

## Gates

- backend: `ruff check`, 4051 passed / 13 deselected / 1 xfailed
- frontend: `npm run lint`, `tsc --noEmit`, 100 vitest passed (7 files)

## Carried, with the reason

Cookies are matched by name, while their real identity is (name, domain, path). Two cookies sharing a name for `/` and `/admin` would still lose one — but the saved-credential metadata endpoint exposes only names, so matching on the triple means widening that response first.

An all-blank set still means "do not touch the cookies" rather than "delete them all". Deleting every cookie is what the "Use without login" control is for, and reading a form of empty rows as a wipe is the more dangerous of the two.

Review: uitgevoerd · gates 5/5 groen · Sol 4 gemeld → 4 bevestigd → 3 gefixt (critical 0, high 0) · ronde 1 · mergeable
