### PR TITLE
fix(portal): tell two same-named cookies apart, and stop ignoring a removal

### DIFF
--- a/klai-portal/backend/app/api/app_knowledge_bases.py
+++ b/klai-portal/backend/app/api/app_knowledge_bases.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.connectors import _resolve_kept_cookies
 from app.api.dependencies import _load_org_or_500, get_kb_with_access, require_capability
 from app.core.config import settings
 from app.core.database import get_db
@@ -2328,24 +2329,12 @@ async def _resolve_web_crawler_probe_cookies(
         # set than the one being stored is worth less than no probe, and
         # crawl4ai rejects a cookie with no value outright.
         saved = await _load_saved_web_crawler_cookies(kb, connector_id, org_id, db, probe_url)
-        by_name = {c["name"]: c for c in (saved or []) if isinstance(c, dict) and c.get("name")}
-        resolved: list[dict] = []
-        for cookie in cookies:
-            if not isinstance(cookie, dict):
-                continue
-            if cookie.get("value"):
-                resolved.append(cookie)
-                continue
-            kept = by_name.get(cookie.get("name"))
-            if kept is None or not kept.get("value"):
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=(
-                        f"No saved value to keep for cookie {cookie.get('name')!r}. Paste its value, or remove the row."
-                    ),
-                )
-            resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})
-        return resolved
+        # One resolver for both paths, so the probe can never test a set the
+        # save would reject -- or keep a different cookie than the save keeps.
+        return _resolve_kept_cookies(
+            {"cookies": cookies},
+            {"cookies": [c for c in (saved or []) if isinstance(c, dict)]},
+        )
     return cookies
 
 

--- a/klai-portal/backend/app/api/connectors.py
+++ b/klai-portal/backend/app/api/connectors.py
@@ -415,8 +415,25 @@ class ConnectorOut(BaseModel):
     needs_reconfiguration: bool = False
 
 
+class SavedCookieIdentity(BaseModel):
+    """What identifies a stored cookie, without revealing it.
+
+    A cookie is identified by name AND domain AND path -- two cookies may
+    share a name across paths. The wizard sends these back on a row it left
+    blank, so "keep the stored value" resolves to exactly one cookie instead
+    of whichever happened to be first with that name.
+
+    No value, ever: this is metadata for a form, not a way to read the vault.
+    """
+
+    name: str
+    domain: str = ""
+    path: str = "/"
+
+
 class ConnectorCredentialMetadataOut(BaseModel):
     cookie_names: list[str] = Field(default_factory=list)
+    cookies: list[SavedCookieIdentity] = Field(default_factory=list)
 
 
 # -- Helpers ------------------------------------------------------------------
@@ -589,6 +606,19 @@ async def _merge_saved_sensitive_credentials(
     needs_kept_cookies = connector.connector_type == "web_crawler" and any(
         isinstance(cookie, dict) and not cookie.get("value") for cookie in (config.get("cookies") or [])
     )
+    if needs_kept_cookies and _origin((connector.config or {}).get("base_url")) != _origin(config.get("base_url")):
+        # The same edit moved the site to another origin. A blank row asks to
+        # keep a cookie captured for the OLD host, and honouring it would walk
+        # straight past the rule that cookies must not survive that move: the
+        # prefilled row carries the old domain, so `cookies` looks freshly
+        # supplied and `_stale_credentials_cross_origin` never fires.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "The base URL now points at a different site, so the saved cookies "
+                "cannot be kept. Paste a value for every cookie."
+            ),
+        )
     if (not missing_fields and not needs_kept_cookies) or connector.encrypted_credentials is None:
         if needs_kept_cookies:
             # Nothing stored to keep a value from, so the blank rows cannot be
@@ -638,6 +668,34 @@ def _assert_no_valueless_cookies(config: dict) -> None:
             )
 
 
+def _match_saved_cookie(row: dict, saved: list[dict]) -> dict | None:
+    """Find the stored cookie a blank row is asking to keep.
+
+    On (name, domain, path), because that is what identifies a cookie: two may
+    share a name across paths, and matching on name alone hands back whichever
+    came first -- so a partial replacement would still lose one of them.
+
+    Falls back to the name alone when the row carries neither domain nor path,
+    which is what a wizard older than this change sends. That fallback fires
+    only when the name is unambiguous; when it is not, the caller gets the 422
+    and is asked to paste the value rather than being handed a guess.
+    """
+    name = row.get("name")
+    if not name:
+        return None
+    by_name = [c for c in saved if c.get("name") == name]
+    if not by_name:
+        return None
+
+    domain, path = row.get("domain"), row.get("path")
+    if domain or path:
+        exact = [
+            c for c in by_name if (not domain or c.get("domain") == domain) and (not path or c.get("path") == path)
+        ]
+        return exact[0] if len(exact) == 1 else None
+    return by_name[0] if len(by_name) == 1 else None
+
+
 def _resolve_kept_cookies(config: dict, saved_credentials: dict) -> list[dict]:
     """Fill in the cookies the caller left blank from what is already stored.
 
@@ -652,11 +710,7 @@ def _resolve_kept_cookies(config: dict, saved_credentials: dict) -> list[dict]:
     HTTP 200.
     """
     incoming = config.get("cookies") or []
-    saved_by_name = {
-        cookie["name"]: cookie
-        for cookie in (saved_credentials.get("cookies") or [])
-        if isinstance(cookie, dict) and cookie.get("name")
-    }
+    saved = [c for c in (saved_credentials.get("cookies") or []) if isinstance(c, dict)]
 
     resolved: list[dict] = []
     for cookie in incoming:
@@ -665,14 +719,19 @@ def _resolve_kept_cookies(config: dict, saved_credentials: dict) -> list[dict]:
         if cookie.get("value"):
             resolved.append(cookie)
             continue
-        name = cookie.get("name")
-        kept = saved_by_name.get(name)
+        kept = _match_saved_cookie(cookie, saved)
         if kept is None or not kept.get("value"):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(f"No saved value to keep for cookie {name!r}. Paste its value, or remove the row."),
+                detail=(
+                    f"No saved value to keep for cookie {cookie.get('name')!r}. Paste its value, or remove the row."
+                ),
             )
-        resolved.append({**kept, **{k: v for k, v in cookie.items() if v}})
+        # The stored cookie is kept whole. The row supplies identity only:
+        # letting it overwrite domain or path would quietly re-point a cookie
+        # at another host, since the wizard derives those from the base URL
+        # and the same edit may have changed it.
+        resolved.append(dict(kept))
     return resolved
 
 
@@ -703,24 +762,35 @@ def _connector_out(c: PortalConnector) -> ConnectorOut:
     )
 
 
-def _cookie_names_from_credentials(credentials: dict) -> list[str]:
+def _cookie_identities_from_credentials(credentials: dict) -> list[SavedCookieIdentity]:
+    """Identify each stored cookie for the wizard, without its value.
+
+    Deduplicated on (name, domain, path) rather than name alone: two cookies
+    may share a name across paths, and collapsing them here would make one of
+    them unreachable from the form -- and then silently dropped on the next
+    partial replacement.
+    """
     cookies = credentials.get("cookies")
     if not isinstance(cookies, list):
         return []
-    names: list[str] = []
-    seen: set[str] = set()
+    identities: list[SavedCookieIdentity] = []
+    seen: set[tuple[str, str, str]] = set()
     for cookie in cookies:
         if not isinstance(cookie, dict):
             continue
         name = cookie.get("name")
-        if not isinstance(name, str):
+        if not isinstance(name, str) or not name.strip():
             continue
-        cleaned = name.strip()
-        if not cleaned or cleaned in seen:
+        identity = (
+            name.strip(),
+            str(cookie.get("domain") or ""),
+            str(cookie.get("path") or "/"),
+        )
+        if identity in seen:
             continue
-        seen.add(cleaned)
-        names.append(cleaned)
-    return names
+        seen.add(identity)
+        identities.append(SavedCookieIdentity(name=identity[0], domain=identity[1], path=identity[2]))
+    return identities
 
 
 def _normalize_schedule(schedule: str | None) -> str | None:
@@ -908,7 +978,14 @@ async def get_connector_credential_metadata(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail={"error_code": "saved_credentials_unavailable"},
         ) from exc
-    return ConnectorCredentialMetadataOut(cookie_names=_cookie_names_from_credentials(credentials))
+    identities = _cookie_identities_from_credentials(credentials)
+    # cookie_names keeps its old contract -- unique names -- because a client
+    # that has not been reloaded still reads it and turns each entry into a
+    # row. Flattening the identities would hand such a client two identical
+    # rows for two cookies it cannot tell apart.
+    seen: set[str] = set()
+    unique_names = [c.name for c in identities if not (c.name in seen or seen.add(c.name))]
+    return ConnectorCredentialMetadataOut(cookie_names=unique_names, cookies=identities)
 
 
 @router.patch("/{connector_id}", response_model=ConnectorOut)

--- a/klai-portal/backend/tests/routers/test_connectors_canary.py
+++ b/klai-portal/backend/tests/routers/test_connectors_canary.py
@@ -12,7 +12,7 @@ the SSRF reject-list itself is covered by ``test_connectors_ssrf.py``.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from app.api.connectors import (
     WebcrawlerConfig,
     _assert_no_valueless_cookies,
+    _merge_saved_sensitive_credentials,
     _resolve_kept_cookies,
     _validate_connector_config,
 )
@@ -454,3 +455,87 @@ class TestReplaceOneCookie:
         _assert_no_valueless_cookies(
             {"cookies": [{"name": "sid", "value": "x", "domain": "w.example.com", "path": "/"}]}
         )
+
+    def test_two_cookies_sharing_a_name_are_told_apart_by_path(self) -> None:
+        """Matching on the name alone handed back whichever came first, so a
+        partial replacement still lost one of them."""
+        saved = {
+            "cookies": [
+                {"name": "sess", "domain": "w.example.com", "path": "/", "value": "root"},
+                {"name": "sess", "domain": "w.example.com", "path": "/admin", "value": "admin"},
+            ]
+        }
+        resolved = _resolve_kept_cookies(
+            {
+                "cookies": [
+                    {"name": "sess", "domain": "w.example.com", "path": "/admin"},
+                    {"name": "sess", "domain": "w.example.com", "path": "/", "value": "fresh"},
+                ]
+            },
+            saved,
+        )
+
+        assert [(c["path"], c["value"]) for c in resolved] == [
+            ("/admin", "admin"),
+            ("/", "fresh"),
+        ]
+
+    def test_an_ambiguous_blank_row_is_refused_rather_than_guessed(self) -> None:
+        """Two stored cookies share the name and the row says nothing more."""
+        saved = {
+            "cookies": [
+                {"name": "sess", "domain": "w.example.com", "path": "/", "value": "root"},
+                {"name": "sess", "domain": "w.example.com", "path": "/admin", "value": "admin"},
+            ]
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_kept_cookies({"cookies": [{"name": "sess"}]}, saved)
+
+        assert exc_info.value.status_code == 422
+
+    def test_a_row_from_a_moved_base_url_cannot_keep_the_old_cookie(self) -> None:
+        """The row's domain comes from the base URL, which the same edit may
+        have changed. It then no longer identifies the stored cookie, and the
+        answer is to ask for fresh values -- not to carry a cookie captured
+        for one host over to another."""
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_kept_cookies(
+                {"cookies": [{"name": "sess", "domain": "new.example.com", "path": "/"}]},
+                {"cookies": [{"name": "sess", "domain": "old.example.com", "path": "/", "value": "v"}]},
+            )
+
+        assert exc_info.value.status_code == 422
+
+    def test_a_kept_cookie_is_stored_exactly_as_it_was(self) -> None:
+        """The row supplies identity only. Nothing on it overwrites the stored
+        cookie, so keeping one cannot quietly rewrite its domain or path."""
+        resolved = _resolve_kept_cookies(
+            {"cookies": [{"name": "sess", "domain": "w.example.com", "path": "/"}]},
+            {"cookies": [{"name": "sess", "domain": "w.example.com", "path": "/", "value": "v", "httpOnly": True}]},
+        )
+
+        assert resolved == [{"name": "sess", "domain": "w.example.com", "path": "/", "value": "v", "httpOnly": True}]
+
+    @pytest.mark.asyncio
+    async def test_a_blank_row_cannot_carry_a_cookie_to_another_site(self) -> None:
+        """The prefilled row keeps the OLD domain, so `cookies` looks freshly
+        supplied and the cross-origin rule never fires. Without this, cookies
+        captured for one host would be re-saved for another."""
+        connector = MagicMock()
+        connector.connector_type = "web_crawler"
+        connector.encrypted_credentials = b"ENCRYPTED"
+        connector.config = {"base_url": "https://old.example.com/"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _merge_saved_sensitive_credentials(
+                connector=connector,
+                config={
+                    "base_url": "https://new.example.com/",
+                    "cookies": [{"name": "sess", "domain": "old.example.com", "path": "/"}],
+                },
+                org_id=1,
+                db=MagicMock(),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "different site" in str(exc_info.value.detail)

--- a/klai-portal/backend/tests/test_connector_encryption_api.py
+++ b/klai-portal/backend/tests/test_connector_encryption_api.py
@@ -11,7 +11,7 @@ import pytest
 
 from app.api.connectors import (
     _connector_out,
-    _cookie_names_from_credentials,
+    _cookie_identities_from_credentials,
     _drop_stale_credentials_on_origin_change,
     _merge_saved_sensitive_credentials,
 )
@@ -108,8 +108,8 @@ class TestConnectorOutPlaintextSecretRejection:
         assert out.has_saved_credentials is True
 
 
-def test_cookie_names_from_credentials_returns_names_without_values() -> None:
-    names = _cookie_names_from_credentials(
+def test_cookie_identities_carry_no_values() -> None:
+    identities = _cookie_identities_from_credentials(
         {
             "cookies": [
                 {"name": "prod-knowledgebase-session", "value": FAKE_TOKEN},
@@ -118,8 +118,24 @@ def test_cookie_names_from_credentials_returns_names_without_values() -> None:
             ]
         }
     )
-    assert names == ["prod-knowledgebase-session", "XSRF-TOKEN"]
-    assert FAKE_TOKEN not in names
+
+    assert [c.name for c in identities] == ["prod-knowledgebase-session", "XSRF-TOKEN"]
+    assert FAKE_TOKEN not in str(identities)
+
+
+def test_two_cookies_sharing_a_name_across_paths_both_survive() -> None:
+    """Deduplicating on the name alone made one of them unreachable from the
+    form, and a partial replacement then dropped it."""
+    identities = _cookie_identities_from_credentials(
+        {
+            "cookies": [
+                {"name": "sess", "domain": "w.example.com", "path": "/", "value": FAKE_TOKEN},
+                {"name": "sess", "domain": "w.example.com", "path": "/admin", "value": "other"},
+            ]
+        }
+    )
+
+    assert [(c.name, c.path) for c in identities] == [("sess", "/"), ("sess", "/admin")]
 
 
 @pytest.mark.asyncio

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug/-kb-types.ts
@@ -158,4 +158,10 @@ export interface TopTagsResponse {
 export interface CookieRow {
   name: string
   value: string
+  // Carried on a row prefilled from saved credentials, so a row left blank
+  // resolves to exactly one stored cookie. Two cookies can share a name
+  // across paths, and the name alone picks whichever came first. Absent on a
+  // row the operator typed: there is nothing stored to point at yet.
+  domain?: string
+  path?: string
 }

--- a/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/$kbSlug_.edit-connector.$connectorId.tsx
@@ -73,7 +73,8 @@ const GOOGLE_DRIVE_CONNECTOR_TYPES = new Set([
 
 type EditSearch = { step?: StepDeepLink; show?: 'picker' }
 type WebCrawlerAuthMode = 'saved' | 'replace'
-type SavedCredentialMetadata = { cookie_names: string[] }
+type SavedCookieIdentity = { name: string; domain?: string; path?: string }
+type SavedCredentialMetadata = { cookie_names: string[]; cookies?: SavedCookieIdentity[] }
 
 export const Route = createFileRoute('/app/knowledge/$kbSlug_/edit-connector/$connectorId')({
   validateSearch: (search: Record<string, unknown>): EditSearch => ({
@@ -219,6 +220,13 @@ function EditConnectorPage() {
   }
 
   function savedCookieNameRows(): CookieRow[] {
+    // Prefer the full identities: a row that carries domain and path resolves
+    // to exactly one stored cookie when left blank. cookie_names is the older
+    // shape and still works, it just cannot tell two same-named cookies apart.
+    const identities = savedCredentialMetadata?.cookies
+    if (identities?.length) {
+      return identities.map((c) => ({ name: c.name, value: '', domain: c.domain, path: c.path }))
+    }
     const names = savedCredentialMetadata?.cookie_names ?? []
     return names.map((name) => ({ name, value: '' }))
   }

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/CrawlerAuthSetupStep.tsx
@@ -67,6 +67,10 @@ export function CrawlerAuthSetupStep({
   onBack,
 }: CrawlerAuthSetupStepProps) {
   const hasSavedCredentials = mode.kind === 'saved' || mode.savedCredentials !== undefined
+  const allRowsRemoved =
+    mode.kind === 'cookies' &&
+    mode.savedCredentials !== undefined &&
+    mode.rows.every((row) => !row.name.trim())
   const effectiveTestUrl = testUrl || baseUrl
   const testUrlCrossOrigin = Boolean(effectiveTestUrl) && Boolean(baseUrl) && !isSameOrigin(effectiveTestUrl, baseUrl)
 
@@ -139,9 +143,21 @@ export function CrawlerAuthSetupStep({
         ) : (
           <>
             <CookieRowsInput idPrefix={mode.idPrefix} value={mode.rows} onChange={mode.onChange} />
-            {mode.savedCredentials?.hasPrefilledNames && (
+            {mode.savedCredentials?.hasPrefilledNames && !allRowsRemoved && (
               <p className="text-xs text-gray-600">
-                Cookie names are prefilled from saved authentication. Paste fresh values only.
+                Cookie names are prefilled from saved authentication. Leave a value blank
+                to keep the one already saved; remove a row to drop that cookie.
+              </p>
+            )}
+            {allRowsRemoved && (
+              // Saying so, rather than saving and quietly changing nothing.
+              // CookieRowsInput always leaves one blank row behind, so an
+              // empty form cannot mean "delete them all" -- and reading it
+              // that way would wipe an org's session on a stray second click.
+              <p className="text-xs text-[var(--color-destructive)]">
+                Every row is empty, so saving now leaves the saved cookies exactly as they
+                are. To remove authentication entirely, go back and choose
+                &ldquo;Use without login&rdquo;.
               </p>
             )}
             <Button

--- a/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/api.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/-connector-shared/api.ts
@@ -24,8 +24,11 @@ export type CrawlerPreviewRequest = CrawlerAuthPayload & {
 // Removing a row with its x still removes the cookie: the name is then gone.
 export function buildCrawlerCookies(rows: CookieRow[], baseUrl: string): unknown[] | undefined {
   const named = rows.filter((row) => row.name.trim())
+  // Only a form with no names left at all means "do not touch the cookies".
+  // Sending the named rows even when none carries a new value is what makes
+  // REMOVING one work: the row that is gone is then genuinely absent, instead
+  // of the whole field being omitted and the backend restoring both.
   if (named.length === 0) return undefined
-  if (named.every((row) => !row.value.trim())) return undefined
 
   const domain = (() => {
     try {
@@ -39,7 +42,15 @@ export function buildCrawlerCookies(rows: CookieRow[], baseUrl: string): unknown
   // before, so nothing downstream sees this change unless a value is blank.
   return named.map((row) => {
     const value = row.value.trim()
-    return { name: row.name.trim(), ...(value ? { value } : {}), domain, path: '/' }
+    // A prefilled row carries the stored cookie's own domain and path; only a
+    // freshly typed row falls back to the base URL. Overwriting them would
+    // re-point a kept cookie at whatever host the base URL now names.
+    return {
+      name: row.name.trim(),
+      ...(value ? { value } : {}),
+      domain: row.domain ?? domain,
+      path: row.path ?? '/',
+    }
   })
 }
 

--- a/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
+++ b/klai-portal/frontend/src/routes/app/knowledge/__tests__/connector-helpers.test.ts
@@ -142,14 +142,45 @@ describe('buildCrawlerCookies', () => {
     expect(buildCrawlerCookies(rows, base)).toHaveLength(1)
   })
 
-  it('sends nothing when every row is blank', () => {
-    // Not "replace them all with nothing" but "do not touch the cookies",
-    // which is what opening the wizard and saving without editing must do.
+  it('keeps a prefilled row on its own domain and path', () => {
+    // The base URL may have been edited in the same visit. Overwriting the
+    // stored cookie's domain would re-point it at whatever host that now is.
+    const rows = [
+      { name: 'sess', value: '', domain: 'old.example.com', path: '/admin' },
+      { name: 'fresh', value: 'v' },
+    ]
+
+    expect(buildCrawlerCookies(rows, base)).toEqual([
+      { name: 'sess', domain: 'old.example.com', path: '/admin' },
+      { name: 'fresh', value: 'v', domain: 'wiki.example.com', path: '/' },
+    ])
+  })
+
+  it('still sends the named rows when nothing was retyped', () => {
+    // They all resolve to their stored values, so saving changes nothing --
+    // but the rows must travel, because that is what makes REMOVING one
+    // work. Omitting the field entirely restores whatever is in the vault.
     const rows = [
       { name: 'sess', value: '' },
       { name: 'xsrf', value: '' },
     ]
 
-    expect(buildCrawlerCookies(rows, base)).toBeUndefined()
+    expect(buildCrawlerCookies(rows, base)).toHaveLength(2)
+  })
+
+  it('drops a cookie when its row is removed, even with nothing retyped', () => {
+    // Two saved, one row deleted, the other left blank. `xsrf` is absent from
+    // the payload, which is how the backend learns to drop it. Sending
+    // nothing here would have restored both, contradicting the wizard's own
+    // "remove a row to drop that cookie".
+    const rows = [{ name: 'sess', value: '' }]
+
+    expect(buildCrawlerCookies(rows, base)).toEqual([
+      { name: 'sess', domain: 'wiki.example.com', path: '/' },
+    ])
+  })
+
+  it('sends nothing only when no row has a name left', () => {
+    expect(buildCrawlerCookies([{ name: '  ', value: '' }], base)).toBeUndefined()
   })
 })


### PR DESCRIPTION
Both of these were carried out of #1417 with a reason at the time. The reasons did not survive contact with the code.

## Two cookies can share a name

A cookie is identified by **name and domain and path**. Everything here matched on the name alone:

- the metadata endpoint deduplicated on it, so one of two same-named cookies never reached the form at all
- the resolver picked whichever came first, so a partial replacement dropped the other

The endpoint now returns the full identity — never a value — the wizard sends it back on a row it leaves blank, and the resolver matches on all three. It falls back to the name only where that is unambiguous, and answers 422 rather than guessing where it is not.

A kept cookie is now stored **exactly as it was**. The row supplies identity and never overwrites, so keeping a cookie cannot quietly re-point it at another host.

## Removing a cookie did nothing

With two cookies saved, deleting one row and leaving the other blank made `buildCrawlerCookies` return `undefined` — no value had been retyped — so the field was omitted and the backend restored **both**.

The wizard's own text said *"remove a row to drop that cookie"*, and it was not true.

Named rows now always travel. Only a form with no names left means "do not touch the cookies", and the wizard says that out loud instead of saving and quietly changing nothing.

## What review caught that the first fix would have opened

A prefilled row keeps the **old** domain. So an edit that moves `base_url` to another origin made `cookies` look freshly supplied, `_stale_credentials_cross_origin` never fired, and cookies captured for one host were re-saved for another.

A blank row is now refused outright when the origin changed, with a 422 asking for fresh values.

## The wizard's controls, end to end

| action | result |
|---|---|
| a row with a value | use it |
| a row left blank | keep the stored cookie with that identity |
| a row removed with its × | that cookie is dropped |
| no rows with names left | cookies untouched — and the wizard says so |

## Not done on purpose

An empty form still does not mean "delete every cookie". `CookieRowsInput.removeRow` always leaves one blank row behind, so an empty form is one stray click away, and reading it as a wipe would cost an org its session. Removing authentication entirely is what "Use without login" is for, and the wizard now points at it.

## Gates

- backend: `ruff check`, `ruff format --check`, 4057 passed / 13 deselected / 1 xfailed
- frontend: `npm run lint`, `tsc --noEmit`, 103 vitest passed (7 files)

## Carried

One shared normalisation helper for metadata, dedup and matching — they currently differ on a missing field versus an explicitly empty one. And Paraglide keys plus the shared `Alert` for the new wizard text, together with the English strings already hardcoded in that component; translating one message alone would leave it half-translated.

Review: uitgevoerd · gates 5/5 groen · Sol 7 gemeld → 7 bevestigd → 5 gefixt (critical 0, high 1) · ronde 2 · mergeable
