### PR TITLE
fix(monitoring): preserve operator scripts and report API health

### DIFF
--- a/.github/workflows/deploy-compose.yml
+++ b/.github/workflows/deploy-compose.yml
@@ -18,6 +18,7 @@ on:
       - 'deploy/check-klai-librechat-digest.sh'   # Klai LibreChat image must be digest-pinned
       - 'deploy/check-klai-presidio-digest.sh'    # Klai presidio-analyzer image must be digest-pinned
       - 'deploy/scripts/**'                       # Public-safe deploy scripts; operator health scripts live in klai-infra
+      - 'scripts/mistral-api-probe.sh'            # authenticated provider heartbeat
       - 'scripts/smoke-docker-socket-proxy.sh'    # SPEC-SEC-024 M4.3 — smoke-test
       - '.github/workflows/deploy-compose.yml'
   workflow_dispatch:
@@ -135,18 +136,16 @@ jobs:
             # scripts are synced from klai-infra.
             mkdir -p /opt/klai/scripts
             for script in deploy/scripts/*.sh; do
+              name=$(basename "$script")
+              case "$name" in
+                push-health.sh|gpu-health.sh|audit-monitor-coverage.sh|push-component-health.sh) continue ;;
+              esac
               bash -n "$script"
+              install -m 0755 "$script" "/opt/klai/scripts/$name.tmp"
+              mv -f "/opt/klai/scripts/$name.tmp" "/opt/klai/scripts/$name"
             done
-            for script in deploy/scripts/*.sh; do
-              # install(1) truncates and writes in place, so a service deploy
-              # running concurrently can read a half-written compose-up.sh.
-              # Staging next to the target and renaming makes the swap atomic
-              # (same filesystem), so a concurrent reader gets either the old
-              # script or the new one.
-              dest="/opt/klai/scripts/$(basename "$script")"
-              install -m 0755 "$script" "$dest.tmp"
-              mv -f "$dest.tmp" "$dest"
-            done
+            install -m 0755 scripts/mistral-api-probe.sh /opt/klai/scripts/mistral-api-probe.sh.tmp
+            mv -f /opt/klai/scripts/mistral-api-probe.sh.tmp /opt/klai/scripts/mistral-api-probe.sh
             test -x /opt/klai/scripts/backup.sh
 
             # The canary's four patch bind-mounts are gone (Phase 3): it runs the

--- a/.github/workflows/deploy-scripts-tests.yml
+++ b/.github/workflows/deploy-scripts-tests.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     paths:
       - 'deploy/scripts/**'
+      - 'scripts/mistral-api-probe.sh'
       - 'scripts/check-vexa12-deploy-preconditions.sh'
       - '.github/workflows/deploy-compose.yml'
       - 'deploy/librechat/tests/**'
@@ -30,6 +31,7 @@ on:
     branches: [main]
     paths:
       - 'deploy/scripts/**'
+      - 'scripts/mistral-api-probe.sh'
       - 'scripts/check-vexa12-deploy-preconditions.sh'
       - '.github/workflows/deploy-compose.yml'
       - 'deploy/librechat/tests/**'
@@ -56,6 +58,9 @@ jobs:
           for script in deploy/scripts/*.sh; do
             bash -n "$script"
           done
+
+      - name: public script ownership suite
+        run: bash deploy/scripts/tests/status-monitoring.test.sh
 
       - name: compose-up.sh verification suite
         run: bash deploy/scripts/tests/compose-up-verify.test.sh

--- a/deploy/scripts/tests/status-monitoring.test.sh
+++ b/deploy/scripts/tests/status-monitoring.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORKFLOW="${WORKFLOW_FILE:-$ROOT/.github/workflows/deploy-compose.yml}"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/source" "$tmp/dest" "$tmp/bin"
+
+for name in push-health.sh gpu-health.sh audit-monitor-coverage.sh push-component-health.sh; do
+    printf '#!/usr/bin/env bash\necho public\n' > "$tmp/source/$name"
+    printf '#!/usr/bin/env bash\necho private\n' > "$tmp/dest/$name"
+done
+printf '#!/usr/bin/env bash\necho current\n' > "$tmp/source/backup.sh"
+awk '/# Sync public-safe deploy scripts/{copy=1} /test -x \/opt\/klai\/scripts\/backup.sh/{copy=0} copy' \
+    "$WORKFLOW" | sed -e "s#deploy/scripts#$tmp/source#g" \
+        -e "s#/opt/klai/scripts#$tmp/dest#g" > "$tmp/sync.sh"
+bash -e "$tmp/sync.sh"
+for name in push-health.sh gpu-health.sh audit-monitor-coverage.sh push-component-health.sh; do
+    if ! grep -qx 'echo private' "$tmp/dest/$name"; then
+        echo "$name was overwritten by the public deploy" >&2
+        exit 1
+    fi
+done
+grep -qx 'echo current' "$tmp/dest/backup.sh"
+
+printf 'MISTRAL_API_KEY=provider-key\nKUMA_TOKEN_MISTRAL=heartbeat-token\n' > "$tmp/env"
+cat > "$tmp/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+config=$(cat)
+if [[ " $* " == *" -w "* ]]; then
+    [[ "$config" == *'url = "https://api.mistral.ai/v1/models"'* ]]
+    [[ "$config" == *'header = "Authorization: Bearer provider-key"'* ]]
+    headers_file="" body_file=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in -D) headers_file="$2"; shift 2;; -o) body_file="$2"; shift 2;; *) shift;; esac
+    done
+    if [[ -n "${REFLECT_SECRET:-}" ]]; then
+        [[ -z "$headers_file" ]] || printf 'mistral-correlation-id: provider-key\r\n' > "$headers_file"
+        [[ "$body_file" == /dev/null ]] || printf '{"error":"provider-key rejected"}\n' > "$body_file"
+    else
+        [[ -z "$headers_file" ]] || printf '\n' > "$headers_file"
+        [[ "$body_file" == /dev/null ]] || : > "$body_file"
+    fi
+    printf '%s' "${PROVIDER_STATUS:-200}"
+else
+    printf '%s\n' "$config" > "$HEARTBEAT_LOG"
+    [[ -z "${DELIVERY_FAIL:-}" ]]
+fi
+STUB
+chmod +x "$tmp/bin/curl"
+PATH="$tmp/bin:$PATH" KLAI_ENV_FILE="$tmp/env" MISTRAL_PROBE_LOG_FILE="$tmp/probe.log" \
+    HEARTBEAT_LOG="$tmp/heartbeat" bash "$ROOT/scripts/mistral-api-probe.sh" >/dev/null
+grep -q 'heartbeat-token?status=up' "$tmp/heartbeat"
+grep -q '"key_suffix":""' "$tmp/probe.log"
+if grep -q 'provider-key\|"key_suffix":"-key"' "$tmp/probe.log"; then
+    echo "provider key leaked in successful probe log" >&2
+    exit 1
+fi
+PROVIDER_STATUS=401 REFLECT_SECRET=1 PATH="$tmp/bin:$PATH" KLAI_ENV_FILE="$tmp/env" \
+    MISTRAL_PROBE_LOG_FILE="$tmp/probe.log" HEARTBEAT_LOG="$tmp/heartbeat" \
+    bash "$ROOT/scripts/mistral-api-probe.sh" >/dev/null
+grep -q 'heartbeat-token?status=down' "$tmp/heartbeat"
+grep -q '"error":"provider_http_error"' "$tmp/probe.log"
+if grep -q 'provider-key' "$tmp/probe.log"; then
+    echo "reflected provider key leaked in failed probe log" >&2
+    exit 1
+fi
+grep -v KUMA_TOKEN_MISTRAL "$tmp/env" > "$tmp/env-without-heartbeat"
+if PATH="$tmp/bin:$PATH" KLAI_ENV_FILE="$tmp/env-without-heartbeat" \
+    MISTRAL_PROBE_LOG_FILE="$tmp/probe.log" HEARTBEAT_LOG="$tmp/heartbeat" \
+    bash "$ROOT/scripts/mistral-api-probe.sh" >/dev/null 2>"$tmp/error"; then
+    echo "missing heartbeat configuration passed" >&2
+    exit 1
+fi
+grep -qx 'Mistral status heartbeat configuration missing' "$tmp/error"
+if grep -q 'provider-key\|heartbeat-token' "$tmp/error"; then
+    echo "credential leaked in missing-configuration error" >&2
+    exit 1
+fi
+if DELIVERY_FAIL=1 PATH="$tmp/bin:$PATH" KLAI_ENV_FILE="$tmp/env" \
+    MISTRAL_PROBE_LOG_FILE="$tmp/probe.log" HEARTBEAT_LOG="$tmp/heartbeat" \
+    bash "$ROOT/scripts/mistral-api-probe.sh" >/dev/null 2>"$tmp/error"; then
+    echo "failed heartbeat delivery passed" >&2
+    exit 1
+fi
+grep -qx 'Mistral status heartbeat delivery failed' "$tmp/error"
+if grep -q 'provider-key\|heartbeat-token' "$tmp/error"; then
+    echo "credential leaked in delivery error" >&2
+    exit 1
+fi

--- a/scripts/mistral-api-probe.sh
+++ b/scripts/mistral-api-probe.sh
@@ -9,6 +9,21 @@ URL="${MISTRAL_PROBE_URL:-https://api.mistral.ai/v1/models}"
 TIMEOUT="${MISTRAL_PROBE_TIMEOUT:-10}"
 LOG_FILE="${MISTRAL_PROBE_LOG_FILE:-/opt/klai/logs/mistral-api-probe.log}"
 
+push_heartbeat() {
+  local status="$1" token
+  token=$(awk -F= '/^KUMA_TOKEN_MISTRAL=/ {sub(/^[^=]*=/, ""); print; exit}' "$ENV_FILE")
+  if [[ -z "$token" ]]; then
+    echo "Mistral status heartbeat configuration missing" >&2
+    return 1
+  fi
+  # Keep the token out of argv and diagnostics.
+  if ! printf 'url = "https://status.getklai.com/api/push/%s?status=%s&msg=provider-api-auth"\n' \
+    "$token" "$status" | curl --config - --fail --silent --max-time 10 --output /dev/null 2>/dev/null; then
+    echo "Mistral status heartbeat delivery failed" >&2
+    return 1
+  fi
+}
+
 json_escape() {
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read())[1:-1])'
 }
@@ -48,36 +63,24 @@ key=$(
 
 if [[ -z "$key" ]]; then
   emit fail 0 "" "missing_mistral_api_key" ""
+  push_heartbeat down
   exit 0
 fi
 
-key_suffix="${key: -4}"
-headers_file=$(mktemp)
-body_file=$(mktemp)
-curl_error_file="$body_file.curlerr"
-trap 'rm -f "$headers_file" "$body_file" "$curl_error_file"' EXIT
-
 http_status=$(
-  curl -sS -m "$TIMEOUT" \
-    -D "$headers_file" \
-    -o "$body_file" \
-    -w '%{http_code}' \
-    -H "Authorization: Bearer ${key}" \
-    "$URL" 2>"$curl_error_file" || true
-)
-
-correlation_id=$(
-  awk 'BEGIN{IGNORECASE=1} /^mistral-correlation-id:/ {gsub("\r","",$2); print $2; exit} /^x-kong-request-id:/ {gsub("\r","",$2); print $2; exit}' "$headers_file"
+  printf 'header = "Authorization: Bearer %s"\nurl = "%s"\n' "$key" "$URL" | curl --config - -sS -m "$TIMEOUT" \
+    -o /dev/null -w '%{http_code}' 2>/dev/null || true
 )
 
 if [[ "$http_status" == "200" ]]; then
-  emit ok 200 "$key_suffix" "" "$correlation_id"
+  emit ok 200 "" "" ""
+  push_heartbeat up
   exit 0
 fi
 
-error_body=$(head -c 500 "$body_file" 2>/dev/null || true)
-curl_error=$(head -c 500 "$curl_error_file" 2>/dev/null || true)
-if [[ -n "$curl_error" ]]; then
-  error_body="${error_body} curl_error=${curl_error}"
+error_category=provider_transport_error
+if [[ "$http_status" =~ ^[0-9]{3}$ && "$http_status" != "000" ]]; then
+  error_category=provider_http_error
 fi
-emit fail "${http_status:-0}" "$key_suffix" "$error_body" "$correlation_id"
+emit fail "${http_status:-0}" "" "$error_category" ""
+push_heartbeat down


### PR DESCRIPTION
Public config deployments now preserve operator-managed monitoring scripts. The existing provider API probe reports authenticated endpoint health through a push heartbeat and emits fixed diagnostic categories.

Validation: regression reproduced against the previous workflow; 13 deploy-script suites, supplementary guards, 12 artifact unit tests, syntax and version agreement pass. The probe was verified on the target host.
