### PR TITLE
fix(widgets): hide admin preview/test conversations from activity lists

### DIFF
--- a/klai-portal/backend/app/api/admin/platform.py
+++ b/klai-portal/backend/app/api/admin/platform.py
@@ -996,6 +996,7 @@ async def platform_bot_conversations(
                     "first_user_query, language_detected "
                     "FROM widget_conversations "
                     "WHERE widget_id = CAST(:widget_id AS uuid) "
+                    "AND is_preview = false "
                     "AND started_at < :cursor "
                     "ORDER BY started_at DESC LIMIT :limit"
                 ),
@@ -1008,6 +1009,7 @@ async def platform_bot_conversations(
                     "first_user_query, language_detected "
                     "FROM widget_conversations "
                     "WHERE widget_id = CAST(:widget_id AS uuid) "
+                    "AND is_preview = false "
                     "ORDER BY started_at DESC LIMIT :limit"
                 ),
                 params,

--- a/klai-portal/backend/app/api/admin_widgets.py
+++ b/klai-portal/backend/app/api/admin_widgets.py
@@ -954,6 +954,7 @@ async def list_widget_conversations(
                 "first_user_query, language_detected "
                 "FROM widget_conversations "
                 "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND is_preview = false "
                 "AND started_at < :cursor "
                 "ORDER BY started_at DESC LIMIT :limit"
             ),
@@ -966,6 +967,7 @@ async def list_widget_conversations(
                 "first_user_query, language_detected "
                 "FROM widget_conversations "
                 "WHERE widget_id = CAST(:widget_id AS uuid) "
+                "AND is_preview = false "
                 "ORDER BY started_at DESC LIMIT :limit"
             ),
             params,

--- a/klai-portal/backend/tests/test_widget_preview_flagging.py
+++ b/klai-portal/backend/tests/test_widget_preview_flagging.py
@@ -245,3 +245,37 @@ def test_widget_activity_stats_sql_filters_preview_rows() -> None:
         f"found {source.count('is_preview = false')} occurrences. "
         "REQ-15 requires the stats query to exclude admin-preview conversations."
     )
+
+
+def test_list_widget_conversations_sql_filters_preview_rows() -> None:
+    """SQL-source inspection: the recent-conversations list (activity tab)
+    also excludes admin-preview rows, both with and without a pagination
+    cursor.
+    """
+    import inspect
+
+    from app.api.admin_widgets import list_widget_conversations
+
+    source = inspect.getsource(list_widget_conversations)
+    assert source.count("is_preview = false") >= 2, (
+        "list_widget_conversations must filter both the cursor and no-cursor "
+        f"branches on is_preview = false; found {source.count('is_preview = false')} "
+        "occurrences. Otherwise admin preview/test chats leak into the activity tab."
+    )
+
+
+def test_platform_bot_conversations_sql_filters_preview_rows() -> None:
+    """SQL-source inspection: the platform-admin mirror of the recent-
+    conversations list also excludes admin-preview rows, both with and
+    without a pagination cursor.
+    """
+    import inspect
+
+    from app.api.admin.platform import platform_bot_conversations
+
+    source = inspect.getsource(platform_bot_conversations)
+    assert source.count("is_preview = false") >= 2, (
+        "platform_bot_conversations must filter both the cursor and no-cursor "
+        f"branches on is_preview = false; found {source.count('is_preview = false')} "
+        "occurrences. Otherwise admin preview/test chats leak into the platform view."
+    )


### PR DESCRIPTION
## Summary
- `list_widget_conversations` (org-admin activity tab) and `platform_bot_conversations` (platform-admin cross-tenant mirror) both listed `widget_conversations` rows without filtering `is_preview`, so admin preview/test chats appeared mixed in with real visitor conversations.
- `widget_activity_stats` already excluded `is_preview` rows from its aggregates — this brings both conversation-list endpoints in line with that existing filter.
- Deliberately NOT a delete: `widget_conversations`/messages are kept even for soft-deleted widgets by design (REQ-16, SPEC-SEC-CROSS-TENANT-FOLLOWUP-001) specifically so an admin cannot wipe their own audit trail. This is a visibility fix only.

## Test plan
- [x] `uv run pytest` on the widget/platform/conversation test files (113 tests) — all green
- [x] New regression tests: `test_list_widget_conversations_sql_filters_preview_rows`, `test_platform_bot_conversations_sql_filters_preview_rows`
- [x] Sol review pass (uncommitted diff) — 1 finding, fixed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)